### PR TITLE
Fix mouse back/forward buttons: stop tree-view mis-select, add selection history navigation

### DIFF
--- a/Gum.sln
+++ b/Gum.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.0.11012.119
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum", "Gum\Gum.csproj", "{44575902-06A3-424F-A94C-4B7B8EC3ED2C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XnaAndWinforms", "XnaAndWinforms\XnaAndWinforms.csproj", "{C39A973C-66D6-4A6C-82B5-AE0042F210F8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputLibrary", "InputLibrary\InputLibrary.csproj", "{938D9A00-8529-4CE8-9077-E0A3994A73EA}"
@@ -34,8 +36,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E9BDDA50-D0CD-4172-959F-66E2C1DFEB50}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum", "Gum\Gum.csproj", "{44575902-06A3-424F-A94C-4B7B8EC3ED2C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfDataUi", "WpfDataUi\WpfDataUi.csproj", "{7261EDF9-108A-4563-8B73-6B72DED72AE9}"
 EndProject

--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -120,6 +120,13 @@ namespace CommonFormsAndControls
         /// </summary>
         public event Action<Exception>? UnhandledException;
 
+        /// <summary>
+        /// Raised on a mouse "back"/"forward" side-button press over the tree, independent of
+        /// node selection (unlike Left/Right, these buttons never select the hovered node).
+        /// </summary>
+        public event EventHandler? NavigateBackRequested;
+        public event EventHandler? NavigateForwardRequested;
+
         #endregion
 
         #region Event Methods  
@@ -153,18 +160,45 @@ namespace CommonFormsAndControls
 
         private TreeNode? GetNodeAtRowY(int y)
         {
-            // pick a safe X inside the client & left of label area  
-            // (1 px from client-left is usually fine)  
+            // pick a safe X inside the client & left of label area
+            // (1 px from client-left is usually fine)
             return GetNodeAt(1, y);
+        }
+
+        /// <summary>
+        /// Whether releasing <paramref name="button"/> over <paramref name="node"/> should select it.
+        /// Only the left button selects - a mouse "back"/"forward" (or middle) release over a node
+        /// must not be treated as a click on that node.
+        /// </summary>
+        private bool ShouldSelectOnMouseUp(TreeNode node, MouseButtons button)
+        {
+            return (EffectiveModifiers() == Keys.None && MultiSelectBehavior != MultiSelectBehavior.RegularClick) &&
+                   ((mSelectedNodes.Count > 1 && mSelectedNodes.Contains(node)) || IsSelectingOnPush == false) &&
+                   button == MouseButtons.Left;
         }
 
         protected override void OnMouseDown(MouseEventArgs e)
         {
-            // If the user clicks on a node that was not  
-            // previously selected, select it now.  
-            //			BeginUpdate();  
+            // Mouse "back"/"forward" side buttons are navigation, not selection - handle them
+            // independent of the node-selection logic below and don't let them touch it.
+            if (e.Button == MouseButtons.XButton1)
+            {
+                NavigateBackRequested?.Invoke(this, EventArgs.Empty);
+                base.OnMouseDown(e);
+                return;
+            }
+            if (e.Button == MouseButtons.XButton2)
+            {
+                NavigateForwardRequested?.Invoke(this, EventArgs.Empty);
+                base.OnMouseDown(e);
+                return;
+            }
+
+            // If the user clicks on a node that was not
+            // previously selected, select it now.
+            //			BeginUpdate();
 #if !DEBUG
-            try  
+            try
 #endif
             {
                 base.SelectedNode = null;
@@ -240,14 +274,11 @@ namespace CommonFormsAndControls
                     return;
                 }
 
-                // Check to see if a node was clicked on 
+                // Check to see if a node was clicked on
                 var node = this.GetNodeAtRowY(e.Location.Y);
                 if (node != null)
                 {
-                    var shouldSelect =
-                        (EffectiveModifiers() == Keys.None && MultiSelectBehavior != MultiSelectBehavior.RegularClick) &&
-                        ((mSelectedNodes.Count > 1 && mSelectedNodes.Contains(node)) || IsSelectingOnPush == false) &&
-                        e.Button != MouseButtons.Right;
+                    var shouldSelect = ShouldSelectOnMouseUp(node, e.Button);
 
                     if (shouldSelect)
                     {

--- a/Gum/MainWindow.xaml.cs
+++ b/Gum/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using Gum.Commands;
 using Gum.Input;
 using Gum.Dialogs;
 using Gum.Managers;
+using Gum.SelectionHistory;
 using Gum.Settings;
 using Gum.ViewModels;
 using System;
@@ -32,18 +33,21 @@ public enum TabLocation
 public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindowMessage>
 {
     private readonly IMessenger _messenger;
+    private readonly ISelectionHistory _selectionHistory;
 
     public MainWindow(
         MainWindowViewModel mainWindowViewModel,
         MenuStripManager menuStripManager,
         IMessenger messenger,
         IHotkeyManager hotkeyManager,
+        ISelectionHistory selectionHistory,
         IWritableOptions<LayoutSettings> layoutSettings
         )
     {
         DataContext = mainWindowViewModel;
 
         _messenger = messenger;
+        _selectionHistory = selectionHistory;
         messenger.RegisterAll(this);
 
         InitializeComponent();
@@ -64,6 +68,23 @@ public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindow
 
     private void OnPreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
+        // Mouse "back"/"forward" side buttons, over any plain-WPF surface (menus, variable
+        // grid, dialogs, etc.). WinForms-hosted surfaces (tree view, wireframe canvas) never
+        // reach here - raw XButton messages go straight to whichever native window is under
+        // the cursor and don't bubble - so those wire up independently.
+        if (e.ChangedButton == MouseButton.XButton1)
+        {
+            _selectionHistory.NavigateBack();
+            e.Handled = true;
+            return;
+        }
+        if (e.ChangedButton == MouseButton.XButton2)
+        {
+            _selectionHistory.NavigateForward();
+            e.Handled = true;
+            return;
+        }
+
         // When a WinForms control (e.g. the editor) has focus, WPF reports
         // Keyboard.FocusedElement as null. If the user clicks on a WPF element
         // that is not inside a WindowsFormsHost, pull focus back to WPF so that

--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -16,6 +16,7 @@ using System;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
+using Gum.SelectionHistory;
 using Gum.Undo;
 using KeyEventArgs = System.Windows.Forms.KeyEventArgs;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -70,6 +71,9 @@ public class HotkeyManager : IHotkeyManager
 
     public KeyCombination Rename { get; private set; } = KeyCombination.Pressed(GumKey.F2);
 
+    public KeyCombination NavigateBack { get; private set; } = KeyCombination.Alt(GumKey.Left);
+    public KeyCombination NavigateForward { get; private set; } = KeyCombination.Alt(GumKey.Right);
+
     // If adding any new keys here, modify HotkeyViewModel
 
 
@@ -85,6 +89,7 @@ public class HotkeyManager : IHotkeyManager
     private readonly IEditCommands _editCommands;
     private readonly IReorderLogic _reorderLogic;
     private readonly IPluginManager _pluginManager;
+    private readonly ISelectionHistory _selectionHistory;
 
 
     public HotkeyManager(IGuiCommands guiCommands,
@@ -98,7 +103,8 @@ public class HotkeyManager : IHotkeyManager
         IUndoManager undoManager,
         IEditCommands editCommands,
         IReorderLogic reorderLogic,
-        IPluginManager pluginManager)
+        IPluginManager pluginManager,
+        ISelectionHistory selectionHistory)
     {
         _copyPasteLogic = copyPasteLogic;
         _guiCommands = guiCommands;
@@ -112,6 +118,7 @@ public class HotkeyManager : IHotkeyManager
         _editCommands = editCommands;
         _reorderLogic = reorderLogic;
         _pluginManager = pluginManager;
+        _selectionHistory = selectionHistory;
     }
 
     public bool IsPressedInControl(KeyCombination combo)
@@ -145,6 +152,8 @@ public class HotkeyManager : IHotkeyManager
             _ when Search.IsPressed(e)  => _guiCommands.FocusSearch,
             _ when RedoAlt.IsPressed(e) || Redo.IsPressed(e) => _undoManager.PerformRedo,
             _ when Undo.IsPressed(e) => _undoManager.PerformUndo,
+            _ when NavigateBack.IsPressed(e) => _selectionHistory.NavigateBack,
+            _ when NavigateForward.IsPressed(e) => _selectionHistory.NavigateForward,
             _ when ZoomDirection() is { } dir && enableEntireAppZoom => () => _uiSettingsService.BaseFontSize += dir,
             _ => null
         };

--- a/Gum/Plugins/InternalPlugins/SelectionHistory/MainSelectionHistoryPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/SelectionHistory/MainSelectionHistoryPlugin.cs
@@ -1,0 +1,40 @@
+using Gum.DataTypes;
+using Gum.Plugins.BaseClasses;
+using Gum.SelectionHistory;
+using System.ComponentModel.Composition;
+
+namespace Gum.Plugins.InternalPlugins.SelectionHistory;
+
+/// <summary>
+/// Feeds every real element/instance selection into <see cref="ISelectionHistory"/> so the
+/// mouse Back/Forward buttons (wired in ElementTreeViewManager and MainWindow) have a stack
+/// to navigate. Recording is the plugin's only job - the stack and navigation logic live in
+/// SelectionHistoryService, which is independently unit tested.
+/// </summary>
+[Export(typeof(PluginBase))]
+internal class MainSelectionHistoryPlugin : PriorityPlugin
+{
+    private readonly ISelectionHistory _selectionHistory;
+
+    [ImportingConstructor]
+    public MainSelectionHistoryPlugin(ISelectionHistory selectionHistory)
+    {
+        _selectionHistory = selectionHistory;
+    }
+
+    public override void StartUp()
+    {
+        this.InstanceSelected += HandleInstanceSelected;
+        this.ElementSelected += HandleElementSelected;
+    }
+
+    private void HandleInstanceSelected(ElementSave element, InstanceSave instance)
+    {
+        _selectionHistory.RecordSelection(element, instance);
+    }
+
+    private void HandleElementSelected(ElementSave? element)
+    {
+        _selectionHistory.RecordSelection(element, null);
+    }
+}

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -13,6 +13,7 @@ using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.Plugins.InternalPlugins.TreeView.ViewModels;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
+using Gum.SelectionHistory;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
@@ -143,6 +144,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly ITabManager _tabManager;
     private readonly ICircularReferenceManager _circularReferenceManager;
     private readonly IFavoriteComponentManager _favoriteComponentManager;
+    private readonly ISelectionHistory _selectionHistory;
     private readonly ElementTreeViewCreator _viewCreator;
 
     public const int TransparentImageIndex = 0;
@@ -409,6 +411,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         ISetVariableLogic setVariableLogic,
         ICircularReferenceManager circularReferenceManager,
         IFavoriteComponentManager favoriteComponentManager,
+        ISelectionHistory selectionHistory,
         IProjectState projectState,
         StandardElementsManagerGumTool standardElementsManagerGumTool,
         IDragDropManager dragDropManager,
@@ -434,6 +437,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _setVariableLogic = setVariableLogic;
         _circularReferenceManager = circularReferenceManager;
         _favoriteComponentManager = favoriteComponentManager;
+        _selectionHistory = selectionHistory;
         _projectState = projectState;
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
         _pluginManager = pluginManager;
@@ -805,6 +809,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         ObjectTreeView.AfterExpand += (_, _) => _collapseToggleService.OnNodeManuallyChanged();
         ObjectTreeView.AfterCollapse += (_, _) => _collapseToggleService.OnNodeManuallyChanged();
         ObjectTreeView.UnhandledException += ex => _dialogService.ShowMessage(ex.Message);
+        ObjectTreeView.NavigateBackRequested += (_, _) => _selectionHistory.NavigateBack();
+        ObjectTreeView.NavigateForwardRequested += (_, _) => _selectionHistory.NavigateForward();
 
         ConfigureStandardsPalette();
 

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -29,6 +29,7 @@ using Gum.Commands;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Dialogs;
 using Gum.Services.Dialogs;
+using Gum.SelectionHistory;
 using Gum.Undo;
 using Gum.Localization;
 using Gum.Services.Fonts;
@@ -846,6 +847,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             batch.AddExportedValue<ISelectedState>(Locator.GetRequiredService<ISelectedState>());
             batch.AddExportedValue<IElementCommands>(Locator.GetRequiredService<IElementCommands>());
             batch.AddExportedValue<IUndoManager>(Locator.GetRequiredService<IUndoManager>());
+            batch.AddExportedValue<ISelectionHistory>(Locator.GetRequiredService<ISelectionHistory>());
             batch.AddExportedValue<IProjectManager>(Locator.GetRequiredService<IProjectManager>());
 
             // Shared services consumed by PluginBase (via property imports) and by individual

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -8,6 +8,7 @@ using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.ToolCommands;
 using Gum.ToolStates;
+using Gum.SelectionHistory;
 using Gum.Undo;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -175,6 +176,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<ISelectedState, SelectedState>();
         services.AddSingleton<INameVerifier, NameVerifier>();
         services.AddSingleton<IUndoManager, UndoManager>();
+        services.AddSingleton<ISelectionHistory, SelectionHistoryService>();
         // Late-bound seam for folding animation edits into the element undo snapshot (#3406). The relay
         // is what UndoManager/ElementUndoStrategy receive at construction; the animation plugin registers
         // itself as the real provider in its StartUp (via IAnimationUndoProviderRegistrar, bridged into

--- a/Tests/Gum.Presentation.Tests/SelectionHistoryTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectionHistoryTests.cs
@@ -1,0 +1,137 @@
+using Gum.DataTypes;
+using Gum.SelectionHistory;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+public class SelectionHistoryTests : BaseTestClass
+{
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly SelectionHistoryService _selectionHistory;
+
+    public SelectionHistoryTests()
+    {
+        _selectedState = new Mock<ISelectedState>();
+        _selectionHistory = new SelectionHistoryService(_selectedState.Object);
+    }
+
+    [Fact]
+    public void CanNavigateBack_WhenNoHistory_IsFalse()
+    {
+        _selectionHistory.CanNavigateBack.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NavigateBack_WhenNoHistory_DoesNotChangeSelectedState()
+    {
+        _selectionHistory.NavigateBack();
+
+        _selectedState.VerifySet(x => x.SelectedInstance = It.IsAny<InstanceSave>(), Times.Never);
+        _selectedState.VerifySet(x => x.SelectedElement = It.IsAny<ElementSave>(), Times.Never);
+    }
+
+    [Fact]
+    public void NavigateBack_AfterTwoInstanceSelections_RestoresThePreviousInstance()
+    {
+        var elementA = new ScreenSave { Name = "ScreenA" };
+        var instanceA = new InstanceSave { Name = "InstanceA" };
+        var elementB = new ScreenSave { Name = "ScreenB" };
+        var instanceB = new InstanceSave { Name = "InstanceB" };
+
+        _selectionHistory.RecordSelection(elementA, instanceA);
+        _selectionHistory.RecordSelection(elementB, instanceB);
+
+        _selectionHistory.NavigateBack();
+
+        _selectedState.VerifySet(x => x.SelectedInstance = instanceA, Times.Once);
+    }
+
+    [Fact]
+    public void NavigateBack_ThenNavigateForward_RestoresTheLaterSelection()
+    {
+        var instanceA = new InstanceSave { Name = "InstanceA" };
+        var instanceB = new InstanceSave { Name = "InstanceB" };
+        var instanceC = new InstanceSave { Name = "InstanceC" };
+
+        _selectionHistory.RecordSelection(null, instanceA);
+        _selectionHistory.RecordSelection(null, instanceB);
+        _selectionHistory.RecordSelection(null, instanceC);
+
+        _selectionHistory.NavigateBack();
+        _selectionHistory.NavigateBack();
+        _selectionHistory.NavigateForward();
+
+        // Set once by the first NavigateBack (C -> B) and again by the final NavigateForward (A -> B).
+        _selectedState.VerifySet(x => x.SelectedInstance = instanceB, Times.Exactly(2));
+    }
+
+    [Fact]
+    public void NavigateBack_ElementOnlySelection_RestoresSelectedElementNotInstance()
+    {
+        var elementA = new ScreenSave { Name = "ScreenA" };
+        var elementB = new ScreenSave { Name = "ScreenB" };
+        var instanceB = new InstanceSave { Name = "InstanceB" };
+
+        _selectionHistory.RecordSelection(elementA, null);
+        _selectionHistory.RecordSelection(elementB, instanceB);
+
+        _selectionHistory.NavigateBack();
+
+        _selectedState.VerifySet(x => x.SelectedElement = elementA, Times.Once);
+        _selectedState.VerifySet(x => x.SelectedInstance = It.IsAny<InstanceSave>(), Times.Never);
+    }
+
+    [Fact]
+    public void RecordSelection_SameAsCurrentEntry_DoesNotGrowHistory()
+    {
+        var instanceA = new InstanceSave { Name = "InstanceA" };
+        var elementA = new ScreenSave { Name = "ScreenA" };
+
+        _selectionHistory.RecordSelection(elementA, instanceA);
+        _selectionHistory.RecordSelection(elementA, instanceA);
+
+        _selectionHistory.CanNavigateBack.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NavigatingBackAndForward_DoesNotRecordNewHistoryOrTruncateForwardStack()
+    {
+        var instanceA = new InstanceSave { Name = "InstanceA" };
+        var instanceB = new InstanceSave { Name = "InstanceB" };
+        var instanceC = new InstanceSave { Name = "InstanceC" };
+
+        _selectionHistory.RecordSelection(null, instanceA);
+        _selectionHistory.RecordSelection(null, instanceB);
+        _selectionHistory.RecordSelection(null, instanceC);
+
+        _selectionHistory.NavigateBack();
+
+        _selectionHistory.CanNavigateBack.ShouldBeTrue();
+        _selectionHistory.CanNavigateForward.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RecordSelection_AfterNavigatingBack_TruncatesForwardHistory()
+    {
+        var instanceA = new InstanceSave { Name = "InstanceA" };
+        var instanceB = new InstanceSave { Name = "InstanceB" };
+        var instanceC = new InstanceSave { Name = "InstanceC" };
+        var instanceD = new InstanceSave { Name = "InstanceD" };
+
+        _selectionHistory.RecordSelection(null, instanceA);
+        _selectionHistory.RecordSelection(null, instanceB);
+        _selectionHistory.RecordSelection(null, instanceC);
+
+        _selectionHistory.NavigateBack();
+        _selectionHistory.NavigateBack();
+
+        // A genuine new user selection made while parked mid-stack (at A).
+        _selectionHistory.RecordSelection(null, instanceD);
+
+        _selectionHistory.CanNavigateForward.ShouldBeFalse();
+        _selectionHistory.CanNavigateBack.ShouldBeTrue();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
@@ -1,0 +1,124 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Reflection;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class MultiSelectTreeViewNavigationTests : BaseTestClass
+{
+    private readonly MultiSelectTreeView _treeView;
+
+    public MultiSelectTreeViewNavigationTests()
+    {
+        _treeView = new MultiSelectTreeView
+        {
+            // Mirrors ElementTreeViewCreator's real configuration (ElementTreeViewCreator.cs),
+            // since the mis-select bug only reproduces under this combination.
+            IsSelectingOnPush = false,
+            MultiSelectBehavior = MultiSelectBehavior.CtrlDown
+        };
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _treeView.Dispose();
+    }
+
+    private static void RaiseMouseDown(MultiSelectTreeView treeView, MouseButtons button)
+    {
+        InvokeProtected(treeView, "OnMouseDown", new MouseEventArgs(button, 1, 1, 0, 0));
+    }
+
+    // Does not go through OnMouseUp's GetNodeAt hit-test, which requires a real native window
+    // handle - unsafe to force headlessly here (WinForms drag/drop registration needs an STA
+    // thread, which this test host does not guarantee, and forcing it crashed the test process).
+    private static bool InvokeShouldSelectOnMouseUp(MultiSelectTreeView treeView, TreeNode node, MouseButtons button)
+    {
+        MethodInfo? method = typeof(MultiSelectTreeView).GetMethod(
+            "ShouldSelectOnMouseUp", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.ShouldNotBeNull();
+        return (bool)method!.Invoke(treeView, new object[] { node, button })!;
+    }
+
+    private static void InvokeProtected(object target, string methodName, object arg)
+    {
+        MethodInfo? method = target.GetType().GetMethod(
+            methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        method.ShouldNotBeNull();
+        method!.Invoke(target, new[] { arg });
+    }
+
+    [Fact]
+    public void ShouldSelectOnMouseUp_XButton1_ReturnsFalse()
+    {
+        TreeNode node = new TreeNode("SomeNode");
+        _treeView.Nodes.Add(node);
+
+        InvokeShouldSelectOnMouseUp(_treeView, node, MouseButtons.XButton1).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelectOnMouseUp_XButton2_ReturnsFalse()
+    {
+        TreeNode node = new TreeNode("SomeNode");
+        _treeView.Nodes.Add(node);
+
+        InvokeShouldSelectOnMouseUp(_treeView, node, MouseButtons.XButton2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelectOnMouseUp_LeftButton_ReturnsTrue()
+    {
+        TreeNode node = new TreeNode("SomeNode");
+        _treeView.Nodes.Add(node);
+
+        InvokeShouldSelectOnMouseUp(_treeView, node, MouseButtons.Left).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldSelectOnMouseUp_RightButton_ReturnsFalse()
+    {
+        // Pins pre-existing behavior: right-click opens the context menu, it must not select.
+        TreeNode node = new TreeNode("SomeNode");
+        _treeView.Nodes.Add(node);
+
+        InvokeShouldSelectOnMouseUp(_treeView, node, MouseButtons.Right).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OnMouseDown_XButton1_RaisesNavigateBackRequested()
+    {
+        var raised = false;
+        _treeView.NavigateBackRequested += (_, _) => raised = true;
+
+        RaiseMouseDown(_treeView, MouseButtons.XButton1);
+
+        raised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OnMouseDown_XButton2_RaisesNavigateForwardRequested()
+    {
+        var raised = false;
+        _treeView.NavigateForwardRequested += (_, _) => raised = true;
+
+        RaiseMouseDown(_treeView, MouseButtons.XButton2);
+
+        raised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OnMouseDown_LeftButton_DoesNotRaiseNavigationEvents()
+    {
+        var raised = false;
+        _treeView.NavigateBackRequested += (_, _) => raised = true;
+        _treeView.NavigateForwardRequested += (_, _) => raised = true;
+
+        RaiseMouseDown(_treeView, MouseButtons.Left);
+
+        raised.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
@@ -1,6 +1,8 @@
 using CommonFormsAndControls;
 using Shouldly;
+using System;
 using System.Reflection;
+using System.Threading;
 using System.Windows.Forms;
 using Xunit;
 
@@ -30,6 +32,29 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
     private static void RaiseMouseDown(MultiSelectTreeView treeView, MouseButtons button)
     {
         InvokeProtected(treeView, "OnMouseDown", new MouseEventArgs(button, 1, 1, 0, 0));
+    }
+
+    /// <summary>
+    /// OnMouseDown calls base.OnMouseDown(e), which can force the native window handle to be
+    /// created (WinForms mouse-capture handling touches .Handle), requiring an STA thread the
+    /// same way TreeNode.Expand()/Collapse() do (see TreeViewStateServiceTests). xUnit's default
+    /// runner is MTA.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new TargetInvocationException(caught);
+        }
     }
 
     // Does not go through OnMouseUp's GetNodeAt hit-test, which requires a real native window
@@ -89,7 +114,7 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
     }
 
     [Fact]
-    public void OnMouseDown_XButton1_RaisesNavigateBackRequested()
+    public void OnMouseDown_XButton1_RaisesNavigateBackRequested() => RunOnSta(() =>
     {
         var raised = false;
         _treeView.NavigateBackRequested += (_, _) => raised = true;
@@ -97,10 +122,10 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.XButton1);
 
         raised.ShouldBeTrue();
-    }
+    });
 
     [Fact]
-    public void OnMouseDown_XButton2_RaisesNavigateForwardRequested()
+    public void OnMouseDown_XButton2_RaisesNavigateForwardRequested() => RunOnSta(() =>
     {
         var raised = false;
         _treeView.NavigateForwardRequested += (_, _) => raised = true;
@@ -108,10 +133,10 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.XButton2);
 
         raised.ShouldBeTrue();
-    }
+    });
 
     [Fact]
-    public void OnMouseDown_LeftButton_DoesNotRaiseNavigationEvents()
+    public void OnMouseDown_LeftButton_DoesNotRaiseNavigationEvents() => RunOnSta(() =>
     {
         var raised = false;
         _treeView.NavigateBackRequested += (_, _) => raised = true;
@@ -120,5 +145,5 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.Left);
 
         raised.ShouldBeFalse();
-    }
+    });
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -6,6 +6,7 @@ using Gum.Logic;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.SelectionHistory;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
@@ -30,6 +31,7 @@ public class HotkeyManagerTests : BaseTestClass
     private readonly Mock<IEditCommands> _editCommands;
     private readonly Mock<IReorderLogic> _reorderLogic;
     private readonly Mock<IPluginManager> _pluginManager;
+    private readonly Mock<ISelectionHistory> _selectionHistory;
     private readonly HotkeyManager _hotkeyManager;
 
     public HotkeyManagerTests()
@@ -46,6 +48,7 @@ public class HotkeyManagerTests : BaseTestClass
         _editCommands = new Mock<IEditCommands>();
         _reorderLogic = new Mock<IReorderLogic>();
         _pluginManager = new Mock<IPluginManager>();
+        _selectionHistory = new Mock<ISelectionHistory>();
 
         _hotkeyManager = new HotkeyManager(
             _guiCommands.Object,
@@ -59,7 +62,8 @@ public class HotkeyManagerTests : BaseTestClass
             _undoManager.Object,
             _editCommands.Object,
             _reorderLogic.Object,
-            _pluginManager.Object
+            _pluginManager.Object,
+            _selectionHistory.Object
         );
     }
 
@@ -161,6 +165,25 @@ public class HotkeyManagerTests : BaseTestClass
 
         handled.ShouldBeTrue();
         _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -5f), Times.Once);
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_NavigateBack_MatchesAltPlusLeft()
+    {
+        // NavigateBack is Alt+Left: matches only when both the Alt flag and the Left key code are present.
+        // (PreviewKeyDownAppWide's actual dispatch isn't unit-testable here - it constructs a real WPF
+        // KeyEventArgs via Keyboard.PrimaryDevice, which requires an STA thread this test host doesn't
+        // guarantee. Same pre-existing gap applies to Undo/Redo/Search; verified manually instead.)
+        _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Left).ShouldBeTrue();
+        _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Left).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_KeyData_NavigateForward_MatchesAltPlusRight()
+    {
+        // NavigateForward is Alt+Right: matches only when both the Alt flag and the Right key code are present.
+        _hotkeyManager.NavigateForward.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Right).ShouldBeTrue();
+        _hotkeyManager.NavigateForward.IsPressed(System.Windows.Forms.Keys.Right).ShouldBeFalse();
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/CollapseToggleServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/CollapseToggleServiceTests.cs
@@ -1,6 +1,8 @@
 using CommonFormsAndControls;
 using Gum.Plugins.InternalPlugins.TreeView;
 using Shouldly;
+using System;
+using System.Threading;
 using System.Windows.Forms;
 using Xunit;
 
@@ -21,6 +23,29 @@ public class CollapseToggleServiceTests : BaseTestClass
     {
         base.Dispose();
         _treeView?.Dispose();
+    }
+
+    /// <summary>
+    /// TreeNode.Expand()/Collapse() can force the underlying native window handle to be
+    /// created, which requires an STA thread (WinForms drag/drop registration in
+    /// OnHandleCreated throws otherwise); xUnit's default runner is MTA. Same pattern as
+    /// SliderDisplayRangeTests/NullableEnumComboBoxDisplayTests.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new System.Reflection.TargetInvocationException(caught);
+        }
     }
 
     private void SetupTreeWithExpandedNodes()
@@ -51,7 +76,7 @@ public class CollapseToggleServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void Clear_ShouldDiscardSavedState()
+    public void Clear_ShouldDiscardSavedState() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -66,10 +91,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - all collapsed because it re-captured, not restored
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void HandleCollapseAll_ShouldCaptureAndCollapse_OnFirstClick()
+    public void HandleCollapseAll_ShouldCaptureAndCollapse_OnFirstClick() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -80,10 +105,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void HandleCollapseAll_ShouldRecapture_WhenManualChangeOccurred()
+    public void HandleCollapseAll_ShouldRecapture_WhenManualChangeOccurred() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -100,10 +125,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - collapsed again (re-captured, not restored)
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void HandleCollapseAll_ShouldRestore_OnSecondClickWithoutManualChange()
+    public void HandleCollapseAll_ShouldRestore_OnSecondClickWithoutManualChange() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -122,10 +147,10 @@ public class CollapseToggleServiceTests : BaseTestClass
         // Assert - restored to original state
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    }
+    });
 
     [Fact]
-    public void HandleCollapseToElementLevel_ShouldRestore_OnSecondClick()
+    public void HandleCollapseToElementLevel_ShouldRestore_OnSecondClick() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -154,10 +179,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - Button node restored to expanded
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    }
+    });
 
     [Fact]
