### PR TITLE
Move PluginsDialogViewModel to headless Gum.Presentation

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -112,6 +112,13 @@ changelog — update this list when a *new kind* of gotcha is discovered, not fo
   Fixed the same way as `ViewModel.cs`: link the file into `GumCommon.csproj` (mirroring its
   existing `ViewModel.cs` entry) and `<Compile Remove>` it from `Gum.csproj` so it isn't compiled
   twice. Watch for other extension methods declared in a BCL namespace the same way.
+- **A VM's dependency on `IPluginManager` can still block the move even when the interface itself
+  is already in `Gum.Presentation`, if the *operation* it needs naturally returns a tool-only
+  concrete type** (e.g. `PluginContainer`/`IPlugin`, which live in `Gum.csproj` and can't be
+  referenced from the headless assembly). Widen the interface using the same opaque-`object`
+  pattern as `FillWithErrors`/`TreeNodeSelected`: return a small headless DTO (a `record`, e.g.
+  `PluginSummary`) carrying an opaque handle `object`, and have the concrete implementation cast
+  the handle back to its real type internally (#3754).
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
 - *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -1298,6 +1298,38 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             mPluginSettingsSave.Save(PluginSettingsSaveFileName);
     }
 
+    /// <inheritdoc/>
+    public IReadOnlyList<PluginSummary> GetAllPluginSummaries() =>
+        AllPluginContainers.Select(ToPluginSummary).ToList();
+
+    /// <inheritdoc/>
+    public PluginSummary DisableUserPlugin(object pluginHandle)
+    {
+        PluginContainer container = (PluginContainer)pluginHandle;
+        ShutDownPlugin(container.Plugin, PluginShutDownReason.UserDisabled);
+        return ToPluginSummary(container);
+    }
+
+    /// <inheritdoc/>
+    public PluginSummary TryEnablePlugin(object pluginHandle)
+    {
+        PluginContainer container = (PluginContainer)pluginHandle;
+        container.IsEnabled = true;
+        try
+        {
+            container.Plugin.StartUp();
+            ReenablePlugin(container.Plugin);
+        }
+        catch (Exception exception)
+        {
+            container.Fail(exception, "Failed in StartUp");
+        }
+        return ToPluginSummary(container);
+    }
+
+    private static PluginSummary ToPluginSummary(PluginContainer container) =>
+        new(container.Name, container.ToString(), container.IsEnabled, !string.IsNullOrEmpty(container.FailureDetails), container);
+
     internal static void AddInternalPlugins()
     {
     }

--- a/Gum/Services/Dialogs/PluginsDialogView.xaml.cs
+++ b/Gum/Services/Dialogs/PluginsDialogView.xaml.cs
@@ -3,8 +3,14 @@ using System.Windows.Controls;
 namespace Gum.Services.Dialogs;
 
 /// <summary>
-/// Interaction logic for PluginsDialogView.xaml
+/// Interaction logic for PluginsDialogView.xaml.
+///
+/// [Dialog(typeof(PluginsDialogViewModel))] is required, not just naming-convention sugar: the
+/// view model lives in the headless Gum.Presentation assembly, so <see cref="DialogViewResolver"/>
+/// can only pair it with this view via the explicit attribute (naming-convention matching only
+/// pairs types found within the same scanned assembly).
 /// </summary>
