### PR TITLE
Drain IPluginManager Locator calls from PolygonPointInputHandler, ResizeInputHandler, WireframeControl

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs
@@ -1,6 +1,7 @@
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.Services;
@@ -35,6 +36,7 @@ public class EditorContext
     public Layer OverlayLayer { get; }
     public IUiSettingsService UiSettingsService { get; }
     public IToolFontService ToolFontService { get; }
+    public IPluginManager PluginManager { get; }
 
     #endregion
 
@@ -97,10 +99,12 @@ public class EditorContext
         Layer overlayLayer,
         Color lineColor,
         Color textColor,
-        IToolFontService toolFontService)
+        IToolFontService toolFontService,
+        IPluginManager pluginManager)
     {
         UiSettingsService = uiSettingsService;
         ToolFontService = toolFontService;
+        PluginManager = pluginManager;
         SelectedState = selectedState;
         SelectionManager = selectionManager;
         ElementCommands = elementCommands;
@@ -191,7 +195,7 @@ public class EditorContext
             if (DoValuesDiffer(stateSave, possiblyChangedVariableList.Name, oldValue))
             {
                 var instance = element.GetInstance(possiblyChangedVariableList.SourceObject);
-                Locator.GetRequiredService<Gum.Plugins.IPluginManager>().VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
+                PluginManager.VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }
 

--- a/Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.Numerics;
 using System.Windows.Forms;
 using Gum.DataTypes.Variables;
-using Gum.Plugins;
-using Gum.Services;
 using Gum.Wireframe.Editors.Visuals;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -352,7 +350,7 @@ public class PolygonPointInputHandler : InputHandlerBase
             if (oldValue != possiblyChangedVariableList)
             {
                 var instance = selectedElement?.GetInstance(possiblyChangedVariableList.SourceObject);
-                Locator.GetRequiredService<IPluginManager>().VariableSet(selectedElement, instance,
+                Context.PluginManager.VariableSet(selectedElement, instance,
                     possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }

--- a/Tool/EditorTabPlugin_XNA/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Handlers/ResizeInputHandler.cs
@@ -7,8 +7,6 @@ using System.Windows.Forms;
 using EditorTabPlugin_XNA.ExtensionMethods;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
-using Gum.Plugins;
-using Gum.Services;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math;
@@ -667,7 +665,7 @@ public class ResizeInputHandler : InputHandlerBase
             if (DoValuesDiffer(stateSave, possiblyChangedVariableList.Name, oldValue))
             {
                 var instance = element.GetInstance(possiblyChangedVariableList.SourceObject);
-                Locator.GetRequiredService<IPluginManager>().VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
+                Context.PluginManager.VariableSet(element, instance, possiblyChangedVariableList.GetRootName(), oldValue);
             }
         }
 

--- a/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.Commands;
 using Gum.Input;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.Services;
@@ -72,7 +73,8 @@ public class PolygonWireframeEditor : WireframeEditor
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
         IUiSettingsService uiSettingsService,
-        IToolFontService toolFontService)
+        IToolFontService toolFontService,
+        IPluginManager pluginManager)
         : base(
               hotkeyManager,
               selectionManager,
@@ -88,7 +90,8 @@ public class PolygonWireframeEditor : WireframeEditor
               layer,
               System.Drawing.Color.White,
               System.Drawing.Color.White,
-              toolFontService)
+              toolFontService,
+              pluginManager)
     {
         this.layer = layer;
 

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -23,6 +23,7 @@ using Gum.Services;
 using Gum.Commands;
 using Gum.Undo;
 using Gum.Wireframe.Editors.Handlers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Wireframe.Editors.Visuals;
 
@@ -96,7 +97,8 @@ public class StandardWireframeEditor : WireframeEditor
         IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
         IUiSettingsService uiSettingsService,
-        IToolFontService toolFontService)
+        IToolFontService toolFontService,
+        IPluginManager pluginManager)
         : base(
               hotkeyManager,
               selectionManager,
@@ -112,7 +114,8 @@ public class StandardWireframeEditor : WireframeEditor
               layer,
               lineColor,
               textColor,
-              toolFontService)
+              toolFontService,
+              pluginManager)
     {
         _elementCommands = elementCommands;
         _wireframeObjectManager = wireframeObjectManager;

--- a/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/WireframeEditor.cs
@@ -63,7 +63,8 @@ public abstract class WireframeEditor
         Layer layer,
         Color lineColor,
         Color textColor,
-        IToolFontService toolFontService)
+        IToolFontService toolFontService,
+        IPluginManager pluginManager)
     {
         // Create shared EditorContext and MoveInputHandler
         _context = new EditorContext(
@@ -81,7 +82,8 @@ public abstract class WireframeEditor
             layer,
             lineColor,
             textColor,
-            toolFontService);
+            toolFontService,
+            pluginManager);
 
         _moveInputHandler = new MoveInputHandler(_context);
     }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -239,7 +239,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _fileCommands,
             _setVariableLogic,
             _uiSettingsService,