-    public void HandleDifferentButton_ShouldInvalidatePreviousSnapshot()
+    public void HandleDifferentButton_ShouldInvalidatePreviousSnapshot() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -195,10 +220,10 @@ public class CollapseToggleServiceTests : BaseTestClass
         // Assert - restored to state before element-level collapse
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    }
+    });
 
     [Fact]
-    public void OnNodeManuallyChanged_ShouldInvalidateSnapshot()
+    public void OnNodeManuallyChanged_ShouldInvalidateSnapshot() => RunOnSta(() =>
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -215,5 +240,5 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - collapsed because it re-captured instead of restoring
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeViewStateServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeViewStateServiceTests.cs
@@ -4,7 +4,9 @@ using Gum.Plugins.InternalPlugins.TreeView;
 using Gum.Settings;
 using Moq;
 using Shouldly;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
@@ -30,8 +32,31 @@ public class TreeViewStateServiceTests : BaseTestClass
         _treeView?.Dispose();
     }
 
+    /// <summary>
+    /// TreeNode.Expand()/Collapse() can force the underlying native window handle to be
+    /// created, which requires an STA thread (WinForms drag/drop registration in
+    /// OnHandleCreated throws otherwise); xUnit's default runner is MTA. Same pattern as
+    /// SliderDisplayRangeTests/NullableEnumComboBoxDisplayTests.
+    /// </summary>
+    private static void RunOnSta(Action action)
+    {
+        Exception? caught = null;
+        Thread thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { caught = ex; }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (caught != null)
+        {
+            throw new System.Reflection.TargetInvocationException(caught);
+        }
+    }
+
     [Fact]
