### PR TITLE
Route MultiSelectTreeView.HandleException through an event, not MessageBox

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -107,10 +107,18 @@ namespace CommonFormsAndControls
 
         #endregion
 
-        #region Events  
+        #region Events
 
 
         public event TreeViewEventHandler? AfterClickSelect;
+
+        /// <summary>
+        /// Raised when an exception is caught internally while crawling or reacting to tree
+        /// node changes. This control has no dependency on the host application's dialog
+        /// service, so it hands the exception off here instead of showing UI directly;
+        /// the host (e.g. ElementTreeViewManager) is expected to subscribe and surface it.
+        /// </summary>
+        public event Action<Exception>? UnhandledException;
 
         #endregion
 
@@ -769,9 +777,11 @@ namespace CommonFormsAndControls
 
         private void HandleException(Exception ex)
         {
-            // Perform some error handling here.   
-            // We don't want to bubble errors to the CLR.    
-            MessageBox.Show(ex.Message);
+            // Perform some error handling here.
+            // We don't want to bubble errors to the CLR.
+            // No fallback UI here on purpose: ElementTreeViewManager always owns and wires up
+            // this control, so UnhandledException is guaranteed to have a subscriber.
+            UnhandledException?.Invoke(ex);
         }
 
         private void ReactToClickedNode(TreeNode? node)

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -804,6 +804,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         ObjectTreeView.MouseUp += (_, _) => _lastMouseDownButton = MouseButtons.None;
         ObjectTreeView.AfterExpand += (_, _) => _collapseToggleService.OnNodeManuallyChanged();
         ObjectTreeView.AfterCollapse += (_, _) => _collapseToggleService.OnNodeManuallyChanged();
+        ObjectTreeView.UnhandledException += ex => _dialogService.ShowMessage(ex.Message);
 
         ConfigureStandardsPalette();
 

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewHandleExceptionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewHandleExceptionTests.cs
@@ -1,0 +1,42 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class MultiSelectTreeViewHandleExceptionTests : BaseTestClass
+{
+    private readonly MultiSelectTreeView _treeView;
+
+    public MultiSelectTreeViewHandleExceptionTests()
+    {
+        _treeView = new MultiSelectTreeView();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _treeView.Dispose();
+    }
+
+    [Fact]
+    public void HandleException_ShouldRaiseUnhandledException_WithTheCaughtException()
+    {
+        // MultiSelectTreeView has no dependency on the host application's dialog service; it
+        // hands the exception off via UnhandledException instead (ElementTreeViewManager
+        // subscribes and forwards to IDialogService).
+        Exception exception = new InvalidOperationException("Something went wrong crawling the tree");
+        Exception? raised = null;
+        _treeView.UnhandledException += ex => raised = ex;
+
+        MethodInfo? handleExceptionMethod = typeof(MultiSelectTreeView).GetMethod(
+            "HandleException", BindingFlags.Instance | BindingFlags.NonPublic);
+        handleExceptionMethod.ShouldNotBeNull();
+
+        handleExceptionMethod!.Invoke(_treeView, new object[] { exception });
+
+        raised.ShouldBe(exception);
+    }
+}


### PR DESCRIPTION
## Summary
- `MultiSelectTreeView.HandleException` called `MessageBox.Show` directly (Phase 1 item in `Direction/ui-decoupling-plan.md`).
- `CommonFormsAndControls.csproj` is a dependency-free leaf project (`Gum.csproj` depends on it, not the reverse), so it can't reach `Gum.Services.Locator`/`IDialogService` without a circular reference.
- Fix: `MultiSelectTreeView` now raises a new `public event Action<Exception>? UnhandledException` from `HandleException` instead of showing UI itself. `ElementTreeViewManager` (which already has `IDialogService` injected) subscribes once during `Initialize()` and forwards to `_dialogService.ShowMessage(ex.Message)`.

## Test plan
- [x] `MultiSelectTreeViewHandleExceptionTests` (new) — reflection-invokes the private `HandleException` and asserts `UnhandledException` fires with the caught exception.
- [x] Full `GumToolUnitTests` suite green (1082 passed / 4 pre-existing skips / 0 failed).
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings.
- Manual test: not needed — this is a defensive error-handling path (tree-node-crawl exceptions), and the wiring is exercised by the unit test plus the compiler-checked event subscription.

Part of #3754