### PR TITLE
Relocate concrete ReferenceFinder into headless Gum.Presentation (ADR-0005 Phase 3)

### DIFF
--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -30,7 +30,7 @@ using ToolsUtilities;
 
 namespace Gum;
 
-public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPasteProjectProvider
+public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPasteProjectProvider, IReferenceFinderProjectProvider
 {
     #region Fields
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -114,6 +114,9 @@ file static class ServiceCollectionExtensions
         // ICopyPasteProjectProvider: same narrow-port pattern as IDeleteProjectProvider, for CopyPasteLogic's
         // element-name-uniqueness check. Resolves to the same ProjectManager singleton.
         services.AddSingleton<ICopyPasteProjectProvider>(provider => provider.GetRequiredService<ProjectManager>());
+        // IReferenceFinderProjectProvider: same narrow-port pattern, for ReferenceFinder's project reads.
+        // Resolves to the same ProjectManager singleton.
+        services.AddSingleton<IReferenceFinderProjectProvider>(provider => provider.GetRequiredService<ProjectManager>());
         services.AddSingleton<ICommandLineManager, CommandLineManager>();
         services.AddSingleton<IProjectState, ProjectState>();
         // ElementTreeViewManager: drained from a static Self singleton (#3286). Concrete is needed for the

--- a/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
@@ -3,7 +3,6 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
-using Gum.ToolStates;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
@@ -24,7 +23,7 @@ public class ReferenceFinderTests : BaseTestClass
         _project = new GumProjectSave();
         ObjectFinder.Self.GumProjectSave = _project;
 
-        _mocker.GetMock<IProjectState>()
+        _mocker.GetMock<IReferenceFinderProjectProvider>()
             .Setup(x => x.GumProjectSave)
             .Returns(_project);
 

--- a/Tools/Gum.Presentation/Logic/IReferenceFinderProjectProvider.cs
+++ b/Tools/Gum.Presentation/Logic/IReferenceFinderProjectProvider.cs
@@ -1,0 +1,15 @@
+using Gum.DataTypes;
+
+namespace Gum.Logic;
+
+/// <summary>
+/// Narrow headless port <see cref="ReferenceFinder"/> uses to read the loaded project, so the
+/// reference-finding logic no longer needs to depend on the concrete, WinForms-entangled
+/// <c>IProjectManager</c> — whose wider surface drags <c>GeneralSettingsFile</c> and the whole
+/// load/save flow — for that one access (ADR-0005 Phase 3). The live implementation is
+/// <c>ProjectManager</c>, bridged via DI to the same singleton.
+/// </summary>
+public interface IReferenceFinderProjectProvider
+{
+    GumProjectSave? GumProjectSave { get; }
+}

--- a/Tools/Gum.Presentation/Logic/ReferenceFinder.cs
+++ b/Tools/Gum.Presentation/Logic/ReferenceFinder.cs
@@ -4,24 +4,23 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
-using Gum.ToolStates;
 using GumRuntime;
 
 namespace Gum.Logic;
 
 public class ReferenceFinder : IReferenceFinder
 {
-    private readonly IProjectState _projectState;
+    private readonly IReferenceFinderProjectProvider _projectProvider;
 
-    public ReferenceFinder(IProjectState projectState)
+    public ReferenceFinder(IReferenceFinderProjectProvider projectProvider)
     {
-        _projectState = projectState;
+        _projectProvider = projectProvider;
     }
 
     public ElementReferences GetReferencesToElement(ElementSave element, string elementName)
     {
         var changes = new ElementReferences();
-        var project = _projectState.GumProjectSave;
+        var project = _projectProvider.GumProjectSave;
 
         string qualifiedOldName = element switch
         {
@@ -231,7 +230,7 @@ public class ReferenceFinder : IReferenceFinder
 
         // Search all other elements for cross-component qualified references
         // e.g. "Width = Components/ComponentA.Sprite.Width" in ComponentB
-        var project = _projectState.GumProjectSave;
+        var project = _projectProvider.GumProjectSave;
         string? qualifiedElementPrefix = containerElement switch
         {
             ComponentSave => $"Components/{containerElement.Name}",
@@ -290,7 +289,7 @@ public class ReferenceFinder : IReferenceFinder
     public BehaviorReferences GetReferencesToBehavior(BehaviorSave behavior, string oldName)
     {
         var changes = new BehaviorReferences();
-        var project = _projectState.GumProjectSave;
+        var project = _projectProvider.GumProjectSave;
 
         foreach (var element in project.AllElements)
         {
@@ -344,7 +343,7 @@ public class ReferenceFinder : IReferenceFinder
     {
         var changes = new CategoryReferences();
 
-        var project = _projectState.GumProjectSave;
+        var project = _projectProvider.GumProjectSave;
 
         var ownerAsElement = owner as ElementSave;
 
@@ -424,7 +423,7 @@ public class ReferenceFinder : IReferenceFinder
         List<VariableChange> variableChanges = new List<VariableChange>();
         List<VariableReferenceChange> variableReferenceChanges = new List<VariableReferenceChange>();
 
-        var project = _projectState.GumProjectSave;
+        var project = _projectProvider.GumProjectSave;
 
         var changedVariableOwnerElement = owner as ElementSave;
 


### PR DESCRIPTION
## Summary
Relocates concrete `ReferenceFinder` into the headless `Gum.Presentation` assembly (ADR-0005 Phase 3) — the shovel-ready item called out in #3225's last progress update after `DeleteLogic` (#3740) and `CopyPasteLogic` (#3742).

Same shape as the previous two moves: `IReferenceFinder` was already headless (#3360), and the concrete class had a single constructor dependency — `IProjectState`, reading only `.GumProjectSave`. Added `IReferenceFinderProjectProvider`, a narrow port over `ProjectManager` exposing just that property (mirroring `IDeleteProjectProvider`/`ICopyPasteProjectProvider`), swapped the constructor to it, then `git mv`'d the class.

Part of #3225 (not linked via auto-close — it's a long multi-PR tracking issue; closing it here would be premature).

## Test plan
- [x] `Gum.Presentation` compiles standalone (0 errors)
- [x] `GumFull.sln` builds (0 errors)
- [x] `GumToolUnitTests`: 1067 passed / 0 failed / 4 skipped
- [x] `Gum.Presentation.Tests`: 42 passed / 0 failed

Manual test: not needed — behavior-preserving move/seam-seal, covered by unit tests + compilation.
FRB canary: not needed — no FRB1-shared source touched (only `Gum/` tool-side and `Tools/Gum.Presentation/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