-            _toolFontService);
+            _toolFontService,
+            _pluginManager);
 
         _screenshotService = new ScreenshotService(_selectionManager, _wireframeCommands, _guiCommands);
         _singlePixelTextureService = new SinglePixelTextureService();
@@ -1426,7 +1427,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     private void CreateWireframeControl()
     {
-        this._wireframeControl = new WireframeControl();
+        this._wireframeControl = new WireframeControl(_pluginManager);
         this._wireframeControl.AllowDrop = true;
         this._wireframeControl.Dock = DockStyle.Fill;
         this._wireframeControl.Cursor = System.Windows.Forms.Cursors.Default;

--- a/Tool/EditorTabPlugin_XNA/SelectionManager.cs
+++ b/Tool/EditorTabPlugin_XNA/SelectionManager.cs
@@ -2,6 +2,7 @@
 using Gum.DataTypes;
 using Gum.Input;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
@@ -87,6 +88,7 @@ public class SelectionManager : ISelectionManager
     private readonly ISetVariableLogic _setVariableLogic;
     private readonly IUiSettingsService _uiSettingsService;
     private readonly IToolFontService _toolFontService;
+    private readonly IPluginManager _pluginManager;
 
     public virtual bool IsOverBody
     {
@@ -215,7 +217,8 @@ public class SelectionManager : ISelectionManager
         IFileCommands fileCommands,
         ISetVariableLogic setVariableLogic,
         IUiSettingsService uiSettingsService,
-        IToolFontService toolFontService)
+        IToolFontService toolFontService,
+        IPluginManager pluginManager)
     {
         _selectedState = selectedState;
         _toolFontService = toolFontService;
@@ -231,6 +234,7 @@ public class SelectionManager : ISelectionManager
         _fileCommands = fileCommands;
         _setVariableLogic = setVariableLogic;
         _uiSettingsService = uiSettingsService;
+        _pluginManager = pluginManager;
     }
 
     public void Initialize(LayerService layerService)
@@ -824,7 +828,8 @@ public class SelectionManager : ISelectionManager
                         _variableInCategoryPropagationLogic,
                         _wireframeObjectManager,
                         _uiSettingsService,
-                        _toolFontService);
+                        _toolFontService,
+                        _pluginManager);
                 }
             }
         }
@@ -863,7 +868,8 @@ public class SelectionManager : ISelectionManager
             _variableInCategoryPropagationLogic,
             _wireframeObjectManager,
             _uiSettingsService,
-            _toolFontService);
+            _toolFontService,
+            _pluginManager);
     }
 
     #region New Explicit Input Processing System

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -37,6 +37,7 @@ public class WireframeControl : GraphicsDeviceControl
 
     private readonly IDialogService _dialogService;
     private readonly IOutputManager _outputManager;
+    private readonly IPluginManager _pluginManager;
 
     private IHotkeyManager _hotkeyManager;
     private IProjectManager _projectManager;
@@ -78,10 +79,11 @@ public class WireframeControl : GraphicsDeviceControl
 
     #endregion
 
-    public WireframeControl()
+    public WireframeControl(IPluginManager pluginManager)
     {
         _dialogService = Locator.GetRequiredService<IDialogService>();
         _outputManager = Locator.GetRequiredService<IOutputManager>();
+        _pluginManager = pluginManager;
     }
 
     #region Properties
