### PR TITLE
Adopt NuGet Central Package Management for shared test-project packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<Project>
+
+  <!--
+    Scoped to test projects only: this file does NOT set ManagePackageVersionsCentrally here,
+    so it has no effect on production/runtime projects even though it auto-imports for every
+    project in the repo (same directory-walk-up discovery as Directory.Build.props). Each test
+    project opts in individually via `<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>`
+    in its own PropertyGroup. See #3803.
+  -->
+
+  <PropertyGroup>
+    <!-- Local/CI machines may have more than one configured NuGet source (e.g. a private feed);
+         source mapping is a machine-level NuGet.Config concern, not something this repo-checked-in
+         file can resolve, so suppress the resulting NU1507 nag for the projects that opt into CPM. -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+</Project>

--- a/MonoGameGum.Tests/MonoGameGum.Tests.csproj
+++ b/MonoGameGum.Tests/MonoGameGum.Tests.csproj
@@ -7,18 +7,19 @@
     <OutputType>Exe</OutputType>
 	<IsTestProject>true</IsTestProject>
 	<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+	<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-	  <PackageReference Include="coverlet.collector" Version="6.0.4" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-	  <PackageReference Include="Moq" Version="4.20.72" />
-	  <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="xunit" Version="2.5.3" />
-	  <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+	  <PackageReference Include="AutoFixture.AutoMoq" />
+	  <PackageReference Include="coverlet.collector" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+	  <PackageReference Include="Moq" />
+	  <PackageReference Include="Shouldly" />
+	  <PackageReference Include="xunit" />
+	  <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" VersionOverride="3.8.4.1" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Gum.Analyzers.Tests/Gum.Analyzers.Tests.csproj
+++ b/Tests/Gum.Analyzers.Tests/Gum.Analyzers.Tests.csproj
@@ -6,16 +6,20 @@
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<ImplicitUsings>disable</ImplicitUsings>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-		<PackageReference Include="Shouldly" Version="4.2.1" />
+		<!-- Pinned independently of the shared test-package versions below: this project's xunit/
+		     Test.Sdk/Shouldly versions are tied to the Roslyn Analyzer/CodeFix Testing SDK's own
+		     compatibility expectations, not a drift to reconcile. -->
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" VersionOverride="1.1.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" VersionOverride="1.1.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="17.12.0" />
+		<PackageReference Include="xunit" VersionOverride="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" VersionOverride="2.8.2" />
+		<PackageReference Include="Shouldly" VersionOverride="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
+++ b/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
@@ -7,13 +7,14 @@
     <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
+++ b/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
@@ -7,13 +7,14 @@
     <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj
+++ b/Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj
@@ -12,14 +12,15 @@
     <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
@@ -7,13 +7,14 @@
     <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
@@ -7,14 +7,15 @@
     <LangVersion>12.0</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
+++ b/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
@@ -7,14 +7,15 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
+++ b/Tests/GumExpressions.Tests/GumExpressions.Tests.csproj
@@ -6,14 +6,15 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MonoGameFum.FromFile.Tests/MonoGameFum.FromFile.Tests.csproj
+++ b/Tests/MonoGameFum.FromFile.Tests/MonoGameFum.FromFile.Tests.csproj
@@ -7,13 +7,14 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
@@ -8,18 +8,19 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.5.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
-		<PackageReference Include="ShadowDusk.Compiler" Version="0.8.0" />
+		<PackageReference Include="AutoFixture.AutoMoq" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="MonoGame.Framework.DesktopGL" VersionOverride="3.8.4.1" />
+		<PackageReference Include="ShadowDusk.Compiler" VersionOverride="0.8.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj
+++ b/Tests/MonoGameGum.Shapes.Tests/MonoGameGum.Shapes.Tests.csproj
@@ -6,15 +6,16 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-	  <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+	  <PackageReference Include="MonoGame.Framework.DesktopGL" VersionOverride="3.8.4.1" />
 
   </ItemGroup>
 

