### PR TITLE
Drain Locator calls in CommonControlLogic and AlignmentViewModel

### DIFF
--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
 using Gum.Services;
-using Gum.ToolStates;
 using System.Windows.Controls;
 
 namespace Gum.Plugins.AlignmentButtons
@@ -13,9 +12,8 @@ namespace Gum.Plugins.AlignmentButtons
         public AlignmentPluginControl()
         {
             InitializeComponent();
-            
-            this.DataContext = new AlignmentViewModel(new CommonControlLogic());
 
+            this.DataContext = Locator.GetRequiredService<AlignmentViewModel>();
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogic.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogic.cs
@@ -2,7 +2,6 @@
 using Gum.PropertyGridHelpers;
 using Gum.ToolStates;
 using Gum.Commands;
-using Gum.Services;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 
 namespace Gum.Plugins.AlignmentButtons;
@@ -15,13 +14,14 @@ public class CommonControlLogic
     private readonly IFileCommands _fileCommands;
     private readonly ISetVariableLogic _setVariableLogic;
     
-    public CommonControlLogic()
+    public CommonControlLogic(ISelectedState selectedState, WireframeCommands wireframeCommands,
+        IGuiCommands guiCommands, IFileCommands fileCommands, ISetVariableLogic setVariableLogic)
     {
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _wireframeCommands = Locator.GetRequiredService<WireframeCommands>();
-        _guiCommands = Locator.GetRequiredService<IGuiCommands>();
-        _fileCommands = Locator.GetRequiredService<IFileCommands>();
-        _setVariableLogic = Locator.GetRequiredService<ISetVariableLogic>();
+        _selectedState = selectedState;
+        _wireframeCommands = wireframeCommands;
+        _guiCommands = guiCommands;
+        _fileCommands = fileCommands;
+        _setVariableLogic = setVariableLogic;
     }
 
     bool SelectionInheritsFromText()

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -2,15 +2,9 @@
 using Gum.Managers;
 using Gum.Mvvm;
 using Gum.Plugins.AlignmentButtons;
-using Gum.Services;
 using Gum.ToolStates;
 using Gum.Undo;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 
 namespace Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
@@ -47,11 +41,12 @@ public class AlignmentViewModel : ViewModel
     [DependsOn(nameof(DockMargin))]
     public Visibility MarginTextVisibility => DockMargin != 0 ? Visibility.Visible : Visibility.Collapsed;
 
-    public AlignmentViewModel(CommonControlLogic commonControlLogic)
+    public AlignmentViewModel(CommonControlLogic commonControlLogic, ISelectedState selectedState,
+        IUndoManager undoManager)
     {
         _commonControlLogic = commonControlLogic;
-        _selectedState = Locator.GetRequiredService<ISelectedState>();
-        _undoManager = Locator.GetRequiredService<IUndoManager>();
+        _selectedState = selectedState;
+        _undoManager = undoManager;
         DockMarginText = "0";
     }
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -3,6 +3,7 @@ using Gum.Commands;
 using Gum.Controls;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins.AlignmentButtons;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.ToolCommands;
@@ -212,6 +213,7 @@ file static class ServiceCollectionExtensions
         // full IRenameLogic. Resolves to the same RenameLogic singleton, so rename calls fire as before.
         services.AddSingleton<IUndoRenameLogic>(provider => provider.GetRequiredService<RenameLogic>());
         services.AddSingleton<ISetVariableLogic, SetVariableLogic>();
+        services.AddSingleton<CommonControlLogic>();
 
         services.AddSingleton<WireframeCommands>();
         services.AddSingleton<IWireframeCommands>(provider => provider.GetRequiredService<WireframeCommands>());

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/AlignmentButtons/CommonControlLogicTests.cs
@@ -1,0 +1,44 @@
+using Gum.Commands;
+using Gum.Plugins;
+using Gum.Plugins.AlignmentButtons;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Moq.AutoMock;
+using Shouldly;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.AlignmentButtons;
+
+public class CommonControlLogicTests : BaseTestClass
+{
+    private readonly AutoMocker _mocker;
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager;
+    private readonly CommonControlLogic _commonControlLogic;
+
+    public CommonControlLogicTests()
+    {
+        _mocker = new();
+
+        // WireframeCommands is a concrete class (not an interface) with a non-virtual Refresh(),
+        // so Moq can't intercept calls on an auto-generated mock of it. Register a real
+        // WireframeCommands wired to a mocked IWireframeObjectManager instead, so RefreshAndSave's
+        // call to Refresh() is still observable through the interface it delegates to.
+        WireframeCommands wireframeCommands = new(
+            _mocker.Get<IWireframeObjectManager>(),
+            new PluginManager());
+        _mocker.Use(wireframeCommands);
+
+        _commonControlLogic = _mocker.CreateInstance<CommonControlLogic>();
+        _wireframeObjectManager = _mocker.GetMock<IWireframeObjectManager>();
+    }
+
+    [Fact]
+    public void RefreshAndSave_CallsAllThreeInjectedCommands()
+    {
+        _commonControlLogic.RefreshAndSave();
+
+        _mocker.GetMock<IGuiCommands>().Verify(x => x.RefreshVariables(true), Times.Once);
+        _wireframeObjectManager.Verify(x => x.RefreshAll(true, false), Times.Once);
+        _mocker.GetMock<IFileCommands>().Verify(x => x.TryAutoSaveCurrentElement(), Times.Once);
+    }
+}


### PR DESCRIPTION
Part of #3753.

Converts `CommonControlLogic` and `AlignmentViewModel` from
`Locator.GetRequiredService<T>()` self-location to constructor
injection. The last `Locator` call relocates to
`AlignmentPluginControl` (the View boundary), matching the pattern
other Views use to resolve their DataContext VM.

- `CommonControlLogic`: 5 ctor params (`ISelectedState`,
  `WireframeCommands`, `IGuiCommands`, `IFileCommands`,
  `ISetVariableLogic`), all already registered in `Builder.cs`.
  `CommonControlLogic` itself is now also registered there
  (`AddSingleton`) so DI can build the `AlignmentViewModel ->
  CommonControlLogic` chain.
- `AlignmentViewModel`: adds `ISelectedState`/`IUndoManager` ctor
  params; already auto-registered as transient via the `ViewModel`
  scan in `Builder.cs`.
- Boyscout: removed unused `using` directives touched in these files
  (`System`, `System.Collections.Generic`, `System.Linq`,
  `System.Text`, `System.Threading.Tasks`, `Gum.ToolStates` in
  `AlignmentPluginControl.xaml.cs`).

## Test plan
- New `CommonControlLogicTests.RefreshAndSave_CallsAllThreeInjectedCommands`
  pins the ctor + `RefreshAndSave`. `WireframeCommands` is a concrete
  class with a non-virtual `Refresh()`, so a Moq auto-mock of it
  wouldn't intercept the call; instead the test builds a real
  `WireframeCommands` backed by a mocked `IWireframeObjectManager`
  (via `AutoMocker.Use`) so the delegated call is still observable.
- `dotnet build GumFull.sln` - 0 errors.
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` -
  1075 passed, 0 failed, 4 pre-existing skips.
- Manual test: not needed - behavior-preserving drain, covered by
  build + the new pinning test.
