### PR TITLE
Drain IProjectManager Locator call from RenameManager

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -138,7 +138,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         _animationCollectionViewModelManager = new AnimationCollectionViewModelManager(
             _selectedState, _outputManager, _fileWatchManager, _animationFilePathService, _animationVmFactory);
         _renameManager = new RenameManager(
-            _selectedState, _outputManager, _animationFilePathService, _animationCollectionViewModelManager);
+            _selectedState, _outputManager, _animationFilePathService, _animationCollectionViewModelManager, _projectManager);
     }
 
     public override void StartUp()

--- a/Gum/StateAnimationPlugin/Managers/RenameManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/RenameManager.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ToolsUtilities;
-using Gum.Services;
 
 namespace StateAnimationPlugin.Managers
 {
@@ -21,17 +20,20 @@ namespace StateAnimationPlugin.Managers
         private readonly ISelectedState _selectedState;
         private readonly IOutputManager _outputManager;
         private readonly IAnimationCollectionViewModelManager _animationCollectionViewModelManager;
+        private readonly IProjectManager _projectManager;
 
         public RenameManager(
             ISelectedState selectedState,
             IOutputManager outputManager,
             IAnimationFilePathService animationFilePathService,
-            IAnimationCollectionViewModelManager animationCollectionViewModelManager)
+            IAnimationCollectionViewModelManager animationCollectionViewModelManager,
+            IProjectManager projectManager)
         {
             _selectedState = selectedState;
             _outputManager = outputManager;
             _animationFilePathService = animationFilePathService;
             _animationCollectionViewModelManager = animationCollectionViewModelManager;
+            _projectManager = projectManager;
         }
 
         public void HandleRename(ElementSave elementSave, string oldName, ElementAnimationsViewModel viewModel)
@@ -71,7 +73,7 @@ namespace StateAnimationPlugin.Managers
             }
             else // renaming an element that is not currently selected. See if it has an animation, and if so move it
             {
-                var gumProject = Locator.GetRequiredService<IProjectManager>().GumProjectSave;
+                var gumProject = _projectManager.GumProjectSave;
                 if(gumProject == null)
                 {
                     throw new InvalidOperationException("Renaming elements is not supported when a Gum project is null...how did this happen anyway?");

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
@@ -148,7 +148,8 @@ public class AnimationStateRenameErrorTests : BaseTestClass
             Mock.Of<ISelectedState>(s => s.SelectedElement == selectedElement),
             Mock.Of<IOutputManager>(),
             Mock.Of<IAnimationFilePathService>(),
-            Mock.Of<IAnimationCollectionViewModelManager>());
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            Mock.Of<IProjectManager>());
     }
 
     private AnimatedKeyframeViewModel Keyframe(string stateName)

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/RenameManagerTests.cs
@@ -51,6 +51,29 @@ public class RenameManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleRename_Element_NotCurrentlySelected_ReadsProjectManagerGumProjectSave()
+    {
+        RunOnSta(() =>
+        {
+            ComponentSave elementSave = new ComponentSave { Name = "RenamedElement" };
+            ElementAnimationsViewModel viewModel = CreateViewModelWith();
+
+            GumProjectSave gumProjectSave = new GumProjectSave
+            {
+                FullFileName = "C:/NonExistentGumRenameManagerTest/Project.gumx"
+            };
+            Mock<IProjectManager> projectManagerMock = new Mock<IProjectManager>();
+            projectManagerMock.Setup(x => x.GumProjectSave).Returns(gumProjectSave);
+
+            RenameManager renameManager = CreateRenameManager(projectManagerMock.Object);
+
+            renameManager.HandleRename(elementSave, "OldElementName", viewModel);
+
+            projectManagerMock.VerifyGet(x => x.GumProjectSave, Times.AtLeastOnce);
+        });
+    }
+
+    [Fact]
     public void HandleRename_Instance_RenamesQualifiedAnimationNamePrefix()
     {
         RunOnSta(() =>
@@ -144,13 +167,14 @@ public class RenameManagerTests : BaseTestClass
         return viewModel;
     }
 
-    private static RenameManager CreateRenameManager()
+    private static RenameManager CreateRenameManager(IProjectManager? projectManager = null)
     {
         return new RenameManager(
             Mock.Of<ISelectedState>(),
             Mock.Of<IOutputManager>(),
             Mock.Of<IAnimationFilePathService>(),
-            Mock.Of<IAnimationCollectionViewModelManager>());
+            Mock.Of<IAnimationCollectionViewModelManager>(),
+            projectManager ?? Mock.Of<IProjectManager>());
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #3753.

Drains the one remaining `Locator.GetRequiredService<IProjectManager>()` call in `RenameManager` (its ctor was already fully constructor-injected with 4 other params) to a 5th ctor param. `MainStateAnimationPlugin` already holds `IProjectManager` from its own `[ImportingConstructor]`, so no new MEF bridge is needed.

## Changes
- `RenameManager`: add `IProjectManager` ctor param, replace the `Locator` call in the "element not currently selected" branch of `HandleRename(ElementSave, ...)`, drop the now-unused `using Gum.Services;`.
- `MainStateAnimationPlugin`: pass `_projectManager` into `RenameManager`'s construction.
- Test call sites (`RenameManagerTests`, `AnimationStateRenameErrorTests`) updated for the new ctor param.

## Test plan
- New pinning test `RenameManagerTests.HandleRename_Element_NotCurrentlySelected_ReadsProjectManagerGumProjectSave` covers the drained branch: mocks `IProjectManager.GumProjectSave`, verifies it's read, uses a nonexistent file path so the method's `Exists()`/`Move` calls are no-ops.
- Full `GumToolUnitTests` suite green (1075 passed, 4 pre-existing skips).
- `AllPluginsCompositionTests` passes (no new MEF bridge needed).

Manual test: not needed — behavior-preserving drain, covered by build + the new pinning test.
