### PR TITLE
Store injected IMessenger as a field in MainWindow instead of re-resolving via Locator

### DIFF
--- a/Gum/MainWindow.xaml.cs
+++ b/Gum/MainWindow.xaml.cs
@@ -3,7 +3,6 @@ using Gum.Commands;
 using Gum.Input;
 using Gum.Dialogs;
 using Gum.Managers;
-using Gum.Services;
 using Gum.Settings;
 using Gum.ViewModels;
 using System;
@@ -32,7 +31,8 @@ public enum TabLocation
 
 public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindowMessage>
 {
-    
+    private readonly IMessenger _messenger;
+
     public MainWindow(
         MainWindowViewModel mainWindowViewModel,
         MenuStripManager menuStripManager,
@@ -42,9 +42,10 @@ public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindow
         )
     {
         DataContext = mainWindowViewModel;
-        
+
+        _messenger = messenger;
         messenger.RegisterAll(this);
-        
+
         InitializeComponent();
         menuStripManager.PopulateMenu(this.MainMenu);
 
@@ -112,7 +113,7 @@ public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindow
 
     private void OnCloseButtonClick(object? sender, System.Windows.RoutedEventArgs e)
     {
-        Locator.GetRequiredService<IMessenger>().Send(new CloseMainWindowMessage());
+        _messenger.Send(new CloseMainWindowMessage());
     }
 }
 


### PR DESCRIPTION
Part of #3753 — drains a `Locator.GetRequiredService<T>()` self-locating call in `MainWindow` to constructor injection.

`MainWindow`'s ctor already took `IMessenger messenger` and called `messenger.RegisterAll(this)`, but never stored it. `OnCloseButtonClick` instead re-resolved via `Locator.GetRequiredService<IMessenger>().Send(...)` right next to the already-injected instance. Now it stores `_messenger` and uses that field.

Also removed the now-unused `using Gum.Services;` (was only there for `Locator`).

Manual test: not needed — behavior-preserving drain (Locator call → already-injected field), covered by the GumFull.sln build.