@@ -357,7 +359,7 @@ public class WireframeControl : GraphicsDeviceControl
                 if (TopRuler.IsCursorOver == false && LeftRuler.IsCursorOver == false)
                 {
                     var shouldForceNoHighlight = mouseHasEntered == false &&
-                        Locator.GetRequiredService<IPluginManager>().GetIfShouldSuppressRemoveEditorHighlight() == false;
+                        _pluginManager.GetIfShouldSuppressRemoveEditorHighlight() == false;
 
 
                     _selectionManager.Activity(shouldForceNoHighlight);
@@ -413,11 +415,11 @@ public class WireframeControl : GraphicsDeviceControl
         {
             GraphicsDevice.Clear(BackgroundColor);
 
-            Locator.GetRequiredService<IPluginManager>().BeforeRender();
+            _pluginManager.BeforeRender();
 
             Renderer.Self.Draw((SystemManagers)null);
 
-            Locator.GetRequiredService<IPluginManager>().AfterRender();
+            _pluginManager.AfterRender();
 
         }
     }

--- a/Tool/Tests/GumToolUnitTests/Wireframe/Editors/EditorContextTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/Editors/EditorContextTests.cs
@@ -1,0 +1,95 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.PropertyGridHelpers;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors;
+using Moq;
+using RenderingLibrary.Graphics;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace GumToolUnitTests.Wireframe.Editors;
+
+/// <summary>
+/// Pinning tests for EditorContext.DoEndOfSettingValuesLogic(): the PluginManager notification
+/// used to be a self-located Locator.GetRequiredService&lt;IPluginManager&gt;() call, which made this
+/// path untestable (no test registers a Locator provider). It is now constructor-injected.
+/// </summary>
+public class EditorContextTests : BaseTestClass
+{
+    [Fact]
+    public void DoEndOfSettingValuesLogic_ShouldNotifyInjectedPluginManager_WhenVariableListChanged()
+    {
+        // Arrange
+        ScreenSave selectedElement = new ScreenSave();
+
+        StateSave stateSave = new StateSave();
+        VariableListSave<Vector2> pointsVariableList = new VariableListSave<Vector2> { Name = "Points" };
+        stateSave.VariableLists.Add(pointsVariableList);
+
+        Mock<ISelectedState> mockSelectedState = new Mock<ISelectedState>();
+        mockSelectedState.Setup(x => x.SelectedElement).Returns(selectedElement);
+        mockSelectedState.Setup(x => x.SelectedStateSave).Returns(stateSave);
+        mockSelectedState.Setup(x => x.SelectedInstances).Returns(new List<InstanceSave>());
+
+        Mock<IWireframeObjectManager> mockWireframeObjectManager = new Mock<IWireframeObjectManager>();
+        mockWireframeObjectManager.Setup(x => x.GetRepresentation(selectedElement)).Returns(new GraphicalUiElement());
+
+        Mock<IPluginManager> mockPluginManager = new Mock<IPluginManager>();
+
+        SelectionManager selectionManager = new SelectionManager(
+            Mock.Of<ISelectedState>(),
+            Mock.Of<IUndoManager>(),
+            Mock.Of<IEditingManager>(),
+            Mock.Of<IDialogService>(),
+            Mock.Of<IHotkeyManager>(),
+            Mock.Of<IVariableInCategoryPropagationLogic>(),
+            Mock.Of<IWireframeObjectManager>(),
+            Mock.Of<IProjectManager>(),
+            Mock.Of<IGuiCommands>(),
+            Mock.Of<IElementCommands>(),
+            Mock.Of<IFileCommands>(),
+            Mock.Of<ISetVariableLogic>(),
+            Mock.Of<IUiSettingsService>(),
+            Mock.Of<IToolFontService>(),
+            Mock.Of<IPluginManager>());
+
+        EditorContext context = new EditorContext(
+            mockSelectedState.Object,
+            selectionManager,
+            Mock.Of<IElementCommands>(),
+            Mock.Of<IGuiCommands>(),
+            Mock.Of<IFileCommands>(),
+            Mock.Of<ISetVariableLogic>(),
+            Mock.Of<IUndoManager>(),
+            Mock.Of<IVariableInCategoryPropagationLogic>(),
+            Mock.Of<IHotkeyManager>(),
+            mockWireframeObjectManager.Object,
+            Mock.Of<IUiSettingsService>(),
+            new Layer(),
+            System.Drawing.Color.White,
+            System.Drawing.Color.White,
+            Mock.Of<IToolFontService>(),
+            mockPluginManager.Object);
+
+        // Snapshot the "before drag" state so DoEndOfSettingValuesLogic has something to diff against.
+        context.GrabbedState.HandlePush();
+
+        // Act
+        context.DoEndOfSettingValuesLogic();
+
+        // Assert
+        mockPluginManager.Verify(
+            x => x.VariableSet(selectedElement, null, "Points", It.IsAny<object>()),
+            Times.Once);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerHighlightTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerHighlightTests.cs
@@ -2,6 +2,7 @@ using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
@@ -57,7 +58,8 @@ public class SelectionManagerHighlightTests : BaseTestClass
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>(),
             Mock.Of<IUiSettingsService>(),
-            Mock.Of<IToolFontService>());
+            Mock.Of<IToolFontService>(),
+            Mock.Of<IPluginManager>());
 
         _layerService = new Mock<LayerService>();
         _selectionManager.Initialize(_layerService.Object);

