### PR TITLE
Migrate hand-rolled RunOnSta helper to Xunit.StaFact

### DIFF
--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewNavigationTests.cs
@@ -1,8 +1,6 @@
 using CommonFormsAndControls;
 using Shouldly;
-using System;
 using System.Reflection;
-using System.Threading;
 using System.Windows.Forms;
 using Xunit;
 
@@ -32,29 +30,6 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
     private static void RaiseMouseDown(MultiSelectTreeView treeView, MouseButtons button)
     {
         InvokeProtected(treeView, "OnMouseDown", new MouseEventArgs(button, 1, 1, 0, 0));
-    }
-
-    /// <summary>
-    /// OnMouseDown calls base.OnMouseDown(e), which can force the native window handle to be
-    /// created (WinForms mouse-capture handling touches .Handle), requiring an STA thread the
-    /// same way TreeNode.Expand()/Collapse() do (see TreeViewStateServiceTests). xUnit's default
-    /// runner is MTA.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new TargetInvocationException(caught);
-        }
     }
 
     // Does not go through OnMouseUp's GetNodeAt hit-test, which requires a real native window
@@ -113,8 +88,13 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         InvokeShouldSelectOnMouseUp(_treeView, node, MouseButtons.Right).ShouldBeFalse();
     }
 
-    [Fact]
-    public void OnMouseDown_XButton1_RaisesNavigateBackRequested() => RunOnSta(() =>
+    // OnMouseDown calls base.OnMouseDown(e), which can force the native window handle to be
+    // created (WinForms mouse-capture handling touches .Handle), requiring an STA thread the
+    // same way TreeNode.Expand()/Collapse() do (see TreeViewStateServiceTests). xUnit's default
+    // runner is MTA.
+
+    [StaFact]
+    public void OnMouseDown_XButton1_RaisesNavigateBackRequested()
     {
         var raised = false;
         _treeView.NavigateBackRequested += (_, _) => raised = true;
@@ -122,10 +102,10 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.XButton1);
 
         raised.ShouldBeTrue();
-    });
+    }
 
-    [Fact]
-    public void OnMouseDown_XButton2_RaisesNavigateForwardRequested() => RunOnSta(() =>
+    [StaFact]
+    public void OnMouseDown_XButton2_RaisesNavigateForwardRequested()
     {
         var raised = false;
         _treeView.NavigateForwardRequested += (_, _) => raised = true;
@@ -133,10 +113,10 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.XButton2);
 
         raised.ShouldBeTrue();
-    });
+    }
 
-    [Fact]
-    public void OnMouseDown_LeftButton_DoesNotRaiseNavigationEvents() => RunOnSta(() =>
+    [StaFact]
+    public void OnMouseDown_LeftButton_DoesNotRaiseNavigationEvents()
     {
         var raised = false;
         _treeView.NavigateBackRequested += (_, _) => raised = true;
@@ -145,5 +125,5 @@ public class MultiSelectTreeViewNavigationTests : BaseTestClass
         RaiseMouseDown(_treeView, MouseButtons.Left);
 
         raised.ShouldBeFalse();
-    });
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/Plugins/AllPluginsCompositionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/AllPluginsCompositionTests.cs
@@ -6,7 +6,6 @@ using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Gum.Plugins.BaseClasses;
 using Gum.Services;
 using Moq;
@@ -72,31 +71,28 @@ public class AllPluginsCompositionTests : BaseTestClass
         Locator.Register(_locatorStubs);
     }
 
-    [Fact]
+    // Plugin constructors (e.g. MainHotkeyPlugin building its HotkeyView) touch WPF, which requires STA;
+    // xUnit's runner is MTA.
+    [StaFact]
     public void AllPlugins_ComposeWithoutError()
     {
-        // Plugin constructors (e.g. MainHotkeyPlugin building its HotkeyView) touch WPF, which requires STA;
-        // xUnit's runner is MTA.
-        RunOnSta(() =>
+        List<Type> expectedPluginTypes = DiscoverPluginExportTypes();
+        // Sanity check that the catalog is actually populated — guards against a future refactor that
+        // silently drops every plugin and leaves an all-green "0 == 0" assertion.
+        expectedPluginTypes.Count.ShouldBeGreaterThan(20);
+
+        using CompositionContainer container = BuildPluginContainer();
+
+        // Forcing the values composes every plugin; an unsatisfiable import or a throwing constructor
+        // raises a CompositionException here, which is exactly the failure this test exists to catch.
+        PluginBase[] composedPlugins = container.GetExportedValues<PluginBase>().ToArray();
+
+        HashSet<Type> composedTypes = composedPlugins.Select(plugin => plugin.GetType()).ToHashSet();
+        foreach (Type expected in expectedPluginTypes)
         {
-            List<Type> expectedPluginTypes = DiscoverPluginExportTypes();
-            // Sanity check that the catalog is actually populated — guards against a future refactor that
-            // silently drops every plugin and leaves an all-green "0 == 0" assertion.
-            expectedPluginTypes.Count.ShouldBeGreaterThan(20);
-
-            using CompositionContainer container = BuildPluginContainer();
-
-            // Forcing the values composes every plugin; an unsatisfiable import or a throwing constructor
-            // raises a CompositionException here, which is exactly the failure this test exists to catch.
-            PluginBase[] composedPlugins = container.GetExportedValues<PluginBase>().ToArray();
-
-            HashSet<Type> composedTypes = composedPlugins.Select(plugin => plugin.GetType()).ToHashSet();
-            foreach (Type expected in expectedPluginTypes)
-            {
-                composedTypes.ShouldContain(expected);
-            }
-            composedPlugins.Length.ShouldBe(expectedPluginTypes.Count);
-        });
+            composedTypes.ShouldContain(expected);
+        }
+        composedPlugins.Length.ShouldBe(expectedPluginTypes.Count);
     }
 
     private CompositionContainer BuildPluginContainer()
