### PR TITLE
Widen ITreeNode with Children navigation + value equality (#3755)

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -111,6 +111,9 @@ class TreeNodeWrapper : ITreeNode
         ? new TreeNodeWrapper(Node.Parent)
         : null;
 
+    public IEnumerable<ITreeNode> Children =>
+        Node.Nodes.Cast<TreeNode>().Select(child => new TreeNodeWrapper(child));
+
     public FilePath GetFullFilePath() => Node.GetFullFilePath();
 
     public string FullPath => Node.FullPath;
@@ -125,6 +128,13 @@ class TreeNodeWrapper : ITreeNode
     }
 
     public void Expand() => Node.Expand();
+
+    // Value equality keyed on the wrapped node, so wrappers minted afresh by Parent/Children
+    // (a new TreeNodeWrapper each access) compare equal when they wrap the same underlying node.
+    public override bool Equals(object? obj) =>
+        obj is TreeNodeWrapper other && ReferenceEquals(Node, other.Node);
+
+    public override int GetHashCode() => Node.GetHashCode();
 
     public override string ToString() => Node.Text;
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
@@ -2,6 +2,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.Managers;
 using Shouldly;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using ToolsUtilities;
 using Xunit;
@@ -16,18 +17,70 @@ public class TreeNodePredicateExtensionsTests
 {
     private sealed class FakeTreeNode : ITreeNode
     {
+        private readonly List<ITreeNode> _children = new();
         public object? Tag { get; set; }
         public string Text { get; set; } = "";
         public string FullPath { get; set; } = "";
         public ITreeNode? Parent { get; set; }
+        public IEnumerable<ITreeNode> Children => _children;
         public FilePath GetFullFilePath() => new FilePath(FullPath);
         public void Expand() { }
 
         public FakeTreeNode AddChild(FakeTreeNode child)
         {
             child.Parent = this;
+            _children.Add(child);
             return child;
         }
+    }
+
+    [Fact]
+    public void Equals_DifferentUnderlyingNode_ReturnsFalse()
+    {
+        TreeNodeWrapper first = new TreeNodeWrapper(new TreeNode("A"));
+        TreeNodeWrapper second = new TreeNodeWrapper(new TreeNode("A"));
+
+        first.Equals(second).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_Null_ReturnsFalse()
+    {
+        TreeNodeWrapper wrapper = new TreeNodeWrapper(new TreeNode("A"));
+
+        wrapper.Equals(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_SameUnderlyingNode_ReturnsTrueAndSharesHashCode()
+    {
+        TreeNode node = new TreeNode("A");
+        TreeNodeWrapper first = new TreeNodeWrapper(node);
+        TreeNodeWrapper second = new TreeNodeWrapper(node);
+
+        first.Equals(second).ShouldBeTrue();
+        first.GetHashCode().ShouldBe(second.GetHashCode());
+    }
+
+    [Fact]
+    public void GetAllChildrenNodesRecursively_LeafNode_ReturnsEmpty()
+    {
+        FakeTreeNode leaf = new FakeTreeNode { Text = "Leaf" };
+
+        leaf.GetAllChildrenNodesRecursively().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetAllChildrenNodesRecursively_MultiLevelTree_ReturnsDescendantsDepthFirst()
+    {
+        FakeTreeNode root = new FakeTreeNode { Text = "Root" };
+        FakeTreeNode a = root.AddChild(new FakeTreeNode { Text = "A" });
+        FakeTreeNode a1 = a.AddChild(new FakeTreeNode { Text = "A1" });
+        FakeTreeNode b = root.AddChild(new FakeTreeNode { Text = "B" });
+
+        List<ITreeNode> descendants = root.GetAllChildrenNodesRecursively();
+
+        descendants.ShouldBe(new ITreeNode[] { a, a1, b });
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/ITreeNode.cs
+++ b/Tools/Gum.Presentation/Managers/ITreeNode.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using ToolsUtilities;
 
 namespace Gum.Managers;
@@ -15,6 +16,13 @@ public interface ITreeNode
     string Text { get; set; }
 
     string FullPath { get; }
+
+    /// <summary>
+    /// The node's immediate child nodes. Lets callers walk the tree headlessly (e.g. via
+    /// <see cref="TreeNodeNavigationExtensions.GetAllChildrenNodesRecursively"/>) instead of
+    /// depending on the WinForms <c>TreeNode.Nodes</c> collection.
+    /// </summary>
+    IEnumerable<ITreeNode> Children { get; }
 
     void Expand();
 }

--- a/Tools/Gum.Presentation/Managers/TreeNodeNavigationExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeNavigationExtensions.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Headless tree-traversal helpers over <see cref="ITreeNode"/>. Companion to
+/// <see cref="TreeNodeFolderExtensions"/>/<see cref="TreeNodeElementExtensions"/> (which classify
+/// nodes). The WinForms <c>TreeNode</c>-typed <c>GetAllChildrenNodesRecursively</c> overload stays
+/// in ElementTreeViewManager.cs for its own WinForms-native call sites; this mirror works for any
+/// <see cref="ITreeNode"/> implementation.
+/// </summary>
+public static class TreeNodeNavigationExtensions
+{
+    /// <summary>
+    /// Gets all descendant nodes in a flattened, depth-first list. The node itself is not included.
+    /// </summary>
+    public static List<ITreeNode> GetAllChildrenNodesRecursively(this ITreeNode treeNode)
+    {
+        List<ITreeNode> toReturn = new List<ITreeNode>();
+
+        void Fill(ITreeNode parent)
+        {
+            foreach (ITreeNode child in parent.Children)
+            {
+                toReturn.Add(child);
+                Fill(child);
+            }
+        }
+
+        Fill(treeNode);
+
+        return toReturn;
+    }
+}


### PR DESCRIPTION
Part of #3755. Phase 4a of decoupling `ElementTreeViewManager` from WinForms `TreeNode` — lays the child-navigation primitive so ETVM's `.Nodes`-native internals can later convert to `ITreeNode`.

**Change (additive, no call sites converted):**
- `ITreeNode` gains `IEnumerable<ITreeNode> Children`.
- `TreeNodeWrapper` implements `Children` (wraps `Node.Nodes`) and gains value equality (`Equals`/`GetHashCode` keyed on the wrapped node) — so wrappers minted afresh by `Parent`/`Children` compare equal for the same underlying node.
- New headless `GetAllChildrenNodesRecursively(this ITreeNode)` mirroring the existing WinForms `TreeNode` overload, which stays in place.

Value equality confirmed safe: no `ITreeNode` `HashSet`/`Dictionary`/`Contains`/`==` usage relies on reference equality; `operator==` left untouched so `== null` checks are unchanged.

TDD via the `FakeTreeNode` pattern in `TreeNodePredicateExtensionsTests`; 20/20 green, `GumFull.sln` builds clean.