-    public void CaptureAndSaveState_ShouldCaptureExpandedNodes()
+    public void CaptureAndSaveState_ShouldCaptureExpandedNodes() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -51,10 +76,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.ShouldNotBeNull();
         settings.TreeViewState.ExpandedNodes.Count.ShouldBe(1);
         settings.TreeViewState.ExpandedNodes.ShouldContain(rootNodeName);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_ShouldCaptureNestedExpandedNodes()
+    public void CaptureAndSaveState_ShouldCaptureNestedExpandedNodes() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -80,10 +105,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.Count.ShouldBe(2);
         settings.TreeViewState.ExpandedNodes.ShouldContain(expectedComponentsPath);
         settings.TreeViewState.ExpandedNodes.ShouldContain(expectedButtonsFolderPath);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_ShouldCreateTreeViewState_WhenNull()
+    public void CaptureAndSaveState_ShouldCreateTreeViewState_WhenNull() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = null };
@@ -99,10 +124,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         // Assert
         settings.TreeViewState.ShouldNotBeNull();
         settings.TreeViewState.ExpandedNodes.ShouldContain(rootNodeName);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_ShouldDoNothing_WhenCurrentSettingsIsNull()
+    public void CaptureAndSaveState_ShouldDoNothing_WhenCurrentSettingsIsNull() => RunOnSta(() =>
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Returns((UserProjectSettings?)null);
@@ -112,10 +137,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_ShouldDoNothing_WhenTreeViewIsNull()
+    public void CaptureAndSaveState_ShouldDoNothing_WhenTreeViewIsNull() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings();
@@ -126,10 +151,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_ShouldHandleError_Gracefully()
+    public void CaptureAndSaveState_ShouldHandleError_Gracefully() => RunOnSta(() =>
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Throws<System.Exception>();
@@ -142,10 +167,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _mockOutputManager.Verify(x => x.AddError(It.Is<string>(msg => msg.Contains("Error capturing tree view state"))), Times.Once);
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_WithCollapsedTree_ShouldReturnEmptyList()
+    public void CaptureAndSaveState_WithCollapsedTree_ShouldReturnEmptyList() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -160,10 +185,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         settings.TreeViewState.ExpandedNodes.ShouldBeEmpty();
-    }
+    });
 
     [Fact]