@@ -193,27 +189,6 @@ public class AllPluginsCompositionTests : BaseTestClass
             }
 
             return RuntimeHelpers.GetUninitializedObject(serviceType);
-        }
-    }
-
-    /// <summary>
-    /// WPF controls created in some plugin constructors require an STA thread; xUnit's default runner is MTA.
-    /// Copied from RenameManagerTests/MenuStripManagerTests — there is no shared base for this helper.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new Exception("Test body threw on the STA thread.", caught);
         }
     }
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
@@ -44,158 +44,122 @@ public class MenuStripManagerTests : BaseTestClass
         );
     }
 
-    /// <summary>
-    /// Helper to run an action on an STA thread, which is required for WPF controls.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        var thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-            throw new System.Reflection.TargetInvocationException(caught);
-    }
-
-    [Fact]
+    [StaFact]
     public void PopulateMenu_ShouldCreateSixTopLevelMenuItems()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
+        var menu = new Menu();
 
-            _menuStripManager.PopulateMenu(menu);
+        _menuStripManager.PopulateMenu(menu);
 
-            menu.Items.Count.ShouldBe(6);
-            ((MenuItem)menu.Items[0]).Header.ShouldBe("File");
-            ((MenuItem)menu.Items[1]).Header.ShouldBe("Edit");
-            ((MenuItem)menu.Items[2]).Header.ShouldBe("View");
-            ((MenuItem)menu.Items[3]).Header.ShouldBe("Content");
-            ((MenuItem)menu.Items[4]).Header.ShouldBe("Plugins");
-            ((MenuItem)menu.Items[5]).Header.ShouldBe("Help");
-        });
+        menu.Items.Count.ShouldBe(6);
+        ((MenuItem)menu.Items[0]).Header.ShouldBe("File");
+        ((MenuItem)menu.Items[1]).Header.ShouldBe("Edit");
+        ((MenuItem)menu.Items[2]).Header.ShouldBe("View");
+        ((MenuItem)menu.Items[3]).Header.ShouldBe("Content");
+        ((MenuItem)menu.Items[4]).Header.ShouldBe("Plugins");
+        ((MenuItem)menu.Items[5]).Header.ShouldBe("Help");
     }
 
-    [Fact]
+    [StaFact]
     public void RefreshUI_WithSelectedState_ShouldUpdateRemoveStateMenuItem()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _selectedState.Setup(s => s.SelectedStateSave)
-                .Returns(new StateSave { Name = "Running" });
+        var menu = new Menu();
+        _selectedState.Setup(s => s.SelectedStateSave)
+            .Returns(new StateSave { Name = "Running" });
 
-            _menuStripManager.PopulateMenu(menu);
-            _menuStripManager.RefreshUI();
+        _menuStripManager.PopulateMenu(menu);
+        _menuStripManager.RefreshUI();
 
-            // Navigate to Edit > Remove > State item
-            var editMenu = (MenuItem)menu.Items[1];
-            var removeMenu = editMenu.Items
-                .OfType<MenuItem>()
-                .First(mi => mi.Header as string == "Remove");
-            var stateItem = removeMenu.Items
-                .OfType<MenuItem>()
-                .First(mi => ((string)mi.Header).StartsWith("State"));
+        // Navigate to Edit > Remove > State item
+        var editMenu = (MenuItem)menu.Items[1];
+        var removeMenu = editMenu.Items
+            .OfType<MenuItem>()
+            .First(mi => mi.Header as string == "Remove");
+        var stateItem = removeMenu.Items
+            .OfType<MenuItem>()
+            .First(mi => ((string)mi.Header).StartsWith("State"));
 
-            stateItem.Header.ShouldBe("State Running");
-            stateItem.IsEnabled.ShouldBeTrue();
+        stateItem.Header.ShouldBe("State Running");
+        stateItem.IsEnabled.ShouldBeTrue();
 
-            // Now clear selection and refresh again
-            _selectedState.Setup(s => s.SelectedStateSave).Returns((StateSave?)null);
-            _selectedState.Setup(s => s.SelectedStateCategorySave).Returns((StateSaveCategory?)null);
-            _menuStripManager.RefreshUI();
+        // Now clear selection and refresh again
+        _selectedState.Setup(s => s.SelectedStateSave).Returns((StateSave?)null);
+        _selectedState.Setup(s => s.SelectedStateCategorySave).Returns((StateSaveCategory?)null);
+        _menuStripManager.RefreshUI();
 
-            stateItem.Header.ShouldBe("<no state selected>");
-            stateItem.IsEnabled.ShouldBeFalse();
-        });
+        stateItem.Header.ShouldBe("<no state selected>");
+        stateItem.IsEnabled.ShouldBeFalse();
     }
 
-    [Fact]
+    [StaFact]
     public void AddMenuItem_WhenParentExists_ShouldAddChildItem()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        var menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            var result = _menuStripManager.AddMenuItem(new[] { "Edit", "Properties" });
+        var result = _menuStripManager.AddMenuItem(new[] { "Edit", "Properties" });
 
-            result.Header.ShouldBe("Properties");
-            var editMenu = (MenuItem)menu.Items[1];
-            editMenu.Items.OfType<MenuItem>()
-                .ShouldContain(mi => mi.Header as string == "Properties");
-        });
+        result.Header.ShouldBe("Properties");
+        var editMenu = (MenuItem)menu.Items[1];
+        editMenu.Items.OfType<MenuItem>()
+            .ShouldContain(mi => mi.Header as string == "Properties");
     }
 
