### PR TITLE
Mirror ETVM node-search family as headless ITreeNode extensions (#3755)

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
@@ -84,6 +84,57 @@ public class TreeNodePredicateExtensionsTests
     }
 
     [Fact]
+    public void GetInstanceTreeNodeByName_MatchingInstanceNameNested_ReturnsNode()
+    {
+        FakeTreeNode container = new FakeTreeNode { Text = "Element" };
+        FakeTreeNode parentInstance = container.AddChild(new FakeTreeNode { Tag = new InstanceSave { Name = "Parent" } });
+        FakeTreeNode childInstance = parentInstance.AddChild(new FakeTreeNode { Tag = new InstanceSave { Name = "Child" } });
+
+        container.GetInstanceTreeNodeByName("Child").ShouldBe(childInstance);
+    }
+
+    [Fact]
+    public void GetInstanceTreeNodeByName_NonInstanceTagWithMatchingName_ReturnsNull()
+    {
+        FakeTreeNode container = new FakeTreeNode { Text = "Element" };
+        container.AddChild(new FakeTreeNode { Tag = new ScreenSave { Name = "Target" } });
+
+        container.GetInstanceTreeNodeByName("Target").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_InstanceSaveByReference_ReturnsNodeNotSameNamedSibling()
+    {
+        InstanceSave target = new InstanceSave { Name = "Duplicate" };
+        InstanceSave sameNameOther = new InstanceSave { Name = "Duplicate" };
+        FakeTreeNode container = new FakeTreeNode { Text = "Element" };
+        container.AddChild(new FakeTreeNode { Tag = sameNameOther });
+        FakeTreeNode targetNode = container.AddChild(new FakeTreeNode { Tag = target });
+
+        container.GetTreeNodeFor(target).ShouldBe(targetNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_MatchNestedInTree_ReturnsNode()
+    {
+        ComponentSave tag = new ComponentSave { Name = "Comp" };
+        FakeTreeNode root = new FakeTreeNode { Text = "Components" };
+        FakeTreeNode folder = root.AddChild(new FakeTreeNode { Text = "Sub" });
+        FakeTreeNode elementNode = folder.AddChild(new FakeTreeNode { Tag = tag });
+
+        root.GetTreeNodeForTag(tag).ShouldBe(elementNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_NoMatch_ReturnsNull()
+    {
+        FakeTreeNode root = new FakeTreeNode { Text = "Components" };
+        root.AddChild(new FakeTreeNode { Tag = new ComponentSave { Name = "Other" } });
+
+        root.GetTreeNodeForTag(new ComponentSave { Name = "Missing" }).ShouldBeNull();
+    }
+
+    [Fact]
     public void IsPartOfStandardElementsFolderStructure_ElementUnderStandardRoot_ReturnsTrue()
     {
         FakeTreeNode standardRoot = new FakeTreeNode { Text = "Standard" };

--- a/Tools/Gum.Presentation/Managers/TreeNodeSearchExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeSearchExtensions.cs
@@ -1,0 +1,69 @@
+using Gum.DataTypes;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Headless recursive node-search helpers over <see cref="ITreeNode"/>, mirroring the WinForms
+/// <c>TreeNode</c>-typed search methods in ElementTreeViewManager.cs. Each walks a container's
+/// descendants depth-first (the container itself is never matched) using only
+/// <see cref="ITreeNode.Children"/> and <see cref="ITreeNode.Tag"/>, so they work for any
+/// <see cref="ITreeNode"/> implementation. The WinForms overloads stay in ElementTreeViewManager.cs
+/// for its WinForms-native call sites; the root-selecting element/behavior/directory lookups there
+/// still depend on ETVM's WinForms root fields (and, for the directory lookups, project state) and
+/// are not mirrored here.
+/// </summary>
+public static class TreeNodeSearchExtensions
+{
+    /// <summary>
+    /// Searches the container's descendants depth-first for the node whose
+    /// <see cref="ITreeNode.Tag"/> is the same reference as <paramref name="tag"/>.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeForTag(this ITreeNode container, object tag)
+    {
+        foreach (ITreeNode node in container.Children)
+        {
+            if (node.Tag == tag)
+            {
+                return node;
+            }
+
+            ITreeNode? childNode = node.GetTreeNodeForTag(tag);
+            if (childNode != null)
+            {
+                return childNode;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Searches the container's descendants depth-first for the node representing
+    /// <paramref name="instanceSave"/>, matched by reference via its <see cref="ITreeNode.Tag"/>.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeFor(this ITreeNode container, InstanceSave instanceSave) =>
+        container.GetTreeNodeForTag(instanceSave);
+
+    /// <summary>
+    /// Searches the container's descendants depth-first for the instance node whose
+    /// <see cref="InstanceSave.Name"/> equals <paramref name="name"/>.
+    /// </summary>
+    public static ITreeNode? GetInstanceTreeNodeByName(this ITreeNode container, string name)
+    {
+        foreach (ITreeNode node in container.Children)
+        {
+            if (node.Tag is InstanceSave instanceSave && instanceSave.Name == name)
+            {
+                return node;
+            }
+
+            ITreeNode? childNode = node.GetInstanceTreeNodeByName(name);
+            if (childNode != null)
+            {
+                return childNode;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #3755 — Phase 4a of decoupling `ElementTreeViewManager` from WinForms `TreeNode`.

Adds `TreeNodeSearchExtensions` (Gum.Presentation) with headless `ITreeNode` versions of the pure recursive container-traversal searches:

- `GetTreeNodeForTag(container, tag)`
- `GetTreeNodeFor(container, InstanceSave)` (delegates to the tag search)
- `GetInstanceTreeNodeByName(container, name)`

The existing `Children`/`Tag` primitives fully cover these — **no `ITreeNode` widening needed**. Mirrors the #3816 convention: the WinForms `TreeNode` overloads stay in `ElementTreeViewManager.cs` untouched (additive).

Deferred to a later increment (need ETVM to expose its WinForms root fields as `ITreeNode`, or project state): the root-selecting `GetTreeNodeFor(ElementSave/Screen/Component/Standard/Behavior)`, the directory lookups `GetTreeNodeFor(string)`, and the `GetTreeNodeForTag(tag, null)` root-fallback branch.

Verified: `GumFull.sln` builds clean; `TreeNodePredicateExtensionsTests` 25/25 (5 new, red-first via `FakeTreeNode`).
