### PR TITLE
Remove vestigial WinForms TreeNode dependency from MainStatePlugin

### DIFF
--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Windows.Forms;
 using Gum.Commands;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
@@ -78,7 +77,7 @@ public class MainStatePlugin : PriorityPlugin
 
     private void AssignEvents()
     {
-        this.TreeNodeSelected += HandleTreeNodeSelected;
+        this.TreeNodeSelected += _ => HandleTreeNodeSelected();
         
         this.RefreshStateTreeView += HandleRefreshStateTreeView;
         
@@ -204,7 +203,7 @@ public class MainStatePlugin : PriorityPlugin
         RefreshUI(_selectedState.SelectedStateContainer);
     }
 
-    private void HandleTreeNodeSelected(TreeNode? node)
+    private void HandleTreeNodeSelected()
     {
         RefreshTabHeaders();
         


### PR DESCRIPTION
Part of #3225 (Phase 1: WinForms scatter cleanup).

`MainStatePlugin.HandleTreeNodeSelected` never used its `TreeNode` payload -- it's a pure "something got selected, refresh" signal echoed from the (separately WinForms, Phase 4a, out of scope) Element tree. Discards the argument instead of naming `System.Windows.Forms.TreeNode`, dropping the plugin's last WinForms import. `StateTreeViewRightClickService.cs` (successor to the since-renamed `StateTreeViewManager.cs`) already has zero WinForms references, so this closes out that file trio.

No test added: pure signature simplification with no behavior change, verified by the compiler (an actual use of the removed parameter would be a compile error) plus a green `AllPluginsCompositionTests` run.

Manual test: not needed -- behavior-preserving, compiler + build verified.
FRB canary: not needed -- `Gum/` tool-only file, not part of `GumCoreShared`/`FlatRedBall.Forms.Shared` shared projitems.