-    public void CaptureAndSaveState_WithMultipleRootNodes_ShouldCaptureAll()
+    public void CaptureAndSaveState_WithMultipleRootNodes_ShouldCaptureAll() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -189,10 +214,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.ShouldContain(componentsNodeName);
         settings.TreeViewState.ExpandedNodes.ShouldContain(screensNodeName);
         settings.TreeViewState.ExpandedNodes.ShouldNotContain(standardsNodeName);
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenCurrentSettingsIsNull()
+    public void LoadAndApplyState_ShouldDoNothing_WhenCurrentSettingsIsNull() => RunOnSta(() =>
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Returns((UserProjectSettings?)null);
@@ -203,10 +228,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw or expand nodes
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewIsNull()
+    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewIsNull() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings();
@@ -217,10 +242,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewStateIsNull()
+    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewStateIsNull() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = null };
@@ -232,10 +257,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldExpandCorrectNodes()
+    public void LoadAndApplyState_ShouldExpandCorrectNodes() => RunOnSta(() =>
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -263,10 +288,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();  // Components
         _treeView.Nodes[1].IsExpanded.ShouldBeTrue();  // Screens
         _treeView.Nodes[2].IsExpanded.ShouldBeFalse(); // Standards
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldExpandNestedNodes()
+    public void LoadAndApplyState_ShouldExpandNestedNodes() => RunOnSta(() =>
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -298,10 +323,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         componentsNode.IsExpanded.ShouldBeTrue();
         buttonsFolder.IsExpanded.ShouldBeTrue();
         primaryButton.IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldHandleError_Gracefully()
+    public void LoadAndApplyState_ShouldHandleError_Gracefully() => RunOnSta(() =>
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Throws<System.Exception>();
@@ -311,10 +336,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _mockOutputManager.Verify(x => x.AddError(It.Is<string>(msg => msg.Contains("Error applying tree view state"))), Times.Once);
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_ShouldIgnoreNonExistentPaths()
+    public void LoadAndApplyState_ShouldIgnoreNonExistentPaths() => RunOnSta(() =>
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -342,10 +367,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         // Assert - should not throw
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    }
+    });
 
     [Fact]
-    public void LoadAndApplyState_WithEmptyPathsList_ShouldDoNothing()
+    public void LoadAndApplyState_WithEmptyPathsList_ShouldDoNothing() => RunOnSta(() =>
     {
         // Arrange
         var settings = new UserProjectSettings
@@ -364,10 +389,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    }
+    });
 
     [Fact]
