### PR TITLE
Add headless ITreeNode element-type predicates, prune two dead ones (#3755)

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -2586,26 +2586,6 @@ public static class TreeNodeExtensionMethods
     }
 
     /// <summary>
-    /// Determines whether the tree node represents an instance of an element.
-    /// </summary>
-    /// <param name="treeNode">The tree node to check.</param>
-    /// <returns>True if the node's Tag is an InstanceSave instance; otherwise, false.</returns>
-    public static bool IsInstanceTreeNode(this TreeNode treeNode)
-    {
-        return treeNode.Tag is InstanceSave;
-    }
-
-    /// <summary>
-    /// Determines whether the tree node represents a State.
-    /// </summary>
-    /// <param name="treeNode">The tree node to check.</param>
-    /// <returns>True if the node's Tag is a StateSave instance; otherwise, false.</returns>
-    public static bool IsStateSaveTreeNode(this TreeNode treeNode)
-    {
-        return treeNode.Tag is StateSave;
-    }
-
-    /// <summary>
     /// Determines whether the tree node is one of the top-level element container folders
     /// (Screens, Components, Standard, or Behaviors).
     /// </summary>

--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.Managers;
 using Shouldly;
 using System.Windows.Forms;
@@ -97,5 +98,35 @@ public class TreeNodePredicateExtensionsTests
     public void IsTopStandardElementTreeNode_WrongText_ReturnsFalse()
     {
         new FakeTreeNode { Text = "Screens" }.IsTopStandardElementTreeNode().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsBehaviorTreeNode_BehaviorTag_ReturnsTrue()
+    {
+        new FakeTreeNode { Tag = new BehaviorSave() }.IsBehaviorTreeNode().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsComponentTreeNode_ComponentTag_ReturnsTrue()
+    {
+        new FakeTreeNode { Tag = new ComponentSave() }.IsComponentTreeNode().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsScreenTreeNode_ComponentTag_ReturnsFalse()
+    {
+        new FakeTreeNode { Tag = new ComponentSave() }.IsScreenTreeNode().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsScreenTreeNode_ScreenTag_ReturnsTrue()
+    {
+        new FakeTreeNode { Tag = new ScreenSave() }.IsScreenTreeNode().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsStandardElementTreeNode_StandardTag_ReturnsTrue()
+    {
+        new FakeTreeNode { Tag = new StandardElementSave() }.IsStandardElementTreeNode().ShouldBeTrue();
     }
 }

--- a/Tools/Gum.Presentation/Managers/TreeNodeElementExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeElementExtensions.cs
@@ -1,0 +1,21 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Headless element-type classification predicates over <see cref="ITreeNode"/>, keyed off
+/// <see cref="ITreeNode.Tag"/>. Companion to <see cref="TreeNodeFolderExtensions"/> (which classifies
+/// folders/containers). The WinForms <c>TreeNode</c> overloads stay in ElementTreeViewManager.cs for
+/// its own WinForms-native call sites until those convert to <see cref="ITreeNode"/>.
+/// </summary>
+public static class TreeNodeElementExtensions
+{
+    public static bool IsScreenTreeNode(this ITreeNode treeNode) => treeNode.Tag is ScreenSave;
+
+    public static bool IsComponentTreeNode(this ITreeNode treeNode) => treeNode.Tag is ComponentSave;
+
+    public static bool IsBehaviorTreeNode(this ITreeNode treeNode) => treeNode.Tag is BehaviorSave;
+
+    public static bool IsStandardElementTreeNode(this ITreeNode treeNode) => treeNode.Tag is StandardElementSave;
+}


### PR DESCRIPTION
## Phase 4a of #3755 — decouple `ElementTreeViewManager` from WinForms (step 3)

Stacked on #3814. Completes the headless classification-predicate surface so the eventual ETVM-internal `TreeNode`→`ITreeNode` conversion can use `ITreeNode` predicates directly instead of adding them mid-conversion.

### Change
- Added true `ITreeNode` versions of the four `Tag`-based element predicates — `IsScreenTreeNode`, `IsComponentTreeNode`, `IsBehaviorTreeNode`, `IsStandardElementTreeNode` — in `Gum.Presentation`'s new `TreeNodeElementExtensions` (companion to `TreeNodeFolderExtensions`). The WinForms `TreeNode` overloads stay in ETVM for its own still-`TreeNode`-native call sites.
- Removed the dead `IsInstanceTreeNode` / `IsStateSaveTreeNode` (`TreeNode`) predicates — both had zero callers, confirmed by grep and by a clean full-solution build without them.

### Tests
5 new tests via the in-memory `ITreeNode` fake. Full `GumToolUnitTests` suite green (983 passed).

### Verdicts
- **Manual test:** batched — additive headless predicates + dead-code removal, covered by tests + `GumFull.sln` build; folding into the one end-of-stack visual pass.
- **FRB canary:** not needed — tool-only (`Gum.csproj` / `Gum.Presentation`); no `GumCoreShared.projitems` / FRB1-shared source touched.

Part of #3755 (no closing keyword — stacked multi-PR effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
