### PR TITLE
Mirror ETVM directory lookup as headless ITreeNode extensions (#3755)

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodePredicateExtensionsTests.cs
@@ -111,6 +111,26 @@ public class TreeNodePredicateExtensionsTests
     }
 
     [Fact]
+    public void GetTreeNodeFor_AbsoluteDirectoryOutsideKnownCategories_ReturnsNull()
+    {
+        FakeTreeNode screensRoot = new FakeTreeNode { Text = "Screens" };
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Screens = screensRoot };
+
+        roots.GetTreeNodeFor("C:/Project/Other/Sub", "C:/Project/").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_AbsoluteDirectoryUnderNestedScreensSubfolder_ReturnsNestedNode()
+    {
+        FakeTreeNode screensRoot = new FakeTreeNode { Text = "Screens" };
+        FakeTreeNode a = screensRoot.AddChild(new FakeTreeNode { Text = "A" });
+        FakeTreeNode b = a.AddChild(new FakeTreeNode { Text = "B" });
+        FakeElementTreeRoots roots = new FakeElementTreeRoots { Screens = screensRoot };
+
+        roots.GetTreeNodeFor("C:/Project/Screens/A/B", "C:/Project/").ShouldBe(b);
+    }
+
+    [Fact]
     public void GetTreeNodeFor_BehaviorSave_SelectsBehaviorsRoot()
     {
         BehaviorSave tag = new BehaviorSave { Name = "Behavior" };
@@ -119,6 +139,14 @@ public class TreeNodePredicateExtensionsTests
         FakeElementTreeRoots roots = new FakeElementTreeRoots { Behaviors = behaviorsRoot };
 
         roots.GetTreeNodeFor(tag).ShouldBe(behaviorNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_BehaviorsRootNotYetCreated_ReturnsNull()
+    {
+        FakeElementTreeRoots roots = new FakeElementTreeRoots();
+
+        roots.GetTreeNodeFor("C:/Project/Behaviors/A", "C:/Project/").ShouldBeNull();
     }
 
     [Fact]
@@ -154,6 +182,14 @@ public class TreeNodePredicateExtensionsTests
     }
 
     [Fact]
+    public void GetTreeNodeFor_EmptyRelativeDirectory_ReturnsContainerItself()
+    {
+        FakeTreeNode container = new FakeTreeNode { Text = "Screens" };
+
+        container.GetTreeNodeFor("").ShouldBe(container);
+    }
+
+    [Fact]
     public void GetTreeNodeFor_InstanceSaveByReference_ReturnsNodeNotSameNamedSibling()
     {
         InstanceSave target = new InstanceSave { Name = "Duplicate" };
@@ -166,6 +202,15 @@ public class TreeNodePredicateExtensionsTests
     }
 
     [Fact]
+    public void GetTreeNodeFor_NoMatchingSegment_ReturnsNull()
+    {
+        FakeTreeNode container = new FakeTreeNode { Text = "Screens" };
+        container.AddChild(new FakeTreeNode { Text = "A" });
+
+        container.GetTreeNodeFor("missing").ShouldBeNull();
+    }
+
+    [Fact]
     public void GetTreeNodeFor_ScreenSave_SelectsScreensRoot()
     {
         ScreenSave tag = new ScreenSave { Name = "Screen" };
@@ -174,6 +219,15 @@ public class TreeNodePredicateExtensionsTests
         FakeElementTreeRoots roots = new FakeElementTreeRoots { Screens = screensRoot };
 
         roots.GetTreeNodeFor(tag).ShouldBe(screenNode);
+    }
+
+    [Fact]
+    public void GetTreeNodeFor_SegmentCaseInsensitive_ReturnsMatch()
+    {
+        FakeTreeNode container = new FakeTreeNode { Text = "Screens" };
+        FakeTreeNode child = container.AddChild(new FakeTreeNode { Text = "SubFolder" });
+
+        container.GetTreeNodeFor("subfolder").ShouldBe(child);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/TreeNodeDirectoryExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeDirectoryExtensions.cs
@@ -1,0 +1,85 @@
+using System;
+using ToolsUtilities;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Headless mirror of ElementTreeViewManager's directory-path lookup: resolving an absolute
+/// on-disk directory to the tree node representing it. Unlike the tag-based searches in
+/// <see cref="TreeNodeRootSearchExtensions"/>, the root is picked by matching a relative path
+/// prefix ("screens/", "components/", "standards/", "behaviors/") rather than by tag runtime
+/// type, and the remaining path is walked by <see cref="ITreeNode.Text"/> segment rather than by
+/// <see cref="ITreeNode.Tag"/>. The WinForms <c>TreeNode</c> overloads stay in
+/// ElementTreeViewManager.cs for its own WinForms-native call sites.
+/// </summary>
+public static class TreeNodeDirectoryExtensions
+{
+    /// <summary>
+    /// Resolves <paramref name="absoluteDirectory"/> (made relative to
+    /// <paramref name="projectDirectory"/>) to its tree node, selecting the root from
+    /// <paramref name="roots"/> based on which top-level category the path falls under. Returns
+    /// null if the path isn't under any of the four category roots, a category root hasn't been
+    /// created yet, or no node matches the remaining path.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeFor(this IElementTreeRoots roots, string absoluteDirectory, string projectDirectory)
+    {
+        string relative = FileManager.MakeRelative(absoluteDirectory, projectDirectory);
+
+        relative = FileManager.Standardize(relative);
+        // in the tool we use forward slashes:
+        relative = relative.Replace("\\", "/");
+
+        if (relative.StartsWith("screens/"))
+        {
+            return roots.Screens?.GetTreeNodeFor(relative.Substring("screens/".Length));
+        }
+        else if (relative.StartsWith("components/"))
+        {
+            return roots.Components?.GetTreeNodeFor(relative.Substring("components/".Length));
+        }
+        else if (relative.StartsWith("standards/"))
+        {
+            return roots.StandardElements?.GetTreeNodeFor(relative.Substring("standards/".Length));
+        }
+        else if (relative.StartsWith("behaviors/"))
+        {
+            return roots.Behaviors?.GetTreeNodeFor(relative.Substring("behaviors/".Length));
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Walks <paramref name="container"/>'s descendants one <paramref name="relativeDirectory"/>
+    /// segment at a time, matching each segment against a child's <see cref="ITreeNode.Text"/>
+    /// (case-insensitive). Returns <paramref name="container"/> itself for an empty path, or null
+    /// if any segment has no matching child.
+    /// </summary>
+    public static ITreeNode? GetTreeNodeFor(this ITreeNode container, string relativeDirectory)
+    {
+        if (string.IsNullOrEmpty(relativeDirectory))
+        {
+            return container;
+        }
+
+        int indexOfSlash = relativeDirectory.IndexOf('/');
+        string whatToLookFor = relativeDirectory;
+        string sub = "";
+
+        if (indexOfSlash != -1)
+        {
+            whatToLookFor = relativeDirectory.Substring(0, indexOfSlash);
+            sub = relativeDirectory.Substring(indexOfSlash + 1);
+        }
+
+        foreach (ITreeNode node in container.Children)
+        {
+            if (node.Text.Equals(whatToLookFor, StringComparison.OrdinalIgnoreCase))
+            {
+                return node.GetTreeNodeFor(sub);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #3755

Adds `TreeNodeDirectoryExtensions` (Gum.Presentation): `GetTreeNodeFor(IElementTreeRoots, absoluteDirectory, projectDirectory)` selects the category root by relative-path prefix (screens/components/standards/behaviors), then `GetTreeNodeFor(ITreeNode, relativeDirectory)` walks the remaining path by `Text` segment (case-insensitive) — mirroring ETVM's `GetTreeNodeFor(string absoluteDirectory)` and its private path-walk helper. WinForms overloads in `ElementTreeViewManager.cs` stay untouched.

This was the deferred directory-lookup item from #3817/#3819's ledger comment on #3755.

FRB canary: not needed — tool-only change, no GumCommon/MonoGameGum shared source touched.
Manual test: not needed — new headless code path with no existing call sites; covered by unit tests + `GumFull.sln` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)