### PR TITLE
Drain WireframeControl ctor Locator calls for IDialogService/IOutputManager

### DIFF
--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -1427,7 +1427,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     private void CreateWireframeControl()
     {
-        this._wireframeControl = new WireframeControl(_pluginManager);
+        this._wireframeControl = new WireframeControl(_dialogService, _outputManager, _pluginManager);
         this._wireframeControl.AllowDrop = true;
         this._wireframeControl.Dock = DockStyle.Fill;
         this._wireframeControl.Cursor = System.Windows.Forms.Cursors.Default;

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -5,7 +5,6 @@ using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.Wireframe;
@@ -79,10 +78,10 @@ public class WireframeControl : GraphicsDeviceControl
 
     #endregion
 
-    public WireframeControl(IPluginManager pluginManager)
+    public WireframeControl(IDialogService dialogService, IOutputManager outputManager, IPluginManager pluginManager)
     {
-        _dialogService = Locator.GetRequiredService<IDialogService>();
-        _outputManager = Locator.GetRequiredService<IOutputManager>();
+        _dialogService = dialogService;
+        _outputManager = outputManager;
         _pluginManager = pluginManager;
     }
 


### PR DESCRIPTION
## Summary
- `WireframeControl`'s ctor self-located `IDialogService`/`IOutputManager` via `Locator.GetRequiredService<T>()` instead of taking them as ctor params — the one piece deliberately left out of #3773's `IPluginManager` drain to avoid touching a file with 3 concurrent sibling PRs in flight.
- Added `IDialogService dialogService, IOutputManager outputManager` params, assigned directly. `MainEditorTabPlugin` (the sole construction site) already held both as injected fields, so the call site just passes them through — no new MEF bridge.
- Dropped the now-unused `using Gum.Services;` (only import needed for `Locator`).
- No pinning test: `WireframeControl` is a WinForms `GraphicsDeviceControl`, not constructible headlessly, and the compiler already guards every call site (verified only one exists) — same reasoning used for other View-class ctor drains in this migration.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings.
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 1083 passed, 4 skipped (pre-existing), 0 failed.
- Manual test: not needed — behavior-preserving field-injection swap with no observable runtime change; compiler + full suite are the proof.

Closes #3774. Part of #3754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
