### PR TITLE
Remove dead Font-gated UpdateToFontValues in SkiaGum dispatcher

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1175,38 +1175,6 @@ public partial class CustomSetPropertyOnRenderable
         return false;
     }
 
-
-    public static void UpdateToFontValues(IText itext, GraphicalUiElement graphicalUiElement)
-    {
-        if (graphicalUiElement is TextRuntime asTextRuntime && itext is Text text)
-        {
-#if SKIA
-            // #3670/#3703: resolve CustomFontFile/Font-as-path .ttf/.otf sources through
-            // GumFontMapper instead of passing Font straight through as a system family name.
-            string? resolvedFamily = SkiaGum.Content.Fonts.GumFontMapper.ResolveFontFamily(
-                asTextRuntime.UseCustomFont, asTextRuntime.CustomFontFile, asTextRuntime.Font);
-
-            if (resolvedFamily != null || !string.IsNullOrEmpty(asTextRuntime.Font))
-            {
-                text.FontName = resolvedFamily ?? asTextRuntime.Font;
-                text.FontSize = asTextRuntime.FontSize;
-                // Skia draws the outline at render time via RichTextKit's halo (there is no
-                // font-generation step to bake it into, unlike MonoGame/Raylib), so push the
-                // runtime's OutlineThickness onto the renderable here.
-                text.OutlineThickness = asTextRuntime.OutlineThickness;
-            }
-#else
-            if (!string.IsNullOrEmpty(asTextRuntime.Font))
-            {
-                text.FontName = asTextRuntime.Font;
-                text.FontSize = asTextRuntime.FontSize;
-            }
-#endif
-        }
-    }
-
-
-
     private static bool TrySetPropertyOnText(Text text, GraphicalUiElement gue, string propertyName, object value)
     {
         bool handled = false;
@@ -1533,9 +1501,9 @@ public partial class CustomSetPropertyOnRenderable
 #endif
 
         }
-        // Standalone drop shadow (issue #3674). Set directly on the renderable -- NOT routed through
-        // UpdateToFontValues, which is font-gated and would no-op when no Font is set. Mirrors the
-        // shape drop-shadow arms in TrySetPropertiesOnRenderableBase.
+        // Standalone drop shadow (issue #3674). Set directly on the renderable rather than through
+        // ReactToFontValueChange, since these aren't font-cascade inputs. Mirrors the shape
+        // drop-shadow arms in TrySetPropertiesOnRenderableBase.
         else if (propertyName == nameof(text.HasDropshadow))
         {
             text.HasDropshadow = (bool)value;

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -541,6 +541,27 @@ public class TextRuntimeTests
         containedText.OutlineThickness.ShouldBe(7);
     }
 
+    [Fact]
+    public void OutlineThickness_SetProperty_WithNoFontSet_ShouldStillPushToContainedText()
+    {
+        // #3684 as filed pointed at CustomSetPropertyOnRenderable.UpdateToFontValues(IText,
+        // GraphicalUiElement), which gates its whole body (including OutlineThickness) behind
+        // Font being non-empty. That method turned out to have zero callers: both the code-property
+        // path and this SetProperty path route through GraphicalUiElement.UpdateToFontValues()'s
+        // UpdateFontFromProperties delegate, which SystemManagers.Initialize wires to
+        // SystemManagers.UpdateFonts -- an unconditional push, not the gated method. Pinning that
+        // wiring here so a future rewire can't silently reintroduce the Font-gated bug.
+        new RenderingLibrary.SystemManagers().Initialize();
+
+        TextRuntime sut = new();
+        sut.Font = "";
+
+        sut.SetProperty("OutlineThickness", 7);
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.OutlineThickness.ShouldBe(7);
+    }
+
     #endregion
 
     #region PropertyChanged


### PR DESCRIPTION
## Summary
`CustomSetPropertyOnRenderable.UpdateToFontValues(IText, GraphicalUiElement)` in the Skia dispatcher gates OutlineThickness (and FontName/FontSize) behind `Font` being non-empty -- exactly the bug #3684 reports. But that method has zero callers anywhere in the repo: `ReactToFontValueChange` calls the instance `GraphicalUiElement.UpdateToFontValues()` instead, which `SystemManagers.Initialize()` wires to `SystemManagers.UpdateFonts` -- an unconditional push that already covers OutlineThickness/OutlineColor regardless of Font. That rewiring landed incidentally in #3693 (2026-07-14), before #3684 was even filed, so the reported bug doesn't reproduce today.

This PR deletes the dead, misleading method (it looks exactly as broken as the issue describes, which is what led to re-investigating a "live" bug) and adds a regression test pinning the real, unconditional code path so a future rewire can't silently reintroduce the gate.

## Test plan
- [x] New test `OutlineThickness_SetProperty_WithNoFontSet_ShouldStillPushToContainedText` reproduces the issue's exact scenario (`SetProperty`, empty `Font`) against the real delegate wiring -- green, confirming no regression.
- [x] Full `SkiaGum.Tests` suite green (351/351).
- [x] `SkiaGum`, `MonoGameGumShapes` (Apos.Shapes), and `SilkNetGum` (all link this shared file) build clean, 0 errors.
- Manual test: not needed -- dead-code removal plus a unit test on existing, already-correct behavior; no runtime-observable change.
- FRB canary: not needed -- SkiaGum is not FRB-shared source.

Closes #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
