### PR TITLE
Convert remaining concrete PluginManager fields to IPluginManager

### DIFF
--- a/Gum/Commands/EditCommands.cs
+++ b/Gum/Commands/EditCommands.cs
@@ -43,7 +43,7 @@ public class EditCommands : IEditCommands
     private readonly IDialogService _dialogService;
     private readonly ProjectCommands _projectCommands;
     private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     private readonly IProjectManager _projectManager;
     private readonly IDeleteLogic _deleteLogic;
     private readonly IProjectState _projectState;
@@ -59,7 +59,7 @@ public class EditCommands : IEditCommands
         ProjectCommands projectCommands,
         IGuiCommands guiCommands,
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
-        PluginManager pluginManager,
+        IPluginManager pluginManager,
         IDeleteLogic deleteLogic,
         IProjectManager projectManager,
         IProjectState projectState,

--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -42,7 +42,7 @@ public class GuiCommands : IGuiCommands
     private readonly IOutputManager _outputManager;
     // Lazy because PropertyGridManager depends on IGuiCommands; this breaks the DI construction cycle.
     private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
 
     private ISelectedState _selectedState => _lazySelectedState.Value;
 
@@ -53,7 +53,7 @@ public class GuiCommands : IGuiCommands
         IDispatcher dispatcher,
         IOutputManager outputManager,
         Lazy<PropertyGridManager> lazyPropertyGridManager,