-    [Fact]
+    [StaFact]
     public void AddMenuItem_WhenParentDoesNotExist_ShouldInsertBeforeHelp()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        var menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            var result = _menuStripManager.AddMenuItem(new[] { "Tools", "My Tool" });
+        var result = _menuStripManager.AddMenuItem(new[] { "Tools", "My Tool" });
 
-            menu.Items.Count.ShouldBe(7);
-            ((MenuItem)menu.Items[5]).Header.ShouldBe("Tools");
-            ((MenuItem)menu.Items[6]).Header.ShouldBe("Help");
-            result.Header.ShouldBe("My Tool");
-        });
+        menu.Items.Count.ShouldBe(7);
+        ((MenuItem)menu.Items[5]).Header.ShouldBe("Tools");
+        ((MenuItem)menu.Items[6]).Header.ShouldBe("Help");
+        result.Header.ShouldBe("My Tool");
     }
 
-    [Fact]
+    [StaFact]
     public void RefreshUI_WithSelectedElement_ShouldUpdateRemoveElementMenuItem()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _selectedState.Setup(s => s.SelectedElement)
-                .Returns(new ComponentSave { Name = "MyButton" });
+        var menu = new Menu();
+        _selectedState.Setup(s => s.SelectedElement)
+            .Returns(new ComponentSave { Name = "MyButton" });
 
-            _menuStripManager.PopulateMenu(menu);
-            _menuStripManager.RefreshUI();
+        _menuStripManager.PopulateMenu(menu);
+        _menuStripManager.RefreshUI();
 
-            var editMenu = (MenuItem)menu.Items[1];
-            var removeMenu = editMenu.Items
-                .OfType<MenuItem>()
-                .First(mi => mi.Header as string == "Remove");
-            var elementItem = removeMenu.Items
-                .OfType<MenuItem>()
-                .First(mi => mi.Header as string == "MyButton");
+        var editMenu = (MenuItem)menu.Items[1];
+        var removeMenu = editMenu.Items
+            .OfType<MenuItem>()
+            .First(mi => mi.Header as string == "Remove");
+        var elementItem = removeMenu.Items
+            .OfType<MenuItem>()
+            .First(mi => mi.Header as string == "MyButton");
 
-            elementItem.IsEnabled.ShouldBeTrue();
+        elementItem.IsEnabled.ShouldBeTrue();
 
-            // StandardElementSave should NOT enable the remove item
-            _selectedState.Setup(s => s.SelectedElement)
-                .Returns(new StandardElementSave { Name = "Text" });
-            _menuStripManager.RefreshUI();
+        // StandardElementSave should NOT enable the remove item
+        _selectedState.Setup(s => s.SelectedElement)
+            .Returns(new StandardElementSave { Name = "Text" });
+        _menuStripManager.RefreshUI();
 
-            elementItem.Header.ShouldBe("<no element selected>");
-            elementItem.IsEnabled.ShouldBeFalse();
-        });
+        elementItem.Header.ShouldBe("<no element selected>");
+        elementItem.IsEnabled.ShouldBeFalse();
     }
 
-    [Fact]
+    [StaFact]
     public void GetItem_ShouldReturnNull_WhenItemDoesNotExist()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        var menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            var result = _menuStripManager.GetItem("Nonexistent");
+        var result = _menuStripManager.GetItem("Nonexistent");
 
-            result.ShouldBeNull();
-        });
+        result.ShouldBeNull();
     }
 
-    [Theory]
+    [StaTheory]
     [InlineData("File")]
     [InlineData("Edit")]
     [InlineData("View")]
@@ -204,149 +168,134 @@ public class MenuStripManagerTests : BaseTestClass
     [InlineData("Help")]
     public void GetItem_ReturnsItem_ForExistingTopLevelMenus(string menuName)
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        var menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            var result = _menuStripManager.GetItem(menuName);
+        var result = _menuStripManager.GetItem(menuName);
 
-            result.ShouldNotBeNull();
-            (result.Header as string).ShouldBe(menuName);
-        });
+        result.ShouldNotBeNull();
+        (result.Header as string).ShouldBe(menuName);
     }
 
-    [Fact]
+    [StaFact]
     public void PopulateMenu_CalledTwice_DoesNotDuplicateItems()
     {
-        RunOnSta(() =>
-        {
-            var menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
-            var countAfterFirst = menu.Items.Count;
+        var menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
+        var countAfterFirst = menu.Items.Count;
 
-            _menuStripManager.PopulateMenu(menu);
-            var countAfterSecond = menu.Items.Count;
+        _menuStripManager.PopulateMenu(menu);
+        var countAfterSecond = menu.Items.Count;
 
-            countAfterSecond.ShouldBe(countAfterFirst);
-        });
+        countAfterSecond.ShouldBe(countAfterFirst);
     }
 
