### PR TITLE
Add SkiaInGum.csproj FRB canary coverage + fix its RenderableShapeBase build break

### DIFF
--- a/.claude/skills/frb-build-verification/SKILL.md
+++ b/.claude/skills/frb-build-verification/SKILL.md
@@ -27,6 +27,7 @@ Pick by what you changed. **The "Lives in" column is the repo containing the `.c
 |---|---|---|---|
 | `GumCommon/` (anything in `GumCoreShared.projitems`) | **Gum repo** (this repo) | `GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj` | GumCommon shared into FRB |
 | `MonoGameGum/Forms/` (in `FlatRedBall.Forms.Shared.projitems`) | **FlatRedBall sibling repo** | `Engines/Forms/FlatRedBall.Forms/FlatRedBall.Forms.DesktopGlNet6/FlatRedBall.Forms.DesktopGlNet6.csproj` | Forms shared into FRB |
+| Types referenced by `Gum/SvgPlugin/SkiaInGumShared/` (e.g. renames/moves in `Runtimes/GumShapes/`, `Runtimes/SkiaGum/`) | **Gum repo** (this repo) | `Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj` | Legacy FRB Skia-adapter layer — references `GumCore.DesktopGlNet6.csproj` directly, so it also needs the FlatRedBall sibling even though its own `.csproj` lives here |
 
 `GueDeriving/*Runtime`, `MonoGameGum/Renderables/`, `MonoGameGum/ExtensionMethods/`, `MonoGameGum/Input/` (Cursor, Keyboard, gamepad drivers), and the `Forms/DefaultVisuals/` runtimes are **not** compiled by FRB1 (it generates its own) — changing only those needs no FRB build.
 

--- a/Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj
+++ b/Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj
@@ -32,6 +32,18 @@
 		<Folder Include="Rendering\" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- RenderableShapeAdapter.cs (below, via SkiaInGumShared.projitems) needs the real
+		     RenderableShapeBase from Runtimes/SkiaGum — mirrors the Link include SkiaPlugin.csproj
+		     already has for the same file. -->
+		<Compile Include="..\..\..\Runtimes\SkiaGum\Renderables\RenderableShapeBase.cs">
+			<Link>Renderables\RenderableShapeBase.cs</Link>
+		</Compile>
+		<Compile Include="..\..\..\Runtimes\SkiaGum\Renderables\BlendToSkBlendModeExtensions.cs">
+			<Link>Renderables\BlendToSkBlendModeExtensions.cs</Link>
+		</Compile>
+	</ItemGroup>
+
 	<Import Project="SkiaInGumShared.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
## Summary
- `frb-build-verification` only tracked 2 FRB-adjacent build targets. A third, `Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj`, wasn't covered.
- That gap let `RenderableShapeAdapter.cs` silently break: it referenced `SkiaGum.Renderables.RenderableShapeBase`, but `SkiaInGum.csproj` never referenced `Runtimes/SkiaGum` at all (only `GumCore.DesktopGlNet6.csproj`, which doesn't pull it in). `SkiaPlugin.csproj` (the working tool-side project) already solves this by `<Compile Include>`-linking the file directly — mirrored that fix here (`RenderableShapeBase.cs` + its `BlendToSkBlendModeExtensions.cs` dependency).
- Added the csproj as a new canary row.

## Test plan
- [x] `dotnet build Gum/SvgPlugin/SkiaInGumShared/SkiaInGum.csproj -c Debug` — 0 errors (was 6 CS0246 errors)
- [x] `dotnet build GumFull.sln` — still 0 errors