### PR TITLE
Gum.SilkNet: dispatch CustomCursor to a real Silk.NET StandardCursor

### DIFF
--- a/MonoGameGum/Input/Cursor.cs
+++ b/MonoGameGum/Input/Cursor.cs
@@ -98,6 +98,33 @@ public partial class Cursor : ICursor
             }
 #endif
 
+#if SILK
+            if (_mouse != null)
+            {
+                var silkCursor = _mouse.Cursor;
+                silkCursor.Type = Silk.NET.Input.CursorType.Standard;
+                switch (value)
+                {
+                    case Cursors.Arrow:
+                    case null:
+                        silkCursor.StandardCursor = Silk.NET.Input.StandardCursor.Arrow;
+                        break;
+                    case Cursors.SizeNS:
+                        silkCursor.StandardCursor = Silk.NET.Input.StandardCursor.VResize;
+                        break;
+                    case Cursors.SizeWE:
+                        silkCursor.StandardCursor = Silk.NET.Input.StandardCursor.HResize;
+                        break;
+                    case Cursors.SizeNWSE:
+                        silkCursor.StandardCursor = Silk.NET.Input.StandardCursor.NwseResize;
+                        break;
+                    case Cursors.SizeNESW:
+                        silkCursor.StandardCursor = Silk.NET.Input.StandardCursor.NeswResize;
+                        break;
+                }
+            }
+#endif
+
 #if SOKOL
             switch (value)
             {

--- a/Tests/SilkNetGum.Tests/CursorSilkTests.cs
+++ b/Tests/SilkNetGum.Tests/CursorSilkTests.cs
@@ -1,4 +1,5 @@
 using Gum.Input;
+using Gum.Wireframe;
 using Moq;
 using Shouldly;
 using Silk.NET.Input;
@@ -62,5 +63,32 @@ public class CursorSilkTests
         cursor.Activity(0);
 
         cursor.ScrollWheelChange.ShouldBe(2);
+    }
+
+    [Fact]
+    public void CustomCursor_SizeWE_SetsHResizeStandardCursor()
+    {
+        (Cursor cursor, Mock<IMouse> mouse) = CreateAttachedCursor();
+        var silkCursor = new Mock<Silk.NET.Input.ICursor>();
+        silkCursor.SetupAllProperties();
+        mouse.SetupGet(m => m.Cursor).Returns(silkCursor.Object);
+
+        cursor.CustomCursor = Cursors.SizeWE;
+
+        silkCursor.Object.StandardCursor.ShouldBe(StandardCursor.HResize);
+        silkCursor.Object.Type.ShouldBe(CursorType.Standard);
+    }
+
+    [Fact]
+    public void CustomCursor_Null_SetsArrowStandardCursor()
+    {
+        (Cursor cursor, Mock<IMouse> mouse) = CreateAttachedCursor();
+        var silkCursor = new Mock<Silk.NET.Input.ICursor>();
+        silkCursor.SetupAllProperties();
+        mouse.SetupGet(m => m.Cursor).Returns(silkCursor.Object);
+
+        cursor.CustomCursor = null;
+
+        silkCursor.Object.StandardCursor.ShouldBe(StandardCursor.Arrow);
     }
 }


### PR DESCRIPTION
## Summary
- `Cursor.cs`'s `CustomCursor` setter dispatches to a real OS cursor on MonoGame/KNI, raylib, and Sokol, but had no branch for Silk.NET — so hover-cursor changes (Splitter resize, etc.) were a silent no-op on that backend.
- Adds the missing `#if SILK` branch, mapping Gum's `Cursors` enum onto `Silk.NET.Input`'s `IMouse.Cursor.StandardCursor` (`HResize`/`VResize`/`NwseResize`/`NeswResize`/`Arrow`), forcing `Cursor.Type = CursorType.Standard` first so a prior custom-image cursor can't linger.

Closes #3747.

## Test plan
- [x] New `CursorSilkTests` cases (`CustomCursor_SizeWE_SetsHResizeStandardCursor`, `CustomCursor_Null_SetsArrowStandardCursor`) — red before the fix, green after.
- [x] `SilkNetGum.Tests` full suite green (27/27).
- [x] `MonoGameGum.Tests` green (1882/1882) — confirms the XNALIKE branch is untouched.
- [x] `RaylibGum` / `KniGum` build clean, 0 errors — confirms the adjacent RAYLIB/SOKOL branches are untouched.
- [x] Manual test: built `SilkNetGumThemesShowcase`, hovered the Splitter divider in the AllControls screen — cursor now switches to a horizontal-resize shape while hovering and back to arrow off it. Confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