-    [Fact]
+    [StaFact]
     public void ContentMenu_OrdersByLayoutTable_RegardlessOfRegistrationOrder()
     {
-        RunOnSta(() =>
+        Menu firstMenu = new Menu();
+        _menuStripManager.PopulateMenu(firstMenu);
+
+        // Register in one order
+        _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
+
+        object[] firstHeaders = HeadersOf(firstMenu, "Content");
+
+        MenuStripManager secondManager = new MenuStripManager(
+            _selectedState.Object,
+            _undoManager.Object,
+            _editCommands.Object,
+            _dialogService.Object,
+            _fileCommands.Object,
+            _projectManager.Object,
+            _messenger.Object);
+        Menu secondMenu = new Menu();
+        secondManager.PopulateMenu(secondMenu);
+
+        // Register in a different order
+        secondManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
+        secondManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
+        secondManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        secondManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
+        secondManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
+        secondManager.AddMenuItem(new[] { "Content", "View Font Cache" });
+
+        object[] secondHeaders = HeadersOf(secondMenu, "Content");
+
+        firstHeaders.ShouldBe(secondHeaders);
+
+        object[] expected = new object[]
         {
-            Menu firstMenu = new Menu();
-            _menuStripManager.PopulateMenu(firstMenu);
-
-            // Register in one order
-            _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
-
-            object[] firstHeaders = HeadersOf(firstMenu, "Content");
-
-            MenuStripManager secondManager = new MenuStripManager(
-                _selectedState.Object,
-                _undoManager.Object,
-                _editCommands.Object,
-                _dialogService.Object,
-                _fileCommands.Object,
-                _projectManager.Object,
-                _messenger.Object);
-            Menu secondMenu = new Menu();
-            secondManager.PopulateMenu(secondMenu);
-
-            // Register in a different order
-            secondManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
-            secondManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
-            secondManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
-            secondManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
-            secondManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
-            secondManager.AddMenuItem(new[] { "Content", "View Font Cache" });
-
-            object[] secondHeaders = HeadersOf(secondMenu, "Content");
-
-            firstHeaders.ShouldBe(secondHeaders);
-
-            object[] expected = new object[]
-            {
-                "Find file references...",
-                "<separator>",
-                "Add Forms Components",
-                "Import from .gumx...",
-                "<separator>",
-                "Clear Font Cache",
-                "Re-create missing font files",
-                "Force re-create all font files",
-                "View Font Cache",
-            };
-            firstHeaders.ShouldBe(expected);
-        });
+            "Find file references...",
+            "<separator>",
+            "Add Forms Components",
+            "Import from .gumx...",
+            "<separator>",
+            "Clear Font Cache",
+            "Re-create missing font files",
+            "Force re-create all font files",
+            "View Font Cache",
+        };
+        firstHeaders.ShouldBe(expected);
     }
 
-    [Fact]
+    [StaFact]
     public void ContentMenu_AfterRemoveAndReadd_RestoresLayoutPosition()
     {
-        RunOnSta(() =>
-        {
-            Menu menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        Menu menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
 
-            MenuItem content = (MenuItem)menu.Items.OfType<MenuItem>()
-                .First(mi => mi.Header as string == "Content");
-            MenuItem addForms = content.Items.OfType<MenuItem>()
-                .First(mi => mi.Header as string == "Add Forms Components");
+        MenuItem content = (MenuItem)menu.Items.OfType<MenuItem>()
+            .First(mi => mi.Header as string == "Content");
+        MenuItem addForms = content.Items.OfType<MenuItem>()
+            .First(mi => mi.Header as string == "Add Forms Components");
 
-            // Simulate the project-load handler removing the item when the project
-            // already has forms imported.
-            content.Items.Remove(addForms);
+        // Simulate the project-load handler removing the item when the project
+        // already has forms imported.
+        content.Items.Remove(addForms);
 
-            // Now simulate re-adding it on a subsequent project load (forms not present).
-            // The Forms plugin uses AddMenuItemTo which appends directly into the parent's
-            // Items collection, so mimic that path here and then re-apply the layout.
-            MenuItem readded = new MenuItem { Header = "Add Forms Components" };
-            content.Items.Add(readded);
-            _menuStripManager.ApplyLayout("Content");
+        // Now simulate re-adding it on a subsequent project load (forms not present).
+        // The Forms plugin uses AddMenuItemTo which appends directly into the parent's
+        // Items collection, so mimic that path here and then re-apply the layout.
+        MenuItem readded = new MenuItem { Header = "Add Forms Components" };
+        content.Items.Add(readded);
+        _menuStripManager.ApplyLayout("Content");
 
-            object[] headers = HeadersOf(menu, "Content");
+        object[] headers = HeadersOf(menu, "Content");
 
-            // The re-added item must land back in its forms group, not at the end.
-            int formsIndex = Array.IndexOf(headers, (object)"Add Forms Components");
-            int importIndex = Array.IndexOf(headers, (object)"Import from .gumx...");
-            int clearFontIndex = Array.IndexOf(headers, (object)"Clear Font Cache");
+        // The re-added item must land back in its forms group, not at the end.
+        int formsIndex = Array.IndexOf(headers, (object)"Add Forms Components");
+        int importIndex = Array.IndexOf(headers, (object)"Import from .gumx...");
+        int clearFontIndex = Array.IndexOf(headers, (object)"Clear Font Cache");
 
-            formsIndex.ShouldBeLessThan(importIndex);
-            importIndex.ShouldBeLessThan(clearFontIndex);
-        });
+        formsIndex.ShouldBeLessThan(importIndex);
+        importIndex.ShouldBeLessThan(clearFontIndex);
     }
 
