### PR TITLE
Add family+style embedded-font registration to Skia's GumFontMapper

### DIFF
--- a/Runtimes/SkiaGum/Content/Fonts/GumFontMapper.cs
+++ b/Runtimes/SkiaGum/Content/Fonts/GumFontMapper.cs
@@ -2,6 +2,7 @@ using RenderingLibrary.Graphics.Fonts;
 using SkiaSharp;
 using System;
 using System.Collections.Concurrent;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Topten.RichTextKit;
@@ -28,6 +29,23 @@ public class GumFontMapper : FontMapper
 
     private static readonly ConditionalWeakTable<SKTypeface, string> typefaceKeys = new();
     private static int nextTypefaceId;
+
+    /// <summary>
+    /// Embedded fonts registered via <see cref="RegisterFont"/>, keyed by family name + style slot
+    /// (as opposed to <see cref="registry"/>, which is keyed by file path or typeface instance).
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, SKTypeface> embeddedFontRegistry =
+        new ConcurrentDictionary<string, SKTypeface>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Font weight above which <see cref="TypefaceFromStyle"/> treats a run as bold when resolving
+    /// an <see cref="embeddedFontRegistry"/> style slot. 400 is <see cref="Style"/>'s regular-weight
+    /// default; anything above it is a bold request, whether that's <c>TextRuntime.IsBold</c> on Skia
+    /// (which maps to <c>Style.FontWeight</c> 600 via <c>BoldWeight</c> 1.5) or the <c>[IsBold]</c>
+    /// BBCode tag (which sets <c>Style.FontWeight</c> 700 directly) -- a plain <c>&gt;= 700</c> check
+    /// would miss the former.
+    /// </summary>
+    private const int RegularFontWeight = 400;
 
     /// <summary>
     /// Registers an already-loaded <see cref="SKTypeface"/> directly (as opposed to
@@ -80,6 +98,30 @@ public class GumFontMapper : FontMapper
     }
 
     /// <summary>
+    /// Registers an in-memory TTF/OTF (<paramref name="fontData"/>) under <paramref name="familyName"/>
+    /// plus an optional style slot ("Bold"/"Italic"/"BoldItalic", or null for the default cut) and
+    /// returns the loaded <see cref="SKTypeface"/>, or null if the data doesn't parse as a font. Mirrors
+    /// the KernSmith <c>RegisterFont(familyName, fontData, style)</c> surface XNA-like/raylib themes call
+    /// through <c>Gum.Themes.ThemePlatform.RegisterFont</c>, so a theme's embedded fonts (which never
+    /// touch disk) resolve on Skia through the same family+style vocabulary a theme already uses for
+    /// every other backend, instead of the file-path/instance-only <see cref="RegisterFontFile"/> /
+    /// <see cref="RegisterTypeface"/> (#3671). Unlike those two, callers keep addressing the font by
+    /// <paramref name="familyName"/> -- <see cref="TypefaceFromStyle"/> picks the matching style slot
+    /// from a run's bold/italic state.
+    /// </summary>
+    public static SKTypeface? RegisterFont(string familyName, byte[] fontData, string? style = null)
+    {
+        SKTypeface? typeface = SKTypeface.FromStream(new MemoryStream(fontData));
+        if (typeface == null)
+        {
+            return null;
+        }
+
+        embeddedFontRegistry[GetEmbeddedFontKey(familyName, style)] = typeface;
+        return typeface;
+    }
+
+    /// <summary>
     /// Resolves the family-name to assign as <c>Text.FontName</c> for the given TextRuntime font
     /// properties. <see cref="BmfcSave.ResolveTtfSourcePath"/> is the single backend-agnostic
     /// "which property is a font file" decision (also used by XNA-like/raylib's bake path), so
@@ -105,11 +147,40 @@ public class GumFontMapper : FontMapper
     /// <inheritdoc/>
     public override SKTypeface TypefaceFromStyle(IStyle style, bool ignoreFontVariants)
     {
-        if (style.FontFamily != null && registry.TryGetValue(style.FontFamily, out SKTypeface? typeface))
+        if (style.FontFamily != null)
         {
-            return typeface;
+            string styleSlot = GetStyleSlot(isBold: style.FontWeight > RegularFontWeight, isItalic: style.FontItalic);
+            if (embeddedFontRegistry.TryGetValue(GetEmbeddedFontKey(style.FontFamily, styleSlot), out SKTypeface? embeddedTypeface))
+            {
+                return embeddedTypeface;
+            }
+
+            // Requested style slot (e.g. Bold) has no registered cut -- fall back to the family's
+            // default cut rather than dropping straight to a system font, so a theme that only
+            // bundled one weight still renders with it instead of silently swapping typefaces.
+            if (styleSlot.Length > 0
+                && embeddedFontRegistry.TryGetValue(GetEmbeddedFontKey(style.FontFamily, null), out embeddedTypeface))
+            {
+                return embeddedTypeface;
+            }
+
+            if (registry.TryGetValue(style.FontFamily, out SKTypeface? typeface))
+            {
+                return typeface;
+            }
         }
 
         return base.TypefaceFromStyle(style, ignoreFontVariants);
     }
+
+    private static string GetEmbeddedFontKey(string familyName, string? style) =>
+        $"{familyName} {style}";
+
+    private static string GetStyleSlot(bool isBold, bool isItalic) => (isBold, isItalic) switch
+    {
+        (true, true) => "BoldItalic",
+        (true, false) => "Bold",
+        (false, true) => "Italic",
+        (false, false) => string.Empty,
+    };
 }

