### PR TITLE
Move AnimationFilePathService to Gum.Presentation (#3754)

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -113,6 +113,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         IMessenger messenger,
         IOutputManager outputManager,
         IFileWatchManager fileWatchManager,
+        IFileCommands fileCommands,
         IProjectState projectState,
         IProjectManager projectManager,
         IWireframeObjectManager wireframeObjectManager,
@@ -130,7 +131,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         _undoManager = undoManager;
         _animationUndoProviderRegistrar = animationUndoProviderRegistrar;
 
-        _animationFilePathService = new AnimationFilePathService(_selectedState);
+        _animationFilePathService = new AnimationFilePathService(_selectedState, fileCommands);
         _duplicateService = new DuplicateService(_dialogService, _projectManager);
         _elementDeleteService = new ElementDeleteService(_animationFilePathService, _dialogService);
         _settingsManager = new SettingsManager();

--- a/Tests/Gum.Presentation.Tests/AnimationFilePathServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/AnimationFilePathServiceTests.cs
@@ -1,0 +1,74 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using StateAnimationPlugin.Managers;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+public class AnimationFilePathServiceTests
+{
+    private static AnimationFilePathService BuildSut(
+        out Mock<ISelectedState> selectedStateMock,
+        out Mock<IFileCommands> fileCommandsMock)
+    {
+        selectedStateMock = new Mock<ISelectedState>();
+        fileCommandsMock = new Mock<IFileCommands>();
+
+        return new AnimationFilePathService(selectedStateMock.Object, fileCommandsMock.Object);
+    }
+
+    [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementName_ShouldReturnNull_WhenNoElementIsSelected()
+    {
+        AnimationFilePathService sut = BuildSut(out _, out _);
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor("MyComponent");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementName_ShouldReturnGanxPath_WhenElementIsSelected()
+    {
+        AnimationFilePathService sut = BuildSut(out Mock<ISelectedState> selectedStateMock, out Mock<IFileCommands> fileCommandsMock);
+        ComponentSave selectedElement = new ComponentSave { Name = "MyComponent" };
+        selectedStateMock.Setup(s => s.SelectedElement).Returns(selectedElement);
+        fileCommandsMock.Setup(f => f.GetFullPathXmlFile(selectedElement, "MyComponent"))
+            .Returns(new FilePath(@"C:\Project\Components\MyComponent.gucx"));
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor("MyComponent");
+
+        result.ShouldNotBeNull();
+        result!.FullPath.ShouldBe(new FilePath(@"C:\Project\Components\MyComponentAnimations.ganx").FullPath);
+    }
+
+    [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementSave_ShouldReturnNull_WhenXmlPathCannotBeResolved()
+    {
+        AnimationFilePathService sut = BuildSut(out _, out Mock<IFileCommands> fileCommandsMock);
+        ComponentSave elementSave = new ComponentSave { Name = "MyComponent" };
+        fileCommandsMock.Setup(f => f.GetFullPathXmlFile(elementSave, "MyComponent")).Returns((FilePath?)null);
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor(elementSave);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementSave_ShouldReturnGanxPath_WhenXmlPathResolves()
+    {
+        AnimationFilePathService sut = BuildSut(out _, out Mock<IFileCommands> fileCommandsMock);
+        ComponentSave elementSave = new ComponentSave { Name = "MyComponent" };
+        fileCommandsMock.Setup(f => f.GetFullPathXmlFile(elementSave, "MyComponent"))
+            .Returns(new FilePath(@"C:\Project\Components\MyComponent.gucx"));
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor(elementSave);
+
+        result.ShouldNotBeNull();
+        result!.FullPath.ShouldBe(new FilePath(@"C:\Project\Components\MyComponentAnimations.ganx").FullPath);
+    }
+}

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
@@ -1,10 +1,6 @@
-﻿using Gum.DataTypes;
+using Gum.Commands;
+using Gum.DataTypes;
 using Gum.ToolStates;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers;
@@ -12,18 +8,20 @@ namespace StateAnimationPlugin.Managers;
 public class AnimationFilePathService : IAnimationFilePathService
 {
     private readonly ISelectedState _selectedState;
+    private readonly IFileCommands _fileCommands;
 
-    public AnimationFilePathService(ISelectedState selectedState)
+    public AnimationFilePathService(ISelectedState selectedState, IFileCommands fileCommands)
     {
         _selectedState = selectedState;
+        _fileCommands = fileCommands;
     }
 
     /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(string elementName)
     {
         var selectedElement = _selectedState.SelectedElement;
-        var fullPathXmlForElement = 
-            selectedElement != null ? ElementSaveExtensionMethodsGumTool.GetFullPathXmlFile(selectedElement, elementName)
+        var fullPathXmlForElement =
+            selectedElement != null ? _fileCommands.GetFullPathXmlFile(selectedElement, elementName)
             : null;
 
         if (fullPathXmlForElement == null)
@@ -41,7 +39,7 @@ public class AnimationFilePathService : IAnimationFilePathService
     /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(ElementSave elementSave)
     {
-        var fullPathXmlForElement = elementSave.GetFullPathXmlFile();
+        var fullPathXmlForElement = _fileCommands.GetFullPathXmlFile(elementSave, elementSave.Name);
 
         if (fullPathXmlForElement == null)
         {


### PR DESCRIPTION
## Summary

Round 6 on issue #3754: moved `AnimationFilePathService` (the last remaining "not yet mechanical" candidate from the Round 5 open list) to `Gum.Presentation`.

- Blocker was the `Locator`-coupled `ElementSaveExtensionMethodsGumTool.GetFullPathXmlFile` extension method — routed both call sites through the already-injected `IFileCommands.GetFullPathXmlFile(element, elementName)` instead, the same fix PR #3809 applied to `FileChangeReactionLogic`.
- `MainStateAnimationPlugin` (MEF plugin) now takes `IFileCommands` as a ctor param and passes it through to `AnimationFilePathService`; `IFileCommands` was already MEF-bridged, so no `PluginBridgedServiceTypes`/`LoadPlugins` change needed.
- Added a pinning test file (`AnimationFilePathServiceTests.cs`, 4 tests) since none existed for this class directly.
- Ratchet baseline unchanged: `SelfStaticReferenceCount` stays at 293 (the moved file had no `.Self` calls).

Part of #3754

## Test plan

- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `dotnet test Tests/Gum.Presentation.Tests` — 333/333 passed
- [x] `dotnet test Tool/Tests/GumToolUnitTests` — 956/956 passed (4 pre-existing skips), including `AllPluginsCompositionTests` and `UiDecouplingRatchetTests`

Manual test: not needed — pure relocation + constructor injection swap, behavior-preserving, covered by unit tests + compilation.
FRB canary: not needed — no FRB1-shared source touched (Gum tool-only files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
