### PR TITLE
Mirror ETVM root-selecting search overloads as headless ITreeNode extensions (#3755)

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -141,7 +141,7 @@ class TreeNodeWrapper : ITreeNode
 
 #endregion
 
-public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, IRecipient<ApplicationStartupMessage>
+public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, IRecipient<ApplicationStartupMessage>, IElementTreeRoots
 {
     #region Fields
 
@@ -330,6 +330,13 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     public TreeNode RootStandardElementsTreeNode => mStandardElementsTreeNode;
 
     public TreeNode RootBehaviorsTreeNode => mBehaviorsTreeNode;
+
+    // Headless ITreeNode-typed mirrors of the four WinForms root fields above, enabling the
+    // root-selecting searches in TreeNodeRootSearchExtensions.
+    ITreeNode? IElementTreeRoots.Screens => mScreensTreeNode != null ? new TreeNodeWrapper(mScreensTreeNode) : null;
+    ITreeNode? IElementTreeRoots.Components => mComponentsTreeNode != null ? new TreeNodeWrapper(mComponentsTreeNode) : null;
+    ITreeNode? IElementTreeRoots.StandardElements => mStandardElementsTreeNode != null ? new TreeNodeWrapper(mStandardElementsTreeNode) : null;
+    ITreeNode? IElementTreeRoots.Behaviors => mBehaviorsTreeNode != null ? new TreeNodeWrapper(mBehaviorsTreeNode) : null;
 
     private IDragDropManager _dragDropManager;
     private readonly ICopyPasteLogic _copyPasteLogic;

--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
@@ -34,6 +34,14 @@ public class TreeNodePredicateExtensionsTests
         }
     }
 
+    private sealed class FakeElementTreeRoots : IElementTreeRoots
+    {
+        public ITreeNode? Screens { get; set; }
+        public ITreeNode? Components { get; set; }
+        public ITreeNode? StandardElements { get; set; }
+        public ITreeNode? Behaviors { get; set; }
+    }
+
     [Fact]
     public void Equals_DifferentUnderlyingNode_ReturnsFalse()
     {
@@ -103,6 +111,49 @@ public class TreeNodePredicateExtensionsTests
     }
 
     [Fact]