--- a/Tests/SkiaGum.Tests/Content/GumFontMapperTests.cs
+++ b/Tests/SkiaGum.Tests/Content/GumFontMapperTests.cs
@@ -172,4 +172,65 @@ public class GumFontMapperTests
 
         resolved.ShouldBeSameAs(typeface);
     }
+
+    // Embedded font bytes (#3671): registers raw TTF bytes under a family name plus an optional style
+    // slot ("Bold"/"Italic"/"BoldItalic"/null), mirroring the KernSmith RegisterFont(familyName, fontData,
+    // style) surface XNA-like/raylib themes call through Gum.Themes.ThemePlatform.RegisterFont -- so a
+    // theme's embedded fonts resolve on Skia through the same family+style vocabulary, instead of the
+    // path/instance-only registries RegisterFontFile/RegisterTypeface offer.
+
+    [Fact]
+    public void RegisterFont_WithValidBytes_ReturnsNonNullTypeface()
+    {
+        byte[] fontBytes = File.ReadAllBytes(FixtureTtfPath);
+
+        SKTypeface? typeface = GumFontMapper.RegisterFont("RegisterFontValidFamily", fontBytes);
+
+        typeface.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void RegisterFont_WithInvalidBytes_ReturnsNull()
+    {
+        byte[] invalidBytes = new byte[] { 1, 2, 3, 4, 5 };
+
+        SKTypeface? typeface = GumFontMapper.RegisterFont("RegisterFontInvalidFamily", invalidBytes);
+
+        typeface.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(600)] // TextRuntime.IsBold on Skia sets BoldWeight=1.5 -> Style.FontWeight 400*1.5=600
+    [InlineData(700)] // The [IsBold] BBCode tag sets Style.FontWeight directly to 700
+    public void TypefaceFromStyle_WithBoldWeight_ResolvesRegisteredBoldCut(int boldFontWeight)
+    {
+        string family = $"TypefaceFromStyleBoldFamily{boldFontWeight}";
+        byte[] fontBytes = File.ReadAllBytes(FixtureTtfPath);
+        SKTypeface? regularTypeface = GumFontMapper.RegisterFont(family, fontBytes, style: null);
+        SKTypeface? boldTypeface = GumFontMapper.RegisterFont(family, fontBytes, style: "Bold");
+        GumFontMapper mapper = new();
+        Style regularStyle = new() { FontFamily = family, FontWeight = 400, FontItalic = false };
+        Style boldStyle = new() { FontFamily = family, FontWeight = boldFontWeight, FontItalic = false };
+
+        SKTypeface resolvedRegular = mapper.TypefaceFromStyle(regularStyle, ignoreFontVariants: false);
+        SKTypeface resolvedBold = mapper.TypefaceFromStyle(boldStyle, ignoreFontVariants: false);
+
+        resolvedRegular.ShouldBeSameAs(regularTypeface);
+        resolvedBold.ShouldBeSameAs(boldTypeface);
+        resolvedBold.ShouldNotBeSameAs(resolvedRegular);
+    }
+
+    [Fact]
+    public void TypefaceFromStyle_WithoutMatchingStyleSlotRegistered_FallsBackToDefaultCut()
+    {
+        string family = "TypefaceFromStyleFallbackFamily";
+        byte[] fontBytes = File.ReadAllBytes(FixtureTtfPath);
+        SKTypeface? regularTypeface = GumFontMapper.RegisterFont(family, fontBytes, style: null);
+        GumFontMapper mapper = new();
+        Style boldStyle = new() { FontFamily = family, FontWeight = 700, FontItalic = false };
+
+        SKTypeface resolved = mapper.TypefaceFromStyle(boldStyle, ignoreFontVariants: false);
+
+        resolved.ShouldBeSameAs(regularTypeface);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `GumFontMapper.RegisterFont(familyName, byte[] fontData, string? style)` — registers an in-memory TTF/OTF keyed by (family, style), returning the loaded `SKTypeface` (null on invalid data).
- Extends `TypefaceFromStyle` to resolve Bold/Italic from `Style.FontWeight`/`FontItalic` against the new registry, falling back to the family's default cut when the exact style slot isn't registered, before falling through to the existing path/instance registries and system-font resolution.

## Why
Every shipped theme registers embedded fonts through `Gum.Themes.ThemePlatform.RegisterFont(familyName, byte[] fontData, style)`, which on XNA-like/Raylib forwards to KernSmith's `RegisterFont(familyName, fontData, style)` — a (family, style)-keyed registry so a control's `Font`/`IsBold`/`IsItalic` resolve to the right cut. `GumFontMapper` (added in #3707) only had `RegisterFontFile` (path-keyed) and `RegisterTypeface` (instance-keyed) — neither matches that shape, which was flagged as a blocker in #3671's own status-check comment before a Skia branch of `ThemePlatform` can be written.

Part of #3671. Follow-up (not in this PR): wire a Skia branch into `ThemePlatform.cs` once `.Skia`/`.Silk` theme csproj variants exist.

## Test plan
- [x] New unit tests in `Tests/SkiaGum.Tests/Content/GumFontMapperTests.cs` (TDD: written first, confirmed red on missing API, green after implementation).
- [x] Full `SkiaGum.Tests` suite green (356/356).
- [x] `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` — no new warnings.
- Manual test: not needed — no consumer wired to this API yet (that's the follow-up `ThemePlatform` piece of #3671); covered by unit tests + compilation.
- FRB canary: not needed — SkiaGum isn't consumed by FRB1 (not part of `GumCoreShared`/`FlatRedBall.Forms.Shared`).