-        PluginManager pluginManager)
+        IPluginManager pluginManager)
     {
         _lazySelectedState = lazySelectedState;
         _dispatcher = dispatcher;

--- a/Gum/Commands/WireframeCommands.cs
+++ b/Gum/Commands/WireframeCommands.cs
@@ -6,9 +6,9 @@ namespace Gum.Commands;
 public class WireframeCommands : IWireframeCommands
 {
     private readonly IWireframeObjectManager _wireframeObjectManager;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     public WireframeCommands(IWireframeObjectManager wireframeObjectManager,
-        PluginManager pluginManager)
+        IPluginManager pluginManager)
     {
         _wireframeObjectManager = wireframeObjectManager;
         _pluginManager = pluginManager;

--- a/Gum/Plugins/IPluginManager.cs
+++ b/Gum/Plugins/IPluginManager.cs
@@ -7,6 +7,7 @@ using Gum.Managers;
 using Gum.Plugins.BaseClasses;
 using Gum.Wireframe;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -155,4 +156,17 @@ public interface IPluginManager
     void BeforeRender();
     void AfterRender();
     void BehaviorReferencesChanged(ElementSave elementSave);
+
+    // Widened for #3753 (concrete-field cleanup pass): SelectedState, ElementCommands, EditCommands,
+    // GuiCommands, WireframeCommands, WireframeObjectManager, and ElementTreeViewManager previously took
+    // the concrete PluginManager as a ctor/field type because these weren't on the interface yet.
+    void RefreshVariableView(bool force);
+    void WireframePropertyChanged(string propertyName);
+    IRenderableIpso CreateRenderableForType(string type);
+    void WireframeRefreshed();
+    // Sealed to object (not System.Windows.Forms.TreeNode) per the WinForms/WPF interface-leak ratchet
+    // (UiDecouplingRatchetTests) -- same pattern as ITabManager.AddControl.
+    void TreeNodeSelected(object? treeNode);
+    bool IsInitialized { get; }
+    void SetHighlightedIpso(GraphicalUiElement? positionedSizedObject);
 }

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -375,7 +375,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly IProjectState _projectState;
     private readonly ICollapseToggleService _collapseToggleService;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     private readonly IDispatcher _dispatcher;
 
     public bool HasMouseOver
@@ -412,7 +412,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         IProjectState projectState,
         StandardElementsManagerGumTool standardElementsManagerGumTool,
         IDragDropManager dragDropManager,
-        PluginManager pluginManager,
+        IPluginManager pluginManager,
         IDispatcher dispatcher)
     {
         _selectedState = selectedState;

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -376,8 +376,8 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
     public virtual void ElementSelected(ElementSave? elementSave) =>
         CallMethodOnPlugin(plugin => plugin.CallElementSelected(elementSave));
 
-    internal void TreeNodeSelected(TreeNode? treeNode) =>
-        CallMethodOnPlugin(plugin => plugin.CallTreeNodeSelected(treeNode));
+    public void TreeNodeSelected(object? treeNode) =>
+        CallMethodOnPlugin(plugin => plugin.CallTreeNodeSelected(treeNode as TreeNode));
 
     internal void StateWindowTreeNodeSelected(TreeNode treeNode) =>
         CallMethodOnPlugin(plugin => plugin.CallStateWindowTreeNodeSelected(treeNode));
@@ -478,7 +478,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
     public void RefreshBehaviorView(ElementSave elementSave) =>
         CallMethodOnPlugin(plugin => plugin.CallRefreshBehaviorUi());
 
-    internal void RefreshVariableView(bool force) =>
+    public void RefreshVariableView(bool force) =>
         CallMethodOnPlugin(plugin => plugin.CallRefreshVariableView(force));
 
     public void BehaviorReferencesChanged(ElementSave elementSave) =>
@@ -488,10 +488,10 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
         CallMethodOnPlugin(
             plugin => plugin.CallWireframeRefreshed());
 
-    internal void WireframePropertyChanged(string propertyName) =>
+    public void WireframePropertyChanged(string propertyName) =>
         CallMethodOnPlugin(plugin => plugin.CallWireframePropertyChanged(propertyName));
 
-    internal IRenderableIpso CreateRenderableForType(string type)
+    public IRenderableIpso CreateRenderableForType(string type)
     {
         IRenderableIpso toReturn = null;
 

--- a/Gum/ToolCommands/ElementCommands.cs
+++ b/Gum/ToolCommands/ElementCommands.cs
@@ -29,7 +29,7 @@ public class ElementCommands : IElementCommands
     private readonly IFileCommands _fileCommands;
     private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     private readonly IProjectManager _projectManager;
     private readonly IProjectState _projectState;
 
@@ -40,7 +40,7 @@ public class ElementCommands : IElementCommands
         IFileCommands fileCommands,
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
-        PluginManager pluginManager,
+        IPluginManager pluginManager,
         IProjectManager projectManager,
         IProjectState projectState)
     {

--- a/Gum/ToolStates/SelectedState.cs
+++ b/Gum/ToolStates/SelectedState.cs
@@ -25,7 +25,7 @@ public class SelectedState : ISelectedState
     #region Fields
     
     private readonly IGuiCommands _guiCommands;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     private readonly IMessenger _messenger;
     // Lazy because PropertyGridManager depends on ISelectedState; this breaks the DI construction cycle.
     private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
@@ -342,7 +342,7 @@ public class SelectedState : ISelectedState
 
 
     public SelectedState(IGuiCommands guiCommands,
-        PluginManager pluginManager,
+        IPluginManager pluginManager,
         IMessenger messenger,
         Lazy<PropertyGridManager> lazyPropertyGridManager)
     {

--- a/Gum/Wireframe/WireframeObjectManager.cs
+++ b/Gum/Wireframe/WireframeObjectManager.cs
@@ -52,7 +52,7 @@ public partial class WireframeObjectManager : IWireframeObjectManager
     private readonly IGuiCommands _guiCommands;
     GraphicalUiElementManager gueManager;
     private LocalizationService _localizationService;
-    private readonly PluginManager _pluginManager;
+    private readonly IPluginManager _pluginManager;
     private readonly IProjectState _projectState;
 
     public WireframeObjectManager(IFontManager fontManager,
@@ -60,7 +60,7 @@ public partial class WireframeObjectManager : IWireframeObjectManager
         IDialogService dialogService,
         IGuiCommands guiCommands,
         LocalizationService localizationService,
-        PluginManager pluginManager,
+        IPluginManager pluginManager,
         IProjectState projectState)
     {
         _fontManager = fontManager;

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -357,7 +357,7 @@ public class WireframeControl : GraphicsDeviceControl
                 if (TopRuler.IsCursorOver == false && LeftRuler.IsCursorOver == false)
                 {
                     var shouldForceNoHighlight = mouseHasEntered == false &&
-                        Locator.GetRequiredService<PluginManager>().GetIfShouldSuppressRemoveEditorHighlight() == false;
+                        Locator.GetRequiredService<IPluginManager>().GetIfShouldSuppressRemoveEditorHighlight() == false;
 
 
                     _selectionManager.Activity(shouldForceNoHighlight);
@@ -413,11 +413,11 @@ public class WireframeControl : GraphicsDeviceControl
         {
             GraphicsDevice.Clear(BackgroundColor);
 
-            Locator.GetRequiredService<PluginManager>().BeforeRender();
+            Locator.GetRequiredService<IPluginManager>().BeforeRender();
 
             Renderer.Self.Draw((SystemManagers)null);
 
-            Locator.GetRequiredService<PluginManager>().AfterRender();
+            Locator.GetRequiredService<IPluginManager>().AfterRender();
 
         }
     }

--- a/Tool/Tests/GumToolUnitTests/ToolCommands/ElementCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolCommands/ElementCommandsTests.cs
@@ -26,7 +26,7 @@ public class ElementCommandsTests
     Mock<IFileCommands> _fileCommands;
     Mock<IVariableInCategoryPropagationLogic> _variableInCategoryPropagationLogic;
     Mock<IWireframeObjectManager> _wireframeObjectManager;
-    Mock<PluginManager> _pluginManager;
+    Mock<IPluginManager> _pluginManager;
     Mock<IProjectManager> _projectManager;
     Mock<IProjectState> _projectState;
 
@@ -39,7 +39,7 @@ public class ElementCommandsTests
         _fileCommands = new Mock<IFileCommands>();
         _variableInCategoryPropagationLogic = new Mock<IVariableInCategoryPropagationLogic>();
         _wireframeObjectManager = new Mock<IWireframeObjectManager>();
-        _pluginManager = new Mock<PluginManager>();
+        _pluginManager = new Mock<IPluginManager>();
         _projectManager = new Mock<IProjectManager>();
         _projectState = new Mock<IProjectState>();
 

--- a/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ToolStates/SelectedStateTests.cs
@@ -14,14 +14,14 @@ namespace GumToolUnitTests.ToolStates;
 public class SelectedStateTests : BaseTestClass
 {
     private readonly Mock<IGuiCommands> _guiCommands;
-    private readonly Mock<PluginManager> _pluginManager;
+    private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<IMessenger> _messenger;
     private readonly SelectedState _selectedState;
 
     public SelectedStateTests()
     {
         _guiCommands = new Mock<IGuiCommands>();
-        _pluginManager = new Mock<PluginManager> { CallBase = false };
+        _pluginManager = new Mock<IPluginManager>();
         _messenger = new Mock<IMessenger>();
         _selectedState = new SelectedState(
             _guiCommands.Object,
@@ -88,17 +88,17 @@ public class SelectedStateTests : BaseTestClass
         var invocationOrder = new List<string>();
         _pluginManager
             .Setup(p => p.ReactToStateSaveSelected(It.IsAny<StateSave>()))
-            .Callback(() => invocationOrder.Add(nameof(PluginManager.ReactToStateSaveSelected)));
+            .Callback(() => invocationOrder.Add(nameof(IPluginManager.ReactToStateSaveSelected)));
         _pluginManager
             .Setup(p => p.ElementSelected(It.IsAny<ElementSave>()))
-            .Callback(() => invocationOrder.Add(nameof(PluginManager.ElementSelected)));
+            .Callback(() => invocationOrder.Add(nameof(IPluginManager.ElementSelected)));
 
         _selectedState.SelectedElement = screen;
 
-        invocationOrder.ShouldContain(nameof(PluginManager.ReactToStateSaveSelected));
-        invocationOrder.ShouldContain(nameof(PluginManager.ElementSelected));
-        invocationOrder.IndexOf(nameof(PluginManager.ReactToStateSaveSelected))
-            .ShouldBeLessThan(invocationOrder.IndexOf(nameof(PluginManager.ElementSelected)));
+        invocationOrder.ShouldContain(nameof(IPluginManager.ReactToStateSaveSelected));
+        invocationOrder.ShouldContain(nameof(IPluginManager.ElementSelected));
+        invocationOrder.IndexOf(nameof(IPluginManager.ReactToStateSaveSelected))
+            .ShouldBeLessThan(invocationOrder.IndexOf(nameof(IPluginManager.ElementSelected)));
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerStateApplicationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerStateApplicationTests.cs
@@ -52,7 +52,7 @@ public class WireframeObjectManagerStateApplicationTests : BaseTestClass
             Mock.Of<IDialogService>(),
             Mock.Of<IGuiCommands>(),
             new LocalizationService(),
-            new Mock<PluginManager> { CallBase = false }.Object,
+            Mock.Of<IPluginManager>(),
             Mock.Of<IProjectState>());
     }
 


### PR DESCRIPTION
Closes #3753.

Finishes the "New (2026-07-17)" checklist item: 7 pre-existing classes still held a concrete `PluginManager` field (never `.Self`/`Locator`-based, just typed concrete from day one). Widened `IPluginManager` with the members that forced concrete typing (`RefreshVariableView`, `WireframePropertyChanged`, `CreateRenderableForType`, `WireframeRefreshed`, `TreeNodeSelected`, `IsInitialized`, `SetHighlightedIpso`), then swapped `SelectedState`, `ElementCommands`, `EditCommands`, `GuiCommands`, `WireframeCommands`, `WireframeObjectManager`, and `ElementTreeViewManager` to take `IPluginManager`.

`TreeNodeSelected` is sealed to `object` (not `System.Windows.Forms.TreeNode`) to satisfy `UiDecouplingRatchetTests.WinFormsOrWpfTypeLeaksInInterfaceSignatures_DoesNotExceedBaseline` — same pattern as `ITabManager.AddControl`.

Bundled the deferred `WireframeControl.cs` sites too: its 3 `Locator.GetRequiredService<PluginManager>()` calls now resolve `IPluginManager`. (`PolygonPointInputHandler`/`ResizeInputHandler` were already on `IPluginManager`.)

Behavior-preserving type widening — no logic changes.

**Also updates `Direction/ui-decoupling-plan.md`:** declares Phase 2 complete, and reclassifies the deferred `WireframeControl`/`PolygonPointInputHandler`/`ResizeInputHandler` multi-layer ctor-injection from "Phase 2 leftover" to Phase 4b — those three files are WinForms-typed at the core (not just Locator-coupled) and get rewritten wholesale by Phase 4b's rendering-host contract, so threading DI through them now would be wasted work.

Manual test: not needed — compiler + full `GumToolUnitTests` suite (1081 passed) are the proof.
FRB canary: not needed — no FRB1-shared source touched.