+    public void GetTreeNodeFor_BehaviorSave_SelectsBehaviorsRoot()
+    {
+        BehaviorSave tag = new BehaviorSave { Name = "Behavior" };
+        FakeTreeNode behaviorsRoot = new FakeTreeNode { Text = "Behaviors" };
+        FakeTreeNode behaviorNode = behaviorsRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Behaviors = behaviorsRoot };
+
+        roots.GetTreeNodeFor(tag).ShouldBe(behaviorNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_ComponentSave_SelectsComponentsRoot()
+    {
+        ComponentSave tag = new ComponentSave { Name = "Comp" };
+        FakeTreeNode componentsRoot = new FakeTreeNode { Text = "Components" };
+        FakeTreeNode componentNode = componentsRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Components = componentsRoot };
+
+        roots.GetTreeNodeFor(tag).ShouldBe(componentNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_ElementSaveComponentSave_SelectsComponentsRootNotScreens()
+    {
+        ComponentSave tag = new ComponentSave { Name = "Comp" };
+        FakeTreeNode screensRoot = new FakeTreeNode { Text = "Screens" };
+        FakeTreeNode componentsRoot = new FakeTreeNode { Text = "Components" };
+        FakeTreeNode componentNode = componentsRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Screens = screensRoot, Components = componentsRoot };
+        ElementSave elementSave = tag;
+
+        roots.GetTreeNodeFor(elementSave).ShouldBe(componentNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_ElementSaveNull_ReturnsNull()
+    {
+        FakeElementTreeRoots roots = new FakeElementTreeRoots();
+
+        roots.GetTreeNodeFor((ElementSave?)null).ShouldBeNull();
+    }
+
+    [Fact]
     public void GetTreeNodeFor_InstanceSaveByReference_ReturnsNodeNotSameNamedSibling()
     {
         InstanceSave target = new InstanceSave { Name = "Duplicate" };
@@ -112,6 +163,40 @@ public class TreeNodePredicateExtensionsTests
         FakeTreeNode targetNode = container.AddChild(new FakeTreeNode { Tag = target });
 
         container.GetTreeNodeFor(target).ShouldBe(targetNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_ScreenSave_SelectsScreensRoot()
+    {
+        ScreenSave tag = new ScreenSave { Name = "Screen" };
+        FakeTreeNode screensRoot = new FakeTreeNode { Text = "Screens" };
+        FakeTreeNode screenNode = screensRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Screens = screensRoot };
+
+        roots.GetTreeNodeFor(tag).ShouldBe(screenNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_StandardElementSave_SelectsStandardElementsRoot()
+    {
+        StandardElementSave tag = new StandardElementSave { Name = "Sprite" };
+        FakeTreeNode standardRoot = new FakeTreeNode { Text = "Standard" };
+        FakeTreeNode standardNode = standardRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { StandardElements = standardRoot };
+
+        roots.GetTreeNodeFor(tag).ShouldBe(standardNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_ExplicitContainer_OverridesTagTypeRootInference()
+    {
+        ComponentSave tag = new ComponentSave { Name = "Comp" };
+        FakeTreeNode componentsRoot = new FakeTreeNode { Text = "Components" };
+        FakeTreeNode explicitContainer = new FakeTreeNode { Text = "Sub" };
+        FakeTreeNode explicitNode = explicitContainer.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Components = componentsRoot };
+
+        roots.GetTreeNodeForTag(tag, explicitContainer).ShouldBe(explicitNode);
     }
 
     [Fact]
@@ -132,6 +217,34 @@ public class TreeNodePredicateExtensionsTests
         root.AddChild(new FakeTreeNode { Tag = new ComponentSave { Name = "Other" } });
 
         root.GetTreeNodeForTag(new ComponentSave { Name = "Missing" }).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_NullContainerAndRootNotYetCreated_ReturnsNull()
+    {
+        FakeElementTreeRoots roots = new FakeElementTreeRoots();
+
+        roots.GetTreeNodeForTag(new BehaviorSave { Name = "Behavior" }).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_NullContainerUnrecognizedTagType_ReturnsNull()
+    {
+        FakeTreeNode behaviorsRoot = new FakeTreeNode { Text = "Behaviors" };
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Behaviors = behaviorsRoot };
+
+        roots.GetTreeNodeForTag(new InstanceSave { Name = "Instance" }).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTreeNodeForTag_NullContainerWithBehaviorTag_SelectsBehaviorsRoot()
+    {
+        BehaviorSave tag = new BehaviorSave { Name = "Behavior" };
+        FakeTreeNode behaviorsRoot = new FakeTreeNode { Text = "Behaviors" };
+        FakeTreeNode behaviorNode = behaviorsRoot.AddChild(new FakeTreeNode { Tag = tag });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Behaviors = behaviorsRoot };
+
+        roots.GetTreeNodeForTag(tag).ShouldBe(behaviorNode);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/IElementTreeRoots.cs
+++ b/Tools/Gum.Presentation/Managers/IElementTreeRoots.cs
@@ -1,0 +1,15 @@
+namespace Gum.Managers;
+
+/// <summary>
+/// Exposes the four top-level category root nodes of the element tree (Screens, Components,
+/// Standard Elements, Behaviors) headlessly, so root-selecting searches
+/// (<see cref="TreeNodeRootSearchExtensions"/>) can run without the WinForms-native
+/// <c>TreeNode</c> fields ElementTreeViewManager stores them in.
+/// </summary>
+public interface IElementTreeRoots
+{
+    ITreeNode? Screens { get; }
+    ITreeNode? Components { get; }
+    ITreeNode? StandardElements { get; }
+    ITreeNode? Behaviors { get; }
+}

--- a/Tools/Gum.Presentation/Managers/TreeNodeRootSearchExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeRootSearchExtensions.cs
@@ -1,0 +1,62 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Headless root-selecting search helpers mirroring the WinForms <c>TreeNode</c>-typed overloads
+/// in ElementTreeViewManager.cs that pick one of its four category root fields (Screens,
+/// Components, Standard Elements, Behaviors) before searching. Each selects the matching root
+/// from <see cref="IElementTreeRoots"/> and delegates to
+/// <see cref="TreeNodeSearchExtensions.GetTreeNodeForTag(ITreeNode, object)"/>. The WinForms
+/// overloads stay in ElementTreeViewManager.cs for its WinForms-native call sites.
+/// </summary>
+public static class TreeNodeRootSearchExtensions
+{
+    /// <summary>
+    /// Selects the root matching <paramref name="elementSave"/>'s runtime type (Screen, Component,
+    /// or Standard Element) and searches it for the matching node. Returns null for a null
+    /// <paramref name="elementSave"/> or an unrecognized element type.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, ElementSave? elementSave) =>
+        elementSave switch
+        {
+            null => null,
+            ScreenSave screenSave => roots.GetTreeNodeFor(screenSave),
+            ComponentSave componentSave => roots.GetTreeNodeFor(componentSave),
+            StandardElementSave standardElementSave => roots.GetTreeNodeFor(standardElementSave),
+            _ => null
+        };
+
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, ScreenSave screenSave) =>
+        roots.Screens?.GetTreeNodeForTag(screenSave);
+
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, ComponentSave componentSave) =>
+        roots.Components?.GetTreeNodeForTag(componentSave);
+
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, StandardElementSave standardElementSave) =>
+        roots.StandardElements?.GetTreeNodeForTag(standardElementSave);
+
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, BehaviorSave behavior) =>
+        roots.Behaviors?.GetTreeNodeForTag(behavior);
+
+    /// <summary>
+    /// Searches <paramref name="container"/> for the node tagged with <paramref name="tag"/>. When
+    /// <paramref name="container"/> is omitted, the root is inferred from <paramref name="tag"/>'s
+    /// runtime type (Screen/Component/Standard Element/Behavior); an unrecognized type or a root
+    /// that hasn't been created yet returns null.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeForTag(this IElementTreeRoots roots, object tag, ITreeNode? container = null)
+    {
+        container ??= tag switch
+        {
+            ScreenSave => roots.Screens,
+            ComponentSave => roots.Components,
+            StandardElementSave => roots.StandardElements,
+            BehaviorSave => roots.Behaviors,
+            _ => null
+        };
+
+        return container?.GetTreeNodeForTag(tag);
+    }
+}


### PR DESCRIPTION
Part of #3755

Adds `IElementTreeRoots` + `TreeNodeRootSearchExtensions` (Gum.Presentation) mirroring the root-selecting overloads that PR #3817 deferred: `GetTreeNodeFor(ElementSave?/ScreenSave/ComponentSave/StandardElementSave/BehaviorSave)` and the `GetTreeNodeForTag(tag, container=null)` root-fallback branch.

ETVM implements `IElementTreeRoots` by wrapping its four WinForms root fields (`mScreensTreeNode` etc.) in `TreeNodeWrapper` — the enabling move the deferred work needed. The existing WinForms-typed overloads in `ElementTreeViewManager.cs` are untouched (mirror, not delegate — same convention as #3814-#3817).

Deferred: the directory lookups (`GetTreeNodeFor(string absoluteDirectory)` + its path-walk helper) — different recipe (Text-segment walk, needs `_projectState.GumProjectSave`), left as their own increment.

FRB canary: not needed — tool-only change, no GumCommon/MonoGameGum shared source touched.
Manual test: not needed — new headless code path with no existing call sites; covered by unit tests + `GumFull.sln` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)