-    public void RoundTrip_ShouldPreserveExpandedState()
+    public void RoundTrip_ShouldPreserveExpandedState() => RunOnSta(() =>
     {
         // Arrange - Create first tree with some nodes expanded
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -414,5 +439,5 @@ public class TreeViewStateServiceTests : BaseTestClass
         freshComponentsNode.IsExpanded.ShouldBeTrue();
         freshButtonsFolder.IsExpanded.ShouldBeTrue();
         freshScreensNode.IsExpanded.ShouldBeFalse();
-    }
+    });
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -11,6 +11,7 @@ using Gum.Commands;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Services.Dialogs;
 using Gum.Dialogs;
+using Gum.SelectionHistory;
 using Gum.Undo;
 using Gum.Localization;
 using Gum.Services.Fonts;
@@ -45,6 +46,7 @@ internal static class PluginBridgedServiceTypes
         typeof(ISelectedState),
         typeof(IElementCommands),
         typeof(IUndoManager),
+        typeof(ISelectionHistory),
         typeof(IProjectManager),
 
         typeof(IGuiCommands),

--- a/Tools/Gum.Presentation/Managers/IHotkeyManager.cs
+++ b/Tools/Gum.Presentation/Managers/IHotkeyManager.cs
@@ -39,6 +39,8 @@ public interface IHotkeyManager
     KeyCombination ZoomCameraOut { get; }
     KeyCombination ZoomCameraOutAlternative { get; }
     KeyCombination Rename { get; }
