### PR TITLE
Drain FormsFileService/MainGumFormsPlugin off Locator for IProjectState

### DIFF
--- a/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
+++ b/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
@@ -33,15 +33,18 @@ internal class MainGumFormsPlugin : PluginBase
     private readonly FormsFileService _formsFileService;
     private readonly IImportLogic _importLogic;
     private readonly IFileWatchManager _fileWatchManager;
+    private readonly IProjectState _projectState;
 
     #endregion
 
     [ImportingConstructor]
     public MainGumFormsPlugin(
         IImportLogic importLogic,
-        IFileWatchManager fileWatchManager)
+        IFileWatchManager fileWatchManager,
+        IProjectState projectState)
     {
-        _formsFileService = new FormsFileService();
+        _projectState = projectState;
+        _formsFileService = new FormsFileService(_projectState);
         _importLogic = importLogic;
         _fileWatchManager = fileWatchManager;
     }
@@ -111,11 +114,9 @@ internal class MainGumFormsPlugin : PluginBase
 
     private void HandleAddFormsComponents(object? sender, System.Windows.RoutedEventArgs e)
     {
-        var projectState = Locator.GetRequiredService<IProjectState>();
-
         #region Early Out
 
-        if (projectState.NeedsToSaveProject)
+        if (_projectState.NeedsToSaveProject)
         {
             _dialogService.ShowMessage("You must first save the project before importing forms");
             return;
@@ -127,7 +128,7 @@ internal class MainGumFormsPlugin : PluginBase
             _dialogService,
             _fileCommands,
             _importLogic,
-            projectState,
+            _projectState,
             _fileWatchManager,
             Locator.GetRequiredService<ISkiaShapeStandardsLogic>());
         _dialogService.Show(viewModel);

--- a/Gum/GumFormsPlugin/Services/FormsFileService.cs
+++ b/Gum/GumFormsPlugin/Services/FormsFileService.cs
@@ -1,4 +1,3 @@
-using Gum.Services;
 using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
@@ -21,6 +20,13 @@ public class FormsFileService
     public const string DefaultThemeName = "Standard";
 
     private const string FormsGumxName = "GumProject.gumx";
+
+    private readonly IProjectState _projectState;
+
+    public FormsFileService(IProjectState projectState)
+    {
+        _projectState = projectState;
+    }
 
     /// <summary>
     /// Returns the names of themes shipped with the tool (folders present under
@@ -62,8 +68,7 @@ public class FormsFileService
     /// </summary>
     public Dictionary<string, FilePath> GetSourceDestinations(string themeName, bool isIncludeDemoScreenGum)
     {
-        var projectState = Locator.GetRequiredService<IProjectState>();
-        var destinationFolder = projectState.ProjectDirectory;
+        var destinationFolder = _projectState.ProjectDirectory;
 
         var sourceDestinations = new Dictionary<string, FilePath>();
 

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -850,7 +850,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 
             // Per-plugin services needed at construction time (via [ImportingConstructor]):
             // MainSkiaPlugin (IWireframeCommands), MainFontPlugin (IFontManager, IProjectState),
-            // MainGumFormsPlugin (IImportLogic, IFileWatchManager). IProjectState and
+            // MainGumFormsPlugin (IImportLogic, IFileWatchManager, IProjectState). IProjectState and
             // IFileWatchManager are also stepping stones for later, heavier plugin drains.
             batch.AddExportedValue<IWireframeCommands>(Locator.GetRequiredService<IWireframeCommands>());
             batch.AddExportedValue<IFontManager>(Locator.GetRequiredService<IFontManager>());

--- a/Tool/Tests/GumToolUnitTests/FormsPlugin/FormsFileServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/FormsPlugin/FormsFileServiceTests.cs
@@ -1,0 +1,36 @@
+using Gum.ToolStates;
+using GumFormsPlugin.Services;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.FormsPlugin;
+
+public class FormsFileServiceTests : BaseTestClass
+{
+    [Fact]
+    public void GetSourceDestinations_ReturnsEmpty_WhenProjectDirectoryIsNull()
+    {
+        var projectState = new Mock<IProjectState>();
+        projectState.Setup(p => p.ProjectDirectory).Returns((string?)null);
+        var formsFileService = new FormsFileService(projectState.Object);
+
+        var sourceDestinations = formsFileService.GetSourceDestinations(
+            FormsFileService.DefaultThemeName, isIncludeDemoScreenGum: false);
+
+        sourceDestinations.ShouldBeEmpty();
+        projectState.VerifyGet(p => p.ProjectDirectory, Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public void GetSourceDestinations_ReturnsEmpty_WhenThemeDirectoryDoesNotExist()
+    {
+        var projectState = new Mock<IProjectState>();
+        projectState.Setup(p => p.ProjectDirectory).Returns("C:/SomeProject/");
+        var formsFileService = new FormsFileService(projectState.Object);
+
+        var sourceDestinations = formsFileService.GetSourceDestinations(
+            "ThemeThatDoesNotExist", isIncludeDemoScreenGum: false);
+
+        sourceDestinations.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
Part of #3753 (Phase 2 continuation of the UI-decoupling plan).

Drains `FormsFileService` and `MainGumFormsPlugin` off `Locator.GetRequiredService<IProjectState>()` to constructor injection. `IProjectState` was already MEF-bridged in `PluginManager.LoadPlugins`, so this just adds it as a third `[ImportingConstructor]` param.

Drive-by: also replaced the `HandleAddFormsComponents` method-body `Locator.GetRequiredService<IProjectState>()` lookup with the now-injected field (the `ISkiaShapeStandardsLogic` Locator call in that same method is left as-is — single-use, out of scope).

## Test plan
- New `FormsFileServiceTests` (mocked `IProjectState`) covers the empty-project-directory and missing-theme-directory early-outs.
- `dotnet build GumFull.sln` — 0 errors.
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — full suite green (1076 passed, 4 pre-existing skips), including `AllPluginsCompositionTests`.

Manual test: not needed — behavior-preserving drain, covered by build + the new pinning test.