-    [Fact]
+    [StaFact]
     public void ContentMenu_UnknownItem_GoesToEndWithSeparator()
     {
-        RunOnSta(() =>
-        {
-            Menu menu = new Menu();
-            _menuStripManager.PopulateMenu(menu);
+        Menu menu = new Menu();
+        _menuStripManager.PopulateMenu(menu);
 
-            _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
-            _menuStripManager.AddMenuItem(new[] { "Content", "Some Third-Party Plugin Item" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Some Third-Party Plugin Item" });
 
-            object[] headers = HeadersOf(menu, "Content");
+        object[] headers = HeadersOf(menu, "Content");
 
-            headers[^2].ShouldBe("<separator>");
-            headers[^1].ShouldBe("Some Third-Party Plugin Item");
-        });
+        headers[^2].ShouldBe("<separator>");
+        headers[^1].ShouldBe("Some Third-Party Plugin Item");
     }
 
     private static object[] HeadersOf(Menu menu, string topMenuName)

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/CollapseToggleServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/CollapseToggleServiceTests.cs
@@ -1,8 +1,6 @@
 using CommonFormsAndControls;
 using Gum.Plugins.InternalPlugins.TreeView;
 using Shouldly;
-using System;
-using System.Threading;
 using System.Windows.Forms;
 using Xunit;
 
@@ -23,29 +21,6 @@ public class CollapseToggleServiceTests : BaseTestClass
     {
         base.Dispose();
         _treeView?.Dispose();
-    }
-
-    /// <summary>
-    /// TreeNode.Expand()/Collapse() can force the underlying native window handle to be
-    /// created, which requires an STA thread (WinForms drag/drop registration in
-    /// OnHandleCreated throws otherwise); xUnit's default runner is MTA. Same pattern as
-    /// SliderDisplayRangeTests/NullableEnumComboBoxDisplayTests.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new System.Reflection.TargetInvocationException(caught);
-        }
     }
 
     private void SetupTreeWithExpandedNodes()
@@ -75,8 +50,12 @@ public class CollapseToggleServiceTests : BaseTestClass
         }
     }
 
-    [Fact]
-    public void Clear_ShouldDiscardSavedState() => RunOnSta(() =>
+    // TreeNode.Expand()/Collapse() can force the underlying native window handle to be
+    // created, which requires an STA thread (WinForms drag/drop registration in
+    // OnHandleCreated throws otherwise); xUnit's default runner is MTA.
+
+    [StaFact]
+    public void Clear_ShouldDiscardSavedState()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -91,10 +70,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - all collapsed because it re-captured, not restored
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void HandleCollapseAll_ShouldCaptureAndCollapse_OnFirstClick() => RunOnSta(() =>
+    [StaFact]
+    public void HandleCollapseAll_ShouldCaptureAndCollapse_OnFirstClick()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -105,10 +84,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void HandleCollapseAll_ShouldRecapture_WhenManualChangeOccurred() => RunOnSta(() =>
+    [StaFact]
+    public void HandleCollapseAll_ShouldRecapture_WhenManualChangeOccurred()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -125,10 +104,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - collapsed again (re-captured, not restored)
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void HandleCollapseAll_ShouldRestore_OnSecondClickWithoutManualChange() => RunOnSta(() =>
+    [StaFact]
+    public void HandleCollapseAll_ShouldRestore_OnSecondClickWithoutManualChange()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -147,10 +126,10 @@ public class CollapseToggleServiceTests : BaseTestClass
         // Assert - restored to original state
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    });
+    }
 
-    [Fact]
-    public void HandleCollapseToElementLevel_ShouldRestore_OnSecondClick() => RunOnSta(() =>
+    [StaFact]
+    public void HandleCollapseToElementLevel_ShouldRestore_OnSecondClick()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -179,10 +158,10 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - Button node restored to expanded
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    });
+    }
 
-    [Fact]
-    public void HandleDifferentButton_ShouldInvalidatePreviousSnapshot() => RunOnSta(() =>
+    [StaFact]
+    public void HandleDifferentButton_ShouldInvalidatePreviousSnapshot()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -220,10 +199,10 @@ public class CollapseToggleServiceTests : BaseTestClass
         // Assert - restored to state before element-level collapse
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _treeView.Nodes[0].Nodes[0].IsExpanded.ShouldBeTrue();
-    });
+    }
 
-    [Fact]
-    public void OnNodeManuallyChanged_ShouldInvalidateSnapshot() => RunOnSta(() =>
+    [StaFact]
+    public void OnNodeManuallyChanged_ShouldInvalidateSnapshot()
     {
         // Arrange
         SetupTreeWithExpandedNodes();
@@ -240,5 +219,5 @@ public class CollapseToggleServiceTests : BaseTestClass
 
         // Assert - collapsed because it re-captured instead of restoring
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeViewStateServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeViewStateServiceTests.cs
@@ -6,7 +6,6 @@ using Moq;
 using Shouldly;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Windows.Forms;
 
 namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
@@ -32,31 +31,12 @@ public class TreeViewStateServiceTests : BaseTestClass
         _treeView?.Dispose();
     }
 
-    /// <summary>
-    /// TreeNode.Expand()/Collapse() can force the underlying native window handle to be
-    /// created, which requires an STA thread (WinForms drag/drop registration in
-    /// OnHandleCreated throws otherwise); xUnit's default runner is MTA. Same pattern as
-    /// SliderDisplayRangeTests/NullableEnumComboBoxDisplayTests.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new System.Reflection.TargetInvocationException(caught);
-        }
-    }
+    // TreeNode.Expand()/Collapse() can force the underlying native window handle to be
+    // created, which requires an STA thread (WinForms drag/drop registration in
+    // OnHandleCreated throws otherwise); xUnit's default runner is MTA.
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldCaptureExpandedNodes() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldCaptureExpandedNodes()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -76,10 +56,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.ShouldNotBeNull();
         settings.TreeViewState.ExpandedNodes.Count.ShouldBe(1);
         settings.TreeViewState.ExpandedNodes.ShouldContain(rootNodeName);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldCaptureNestedExpandedNodes() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldCaptureNestedExpandedNodes()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -105,10 +85,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.Count.ShouldBe(2);
         settings.TreeViewState.ExpandedNodes.ShouldContain(expectedComponentsPath);
         settings.TreeViewState.ExpandedNodes.ShouldContain(expectedButtonsFolderPath);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldCreateTreeViewState_WhenNull() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldCreateTreeViewState_WhenNull()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = null };