+    KeyCombination NavigateBack { get; }
+    KeyCombination NavigateForward { get; }
 
     /// <summary>
     /// Handles application-wide hotkeys (search, undo/redo, zoom). Callers at the WinForms/WPF boundary

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
@@ -57,6 +57,9 @@ namespace Gum.Plugins.InternalPlugins.Hotkey.ViewModels
 
             Add(_hotkeyManager.Rename, "Rename State");
 
+            Add(_hotkeyManager.NavigateBack, "Navigate Back");
+            Add(_hotkeyManager.NavigateForward, "Navigate Forward");
+
         }
 
         private void Add(KeyCombination keyCombination, string action)

--- a/Tools/Gum.Presentation/SelectionHistory/ISelectionHistory.cs
+++ b/Tools/Gum.Presentation/SelectionHistory/ISelectionHistory.cs
@@ -1,0 +1,13 @@
+using Gum.DataTypes;
+
+namespace Gum.SelectionHistory;
+
+public interface ISelectionHistory
+{
+    bool CanNavigateBack { get; }
+    bool CanNavigateForward { get; }
+
+    void RecordSelection(ElementSave? element, InstanceSave? instance);
+    void NavigateBack();
+    void NavigateForward();
+}

--- a/Tools/Gum.Presentation/SelectionHistory/SelectionHistoryService.cs
+++ b/Tools/Gum.Presentation/SelectionHistory/SelectionHistoryService.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.ToolStates;
+
+namespace Gum.SelectionHistory;
+
+/// <summary>
+/// Browser-style back/forward navigation over element/instance selections. Selections are
+/// recorded via <see cref="RecordSelection"/> (wired to the real selection cascade by
+/// SelectionHistoryPlugin) and replayed onto <see cref="ISelectedState"/> by NavigateBack/Forward.
+/// </summary>
+public class SelectionHistoryService : ISelectionHistory
+{
+    private readonly ISelectedState _selectedState;
+
+    private readonly List<(ElementSave? Element, InstanceSave? Instance)> _entries = new();
+    private int _currentIndex = -1;
+
+    // Guards against NavigateBack/Forward's own selection re-entering RecordSelection through the
+    // plugin cascade, which would otherwise truncate the very forward/back branch being navigated to.
+    private bool _isNavigating;
+
+    public SelectionHistoryService(ISelectedState selectedState)
+    {
+        _selectedState = selectedState;
+    }
+
+    public bool CanNavigateBack => _currentIndex > 0;
+    public bool CanNavigateForward => _currentIndex < _entries.Count - 1;
+
+    public void RecordSelection(ElementSave? element, InstanceSave? instance)
+    {
+        if (_isNavigating)
+        {
+            return;
+        }
+
+        if (_currentIndex >= 0)
+        {
+            var current = _entries[_currentIndex];
+            if (current.Element == element && current.Instance == instance)
+            {
+                return;
+            }
+        }
+
+        // A new selection made while parked mid-stack discards the forward branch, matching
+        // standard browser back/forward semantics.
+        if (_currentIndex < _entries.Count - 1)
+        {
+            _entries.RemoveRange(_currentIndex + 1, _entries.Count - _currentIndex - 1);
+        }
+
+        _entries.Add((element, instance));
+        _currentIndex = _entries.Count - 1;
+    }
+
+    public void NavigateBack()
+    {
+        if (!CanNavigateBack)
+        {
+            return;
+        }
+
+        _currentIndex--;
+        ApplyCurrentEntry();
+    }
+
+    public void NavigateForward()
+    {
+        if (!CanNavigateForward)
+        {
+            return;
+        }
+
+        _currentIndex++;
+        ApplyCurrentEntry();
+    }
+
+    private void ApplyCurrentEntry()
+    {
+        var entry = _entries[_currentIndex];
+
+        _isNavigating = true;
+        try
+        {
+            if (entry.Instance != null)
+            {
+                _selectedState.SelectedInstance = entry.Instance;
+            }
+            else
+            {
+                _selectedState.SelectedElement = entry.Element;
+            }
+        }
+        finally
+        {
+            _isNavigating = false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3804

Two related fixes for the mouse back/forward side buttons:

1. **Tree view mis-select bug** - `MultiSelectTreeView.OnMouseUp` only excluded `Right` from selecting the hovered node, so Back/Forward (and Middle) fell through and mis-selected whatever was under the cursor. Fixed to allow-list `Left` only.
2. **Selection history navigation** - new `SelectionHistoryService` (browser-style back/forward stack over element/instance selections), fed by a `SelectionHistoryPlugin` that records real selections. Wired to the mouse buttons on the tree view and, via `MainWindow.PreviewMouseDown`, general WPF chrome (menus, variable grid, dialogs).

**Scoped out (follow-up):** the XNA wireframe canvas isn't wired to the buttons yet.

Also reorders `Gum.sln` so `Gum` is the first project entry - Visual Studio defaults the startup project to the first listing when a worktree has no `.suo` yet, so this makes freshly-opened worktrees default to the right startup project.

## Test plan
- [x] `SelectionHistoryTests` (Gum.Presentation.Tests) - stack semantics: dedup, truncate-on-new-branch, re-entrancy guard
- [x] `MultiSelectTreeViewNavigationTests` (GumToolUnitTests) - mis-select regression + new nav events
- [x] Full `GumFull.sln` build - 0 errors
- [x] `Gum.Presentation.Tests` 259/259, `GumToolUnitTests` 1024/1028 (4 unrelated pre-existing skips), `MonoGameGum.Tests` 1884/1884
- [x] Manual test in progress