+[Dialog(typeof(PluginsDialogViewModel))]
 public partial class PluginsDialogView : UserControl
 {
     public PluginsDialogView()

--- a/Tests/Gum.Presentation.Tests/PluginsDialogViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/PluginsDialogViewModelTests.cs
@@ -1,0 +1,92 @@
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) test for PluginsDialogViewModel/PluginItemViewModel, relocated out
+/// of Gum.csproj into the headless Gum.Presentation assembly (ADR-0005, #3754). The three static
+/// PluginManager calls it used to make directly (AllPluginContainers/ShutDownPlugin/ReenablePlugin)
+/// are now IPluginManager.GetAllPluginSummaries/DisableUserPlugin/TryEnablePlugin, so this test
+/// exercises that seam via a mock rather than the concrete PluginManager. Its View
+/// (PluginsDialogView) stays in the Gum tool assembly, paired via [Dialog(typeof(...))] - see
+/// DialogViewResolverTests (GumToolUnitTests) for the cross-assembly resolution pin.
+/// </summary>
+public class PluginsDialogViewModelTests
+{
+    [Fact]
+    public void Constructor_PopulatesOneItemPerPluginSummary()
+    {
+        object handle = new();
+        PluginSummary summary = new("My Plugin", "My Plugin", true, false, handle);
+        Mock<IPluginManager> pluginManager = new();
+        pluginManager.Setup(p => p.GetAllPluginSummaries()).Returns([summary]);
+        Mock<IDialogService> dialogService = new();
+
+        PluginsDialogViewModel viewModel = new(dialogService.Object, pluginManager.Object);
+
+        viewModel.Plugins.Count.ShouldBe(1);
+        viewModel.Plugins[0].DisplayText.ShouldBe("My Plugin");
+        viewModel.Plugins[0].IsEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_SetFalse_DisablesPluginByHandle_AndAdoptsReturnedSummary()
+    {
+        object handle = new();
+        PluginSummary initial = new("My Plugin", "My Plugin", true, false, handle);
+        PluginSummary disabled = new("My Plugin", "My Plugin", false, false, handle);
+        Mock<IPluginManager> pluginManager = new();
+        pluginManager.Setup(p => p.GetAllPluginSummaries()).Returns([initial]);
+        pluginManager.Setup(p => p.DisableUserPlugin(handle)).Returns(disabled);
+        Mock<IDialogService> dialogService = new();
+        PluginsDialogViewModel viewModel = new(dialogService.Object, pluginManager.Object);
+
+        viewModel.Plugins[0].IsEnabled = false;
+
+        pluginManager.Verify(p => p.DisableUserPlugin(handle), Times.Once);
+        viewModel.Plugins[0].IsEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsEnabled_SetTrue_WithoutFailureDetails_EnablesWithoutPrompting()
+    {
+        object handle = new();
+        PluginSummary disabled = new("My Plugin", "My Plugin", false, false, handle);
+        PluginSummary reenabled = new("My Plugin", "My Plugin", true, false, handle);
+        Mock<IPluginManager> pluginManager = new();
+        pluginManager.Setup(p => p.GetAllPluginSummaries()).Returns([disabled]);
+        pluginManager.Setup(p => p.TryEnablePlugin(handle)).Returns(reenabled);
+        Mock<IDialogService> dialogService = new();
+        PluginsDialogViewModel viewModel = new(dialogService.Object, pluginManager.Object);
+
+        viewModel.Plugins[0].IsEnabled = true;
+
+        dialogService.Verify(
+            d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()),
+            Times.Never);
+        pluginManager.Verify(p => p.TryEnablePlugin(handle), Times.Once);
+        viewModel.Plugins[0].IsEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsEnabled_SetTrue_WithFailureDetails_PromptsAndSkipsEnable_WhenDeclined()
+    {
+        object handle = new();
+        PluginSummary crashed = new("My Plugin", "My Plugin(Failed in StartUp)", false, true, handle);
+        Mock<IPluginManager> pluginManager = new();
+        pluginManager.Setup(p => p.GetAllPluginSummaries()).Returns([crashed]);
+        Mock<IDialogService> dialogService = new();
+        dialogService
+            .Setup(d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()))
+            .Returns(MessageDialogResult.Negative);
+        PluginsDialogViewModel viewModel = new(dialogService.Object, pluginManager.Object);
+
+        viewModel.Plugins[0].IsEnabled = true;
+
+        pluginManager.Verify(p => p.TryEnablePlugin(It.IsAny<object>()), Times.Never);
+        viewModel.Plugins[0].IsEnabled.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Dialogs/DialogViewResolverTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Dialogs/DialogViewResolverTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Gum.Dialogs;
 using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
 using Gum.Plugins.VariableGrid;
 using Gum.Services.Dialogs;
@@ -24,13 +25,13 @@ public class DialogViewResolverTests
     [Fact]
     public void GetDialogViewType_ResolvesFromOwnAssembly_WhenViewModelAndViewAreCoLocated()
     {
-        // PluginsDialogViewModel/PluginsDialogView still live together in Gum.dll and pair via the
+        // ThemingDialogViewModel/ThemingDialogView still live together in Gum.dll and pair via the
         // original naming-convention path (no [Dialog] attribute, no fallback assembly needed).
         DialogViewResolver resolver = new(NullLogger<DialogViewResolver>.Instance, new StubAssemblyProvider());
 
-        Type? viewType = resolver.GetDialogViewType(typeof(PluginsDialogViewModel));
+        Type? viewType = resolver.GetDialogViewType(typeof(ThemingDialogViewModel));
 
-        viewType.ShouldBe(typeof(PluginsDialogView));
+        viewType.ShouldBe(typeof(ThemingDialogView));
     }
 
     [Fact]
@@ -44,6 +45,19 @@ public class DialogViewResolverTests
         Type? viewType = resolver.GetDialogViewType(typeof(MessageDialogViewModel));
 
         viewType.ShouldBe(typeof(MessageDialogView));
+    }
+
+    [Fact]
+    public void GetDialogViewType_FallsBackToCandidateAssemblies_WhenViewModelMovedButViewStayedInToolAssembly()
+    {
+        // PluginsDialogViewModel moved into the headless Gum.Presentation assembly (#3754);
+        // PluginsDialogView (its [Dialog]-attributed View) stayed behind in the Gum tool assembly.
+        StubAssemblyProvider assemblyProvider = new(typeof(PluginsDialogView).Assembly);
+        DialogViewResolver resolver = new(NullLogger<DialogViewResolver>.Instance, assemblyProvider);
+
+        Type? viewType = resolver.GetDialogViewType(typeof(PluginsDialogViewModel));
+
+        viewType.ShouldBe(typeof(PluginsDialogView));
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Dialogs/PluginsDialogViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/PluginsDialogViewModel.cs
@@ -1,52 +1,56 @@
-using System;
 using System.Collections.ObjectModel;
 using Gum.Plugins;
 
 namespace Gum.Services.Dialogs;
 
+/// <summary>
+/// View model backing the "Manage Plugins" dialog. Lists every loaded plugin and lets the user
+/// enable/disable them via <see cref="IPluginManager"/>.
+/// </summary>
 public class PluginsDialogViewModel : DialogViewModel
 {
     public string Title { get => Get<string>(); set => Set(value); }
 
     public ObservableCollection<PluginItemViewModel> Plugins { get; } = [];
 
-    private readonly IDialogService dialogService;
-
-    public PluginsDialogViewModel(IDialogService dialogService)
+    public PluginsDialogViewModel(IDialogService dialogService, IPluginManager pluginManager)
     {
-        this.dialogService = dialogService;
-
         Title = "Manage Plugins";
         AffirmativeText = "Close";
         NegativeText = null;
 
-        foreach (var container in PluginManager.AllPluginContainers)
+        foreach (PluginSummary summary in pluginManager.GetAllPluginSummaries())
         {
-            Plugins.Add(new PluginItemViewModel(container, dialogService));
+            Plugins.Add(new PluginItemViewModel(summary, pluginManager, dialogService));
         }
     }
 }
 
+/// <summary>
+/// A single row in the "Manage Plugins" dialog. Wraps a <see cref="PluginSummary"/> snapshot and
+/// re-fetches it from <see cref="IPluginManager"/> whenever the user toggles the plugin.
+/// </summary>
 public class PluginItemViewModel : Mvvm.ViewModel
 {
-    private readonly PluginContainer container;
+    private readonly IPluginManager pluginManager;
     private readonly IDialogService dialogService;
+    private PluginSummary summary;
 
-    public string DisplayText => container.ToString();
+    public string DisplayText => summary.DisplayText;
 
     public bool IsEnabled
     {
-        get => container.IsEnabled;
+        get => summary.IsEnabled;
         set
         {
-            if (value == container.IsEnabled)
+            if (value == summary.IsEnabled)
             {
                 return;
             }
 
             if (!value)
             {
-                PluginManager.ShutDownPlugin(container.Plugin, PluginShutDownReason.UserDisabled);
+                summary = pluginManager.DisableUserPlugin(summary.PluginHandle);
                 NotifyPropertyChanged();
                 NotifyPropertyChanged(nameof(DisplayText));
             }
@@ -57,9 +61,10 @@ public class PluginItemViewModel : Mvvm.ViewModel
         }
     }
 
-    public PluginItemViewModel(PluginContainer container, IDialogService dialogService)
+    public PluginItemViewModel(PluginSummary summary, IPluginManager pluginManager, IDialogService dialogService)
     {
-        this.container = container;
+        this.summary = summary;
+        this.pluginManager = pluginManager;
         this.dialogService = dialogService;
     }
 
@@ -67,26 +72,17 @@ public class PluginItemViewModel : Mvvm.ViewModel
     {
         bool shouldEnable = true;
 
-        if (!string.IsNullOrEmpty(container.FailureDetails))
+        if (summary.HasFailureDetails)
         {
             shouldEnable = dialogService.ShowYesNoMessage(
-                "The plugin " + container.Name + " has crashed so" +
+                "The plugin " + summary.Name + " has crashed so" +
                 " it was disabled.  Are you sure you want to re-enable it?",
                 "Re-enable crashed plugin?");
         }
 
         if (shouldEnable)
         {
-            container.IsEnabled = true;
-            try
-            {
-                container.Plugin.StartUp();
-                PluginManager.ReenablePlugin(container.Plugin);
-            }
-            catch (Exception exception)
-            {
-                container.Fail(exception, "Failed in StartUp");
-            }
+            summary = pluginManager.TryEnablePlugin(summary.PluginHandle);
         }
 
         NotifyPropertyChanged(nameof(IsEnabled));

--- a/Tools/Gum.Presentation/Plugins/IPluginManager.cs
+++ b/Tools/Gum.Presentation/Plugins/IPluginManager.cs
@@ -167,4 +167,27 @@ public interface IPluginManager
     void TreeNodeSelected(object? treeNode);
     bool IsInitialized { get; }
     void SetHighlightedIpso(GraphicalUiElement? positionedSizedObject);
+
+    // Widened for #3754: PluginsDialogViewModel (the "Manage Plugins" dialog) previously called
+    // the concrete PluginManager's static AllPluginContainers/ShutDownPlugin/ReenablePlugin members
+    // directly. IPlugin/PluginContainer live in the tool-only Gum.csproj (which this headless
+    // Gum.Presentation assembly cannot reference), so plugin identity crosses this interface as the
+    // opaque PluginSummary.PluginHandle token instead - see PluginSummary.
+
+    /// <summary>
+    /// Returns a snapshot of every loaded plugin, for the "Manage Plugins" dialog.
+    /// </summary>
+    IReadOnlyList<PluginSummary> GetAllPluginSummaries();
+
+    /// <summary>
+    /// Disables the plugin identified by <paramref name="pluginHandle"/> as user-initiated
+    /// (persisting the disabled state) and returns its updated summary.
+    /// </summary>
+    PluginSummary DisableUserPlugin(object pluginHandle);
+
+    /// <summary>
+    /// Re-enables a previously-disabled plugin identified by <paramref name="pluginHandle"/>,
+    /// retrying its <c>StartUp()</c>, and returns its updated summary.
+    /// </summary>
+    PluginSummary TryEnablePlugin(object pluginHandle);
 }

--- a/Tools/Gum.Presentation/Plugins/PluginSummary.cs
+++ b/Tools/Gum.Presentation/Plugins/PluginSummary.cs
@@ -1,0 +1,11 @@
+namespace Gum.Plugins;
+
+/// <summary>
+/// Read-only snapshot of a loaded plugin, used by the "Manage Plugins" dialog
+/// (<c>PluginsDialogViewModel</c>). <see cref="PluginHandle"/> is an opaque token — pass it back
+/// into <see cref="IPluginManager.DisableUserPlugin"/> / <see cref="IPluginManager.TryEnablePlugin"/>
+/// to act on this plugin. It is typed as <see cref="object"/> (the concrete PluginManager casts it
+/// back to its own container type) because the real plugin container type lives in the tool-only
+/// Gum.csproj, which this headless Gum.Presentation assembly cannot reference.
+/// </summary>
+public record PluginSummary(string Name, string DisplayText, bool IsEnabled, bool HasFailureDetails, object PluginHandle);


### PR DESCRIPTION
Part of #3754.

Moves `PluginsDialogViewModel`/`PluginItemViewModel` (the "Manage Plugins" dialog) out of `Gum.csproj` into the headless `Gum.Presentation` assembly (ADR-0005).

## What changed
- `PluginsDialogViewModel`/`PluginItemViewModel` called the concrete `PluginManager`'s static `AllPluginContainers`/`ShutDownPlugin`/`ReenablePlugin` members directly, which blocked the move.
- Widened `IPluginManager` with `GetAllPluginSummaries()`, `DisableUserPlugin(object)`, `TryEnablePlugin(object)`, backed by new instance methods on the concrete `PluginManager` (the static methods stay, for `PluginManager`'s own internal use).
- `PluginContainer`/`IPlugin` live in the tool-only `Gum.csproj`, which `Gum.Presentation` cannot reference, so plugin identity crosses the interface as an opaque `object` handle wrapped in a new `PluginSummary` record (`Name`, `DisplayText`, `IsEnabled`, `HasFailureDetails`, `PluginHandle`) - same pattern already used by `FillWithErrors`/`TreeNodeSelected`.
- Moved the VM to `Tools/Gum.Presentation/Dialogs/PluginsDialogViewModel.cs`. The View (`PluginsDialogView`) stays in `Gum.csproj`, now paired via `[Dialog(typeof(PluginsDialogViewModel))]` since naming-convention resolution only works within a single assembly.
- Updated `DialogViewResolverTests`: swapped the "co-located in one assembly" pin from `PluginsDialogViewModel` to `ThemingDialogViewModel` (still tool-only) and added a cross-assembly pin for `PluginsDialogViewModel` -> `PluginsDialogView`.
- Added `PluginsDialogViewModelTests` (`Gum.Presentation.Tests`) covering the enable/disable flow, including the "crashed plugin" re-enable confirmation prompt.
- Appended one gotcha to `Direction/ui-decoupling-plan.md`'s Known Gotchas list (interface widening via opaque-object DTO when the natural return type is tool-only).

## Test plan
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` - 1038 passed, 0 failed.
- `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` - 161 passed, 0 failed.
- `dotnet build GumFull.sln` - 0 errors, no new warnings.