@@ -124,10 +104,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         // Assert
         settings.TreeViewState.ShouldNotBeNull();
         settings.TreeViewState.ExpandedNodes.ShouldContain(rootNodeName);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldDoNothing_WhenCurrentSettingsIsNull() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldDoNothing_WhenCurrentSettingsIsNull()
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Returns((UserProjectSettings?)null);
@@ -137,10 +117,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldDoNothing_WhenTreeViewIsNull() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldDoNothing_WhenTreeViewIsNull()
     {
         // Arrange
         var settings = new UserProjectSettings();
@@ -151,10 +131,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_ShouldHandleError_Gracefully() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_ShouldHandleError_Gracefully()
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Throws<System.Exception>();
@@ -167,10 +147,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _mockOutputManager.Verify(x => x.AddError(It.Is<string>(msg => msg.Contains("Error capturing tree view state"))), Times.Once);
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_WithCollapsedTree_ShouldReturnEmptyList() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_WithCollapsedTree_ShouldReturnEmptyList()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -185,10 +165,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         settings.TreeViewState.ExpandedNodes.ShouldBeEmpty();
-    });
+    }
 
-    [Fact]
-    public void CaptureAndSaveState_WithMultipleRootNodes_ShouldCaptureAll() => RunOnSta(() =>
+    [StaFact]
+    public void CaptureAndSaveState_WithMultipleRootNodes_ShouldCaptureAll()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -214,10 +194,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         settings.TreeViewState.ExpandedNodes.ShouldContain(componentsNodeName);
         settings.TreeViewState.ExpandedNodes.ShouldContain(screensNodeName);
         settings.TreeViewState.ExpandedNodes.ShouldNotContain(standardsNodeName);
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenCurrentSettingsIsNull() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldDoNothing_WhenCurrentSettingsIsNull()
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Returns((UserProjectSettings?)null);
@@ -228,10 +208,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw or expand nodes
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewIsNull() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewIsNull()
     {
         // Arrange
         var settings = new UserProjectSettings();
@@ -242,10 +222,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert - should not throw
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewStateIsNull() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldDoNothing_WhenTreeViewStateIsNull()
     {
         // Arrange
         var settings = new UserProjectSettings { TreeViewState = null };
@@ -257,10 +237,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldExpandCorrectNodes() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldExpandCorrectNodes()
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -288,10 +268,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();  // Components
         _treeView.Nodes[1].IsExpanded.ShouldBeTrue();  // Screens
         _treeView.Nodes[2].IsExpanded.ShouldBeFalse(); // Standards
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldExpandNestedNodes() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldExpandNestedNodes()
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -323,10 +303,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         componentsNode.IsExpanded.ShouldBeTrue();
         buttonsFolder.IsExpanded.ShouldBeTrue();
         primaryButton.IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldHandleError_Gracefully() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldHandleError_Gracefully()
     {
         // Arrange
         _mockSettingsManager.Setup(x => x.CurrentSettings).Throws<System.Exception>();
@@ -336,10 +316,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _mockOutputManager.Verify(x => x.AddError(It.Is<string>(msg => msg.Contains("Error applying tree view state"))), Times.Once);
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_ShouldIgnoreNonExistentPaths() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_ShouldIgnoreNonExistentPaths()
     {
         // Arrange
         var componentsNodeName = "Components";
@@ -367,10 +347,10 @@ public class TreeViewStateServiceTests : BaseTestClass
         // Assert - should not throw
         _treeView.Nodes[0].IsExpanded.ShouldBeTrue();
         _mockOutputManager.Verify(x => x.AddError(It.IsAny<string>()), Times.Never);
-    });
+    }
 
-    [Fact]
-    public void LoadAndApplyState_WithEmptyPathsList_ShouldDoNothing() => RunOnSta(() =>
+    [StaFact]
+    public void LoadAndApplyState_WithEmptyPathsList_ShouldDoNothing()
     {
         // Arrange
         var settings = new UserProjectSettings
@@ -389,10 +369,10 @@ public class TreeViewStateServiceTests : BaseTestClass
 
         // Assert
         _treeView.Nodes[0].IsExpanded.ShouldBeFalse();
-    });
+    }
 
-    [Fact]
-    public void RoundTrip_ShouldPreserveExpandedState() => RunOnSta(() =>
+    [StaFact]
+    public void RoundTrip_ShouldPreserveExpandedState()
     {
         // Arrange - Create first tree with some nodes expanded
         var settings = new UserProjectSettings { TreeViewState = new TreeViewState() };
@@ -439,5 +419,5 @@ public class TreeViewStateServiceTests : BaseTestClass
         freshComponentsNode.IsExpanded.ShouldBeTrue();
         freshButtonsFolder.IsExpanded.ShouldBeTrue();
         freshScreensNode.IsExpanded.ShouldBeFalse();
-    });
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/NullableEnumComboBoxDisplayTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/NullableEnumComboBoxDisplayTests.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Shouldly;
 using WpfDataUi;
 using WpfDataUi.Controls;
@@ -77,108 +76,76 @@ public class NullableEnumComboBoxDisplayTests : BaseTestClass
         matchedDisplayer.ShouldBeNull();
     }
 
