### PR TITLE
Extract tree-view icon-index logic into testable TreeNodeImageLogic (#3755)

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -196,51 +196,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     public const int LottieAnimationInstanceImageIndex = 39;
     public const int SvgInstanceImageIndex = 40;
 
-    /// <summary>
-    /// Returns the per-type (blue-tinted) icon for an instance whose BaseType
-    /// is a standard element. Falls back to the generic
-    /// <see cref="InstanceImageIndex"/> for component-typed instances or
-    /// unrecognized types.
-    /// </summary>
-    public static int GetImageIndexForInstance(string? baseType) => baseType switch
-    {
-        "Container" => ContainerInstanceImageIndex,
-        "Sprite" => SpriteInstanceImageIndex,
-        "NineSlice" => NineSliceInstanceImageIndex,
-        "Text" => TextInstanceImageIndex,
-        "Rectangle" => RectangleInstanceImageIndex,
-        "ColoredRectangle" => ColoredRectangleInstanceImageIndex,
-        "Circle" => CircleInstanceImageIndex,
-        "ColoredCircle" => ColoredCircleInstanceImageIndex,
-        "RoundedRectangle" => RoundedRectangleInstanceImageIndex,
-        "Polygon" => PolygonInstanceImageIndex,
-        "Arc" => ArcInstanceImageIndex,
-        "Line" => LineInstanceImageIndex,
-        "Canvas" => CanvasInstanceImageIndex,
-        "LottieAnimation" => LottieAnimationInstanceImageIndex,
-        "Svg" => SvgInstanceImageIndex,
-        _ => InstanceImageIndex,
-    };
-
-    public static int GetImageIndexForStandardElement(string? name) => name switch
-    {
-        "Container" => ContainerImageIndex,
-        "Sprite" => SpriteImageIndex,
-        "NineSlice" => NineSliceImageIndex,
-        "Text" => TextImageIndex,
-        "Rectangle" => RectangleImageIndex,
-        "ColoredRectangle" => ColoredRectangleImageIndex,
-        "Circle" => CircleImageIndex,
-        "ColoredCircle" => ColoredCircleImageIndex,
-        "RoundedRectangle" => RoundedRectangleImageIndex,
-        "Polygon" => PolygonImageIndex,
-        "Arc" => ArcImageIndex,
-        "Line" => LineImageIndex,
-        "Canvas" => CanvasImageIndex,
-        "LottieAnimation" => LottieAnimationImageIndex,
-        "Svg" => SvgImageIndex,
-        _ => StandardElementImageIndex,
-    };
+    // The per-type icon maps and the node icon-decision logic now live on TreeNodeImageLogic
+    // (accessed via _treeNodeImageLogic) so they can be unit-tested without the WinForms tree.
 
     // Part of the phantom right-click workaround. Subscribed in Initialize(),
     // checked in ObjectTreeView_MouseClick(). See comments at both sites.
@@ -376,6 +333,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly ISetVariableLogic _setVariableLogic;
     private readonly IProjectState _projectState;
     private readonly ICollapseToggleService _collapseToggleService;
+    private readonly TreeNodeImageLogic _treeNodeImageLogic;
     private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
     private readonly IPluginManager _pluginManager;
     private readonly IDispatcher _dispatcher;
@@ -443,6 +401,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         _pluginManager = pluginManager;
         _dispatcher = dispatcher;
         _collapseToggleService = new CollapseToggleService();
+        _treeNodeImageLogic = new TreeNodeImageLogic();
         _recordedSelectedInstances = new List<InstanceSave>();
         TreeNodeExtensionMethods.ElementTreeViewManager = this;
         AddCursor = GetAddCursor();
@@ -552,11 +511,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         var treeNode = GetTreeNodeFor(element);
         if (treeNode == null) return;
 
-        bool showExclamation = element.IsSourceFileMissing || hasErrors;
-        int normalIndex = element is ScreenSave ? ScreenImageIndex
-                        : element is ComponentSave ? ComponentImageIndex
-                        : GetImageIndexForStandardElement(element.Name);
-        int desiredIndex = showExclamation ? ExclamationIndex : normalIndex;
+        int desiredIndex = _treeNodeImageLogic.GetElementRefreshImageIndex(element, hasErrors);
 
         if (treeNode.ImageIndex != desiredIndex)
             treeNode.ImageIndex = desiredIndex;
@@ -1242,7 +1197,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             {
                 if (GetTreeNodeFor(standardSave) == null &&  ShouldShow(standardSave))
                 {
-                    AddTreeNodeForElement(standardSave, mStandardElementsTreeNode, GetImageIndexForStandardElement(standardSave.Name));
+                    AddTreeNodeForElement(standardSave, mStandardElementsTreeNode, _treeNodeImageLogic.GetImageIndexForStandardElement(standardSave.Name));
                 }
             }
         }
