### PR TITLE
Seal ITabManager/IBitmapLoader WPF type leaks (#3225)

### DIFF
--- a/Gum/Managers/ITabManager.cs
+++ b/Gum/Managers/ITabManager.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 
@@ -6,6 +5,11 @@ namespace Gum.Managers;
 
 public interface ITabManager
 {
-    PluginTab AddControl(FrameworkElement element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom);
+    /// <summary>
+    /// Adds <paramref name="element"/> as a new tab. Typed as <see cref="object"/> to keep this
+    /// interface free of WPF types (issue #3225); the concrete implementation expects a
+    /// <c>System.Windows.FrameworkElement</c>.
+    /// </summary>
+    PluginTab AddControl(object element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom);
     void RemoveTab(PluginTab plugin);
 }

--- a/Gum/StateAnimationPlugin/Managers/BitmapFrameFactory.cs
+++ b/Gum/StateAnimationPlugin/Managers/BitmapFrameFactory.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using System.Windows.Media.Imaging;
+
+namespace StateAnimationPlugin.Managers
+{
+    /// <summary>
+    /// Decodes the raw encoded image bytes returned by <see cref="IBitmapLoader"/> into a WPF
+    /// <see cref="BitmapFrame"/>. Kept separate from <see cref="IBitmapLoader"/> so that interface
+    /// stays free of WPF types (issue #3225) while its WPF-based consumers still get a frame.
+    /// </summary>
+    internal static class BitmapFrameFactory
+    {
+        public static BitmapFrame? Create(byte[]? imageBytes) =>
+            imageBytes is null || imageBytes.Length == 0 ? null : BitmapFrame.Create(new MemoryStream(imageBytes));
+    }
+}

--- a/Gum/StateAnimationPlugin/Managers/BitmapLoader.cs
+++ b/Gum/StateAnimationPlugin/Managers/BitmapLoader.cs
@@ -1,17 +1,17 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
-using System.Windows.Media.Imaging;
 
 namespace StateAnimationPlugin.Managers
 {
     public class BitmapLoader : IBitmapLoader
     {
-        // Caches each decoded frame by resource name. This preserves the "decode once,
-        // share the frame" behavior the icons used to get from AnimatedKeyframeViewModel's
+        // Caches each resource's raw bytes by resource name. This preserves the "read once,
+        // share the bytes" behavior the icons used to get from AnimatedKeyframeViewModel's
         // static fields, now that every view model loads its icons via this instance.
-        private readonly Dictionary<string, BitmapFrame> _cache = new();
+        private readonly Dictionary<string, byte[]> _cache = new();
 
-        public BitmapFrame LoadImage(string resourceName)
+        public byte[] LoadImage(string resourceName)
         {
             if (_cache.TryGetValue(resourceName, out var cached))
             {
@@ -21,12 +21,13 @@ namespace StateAnimationPlugin.Managers
             Assembly thisassembly = Assembly.GetExecutingAssembly();
 
             string fullName = "StateAnimationPlugin.Resources." + resourceName;
-            using (var imageStream =
-                thisassembly.GetManifestResourceStream(fullName))
+            using (var imageStream = thisassembly.GetManifestResourceStream(fullName))
+            using (var memoryStream = new MemoryStream())
             {
-                var frame = BitmapFrame.Create(imageStream);
-                _cache[resourceName] = frame;
-                return frame;
+                imageStream!.CopyTo(memoryStream);
+                byte[] bytes = memoryStream.ToArray();
+                _cache[resourceName] = bytes;
+                return bytes;
             }
         }
     }

--- a/Gum/StateAnimationPlugin/Managers/IBitmapLoader.cs
+++ b/Gum/StateAnimationPlugin/Managers/IBitmapLoader.cs
@@ -1,14 +1,13 @@
-using System.Windows.Media.Imaging;
-
 namespace StateAnimationPlugin.Managers
 {
     /// <summary>
-    /// Loads the plugin's embedded icon resources as WPF <see cref="BitmapFrame"/>s.
-    /// Drained from the former <c>Singleton&lt;BitmapLoader&gt;</c> so the animation view
-    /// models can take it by constructor and be substituted in tests.
+    /// Loads the plugin's embedded icon resources as raw encoded image bytes (ADR-0004: image data
+    /// is neutral <c>byte[]</c> at this seam; a WPF-aware caller decodes it, e.g. via
+    /// <see cref="BitmapFrameFactory"/>). Drained from the former <c>Singleton&lt;BitmapLoader&gt;</c>
+    /// so the animation view models can take it by constructor and be substituted in tests.
     /// </summary>
     public interface IBitmapLoader
     {
-        BitmapFrame LoadImage(string resourceName);
+        byte[] LoadImage(string resourceName);
     }
 }

--- a/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
@@ -292,9 +292,9 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
     public AnimatedKeyframeViewModel(IBitmapLoader bitmapLoader)
     {
         _bitmapLoader = bitmapLoader;
-        mStateBitmap = bitmapLoader.LoadImage("StateAnimationIcon.png");
-        mAnimationBitmap = bitmapLoader.LoadImage("ReferencedAnimationIcon.png");
-        mEventBitmap = bitmapLoader.LoadImage("NamedEventIcon.png");
+        mStateBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("StateAnimationIcon.png"))!;
+        mAnimationBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("ReferencedAnimationIcon.png"))!;
+        mEventBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("NamedEventIcon.png"))!;
     }
 
     public AnimatedKeyframeViewModel Clone()