-    [Fact]
+    [StaFact]
     public void ComboBoxDisplay_NullableEnumPropertyType_CustomOptionsIncludesNullEntryAndAllEnumValues()
     {
-        RunOnSta(() =>
-        {
-            TestComboBoxDisplay display = new TestComboBoxDisplay();
-            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
-            display.InstanceMember = member;
+        TestComboBoxDisplay display = new TestComboBoxDisplay();
+        InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+        display.InstanceMember = member;
 
-            List<object?> options = display.GetCustomOptions().ToList();
+        List<object?> options = display.GetCustomOptions().ToList();
 
-            // Convention: the no-value sentinel is the "<None>" string, matching
-            // StateReferencingInstanceMember.HandleCustomSet which translates that
-            // string back to null on commit. Using a string sentinel rather than
-            // literal null is required because WPF ComboBox does not handle a null
-            // SelectedItem cleanly — selecting the null item deselects instead.
-            options.Count(o => Equals(o, ComboBoxDisplay.NullSentinel)).ShouldBe(1, "exactly one <None> entry should be present for the no-value option");
-            options.ShouldContain(SampleEnum.Alpha);
-            options.ShouldContain(SampleEnum.Beta);
-            options.ShouldContain(SampleEnum.Gamma);
-            options.Count.ShouldBe(4);
-        });
+        // Convention: the no-value sentinel is the "<None>" string, matching
+        // StateReferencingInstanceMember.HandleCustomSet which translates that
+        // string back to null on commit. Using a string sentinel rather than
+        // literal null is required because WPF ComboBox does not handle a null
+        // SelectedItem cleanly — selecting the null item deselects instead.
+        options.Count(o => Equals(o, ComboBoxDisplay.NullSentinel)).ShouldBe(1, "exactly one <None> entry should be present for the no-value option");
+        options.ShouldContain(SampleEnum.Alpha);
+        options.ShouldContain(SampleEnum.Beta);
+        options.ShouldContain(SampleEnum.Gamma);
+        options.Count.ShouldBe(4);
     }
 
-    [Fact]
+    [StaFact]
     public void ComboBoxDisplay_NonNullableEnumPropertyType_CustomOptionsHasNoNullEntry()
     {
-        RunOnSta(() =>
-        {
-            TestComboBoxDisplay display = new TestComboBoxDisplay();
-            InstanceMember member = MakeMemberOfType(typeof(SampleEnum));
-            display.InstanceMember = member;
+        TestComboBoxDisplay display = new TestComboBoxDisplay();
+        InstanceMember member = MakeMemberOfType(typeof(SampleEnum));
+        display.InstanceMember = member;
 
-            List<object?> options = display.GetCustomOptions().ToList();
+        List<object?> options = display.GetCustomOptions().ToList();
 
-            options.ShouldNotContain(ComboBoxDisplay.NullSentinel);
-            options.Count.ShouldBe(3);
-        });
+        options.ShouldNotContain(ComboBoxDisplay.NullSentinel);
+        options.Count.ShouldBe(3);
     }
 
-    [Fact]
+    [StaFact]
     public void ComboBoxDisplay_NullableEnum_SelectingNoneSentinelWritesSentinelToInstanceMember()
     {
-        RunOnSta(() =>
-        {
-            // The WpfDataUi layer hands the "<None>" sentinel string straight to
-            // InstanceMember.SetValue. The null translation happens one level up,
-            // in StateReferencingInstanceMember.HandleCustomSet, which is exercised
-            // by the variable-grid integration tests rather than here. This test
-            // pins the contract this layer owns: the sentinel reaches SetValue
-            // intact when the user selects the no-value entry.
-            object? backingValue = SampleEnum.Beta;
+        // The WpfDataUi layer hands the "<None>" sentinel string straight to
+        // InstanceMember.SetValue. The null translation happens one level up,
+        // in StateReferencingInstanceMember.HandleCustomSet, which is exercised
+        // by the variable-grid integration tests rather than here. This test
+        // pins the contract this layer owns: the sentinel reaches SetValue
+        // intact when the user selects the no-value entry.
+        object? backingValue = SampleEnum.Beta;
 
-            TestComboBoxDisplay display = new TestComboBoxDisplay();
-            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
-            member.CustomGetEvent += _ => backingValue;
-            member.CustomSetPropertyEvent += (_, args) => backingValue = args.Value;
-            display.InstanceMember = member;
+        TestComboBoxDisplay display = new TestComboBoxDisplay();
+        InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+        member.CustomGetEvent += _ => backingValue;
+        member.CustomSetPropertyEvent += (_, args) => backingValue = args.Value;
+        display.InstanceMember = member;
 
-            display.SimulateUserSelects(ComboBoxDisplay.NullSentinel);
+        display.SimulateUserSelects(ComboBoxDisplay.NullSentinel);
 
-            backingValue.ShouldBe(ComboBoxDisplay.NullSentinel);
-        });
+        backingValue.ShouldBe(ComboBoxDisplay.NullSentinel);
     }
 
