### PR TITLE
Drain MainWindowPlugin's Locator call to constructor injection

### DIFF
--- a/Gum/Gui/Plugins/MainWindowPlugin.cs
+++ b/Gum/Gui/Plugins/MainWindowPlugin.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Gum.Plugins.BaseClasses;
 using System.ComponentModel.Composition;
-using Gum.Services;
 using Gum.ViewModels;
 
 namespace Gum.Gui.Plugins
@@ -9,6 +8,8 @@ namespace Gum.Gui.Plugins
     [Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
     public class MainWindowPlugin : PluginBase
     {
+        private readonly MainWindowViewModel _mainWindowViewModel;
+
         public override string FriendlyName
         {
             get
@@ -25,6 +26,12 @@ namespace Gum.Gui.Plugins
             }
         }
 
+        [ImportingConstructor]
+        public MainWindowPlugin(MainWindowViewModel mainWindowViewModel)
+        {
+            _mainWindowViewModel = mainWindowViewModel;
+        }
+
         public override void StartUp()
         {
             ProjectLoad += new Action<DataTypes.GumProjectSave>(OnProjectLoad);
@@ -33,21 +40,17 @@ namespace Gum.Gui.Plugins
 
         void OnProjectLoad(DataTypes.GumProjectSave obj)
         {
-            MainWindowViewModel vm = Locator.GetRequiredService<MainWindowViewModel>();
-            
             if (obj != null && !string.IsNullOrEmpty(obj.FullFileName))
             {
                 string fileName = obj.FullFileName;
 
-                vm.Title = fileName;
+                _mainWindowViewModel.Title = fileName;
             }
             else
             {
-                vm.Title = "Gum";
+                _mainWindowViewModel.Title = "Gum";
             }
         }
-
-        
 
         public override bool ShutDown(Gum.Plugins.PluginShutDownReason shutDownReason)
         {

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -40,6 +40,7 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
 using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.PropertyGridHelpers;
+using Gum.ViewModels;
 
 namespace Gum.Plugins;
 
@@ -949,6 +950,8 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             // live IAnimationUndoProvider with the already-constructed UndoManager/ElementUndoStrategy.
             batch.AddExportedValue<IAnimationUndoProviderRegistrar>(Locator.GetRequiredService<IAnimationUndoProviderRegistrar>());
 
+            // MainWindowPlugin ctor drain (#3753): updates the main window title on project load/save.
+            batch.AddExportedValue<MainWindowViewModel>(Locator.GetRequiredService<MainWindowViewModel>());
 
             var container = new CompositionContainer(catalog);
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -22,6 +22,7 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Plugins.InternalPlugins.Hotkey.ViewModels;
 using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.PropertyGridHelpers;
+using Gum.ViewModels;
 
 namespace GumToolUnitTests.Plugins;
 
@@ -107,5 +108,8 @@ internal static class PluginBridgedServiceTypes
         // Animation undo (#3406): MainStateAnimationPlugin injects this to register itself as the live
         // IAnimationUndoProvider with UndoManager/ElementUndoStrategy.
         typeof(IAnimationUndoProviderRegistrar),
+
+        // MainWindowPlugin ctor drain (#3753): updates the main window title on project load/save.
+        typeof(MainWindowViewModel),
     };
 }


### PR DESCRIPTION
## Summary
- `MainWindowPlugin` resolved `MainWindowViewModel` via `Locator.GetRequiredService<T>()` inside `OnProjectLoad`. Switched to `[ImportingConstructor]` injection.
- Bridged `MainWindowViewModel` into the MEF plugin container in `PluginManager.LoadPlugins` (already a DI singleton via `Builder.cs`).
- Updated `PluginBridgedServiceTypes.All` so `AllPluginsCompositionTests` covers the new bridge.

Part of #3753

## Test plan
- `dotnet build GumFull.sln` — 0 errors
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter "FullyQualifiedName~AllPluginsCompositionTests"` — passes
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter "FullyQualifiedName~Plugins"` — 294 passed (includes `ServiceProviderCompositionSpikeTests`, which resolves the new bridge from the real DI container)
- Manual test: not needed — behavior-preserving drain, covered by build + AllPluginsCompositionTests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