--- a/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -130,9 +130,9 @@ public partial class AnimationViewModel : ViewModel
         Keyframes = new ObservableCollection<AnimatedKeyframeViewModel>();
         Keyframes.CollectionChanged += HandleKeyframeCollectionChanged;
 
-        mLoopBitmap = bitmapLoader.LoadImage("LoopIcon.png");
+        mLoopBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("LoopIcon.png"))!;
 
-        mPlayOnceBitmap = bitmapLoader.LoadImage("PlayOnceIcon.png");
+        mPlayOnceBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("PlayOnceIcon.png"))!;
         _selectedState = selectedState;
         _wireframeObjectManager = wireframeObjectManager;
     }

--- a/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Gum/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -231,9 +231,9 @@ public partial class ElementAnimationsViewModel : ViewModel
         mPlayTimer.Interval = new TimeSpan(0, 0, 0, 0, mTimerFrequencyInMs);
         mPlayTimer.Tick += HandlePlayTimerTick;
 
-        mPlayBitmap = bitmapLoader.LoadImage("PlayIcon.png");
+        mPlayBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("PlayIcon.png"))!;
 
-        mStopBitmap = bitmapLoader.LoadImage("StopIcon.png");
+        mStopBitmap = BitmapFrameFactory.Create(bitmapLoader.LoadImage("StopIcon.png"))!;
 
         _selectedState = selectedState;
         _nameVerifier = nameVerifier;

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -102,13 +102,15 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
         }
     }
 