-    [Fact]
+    [StaFact]
     public void ComboBoxDisplay_NullableEnum_RoundTripsRealEnumValue()
     {
-        RunOnSta(() =>
-        {
-            SampleEnum? backingValue = null;
+        SampleEnum? backingValue = null;
 
-            TestComboBoxDisplay display = new TestComboBoxDisplay();
-            InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
-            member.CustomGetEvent += _ => backingValue;
-            member.CustomSetPropertyEvent += (_, args) => backingValue = (SampleEnum?)args.Value;
-            display.InstanceMember = member;
+        TestComboBoxDisplay display = new TestComboBoxDisplay();
+        InstanceMember member = MakeMemberOfType(typeof(SampleEnum?));
+        member.CustomGetEvent += _ => backingValue;
+        member.CustomSetPropertyEvent += (_, args) => backingValue = (SampleEnum?)args.Value;
+        display.InstanceMember = member;
 
-            display.SimulateUserSelects(SampleEnum.Gamma);
+        display.SimulateUserSelects(SampleEnum.Gamma);
 
-            backingValue.ShouldBe(SampleEnum.Gamma);
-        });
-    }
-
-    /// <summary>
-    /// WPF controls require an STA thread; xUnit's default runner is MTA.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new System.Reflection.TargetInvocationException(caught);
-        }
+        backingValue.ShouldBe(SampleEnum.Gamma);
     }
 
     private static InstanceMember MakeMemberOfType(Type type)

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SliderDisplayRangeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/SliderDisplayRangeTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using Shouldly;
 using WpfDataUi;
 using WpfDataUi.Controls;
@@ -16,49 +15,43 @@ namespace GumToolUnitTests.PropertyGridHelpers;
 /// </summary>
 public class SliderDisplayRangeTests : BaseTestClass
 {
-    [Fact]
+    [StaFact]
     public void TrySetValueOnUi_ValueAboveMax_PreservesReportedValue()
     {
-        RunOnSta(() =>
-        {
-            SliderDisplay display = new SliderDisplay();
-            display.MinValue = 0;
-            display.MaxValue = 255;
+        SliderDisplay display = new SliderDisplay();
+        display.MinValue = 0;
+        display.MaxValue = 255;
 
-            // Seed the slider with an in-range value so the out-of-range push below
-            // produces a real slider-value change (and thus the coercion that triggers
-            // the clobber). Without a prior in-range value the slider never moves.
-            InstanceMember member = MakeFloatMember(100f);
-            display.InstanceMember = member;
+        // Seed the slider with an in-range value so the out-of-range push below
+        // produces a real slider-value change (and thus the coercion that triggers
+        // the clobber). Without a prior in-range value the slider never moves.
+        InstanceMember member = MakeFloatMember(100f);
+        display.InstanceMember = member;
 
-            display.TrySetValueOnUi(300f);
+        display.TrySetValueOnUi(300f);
 
-            ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
+        ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
 
-            result.ShouldBe(ApplyValueResult.Success);
-            Convert.ToSingle(shown).ShouldBe(300f);
-        });
+        result.ShouldBe(ApplyValueResult.Success);
+        Convert.ToSingle(shown).ShouldBe(300f);
     }
 
-    [Fact]
+    [StaFact]
     public void TrySetValueOnUi_ValueBelowMin_PreservesReportedValue()
     {
-        RunOnSta(() =>
-        {
-            SliderDisplay display = new SliderDisplay();
-            display.MinValue = 10;
-            display.MaxValue = 255;
+        SliderDisplay display = new SliderDisplay();
+        display.MinValue = 10;
+        display.MaxValue = 255;
 
-            InstanceMember member = MakeFloatMember(200f);
-            display.InstanceMember = member;
+        InstanceMember member = MakeFloatMember(200f);
+        display.InstanceMember = member;
 
-            display.TrySetValueOnUi(5f);
+        display.TrySetValueOnUi(5f);
 
-            ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
+        ApplyValueResult result = display.TryGetValueOnUi(out object? shown);
 
-            result.ShouldBe(ApplyValueResult.Success);
-            Convert.ToSingle(shown).ShouldBe(5f);
-        });
+        result.ShouldBe(ApplyValueResult.Success);
+        Convert.ToSingle(shown).ShouldBe(5f);
     }
 
     private static InstanceMember MakeFloatMember(float value)
@@ -67,25 +60,5 @@ public class SliderDisplayRangeTests : BaseTestClass
         member.CustomGetTypeEvent += _ => typeof(float);
         member.CustomGetEvent += _ => value;
         return member;
-    }
-
-    /// <summary>
-    /// WPF controls require an STA thread; xUnit's default runner is MTA.
-    /// </summary>
-    private static void RunOnSta(Action action)
-    {
-        Exception? caught = null;
-        Thread thread = new Thread(() =>
-        {
-            try { action(); }
-            catch (Exception ex) { caught = ex; }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
-        if (caught != null)
-        {
-            throw new System.Reflection.TargetInvocationException(caught);
-        }
     }
 }


### PR DESCRIPTION
Closes #3806

Migrates the copy-pasted `RunOnSta` thread-spinning helper (7 test classes) to `Xunit.StaFact`'s `[StaFact]`/`[StaTheory]` attributes.

**Note on the issue's "shared-STA-collection" suggestion:** I read the actual `Xunit.StaFact` v1.2.69 source (the version compatible with our xunit 2.5.3) — there is no built-in feature to run a whole assembly/collection on one persistent shared STA thread. `ThreadRental` spins up a fresh STA thread per test (constructor, method, and dispose all run on it) and disposes it after — functionally the same lifecycle as the old hand-rolled helper, just enforced by the attribute instead of a pattern a future test author has to remember. That's the actual bug fix here; the "better still" idea in the issue isn't something this library offers.

Only the specific `[Fact]`/`[Theory]` methods that wrapped their body in `RunOnSta` were converted; plain tests in mixed files (e.g. `MultiSelectTreeViewNavigationTests`, `NullableEnumComboBoxDisplayTests`) were left as `[Fact]`.

Full `GumToolUnitTests` suite: 1026 passed, 4 skipped (pre-existing), 0 failed.

Manual test: not needed — pure test-infrastructure change, no production behavior touched; proven by the green suite.
