### PR TITLE
Skip rename confirmation when element name is unchanged

### DIFF
--- a/Tests/Gum.Presentation.Tests/RenameElementDialogViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/RenameElementDialogViewModelTests.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -24,6 +25,28 @@ public class RenameElementDialogViewModelTests : BaseTestClass
         _nameVerifier = new Mock<INameVerifier>();
 
         _viewModel = new RenameElementDialogViewModel(_setVariableLogic.Object, _nameVerifier.Object);
+    }
+
+    [Fact]
+    public void OnAffirmative_ShouldNotChangeName_WhenNewNameMatchesOldName()
+    {
+        _viewModel.ElementSave = new ComponentSave
+        {
+            Name = "Folder/SameName"
+        };
+        _viewModel.Value = "SameName";
+
+        _viewModel.OnAffirmative();
+
+        _setVariableLogic.Verify(x => x.PropertyValueChanged(
+            It.IsAny<string>(),
+            It.IsAny<object>(),
+            It.IsAny<InstanceSave>(),
+            It.IsAny<StateSave>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>()), Times.Never);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Dialogs/RenameElementDialogViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/RenameElementDialogViewModel.cs
@@ -55,17 +55,20 @@ public class RenameElementDialogViewModel : GetUserStringDialogBaseViewModel
         
         string? oldName = ElementSave?.Name;
         string newName = Prefix + Value;
-        
-        ElementSave.Name = newName;
-        
-        _setVariableLogic.PropertyValueChanged("Name",
-            oldName,
-            null,
-            ElementSave.DefaultState,
-            refresh: true,
-            recordUndo: true,
-            trySave: true);
-        
+
+        if (newName != oldName)
+        {
+            ElementSave.Name = newName;
+
+            _setVariableLogic.PropertyValueChanged("Name",
+                oldName,
+                null,
+                ElementSave.DefaultState,
+                refresh: true,
+                recordUndo: true,
+                trySave: true);
+        }
+
         base.OnAffirmative();
     }
 


### PR DESCRIPTION
Closes #3779

`RenameElementDialogViewModel.OnAffirmative` ran the full rename pipeline (including the "may break references" confirmation) even when the new name equaled the old one. Now it short-circuits when `newName == oldName`.

## Test plan
- Added `OnAffirmative_ShouldNotChangeName_WhenNewNameMatchesOldName`, confirmed red before the fix, green after.
- Full `Gum.Presentation.Tests` suite green (251/251).
- `dotnet build GumFull.sln` clean.