--- a/Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj
+++ b/Tests/MonoGameGum.Tests.V2/MonoGameGum.Tests.V2.csproj
@@ -8,17 +8,18 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.5.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+		<PackageReference Include="AutoFixture.AutoMoq" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="MonoGame.Framework.DesktopGL" VersionOverride="3.8.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/MonoGameGum.Tests.V3/MonoGameGum.Tests.V3.csproj
+++ b/Tests/MonoGameGum.Tests.V3/MonoGameGum.Tests.V3.csproj
@@ -7,13 +7,14 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/MonoGameGum.TestsCommon/MonoGameGum.TestsCommon.csproj
+++ b/Tests/MonoGameGum.TestsCommon/MonoGameGum.TestsCommon.csproj
@@ -5,17 +5,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.5.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+		<PackageReference Include="AutoFixture.AutoMoq" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="MonoGame.Framework.DesktopGL" VersionOverride="3.8.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -7,18 +7,17 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-	  <PackageReference Include="Moq" Version="4.20.72" />
-	  <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-	<PackageReference Include="Raylib-cs" Version="8.0.0" />
-
-
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+	  <PackageReference Include="Moq" />
+	  <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+	<PackageReference Include="Raylib-cs" VersionOverride="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/SilkNetGum.Tests/SilkNetGum.Tests.csproj
+++ b/Tests/SilkNetGum.Tests/SilkNetGum.Tests.csproj
@@ -10,19 +10,20 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
     <!-- SKSurface for the in-memory raster canvas; Silk.NET.Input types (IInputContext / IMouse /
          IKeyboard / Key) for mocking input in the Cursor/Keyboard tests. -->
-    <PackageReference Include="SkiaSharp" Version="3.119.1" />
-    <PackageReference Include="Silk.NET.Input" Version="2.21.0" />
+    <PackageReference Include="SkiaSharp" VersionOverride="3.119.1" />
+    <PackageReference Include="Silk.NET.Input" VersionOverride="2.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
+++ b/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
@@ -4,15 +4,16 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Shouldly" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.5.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+		<PackageReference Include="AutoFixture.AutoMoq" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />

--- a/Tests/SokolGum.Tests/SokolGum.Tests.csproj
+++ b/Tests/SokolGum.Tests/SokolGum.Tests.csproj
@@ -7,15 +7,16 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tool/Tests/AutomatedTests/AutomatedTests.csproj
+++ b/Tool/Tests/AutomatedTests/AutomatedTests.csproj
@@ -6,16 +6,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Appium.WebDriver" VersionOverride="4.4.5" />
+    <PackageReference Include="coverlet.collector" VersionOverride="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="17.11.1" />
+    <PackageReference Include="NUnit" VersionOverride="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" VersionOverride="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" VersionOverride="4.6.0" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -9,21 +9,22 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <UseWPF>true</UseWPF>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="AutoFixture.AutoMoq" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Moq.AutoMock" VersionOverride="3.5.0" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.StaFact" VersionOverride="1.2.69" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds a repo-root `Directory.Packages.props` centralizing 7 shared test-only packages: `coverlet.collector`, `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`, `Moq`, `Shouldly`, `AutoFixture.AutoMoq`.
- 21 test projects (`MonoGameGum.Tests`, everything under `Tests/`, `Tool/Tests/GumToolUnitTests`, `Tool/Tests/AutomatedTests`) opt in individually via `ManagePackageVersionsCentrally`; production/runtime projects are untouched.
- Packages that legitimately diverge per project (`MonoGame.Framework.DesktopGL`, `SkiaSharp`, `Raylib-cs`, `Silk.NET.Input`, the Roslyn testing SDK, NUnit, `ShadowDusk.Compiler`, etc.) use `VersionOverride` to keep their existing per-project pin.
- Zero version changes — every project keeps exactly the version it had before this PR.

## Why scoped this way
A root `Directory.Packages.props` auto-imports for every project via the same directory walk-up as `Directory.Build.props`. Setting `ManagePackageVersionsCentrally=true` inside the props file itself would silently force CPM onto every production project too. Instead the file leaves that property unset, and only the 21 opted-in test projects set it themselves — confirmed via a production-project restore (`GumCommon.csproj`) staying green with the file present.

## Test plan
- `dotnet restore` on all 21 opted-in projects: clean, no NU1008/NU1010 errors.
- `dotnet restore` on `GumCommon.csproj` (production): unaffected, confirming the scoping.
- `dotnet test` across the CI-safe suites: 0 failures (MonoGameGum.Tests 1884, GumToolUnitTests 1026, SkiaGum.Tests 358, plus the rest — ~3400 tests total).
- `dotnet build` for Raylib/SilkNet/IntegrationTests/AutomatedTests: clean (pre-existing obsolete-API warnings only, unrelated to this change).
- `SokolGum.Tests`: restore succeeds; build wasn't exercised locally since the Sokol submodule is uninitialized in this worktree (pre-existing, expected per repo guidance — not a regression).

Manual test: not needed — build/csproj plumbing with no runtime-observable behavior, covered by restore/build/test above.
FRB canary: not needed — no `GumCoreShared.projitems`/`FlatRedBall.Forms.Shared.projitems`-tracked source touched.

Closes #3803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
