### PR TITLE
Split IExposeVariableService into Gum.Presentation

### DIFF
--- a/Gum/Services/ExposeVariableService.cs
+++ b/Gum/Services/ExposeVariableService.cs
@@ -1,4 +1,3 @@
-using CommonFormsAndControls;
 using Gum.DataTypes.Variables;
 using Gum.DataTypes;
 using Gum.Logic;
@@ -6,40 +5,12 @@ using Gum.Managers;
 using Gum.Plugins;
 using Gum.ToolStates;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 using Gum.Commands;
 using Gum.Services.Dialogs;
 using Gum.Undo;
 using ToolsUtilities;
-using DialogResult = System.Windows.Forms.DialogResult;
 
 namespace Gum.Services;
-
-#region IExposeVariableService Interface
-
-public interface IExposeVariableService
-{
-    /// <summary>
-    /// Exposes a single instance variable, prompting the user for the exposed name via a dialog. Used by the
-    /// standalone "Expose Variable" row context menu.
-    /// </summary>
-    OptionallyAttemptedGeneralResponse<VariableSave> HandleExposeVariableClick(InstanceSave instanceSave, string rootVariableName);
-
-    /// <summary>
-    /// Exposes a single instance variable under a caller-supplied name, without prompting. Used by callers that
-    /// already determined the exposed name (e.g. the composite color swatch's single-prompt expose, which derives
-    /// every channel's name from one shared base name).
-    /// </summary>
-    OptionallyAttemptedGeneralResponse<VariableSave> ExposeVariable(InstanceSave instanceSave, string rootVariableName, string exposedName);
-
-    void HandleUnexposeVariableClick(VariableSave variableSave, ElementSave elementSave);
-}
-
-#endregion
 
 internal class ExposeVariableService : IExposeVariableService
 {

--- a/Tools/Gum.Presentation/Services/IExposeVariableService.cs
+++ b/Tools/Gum.Presentation/Services/IExposeVariableService.cs
@@ -1,0 +1,23 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using ToolsUtilities;
+
+namespace Gum.Services;
+
+public interface IExposeVariableService
+{
+    /// <summary>
+    /// Exposes a single instance variable, prompting the user for the exposed name via a dialog. Used by the
+    /// standalone "Expose Variable" row context menu.
+    /// </summary>
+    OptionallyAttemptedGeneralResponse<VariableSave> HandleExposeVariableClick(InstanceSave instanceSave, string rootVariableName);
+
+    /// <summary>
+    /// Exposes a single instance variable under a caller-supplied name, without prompting. Used by callers that
+    /// already determined the exposed name (e.g. the composite color swatch's single-prompt expose, which derives
+    /// every channel's name from one shared base name).
+    /// </summary>
+    OptionallyAttemptedGeneralResponse<VariableSave> ExposeVariable(InstanceSave instanceSave, string rootVariableName, string exposedName);
+
+    void HandleUnexposeVariableClick(VariableSave variableSave, ElementSave elementSave);
+}


### PR DESCRIPTION
Part of #3754.

Splits `IExposeVariableService` out of `Gum/Services/ExposeVariableService.cs` (which combined the interface and its WPF/WinForms-coupled implementation in one file) into its own file, `Tools/Gum.Presentation/Services/IExposeVariableService.cs`.

- `ExposeVariableService` (the concrete class) stays tool-side.
- The interface's own types (`OptionallyAttemptedGeneralResponse<T>`, `InstanceSave`, `ElementSave`, `VariableSave`) are already headless-safe.
- Boyscout: dropped `CommonFormsAndControls`/`System.Windows.Forms`/the `DialogResult` alias and three other `System.*` usings that were unused in the remaining class-only file.

## Test plan
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` -- 1016 passed, 0 failed (includes `UiDecouplingRatchetTests`, unchanged).
- `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` -- 245 passed, 0 failed.
- `dotnet build GumFull.sln` -- 0 errors, no new warnings.

Manual test: not needed -- pure interface relocation + dead-using cleanup, no behavior change.
