### PR TITLE
Bump coverlet.collector 6.0.0 -> 6.0.4 in test projects

### DIFF
--- a/MonoGameGum.Tests/MonoGameGum.Tests.csproj
+++ b/MonoGameGum.Tests/MonoGameGum.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-	  <PackageReference Include="coverlet.collector" Version="6.0.0" />
+	  <PackageReference Include="coverlet.collector" Version="6.0.4" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	  <PackageReference Include="Moq" Version="4.20.72" />
 	  <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
+++ b/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
+++ b/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/Tests/MonoGameFum.FromFile.Tests/MonoGameFum.FromFile.Tests.csproj
+++ b/Tests/MonoGameFum.FromFile.Tests/MonoGameFum.FromFile.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj
+++ b/Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj
+++ b/Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/MonoGameGum.Tests.V3/MonoGameGum.Tests.V3.csproj
+++ b/Tests/MonoGameGum.Tests.V3/MonoGameGum.Tests.V3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/Tests/MonoGameGum.TestsCommon/MonoGameGum.TestsCommon.csproj
+++ b/Tests/MonoGameGum.TestsCommon/MonoGameGum.TestsCommon.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 	  <PackageReference Include="Moq" Version="4.20.72" />
 	  <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/SilkNetGum.Tests/SilkNetGum.Tests.csproj
+++ b/Tests/SilkNetGum.Tests/SilkNetGum.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
+++ b/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="coverlet.collector" Version="6.0.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Tests/SokolGum.Tests/SokolGum.Tests.csproj
+++ b/Tests/SokolGum.Tests/SokolGum.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
Closes #3750

Bumps `coverlet.collector` from 6.0.0 to 6.0.4 in the 13 test csproj files still on 6.0.0. Silences nothing (coverlet still bundles Newtonsoft.Json), but moves to the latest patch as suggested in the issue. `AutomatedTests`/`GumToolUnitTests`/`dotnet-serve.Tests` were already on 6.0.2/6.0.4 and left untouched.

## Test plan
- [x] Restored all 12 buildable affected projects (SokolGum.Tests skipped — submodule not initialized locally, unrelated to this change)
- [x] `dotnet test MonoGameGum.Tests` — 1884 passed