### PR TITLE
Add Phase 0 ratchet test for UI/logic decoupling baseline counts

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
@@ -1,0 +1,123 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace GumToolUnitTests.Architecture;
+
+/// <summary>
+/// Issue #3225 Phase 0: baseline counts + a ratchet for the Gum tool UI/logic decoupling effort, so
+/// backsliding is caught mechanically instead of by manual audit (the issue's original hand-written
+/// estimates had drifted far from reality by the time Phase 1 started).
+///
+/// Each test is a source-text scan over Gum/**/*.cs (the tool + its in-tree plugins) at the repo root
+/// discovered from the test assembly's location, not a semantic analysis -- see the per-test comment
+/// for exactly what is counted and what is deliberately excluded. Lower a baseline as items land;
+/// never raise one to make a new violation pass.
+/// </summary>
+public class UiDecouplingRatchetTests
+{
+    private static readonly string ToolSourceRoot = Path.Combine(FindRepoRoot(), "Gum");
+
+    [Fact]
+    public void InlineDialogBypassSites_DoesNotExceedBaseline()
+    {
+        // Sites that pop a WPF Window/MessageBox directly instead of going through
+        // IDialogService.Show<T>(). Excludes Gum/Services/Dialogs/** itself -- that's the
+        // IDialogService implementation; it's the seam everything else should route through, so it's
+        // allowed to talk to WPF directly.
+        //
+        // Not counted here: ElementTreeViewManager.RightClick.cs's direct `new AddInstanceDialogViewModel(...)`
+        // + OnAffirmative() calls. Those construct a dialog ViewModel and drive it headlessly as a command
+        // object for the favorited-component quick-add menu -- no WPF window is ever shown, so it isn't an
+        // IDialogService bypass (audited 2026-07, see issue #3225 progress comments).
+        const int Baseline = 2;
+
+        var pattern = new Regex(@"MessageBox\.Show\(|\bnew\s+\w*Window\s*\(|\.ShowDialog\(");
+
+        int count = SourceFiles()
+            .Where(f => !NormalizePath(f).Contains("/Gum/Services/Dialogs/"))
+            .Sum(f => File.ReadAllLines(f).Count(line => !line.TrimStart().StartsWith("//") && pattern.IsMatch(line)));
+
+        count.ShouldBeLessThanOrEqualTo(Baseline);
+    }
+
+    [Fact]
+    public void SelfStaticReferenceCount_DoesNotExceedBaseline()
+    {
+        const int Baseline = 339;
+
+        var pattern = new Regex(@"\.Self\b");
+        int count = SourceFiles().Sum(f => pattern.Matches(File.ReadAllText(f)).Count);
+
+        count.ShouldBeLessThanOrEqualTo(Baseline);
+    }
+
+    [Fact]
+    public void SystemWindowsUsageInViewModels_DoesNotExceedBaseline()
+    {
+        const int Baseline = 46;
+
+        var pattern = new Regex(@"System\.Windows");
+        int count = SourceFiles()
+            .Where(f => Path.GetFileName(f).Contains("ViewModel", System.StringComparison.OrdinalIgnoreCase))
+            .Sum(f => pattern.Matches(File.ReadAllText(f)).Count);
+
+        count.ShouldBeLessThanOrEqualTo(Baseline);
+    }
+
+    [Fact]
+    public void WinFormsOrWpfTypeLeaksInInterfaceSignatures_DoesNotExceedBaseline()
+    {
+        // Scope: System.Windows* namespaces (WPF's System.Windows tree, WinForms' System.Windows.Forms)
+        // -- the UI-framework widget namespaces the tool is being decoupled from. System.Drawing
+        // (Color, Point) is deliberately excluded: it's the general graphics-primitive namespace used
+        // throughout the whole codebase, runtime included, not tool-UI-framework coupling -- see
+        // ADR-0004 for that separate, broader neutral-types effort.
+        //
+        // Heuristic: a file that declares an interface and imports a System.Windows* namespace, with no
+        // class declared in the same file. The class exclusion avoids false positives from files that
+        // combine an interface with its WPF-heavy implementation (e.g. ExposeVariableService.cs,
+        // ThemingDialogViewModel.cs), where the using is consumed by the class, not the interface
+        // (audited 2026-07 -- both interfaces there only reference Gum/System.Drawing types). Known
+        // blind spot: a leak added to an interface living in a combined interface+class file won't be
+        // caught by this heuristic.
+        const int Baseline = 2;
+
+        var interfacePattern = new Regex(@"\binterface\s+\w+");
+        var classPattern = new Regex(@"\bclass\s+\w+");
+        var usingPattern = new Regex(@"^\s*using\s+System\.Windows(\.\w+)*\s*;", RegexOptions.Multiline);
+
+        int count = SourceFiles().Count(f =>
+        {
+            string text = File.ReadAllText(f);
+            return interfacePattern.IsMatch(text) && !classPattern.IsMatch(text) && usingPattern.IsMatch(text);
+        });
+
+        count.ShouldBeLessThanOrEqualTo(Baseline);
+    }
+
+    private static string FindRepoRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        for (int i = 0; i < 10; i++)
+        {
+            if (Directory.Exists(Path.Combine(current, "Gum")) && File.Exists(Path.Combine(current, "GumFull.sln")))
+            {
+                return current;
+            }
+            string? parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent) || parent == current)
+            {
+                break;
+            }
+            current = parent;
+        }
+        throw new InvalidOperationException("could not locate repo root from " + AppContext.BaseDirectory);
+    }
+
+    private static string NormalizePath(string path) => path.Replace('\\', '/');
+
+    private static IEnumerable<string> SourceFiles() =>
+        Directory.EnumerateFiles(ToolSourceRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !NormalizePath(f).Contains("/obj/") && !NormalizePath(f).Contains("/bin/"));
+}


### PR DESCRIPTION
Part of #3225 (Phase 0: instrument the coupling burn-down).

Adds a mechanical ratchet test (`UiDecouplingRatchetTests`) covering all four Phase 0 baseline metrics -- `.Self` static refs (339), `System.Windows.*` in ViewModels (46), inline dialog-bypass sites (2), WinForms/WPF type leaks in interface signatures (2). Each asserts count ≤ baseline so backsliding fails CI instead of relying on manual audit.

Scoping note: while computing the interface-leak baseline, found `ITabManager`/`IBitmapLoader` still leak `FrameworkElement`/`BitmapFrame` -- contradicts the "Seal ITabManager/IGuiCommands.ShowSpinner -- done" claim from an earlier progress comment. Not fixed here (out of scope for a baseline-only PR); the ratchet's baseline=2 now tracks it honestly.

Also scoped `ElementTreeViewManager.RightClick.cs`/`ImportFromGumxView.xaml.cs` (the other open Phase 1 item): neither is a real `IDialogService` bypass -- the former drives `AddInstanceDialogViewModel` headlessly as a command object (no dialog shown), the latter is the legitimate WPF View code-behind for a registered dialog. No code change needed; noted in the ratchet test's comments.

Manual test: not needed -- new test-only file, no production code changed; verified by the test itself (all 4 pass, and confirmed each fails red when its baseline is artificially lowered).
FRB canary: not needed -- `Tool/` test-only file, not part of `GumCoreShared`/`FlatRedBall.Forms.Shared` shared projitems.