@@ -1416,7 +1371,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         #endregion
     }
 
-    private static TreeNode AddTreeNodeForElement(ElementSave element, TreeNode parentNode, int defaultImageIndex)
+    private TreeNode AddTreeNodeForElement(ElementSave element, TreeNode parentNode, int defaultImageIndex)
     {
         if (parentNode == null)
         {
@@ -1424,10 +1379,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         }
         TreeNode treeNode = new TreeNode();
 
-        if (element.IsSourceFileMissing)
-            treeNode.ImageIndex = ExclamationIndex;
-        else
-            treeNode.ImageIndex = defaultImageIndex;
+        treeNode.ImageIndex = _treeNodeImageLogic.GetCreateImageIndex(element.IsSourceFileMissing, defaultImageIndex);
 
         treeNode.Tag = element;
         
@@ -1436,14 +1388,11 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         return treeNode;
     }
 
-    private static void AddTreeNodeForBehavior(BehaviorSave behavior, TreeNode parentNode, int defaultImageIndex)
+    private void AddTreeNodeForBehavior(BehaviorSave behavior, TreeNode parentNode, int defaultImageIndex)
     {
         TreeNode treeNode = new TreeNode();
 
-        if (behavior.IsSourceFileMissing)
-            treeNode.ImageIndex = ExclamationIndex;
-        else
-            treeNode.ImageIndex = defaultImageIndex;
+        treeNode.ImageIndex = _treeNodeImageLogic.GetCreateImageIndex(behavior.IsSourceFileMissing, defaultImageIndex);
 
         treeNode.Tag = behavior;
 
@@ -2063,15 +2012,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             var element = ObjectFinder.Self.GetElementSave(instance.BaseType);
 
-            int desiredImageIndex = GetImageIndexForInstance(instance.BaseType);
-            if (element == null || element.IsSourceFileMissing)
-            {
-                desiredImageIndex = ExclamationIndex;
-            }
-            else if (instance.Locked)
-            {
-                desiredImageIndex = LockedInstanceImageIndex;
-            }
+            int desiredImageIndex = _treeNodeImageLogic.GetInstanceRefreshImageIndex(instance, element);
 
             if(nodeForInstance.ImageIndex != desiredImageIndex)
             {
@@ -2132,10 +2073,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
         bool validBaseType = ObjectFinder.Self.GetElementSave(instance.BaseType) != null;
 
-        if (validBaseType || tolerateMissingTypes)
-            treeNode.ImageIndex = instance.Locked ? LockedInstanceImageIndex : GetImageIndexForInstance(instance.BaseType);
-        else
-            treeNode.ImageIndex = ExclamationIndex;
+        treeNode.ImageIndex = _treeNodeImageLogic.GetInstanceCreateImageIndex(instance, validBaseType, tolerateMissingTypes);
 
         treeNode.Tag = instance;
 

--- a/Gum/Plugins/InternalPlugins/TreeView/TreeNodeImageLogic.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/TreeNodeImageLogic.cs
@@ -1,0 +1,109 @@
+using Gum.DataTypes;
+using static Gum.Managers.ElementTreeViewManager;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Resolves the tree-view ImageList index for element, behavior, and instance nodes.
+/// Extracted from <see cref="ElementTreeViewManager"/> so the (pure, WinForms-free) icon-decision
+/// logic can be unit-tested directly. The ImageIndex constants themselves still live on
+/// <see cref="ElementTreeViewManager"/> because non-tree code (e.g. ElementTreeViewCreator) references them.
+/// </summary>
+class TreeNodeImageLogic
+{
+    /// <summary>
+    /// Returns the per-type (blue-tinted) icon for an instance whose BaseType is a standard element.
+    /// Falls back to the generic <see cref="InstanceImageIndex"/> for component-typed instances or
+    /// unrecognized types.
+    /// </summary>
+    public int GetImageIndexForInstance(string? baseType) => baseType switch
+    {
+        "Container" => ContainerInstanceImageIndex,
+        "Sprite" => SpriteInstanceImageIndex,
+        "NineSlice" => NineSliceInstanceImageIndex,
+        "Text" => TextInstanceImageIndex,
+        "Rectangle" => RectangleInstanceImageIndex,
+        "ColoredRectangle" => ColoredRectangleInstanceImageIndex,
+        "Circle" => CircleInstanceImageIndex,
+        "ColoredCircle" => ColoredCircleInstanceImageIndex,
+        "RoundedRectangle" => RoundedRectangleInstanceImageIndex,
+        "Polygon" => PolygonInstanceImageIndex,
+        "Arc" => ArcInstanceImageIndex,
+        "Line" => LineInstanceImageIndex,
+        "Canvas" => CanvasInstanceImageIndex,
+        "LottieAnimation" => LottieAnimationInstanceImageIndex,
+        "Svg" => SvgInstanceImageIndex,
+        _ => InstanceImageIndex,
+    };
+
+    /// <summary>
+    /// Returns the per-type (purple-tinted) icon for a standard element by name, falling back to
+    /// <see cref="StandardElementImageIndex"/> for unrecognized names.
+    /// </summary>
+    public int GetImageIndexForStandardElement(string? name) => name switch
+    {
+        "Container" => ContainerImageIndex,
+        "Sprite" => SpriteImageIndex,
+        "NineSlice" => NineSliceImageIndex,
+        "Text" => TextImageIndex,
+        "Rectangle" => RectangleImageIndex,
+        "ColoredRectangle" => ColoredRectangleImageIndex,
+        "Circle" => CircleImageIndex,
+        "ColoredCircle" => ColoredCircleImageIndex,
+        "RoundedRectangle" => RoundedRectangleImageIndex,
+        "Polygon" => PolygonImageIndex,
+        "Arc" => ArcImageIndex,
+        "Line" => LineImageIndex,
+        "Canvas" => CanvasImageIndex,
+        "LottieAnimation" => LottieAnimationImageIndex,
+        "Svg" => SvgImageIndex,
+        _ => StandardElementImageIndex,
+    };
+
+    /// <summary>
+    /// The icon for an existing element node being refreshed: an exclamation when the source file is
+    /// missing or the element has errors, otherwise the per-type element icon.
+    /// </summary>
+    public int GetElementRefreshImageIndex(ElementSave element, bool hasErrors)
+    {
+        bool showExclamation = element.IsSourceFileMissing || hasErrors;
+        int normalIndex = element is ScreenSave ? ScreenImageIndex
+                        : element is ComponentSave ? ComponentImageIndex
+                        : GetImageIndexForStandardElement(element.Name);
+        return showExclamation ? ExclamationIndex : normalIndex;
+    }
+
+    /// <summary>
+    /// The icon for a freshly-created element or behavior node: an exclamation when the source file is
+    /// missing, otherwise the supplied default (type) icon.
+    /// </summary>
+    public int GetCreateImageIndex(bool isSourceFileMissing, int defaultImageIndex)
+        => isSourceFileMissing ? ExclamationIndex : defaultImageIndex;
+
+    /// <summary>
+    /// The icon for a freshly-created instance node. A locked instance shows the lock icon; an instance
+    /// whose base type is missing (and missing types are not tolerated) shows an exclamation.
+    /// </summary>
+    public int GetInstanceCreateImageIndex(InstanceSave instance, bool baseTypeValid, bool tolerateMissingTypes)
+    {
+        if (baseTypeValid || tolerateMissingTypes)
+            return instance.Locked ? LockedInstanceImageIndex : GetImageIndexForInstance(instance.BaseType);
+        else
+            return ExclamationIndex;
+    }
+
+    /// <summary>
+    /// The icon for an existing instance node being refreshed. Exclamation wins when the base element is
+    /// missing or its source file is missing; otherwise a locked instance shows the lock icon, and
+    /// everything else shows the per-type instance icon.
+    /// </summary>
+    public int GetInstanceRefreshImageIndex(InstanceSave instance, ElementSave? baseElement)
+    {
+        int desiredImageIndex = GetImageIndexForInstance(instance.BaseType);
+        if (baseElement == null || baseElement.IsSourceFileMissing)
+            desiredImageIndex = ExclamationIndex;
+        else if (instance.Locked)
+            desiredImageIndex = LockedInstanceImageIndex;
+        return desiredImageIndex;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeNodeImageLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeNodeImageLogicTests.cs
@@ -1,0 +1,127 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+// Characterization (pinning) tests for the icon-index decision logic extracted from
+// ElementTreeViewManager. They assert against the named ImageIndex constants, so they pin the
+// semantic type -> icon mapping and survive any renumbering of the underlying indices.
+public class TreeNodeImageLogicTests
+{
+    private readonly TreeNodeImageLogic _logic = new TreeNodeImageLogic();
+
+    [Fact]
+    public void GetCreateImageIndex_MissingSource_ReturnsExclamation()
+    {
+        _logic.GetCreateImageIndex(isSourceFileMissing: true, defaultImageIndex: ElementTreeViewManager.ComponentImageIndex)
+            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+    }
+
+    [Fact]
+    public void GetCreateImageIndex_PresentSource_ReturnsDefault()
+    {
+        _logic.GetCreateImageIndex(isSourceFileMissing: false, defaultImageIndex: ElementTreeViewManager.ComponentImageIndex)
+            .ShouldBe(ElementTreeViewManager.ComponentImageIndex);
+    }
+
+    [Fact]
+    public void GetElementRefreshImageIndex_ComponentWithErrors_ReturnsExclamation()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+
+        _logic.GetElementRefreshImageIndex(component, hasErrors: true)
+            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+    }
+
+    [Fact]
+    public void GetElementRefreshImageIndex_ScreenNoErrors_ReturnsScreenIcon()
+    {
+        ScreenSave screen = new ScreenSave { Name = "MyScreen" };
+
+        _logic.GetElementRefreshImageIndex(screen, hasErrors: false)
+            .ShouldBe(ElementTreeViewManager.ScreenImageIndex);
+    }
+
+    [Fact]
+    public void GetImageIndexForInstance_KnownStandardType_ReturnsPerTypeInstanceIcon()
+    {
+        _logic.GetImageIndexForInstance("Sprite").ShouldBe(ElementTreeViewManager.SpriteInstanceImageIndex);
+    }
+
+    [Fact]
+    public void GetImageIndexForInstance_UnknownType_ReturnsGenericInstanceIcon()
+    {
+        _logic.GetImageIndexForInstance("SomeComponent").ShouldBe(ElementTreeViewManager.InstanceImageIndex);
+    }
+
+    [Fact]
+    public void GetImageIndexForStandardElement_KnownType_ReturnsPerTypeIcon()
+    {
+        _logic.GetImageIndexForStandardElement("Text").ShouldBe(ElementTreeViewManager.TextImageIndex);
+    }
+
+    [Fact]
+    public void GetImageIndexForStandardElement_UnknownType_ReturnsGenericStandardIcon()
+    {
+        _logic.GetImageIndexForStandardElement("NotAStandard").ShouldBe(ElementTreeViewManager.StandardElementImageIndex);
+    }
+
+    [Fact]
+    public void GetInstanceCreateImageIndex_InvalidBaseTypeNotTolerated_ReturnsExclamation()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Broken", BaseType = "Missing" };
+
+        _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: false, tolerateMissingTypes: false)
+            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+    }
+
+    [Fact]
+    public void GetInstanceCreateImageIndex_LockedInstance_ReturnsLockIcon()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Locked", BaseType = "Sprite", Locked = true };
+
+        _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: true, tolerateMissingTypes: false)
+            .ShouldBe(ElementTreeViewManager.LockedInstanceImageIndex);
+    }
+
+    [Fact]
+    public void GetInstanceCreateImageIndex_ValidUnlocked_ReturnsPerTypeIcon()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Text", BaseType = "Text" };
+
+        _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: true, tolerateMissingTypes: false)
+            .ShouldBe(ElementTreeViewManager.TextInstanceImageIndex);
+    }
+
+    [Fact]
+    public void GetInstanceRefreshImageIndex_LockedInstanceWithValidBase_ReturnsLockIcon()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Locked", BaseType = "Sprite", Locked = true };
+        ComponentSave baseElement = new ComponentSave { Name = "Sprite" };
+
+        _logic.GetInstanceRefreshImageIndex(instance, baseElement)
+            .ShouldBe(ElementTreeViewManager.LockedInstanceImageIndex);
+    }
+
+    [Fact]
+    public void GetInstanceRefreshImageIndex_MissingBaseElement_ReturnsExclamation()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Orphan", BaseType = "Sprite" };
+
+        _logic.GetInstanceRefreshImageIndex(instance, baseElement: null)
+            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+    }
+
+    [Fact]
+    public void GetInstanceRefreshImageIndex_ValidUnlocked_ReturnsPerTypeIcon()
+    {
+        InstanceSave instance = new InstanceSave { Name = "Sprite", BaseType = "Sprite" };
+        ComponentSave baseElement = new ComponentSave { Name = "Sprite" };
+
+        _logic.GetInstanceRefreshImageIndex(instance, baseElement)
+            .ShouldBe(ElementTreeViewManager.SpriteInstanceImageIndex);
+    }
+}