-    public PluginTab AddControl(FrameworkElement element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom)
+    public PluginTab AddControl(object element, string tabTitle, TabLocation tabLocation = TabLocation.CenterBottom)
     {
-        PluginTab newPluginTab = _pluginTabFactory(element);
+        FrameworkElement frameworkElement = (FrameworkElement)element;
+
+        PluginTab newPluginTab = _pluginTabFactory(frameworkElement);
         newPluginTab.Title = tabTitle;
         newPluginTab.Location = tabLocation;
 
-        if (element is WindowsFormsHost host && tabTitle == "Editor")
+        if (frameworkElement is WindowsFormsHost host && tabTitle == "Editor")
         {   // this is kind of a hack to deal with the the airspace issue
             // blocking mouse interaction with the grid splitter and window resize handle
             host.Margin = new Thickness(4, 0, 4, 0);

--- a/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
@@ -81,7 +81,10 @@ public class UiDecouplingRatchetTests
         // (audited 2026-07 -- both interfaces there only reference Gum/System.Drawing types). Known
         // blind spot: a leak added to an interface living in a combined interface+class file won't be
         // caught by this heuristic.
-        const int Baseline = 2;
+        //
+        // ITabManager.AddControl and IBitmapLoader.LoadImage (the 2 sites baseline=2 was tracking)
+        // were sealed to object/byte[] respectively -- see issue #3225.
+        const int Baseline = 0;
 
         var interfacePattern = new Regex(@"\binterface\s+\w+");
         var classPattern = new Regex(@"\bclass\s+\w+");

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapFrameFactoryTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapFrameFactoryTests.cs
@@ -1,0 +1,43 @@
+using System.Windows.Media.Imaging;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
+
+/// <summary>
+/// Characterization tests pinning <see cref="BitmapFrameFactory"/>, the WPF-side decode step added
+/// when <see cref="IBitmapLoader"/> was sealed to a neutral <c>byte[]</c> return type (issue #3225).
+/// </summary>
+public class BitmapFrameFactoryTests : BaseTestClass
+{
+    [Fact]
+    public void Create_EmptyBytes_ReturnsNull()
+    {
+        // Mirrors what Mock.Of<IBitmapLoader>() hands back in other tests -- Moq defaults an
+        // unconfigured byte[]-returning method to Array.Empty<byte>(), not null.
+        BitmapFrame? frame = BitmapFrameFactory.Create([]);
+
+        frame.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_NullBytes_ReturnsNull()
+    {
+        BitmapFrame? frame = BitmapFrameFactory.Create(null);
+
+        frame.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_ValidImageBytes_DecodesToFrameWithPositiveDimensions()
+    {
+        byte[] bytes = new BitmapLoader().LoadImage("PlayIcon.png");
+
+        BitmapFrame? frame = BitmapFrameFactory.Create(bytes);
+
+        frame.ShouldNotBeNull();
+        frame.PixelWidth.ShouldBeGreaterThan(0);
+        frame.PixelHeight.ShouldBeGreaterThan(0);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapLoaderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/BitmapLoaderTests.cs
@@ -6,31 +6,29 @@ namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
 
 /// <summary>
 /// Characterization tests pinning <see cref="BitmapLoader"/> after it was drained from a
-/// <c>Singleton&lt;T&gt;</c> to an injectable <see cref="IBitmapLoader"/>. WPF PNG decode runs
-/// fine on the default (MTA) test thread, so no STA wrapper is needed here.
+/// <c>Singleton&lt;T&gt;</c> to an injectable <see cref="IBitmapLoader"/>.
 /// </summary>
 public class BitmapLoaderTests : BaseTestClass
 {
     [Fact]
-    public void LoadImage_caches_and_returns_the_same_frame_for_a_repeated_resource()
+    public void LoadImage_caches_and_returns_the_same_bytes_for_a_repeated_resource()
     {
         BitmapLoader loader = new BitmapLoader();
 
-        var first = loader.LoadImage("PlayIcon.png");
-        var second = loader.LoadImage("PlayIcon.png");
+        byte[] first = loader.LoadImage("PlayIcon.png");
+        byte[] second = loader.LoadImage("PlayIcon.png");
 
         second.ShouldBeSameAs(first);
     }
 
     [Fact]
-    public void LoadImage_decodes_an_embedded_resource_into_a_frame()
+    public void LoadImage_reads_an_embedded_resource_into_non_empty_bytes()
     {
         BitmapLoader loader = new BitmapLoader();
 
-        var frame = loader.LoadImage("PlayIcon.png");
+        byte[] bytes = loader.LoadImage("PlayIcon.png");
 
-        frame.ShouldNotBeNull();
-        frame.PixelWidth.ShouldBeGreaterThan(0);
-        frame.PixelHeight.ShouldBeGreaterThan(0);
+        bytes.ShouldNotBeNull();
+        bytes.Length.ShouldBeGreaterThan(0);
     }
 }


### PR DESCRIPTION
Seals the two remaining WPF type leaks tracked by `UiDecouplingRatchetTests.WinFormsOrWpfTypeLeaksInInterfaceSignatures_DoesNotExceedBaseline` (baseline=2, added in #3751) and drops the baseline to 0.

- `ITabManager.AddControl` now takes `object` instead of `FrameworkElement`. `MainPanelViewModel` (the WPF implementation) casts back internally.
- `IBitmapLoader.LoadImage` now returns `byte[]` instead of `BitmapFrame`, per ADR-0004 (image data → neutral bytes at the interface, WPF-aware caller decodes). New `BitmapFrameFactory` does that decode for the 3 animation ViewModels that still bind `BitmapFrame` in XAML.

Part of #3225 — not `gh issue develop`-linked, so merging this won't auto-close the issue (other Phase 1 items may remain).

Manual test: not needed — behavior-preserving (interface signature + neutral-type conversion only), covered by unit tests + compilation. All 1074 GumToolUnitTests pass, including the new baseline=0 ratchet run.
