### PR TITLE
Consolidate Phase 3 gotchas into ui-decoupling-plan.md, tighten ratchet baselines

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -29,6 +29,7 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 
 - Always use **Shouldly** — never xUnit `Assert`. Alphabetize test methods within a class.
 - Disable parallel execution in every test project (`[assembly: CollectionBehavior(DisableTestParallelization = true)]`) — Gum uses global singletons.
+- A test asserting on an absolute path must not use a Windows-style `"C:\..."` literal — `Path.IsPathRooted` doesn't recognize a drive letter as rooted on Unix, so macOS/Linux CI treats it as relative and silently prepends the runner's real working directory, corrupting the path. Use a leading-slash literal (e.g. `"/game/Content/"`) instead — rooted on both platforms.
 - Use named parameters for boolean literals.
 
 ## Test at production defaults

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -140,6 +140,34 @@ changelog — update this list when a *new kind* of gotcha is discovered, not fo
   drain, just triggered by a field whose *declared* type already looked headless-safe. Grep for
   `new ConcreteType(` inside a VM's own constructor, not just its field types, when auditing a
   move.
+- **A VM's only obvious blocker (e.g. a `DispatcherTimer`) can mask a second, easy-to-miss one: a
+  direct reference to a runtime-backend-only type** (`RenderingLibrary.Graphics.Renderer`,
+  `SystemManagers`, or similar `Microsoft.Xna.Framework.*` symbols), which is XNALIKE-only and
+  unreachable from the headless net8.0 assembly the same way a WPF type is. Grep the whole VM for
+  `RenderingLibrary`/`Renderer`/`SystemManagers`/XNA symbols before assuming the fix is mechanical
+  — this needs a render-diagnostics port designed, not a relocation. Conversely, an XNA-namespace
+  `using` isn't always load-bearing; verify it's actually referenced before assuming it's a blocker.
+- **Searching for a leaked interface's consumers must not be scoped to `Gum/`.** Top-level folders
+  like `Tool/EditorTabPlugin_XNA/` have their own consumers of tool-wide interfaces
+  (`IProjectManager`, etc.) that a `Gum/`-only grep silently misses, understating the narrowing
+  work and risking a missed call site.
+- **A controller's methods can be `internal` because caller and callee used to share an assembly.**
+  Once the caller (a VM) moves to `Gum.Presentation`, those members need bumping to `public` even
+  though the controller itself doesn't move — the same accessibility-bump cost as injecting an
+  `internal` dependency, just triggered by the *VM* leaving rather than a *dependency* arriving.
+- **Moving a `DialogViewModel` that resolves via naming-convention (no `[Dialog]` attribute) can
+  silently drop `DialogViewResolverTests`' coverage of that resolution path** if it was the last
+  production example still using it. Before swapping such a VM's pin to the cross-assembly fallback
+  pattern, check whether another same-assembly VM/View pair still exercises the naming-convention
+  branch; if not, add a synthetic pair to the test so that path stays covered.
+- **A VM going headless doesn't automatically catch extension methods that operate on it and still
+  live WPF-side.** When narrowing a dependency closure, check for extension methods keyed off the
+  moved type (e.g. an `IDialogServiceExt`-style `Show<T>` helper), not just the type's own members.
+- **An interface can be "mostly" headless-clean with one bad method mixed in.** `IEditVariableService`
+  had 3 clean members plus one (`TryAddEditVariableOptions`) typed against `WpfDataUi.DataTypes
+  .InstanceMember` (a `net8.0-windows`/WPF-only library). Split the interface rather than block the
+  whole move: the clean members go to `Gum.Presentation`, the WPF-typed one moves to a new
+  tool-only sibling interface implemented by the same concrete class.
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
 - *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated

--- a/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
@@ -47,8 +47,11 @@ public class UiDecouplingRatchetTests
         // Dropped from 339 to 327: ElementAnimationsViewModel, SubAnimationSelectionDialogViewModel,
         // and their newly-relocated dependency interfaces (IAnimationCollectionViewModelManager,
         // IRenameManager, IAnimationFilePathService, NameValidator) moved to Gum.Presentation,
-        // taking their .Self call sites out of the Gum/ scan (issue #3754).
-        const int Baseline = 327;
+        // taking their .Self call sites out of the Gum/ scan (issue #3754). Dropped further, from
+        // 327 to 323: BehaviorsViewModel, AlignmentViewModel, CodeWindowViewModel,
+        // MainControlViewModel (VariableGrid and TextureCoordinateSelectionPlugin), and their
+        // relocated dependency interfaces moved to Gum.Presentation.
+        const int Baseline = 323;
 
         var pattern = new Regex(@"\.Self\b");
         int count = SourceFiles().Sum(f => pattern.Matches(File.ReadAllText(f)).Count);
@@ -71,8 +74,14 @@ public class UiDecouplingRatchetTests
         // bool per ADR-0004) and SearchItemViewModel moved to Gum.Presentation (dropped a dead
         // System.Windows.Media.Imaging using); PerformanceViewModel stayed in Gum.csproj (it reads
         // the XNALIKE-only RenderingLibrary.Graphics.Renderer, not movable to the headless assembly)
-        // but lost its own DispatcherTimer coupling via the same IUiTimer seam (issue #3754).
-        const int Baseline = 21;
+        // but lost its own DispatcherTimer coupling via the same IUiTimer seam (issue #3754). Dropped
+        // further, from 21 to 8: ThemingDialogViewModel, ImportFromGumxViewModel, ImportBaseDialogViewModel
+        // (+ its 3 subclasses), MainControlViewModel (VariableGrid and TextureCoordinateSelectionPlugin)
+        // moved to Gum.Presentation, each converting its Visibility/Color/Brush properties to neutral
+        // types. The remaining 8 are ContextMenuItemViewModelExtensions.cs (a WPF-only MenuItem builder,
+        // correctly still tool-side) plus MainWindowViewModel/MainPanelViewModel, which model WPF
+        // window/panel chrome directly and are Phase 4b territory, not Phase 3 candidates.
+        const int Baseline = 8;
 
         var pattern = new Regex(@"System\.Windows");
         int count = SourceFiles()


### PR DESCRIPTION
## Summary

Consolidates the durable gotchas reported by the two waves of parallel VM-migration agents (PRs #3788-3796) into `Direction/ui-decoupling-plan.md`'s Known Gotchas list, and tightens `UiDecouplingRatchetTests`' baselines to the current measured counts:
- `SelfStaticReferenceCount`: 327 -> 323
- `SystemWindowsUsageInViewModels`: 21 -> 8

Also adds a general cross-platform absolute-path test-literal gotcha to the `gum-unit-tests` skill instead of the decoupling doc — it's a testing concern, not WPF-decoupling strategy, and bit two separate PRs this session (macOS CI treats a Windows-style `"C:\..."` literal as relative).

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 1016 passed (incl. all 4 `UiDecouplingRatchetTests` with tightened baselines)
- [x] `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` — 245 passed

Manual test: not needed — docs and test-baseline constants only, no production code touched.

FRB canary: not needed — no FRB1-shared source touched.

Part of #3754