### PR DESCRIPTION
## Phase 4a of #3755 — decouple `ElementTreeViewManager` from WinForms (step 1)

First slice of the multi-week Phase 4a decoupling. Moves the pure icon-index decision logic out of the ~3,100-line `ElementTreeViewManager` god class into a new WinForms-free `TreeNodeImageLogic` service so it can be unit-tested directly.

### What moved
- The two per-type icon maps (`GetImageIndexForInstance`, `GetImageIndexForStandardElement`) — internal-only, moved verbatim.
- The five node icon-decision sites, faithfully (element/behavior create, element refresh, instance create, instance refresh). Per-site logic differs subtly (Locked vs Exclamation ordering), so nothing was unified — each was preserved exactly.
- `AddTreeNodeForElement` / `AddTreeNodeForBehavior` become instance methods (were `static`), per the repo's refactoring direction.

### Tests
14 new characterization (pinning) tests in `TreeNodeImageLogicTests`, asserting against the named `ImageIndex` constants so they pin the semantic type→icon mapping and survive any index renumbering. Full `GumToolUnitTests` suite green (968 passed, 4 pre-existing skips).

### Verdicts
- **Manual test:** batched — behavior-preserving extraction, covered by the pinning tests + `GumFull.sln` build; folding into the one end-of-stack visual pass.
- **FRB canary:** not needed — tool-only code (`Gum.csproj`); no `GumCoreShared.projitems` / FRB1-shared source touched.

Part of #3755. (Deliberately **not** linked via `gh issue develop` and no closing keyword — this is phase 1 of a stacked multi-PR effort, so it must not auto-close the issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