--- a/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerRectangleTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/SelectionManagerRectangleTests.cs
@@ -2,6 +2,7 @@ using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
@@ -77,7 +78,8 @@ public class SelectionManagerRectangleTests : BaseTestClass
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>(),
             Mock.Of<IUiSettingsService>(),
-            Mock.Of<IToolFontService>());
+            Mock.Of<IToolFontService>(),
+            Mock.Of<IPluginManager>());
 
         _layerService = new Mock<LayerService>();
 


### PR DESCRIPTION
## Summary
- `EditorContext`, `PolygonPointInputHandler`, `ResizeInputHandler`, and `WireframeControl` self-located `IPluginManager` via `Locator.GetRequiredService<>()` instead of taking it via constructor injection (flagged in `Direction/ui-decoupling-plan.md` Phase 2 as deferred work).
- `EditorContext` now takes `IPluginManager` in its ctor and exposes it as a public property; both input handlers use `Context.PluginManager` instead of calling `Locator` directly.
- Threaded `IPluginManager` down the existing manual construction chain: `WireframeEditor` -> `StandardWireframeEditor`/`PolygonWireframeEditor` -> `SelectionManager` -> `MainEditorTabPlugin` (which already had `IPluginManager` injected via MEF, so no new bridge needed).
- `WireframeControl` now takes `IPluginManager` in its ctor and uses the field for its three `BeforeRender()`/`AfterRender()`/`GetIfShouldSuppressRemoveEditorHighlight()` calls; `MainEditorTabPlugin.CreateWireframeControl()` passes its existing `_pluginManager` field.
- No construction cycle: everything downstream just receives an already-built `IPluginManager` as a plain ctor param, same as the precedent in the refactoring-direction skill (rule 4).
- Behavior-preserving (same `IPluginManager` instance, just passed instead of self-located), so per the `refactoring-direction` skill this is a pinning test, not new TDD-first tests. Added `EditorContextTests.DoEndOfSettingValuesLogic_ShouldNotifyInjectedPluginManager_WhenVariableListChanged`, which failed with `InvalidOperationException: No service for Gum.Plugins.IPluginManager has been registered` against the pre-fix `Locator` call (no test registers a Locator provider) and passes against the injected version.
- Updated `SelectionManagerHighlightTests`/`SelectionManagerRectangleTests` for the new ctor param.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings in touched files.
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — full suite: 1082 passed, 4 skipped (pre-existing), 0 failed.
- [ ] Manual: resize an instance and drag polygon points in the wireframe editor; confirm plugins still react to variable changes and the wireframe still renders/highlights correctly.

Part of #3754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)