### PR TITLE
Drain UndosViewModel + Undos MainPlugin to constructor injection

### DIFF
--- a/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/MainPlugin.cs
@@ -1,5 +1,7 @@
 ﻿using Gum.Plugins.BaseClasses;
 using Gum.Plugins.InternalPlugins.Undos;
+using Gum.ToolStates;
+using Gum.Undo;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows.Controls;
@@ -12,11 +14,21 @@ namespace Gum.Plugins.Undos
     [Export(typeof(PluginBase))]
     public class MainPlugin : PriorityPlugin
     {
+        private readonly ISelectedState _selectedState;
+        private readonly IUndoManager _undoManager;
+
+        [ImportingConstructor]
+        public MainPlugin(ISelectedState selectedState, IUndoManager undoManager)
+        {
+            _selectedState = selectedState;
+            _undoManager = undoManager;
+        }
+
         public override void StartUp()
         {
             var control = new UndoDisplay();
 
-            UndosViewModel viewModel = new ();
+            UndosViewModel viewModel = new (_selectedState, _undoManager);
             control.DataContext = viewModel;
 
             PluginTab tab = AddControl(control, "History", TabLocation.RightBottom);

--- a/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs
@@ -2,7 +2,6 @@
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Plugins.InternalPlugins.Undos;
-using Gum.Services;
 using Gum.StateAnimation.SaveClasses;
 using Gum.ToolStates;
 using Gum.Undo;
@@ -262,10 +261,10 @@ namespace Gum.Plugins.Undos
             return null;
         }
 
-        public UndosViewModel()
+        public UndosViewModel(ISelectedState selectedState, IUndoManager undoManager)
         {
-            _selectedState = Locator.GetRequiredService<ISelectedState>();
-            _undoManager = Locator.GetRequiredService<IUndoManager>();
+            _selectedState = selectedState;
+            _undoManager = undoManager;
             _undoManager.UndosChanged += HandleUndosChanged;
         }
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/Undos/UndosViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/Undos/UndosViewModelTests.cs
@@ -1,0 +1,49 @@
+using Gum.Plugins.Undos;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Moq.AutoMock;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace GumToolUnitTests.Plugins.Undos;
+
+public class UndosViewModelTests : BaseTestClass
+{
+    private readonly AutoMocker _mocker;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IUndoManager> _undoManager;
+    private readonly UndosViewModel _viewModel;
+
+    public UndosViewModelTests()
+    {
+        _mocker = new AutoMocker();
+        _selectedState = _mocker.GetMock<ISelectedState>();
+        _undoManager = _mocker.GetMock<IUndoManager>();
+        _viewModel = _mocker.CreateInstance<UndosViewModel>();
+    }
+
+    [Fact]
+    public void Constructor_ShouldSubscribeToUndosChanged_SoRaisingItNotifiesHistoryItemsAndUndoIndex()
+    {
+        List<string?> raisedPropertyNames = new List<string?>();
+        _viewModel.PropertyChanged += (sender, args) => raisedPropertyNames.Add(args.PropertyName);
+
+        _undoManager.Raise(
+            undoManager => undoManager.UndosChanged += null,
+            _undoManager.Object,
+            new UndoOperationEventArgs { Operation = UndoOperation.EntireHistoryChange });
+
+        raisedPropertyNames.ShouldContain(nameof(UndosViewModel.HistoryItems));
+        raisedPropertyNames.ShouldContain(nameof(UndosViewModel.UndoIndex));
+    }
+
+    [Fact]
+    public void UndoIndex_ShouldReflectInjectedUndoManagersCurrentElementHistory()
+    {
+        _selectedState.Setup(s => s.SelectedBehavior).Returns((Gum.DataTypes.Behaviors.BehaviorSave?)null);
+        _undoManager.Setup(u => u.CurrentElementHistory).Returns(new ElementHistory { UndoIndex = 3 });
+
+        _viewModel.UndoIndex.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
Drains `UndosViewModel`'s `Locator.GetRequiredService<T>()` calls to real constructor injection (`ISelectedState`, `IUndoManager`), and gives `Gum.Plugins.Undos.MainPlugin` an `[ImportingConstructor]` for the same two services so it can pass them through instead of the VM self-locating. Both services were already bridged into the plugin MEF container in `PluginManager.LoadPlugins`, so no bridging changes were needed.

Part of #3753.

## Testing
- Added `UndosViewModelTests` (construction wiring + `UndosChanged` → `PropertyChanged` notification, `UndoIndex` reflects injected `IUndoManager`).
- `AllPluginsCompositionTests` passes, confirming `MainPlugin`'s new `[ImportingConstructor]` still composes via MEF.
- Full `GumToolUnitTests` suite green (1076 passed, 4 pre-existing skips).

Manual test: not needed — behavior-preserving drain, covered by build + the new pinning test + AllPluginsCompositionTests.
