### PR TITLE
Extract MultiSelectTreeView's Shift+Click range-selection into a testable class

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -26,6 +26,7 @@ namespace CommonFormsAndControls
         private ImageList _elementTreeImages = default!;
         private System.ComponentModel.IContainer _components;
         private TreeNode? nodeOnDragStart;
+        private readonly TreeNodeRangeSelectionLogic _rangeSelectionLogic;
         public ImageList ElementTreeImageList => _elementTreeImages;
 
         #endregion
@@ -641,6 +642,7 @@ namespace CommonFormsAndControls
         public MultiSelectTreeView()
         {
             this._components = new System.ComponentModel.Container();
+            _rangeSelectionLogic = new TreeNodeRangeSelectionLogic();
             InitializeComponent();
             mSelectedNodes = new List<TreeNode>();
             mOriginalColors = new Dictionary<TreeNode, Color>();
@@ -849,114 +851,8 @@ namespace CommonFormsAndControls
                 }
                 else if (EffectiveModifiers() == Keys.Shift)
                 {
-                    // Shift+Click selects nodes between the selected node and here.  
-                    TreeNode ndStart = mSelectedNode;
-                    TreeNode ndEnd = node;
-
-                    if (ndStart.Parent == ndEnd.Parent)
-                    {
-                        // Selected node and clicked node have same parent, easy case.  
-                        if (ndStart.Index < ndEnd.Index)
-                        {
-                            // If the selected node is beneath the clicked node walk down  
-                            // selecting each Visible node until we reach the end.  
-                            while (ndStart != ndEnd)
-                            {
-                                ndStart = ndStart.NextVisibleNode;
-                                if (ndStart == null) break;
-                                SetNodeSelected(ndStart, true);
-                            }
-                        }
-                        else if (ndStart.Index == ndEnd.Index)
-                        {
-                            // Clicked same node, do nothing  
-                        }
-                        else
-                        {
-                            // If the selected node is above the clicked node walk up  
-                            // selecting each Visible node until we reach the end.  
-                            while (ndStart != ndEnd)
-                            {
-                                ndStart = ndStart.PrevVisibleNode;
-                                if (ndStart == null) break;
-                                SetNodeSelected(ndStart, true);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Selected node and clicked node have different parent, hard case.  
-                        // We need to find a common parent to determine if we need  
-                        // to walk down selecting, or walk up selecting.  
-
-                        TreeNode ndStartP = ndStart;
-                        TreeNode ndEndP = ndEnd;
-                        int startDepth = Math.Min(ndStartP.Level, ndEndP.Level);
-
-                        // Bring lower node up to common depth  
-                        while (ndStartP.Level > startDepth)
-                        {
-                            ndStartP = ndStartP.Parent;
-                        }
-
-                        // Bring lower node up to common depth  
-                        while (ndEndP.Level > startDepth)
-                        {
-                            ndEndP = ndEndP.Parent;
-                        }
-
-                        // Walk up the tree until we find the common parent  
-                        while (ndStartP.Parent != ndEndP.Parent)
-                        {
-                            ndStartP = ndStartP.Parent;
-                            ndEndP = ndEndP.Parent;
-                        }
-
-                        // Select the node  
-                        if (ndStartP.Index < ndEndP.Index)
-                        {
-                            // If the selected node is beneath the clicked node walk down  
-                            // selecting each Visible node until we reach the end.  
-                            while (ndStart != ndEnd)
-                            {
-                                ndStart = ndStart.NextVisibleNode;
-                                if (ndStart == null) break;
-                                SetNodeSelected(ndStart, true);
-                            }
-                        }
-                        else if (ndStartP.Index == ndEndP.Index)
-                        {
-                            if (ndStart.Level < ndEnd.Level)
-                            {
-                                while (ndStart != ndEnd)
-                                {
-                                    ndStart = ndStart.NextVisibleNode;
-                                    if (ndStart == null) break;
-                                    SetNodeSelected(ndStart, true);
-                                }
-                            }
-                            else
-                            {
-                                while (ndStart != ndEnd)
-                                {
-                                    ndStart = ndStart.PrevVisibleNode;
-                                    if (ndStart == null) break;
-                                    SetNodeSelected(ndStart, true);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // If the selected node is above the clicked node walk up  
-                            // selecting each Visible node until we reach the end.  
-                            while (ndStart != ndEnd)
-                            {
-                                ndStart = ndStart.PrevVisibleNode;
-                                if (ndStart == null) break;
-                                SetNodeSelected(ndStart, true);
-                            }
-                        }
-                    }
+                    // Shift+Click selects nodes between the selected node and here.
+                    _rangeSelectionLogic.SelectRange(mSelectedNode, node, n => SetNodeSelected(n, true));
                 }
                 else
                 {

--- a/Gum/CommonFormsAndControls/TreeNodeRangeSelectionLogic.cs
+++ b/Gum/CommonFormsAndControls/TreeNodeRangeSelectionLogic.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Windows.Forms;
+
+namespace CommonFormsAndControls;
+
+/// <summary>
+/// Computes which tree nodes fall in a Shift+Click selection range between an anchor node and a
+/// newly-clicked node, walking visible order the same way arrow-key navigation would. Extracted
+/// from <see cref="MultiSelectTreeView"/> so the (pure, decision-only) range logic can be
+/// unit-tested directly instead of only through mouse-event plumbing.
+/// </summary>
+public class TreeNodeRangeSelectionLogic
+{
+    /// <summary>
+    /// Invokes <paramref name="selectNode"/> for every node between <paramref name="start"/>
+    /// (exclusive) and <paramref name="end"/> (inclusive), walking in visible order. Nodes sharing
+    /// a parent are compared directly; otherwise both are walked up to their nearest common
+    /// ancestor to determine direction before walking the visible chain between the original nodes.
+    /// </summary>
+    public void SelectRange(TreeNode start, TreeNode end, Action<TreeNode> selectNode)
+    {
+        if (start.Parent == end.Parent)
+        {
+            WalkAndSelect(start, end, selectNode, forward: start.Index < end.Index);
+            return;
+        }
+
+        TreeNode startAncestor = start;
+        TreeNode endAncestor = end;
+        int commonDepth = Math.Min(startAncestor.Level, endAncestor.Level);
+
+        while (startAncestor.Level > commonDepth)
+        {
+            startAncestor = startAncestor.Parent;
+        }
+        while (endAncestor.Level > commonDepth)
+        {
+            endAncestor = endAncestor.Parent;
+        }
+
+        while (startAncestor.Parent != endAncestor.Parent)
+        {
+            startAncestor = startAncestor.Parent;
+            endAncestor = endAncestor.Parent;
+        }
+
+        bool forward = startAncestor.Index == endAncestor.Index
+            ? start.Level < end.Level
+            : startAncestor.Index < endAncestor.Index;
+
+        WalkAndSelect(start, end, selectNode, forward);
+    }
+
+    private static void WalkAndSelect(TreeNode start, TreeNode end, Action<TreeNode> selectNode, bool forward)
+    {
+        TreeNode? current = start;
+        while (current != end)
+        {
+            current = forward ? current.NextVisibleNode : current.PrevVisibleNode;
+            if (current == null)
+            {
+                break;
+            }
+            selectNode(current);
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeRangeSelectionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeRangeSelectionLogicTests.cs
@@ -1,0 +1,97 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class TreeNodeRangeSelectionLogicTests : BaseTestClass
+{
+    private readonly MultiSelectTreeView _treeView;
+    private readonly TreeNodeRangeSelectionLogic _logic;
+
+    public TreeNodeRangeSelectionLogicTests()
+    {
+        _treeView = new MultiSelectTreeView();
+        _logic = new TreeNodeRangeSelectionLogic();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _treeView.Dispose();
+    }
+
+    // TreeNode.NextVisibleNode/PrevVisibleNode/Expand() can force the underlying native window
+    // handle to be created, which requires an STA thread (see TreeViewStateServiceTests); xUnit's
+    // default runner is MTA.
+
+    [StaFact]
+    public void SelectRange_SameParentForward_SelectsNodesAfterStartUpToAndIncludingEnd()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+        List<TreeNode> selected = new List<TreeNode>();
+
+        _logic.SelectRange(first, third, node => selected.Add(node));
+
+        selected.ShouldBe(new List<TreeNode> { second, third });
+    }
+
+    [StaFact]
+    public void SelectRange_SameParentBackward_SelectsNodesBeforeStartDownToAndIncludingEnd()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+        List<TreeNode> selected = new List<TreeNode>();
+
+        _logic.SelectRange(third, first, node => selected.Add(node));
+
+        selected.ShouldBe(new List<TreeNode> { second, first });
+    }
+
+    [StaFact]
+    public void SelectRange_SameNode_SelectsNothing()
+    {
+        TreeNode only = _treeView.Nodes.Add("Only");
+        List<TreeNode> selected = new List<TreeNode>();
+
+        _logic.SelectRange(only, only, node => selected.Add(node));
+
+        selected.ShouldBeEmpty();
+    }
+
+    [StaFact]
+    public void SelectRange_DifferentParents_WalksThroughCommonAncestorInVisibleOrder()
+    {
+        TreeNode rootA = _treeView.Nodes.Add("RootA");
+        TreeNode childA = rootA.Nodes.Add("ChildA");
+        TreeNode rootB = _treeView.Nodes.Add("RootB");
+        TreeNode childB = rootB.Nodes.Add("ChildB");
+        rootA.Expand();
+        rootB.Expand();
+        List<TreeNode> selected = new List<TreeNode>();
+
+        _logic.SelectRange(childA, childB, node => selected.Add(node));
+
+        selected.ShouldBe(new List<TreeNode> { rootB, childB });
+    }
+
+    [StaFact]
+    public void SelectRange_EndIsAncestorOfStart_WalksBackwardThroughIntermediateNodes()
+    {
+        TreeNode a = _treeView.Nodes.Add("A");
+        TreeNode a1 = a.Nodes.Add("A1");
+        TreeNode a1a = a1.Nodes.Add("A1a");
+        a.Expand();
+        a1.Expand();
+        List<TreeNode> selected = new List<TreeNode>();
+
+        _logic.SelectRange(a1a, a, node => selected.Add(node));
+
+        selected.ShouldBe(new List<TreeNode> { a1, a });
+    }
+}


### PR DESCRIPTION
Part of #3755 (not linked via `gh issue develop` — issue #3755 has repeatedly auto-closed on the first linked PR's merge even with "Part of #N" phrasing, so this stays a plain branch off `origin/main` to avoid repeating that).

## Summary
- Extracts the Shift+Click range-selection algorithm (common-ancestor walk + visible-order selection) out of `MultiSelectTreeView.ReactToClickedNode` into a new `TreeNodeRangeSelectionLogic` class.
- The algorithm previously had **zero test coverage**; it's now unit-tested directly (5 cases: same-parent forward/backward, no-op same node, different-parent walk, end-is-ancestor-of-start tie-break).
- Behavior-preserving — `ReactToClickedNode` now just calls `_rangeSelectionLogic.SelectRange(...)`.
- First real progress on issue #3755's second scope box (`MultiSelectTreeView`, previously untouched). ETVM's own read-side `ITreeNode` mirror layer (the other scope box) is complete per the issue's ledger; further wiring there was found to require hot-path allocation ETVM deliberately avoids, so this PR advances the other half of the issue instead.

## Test plan
- [x] New `TreeNodeRangeSelectionLogicTests` (5 tests) — all pass
- [x] Full `GumToolUnitTests` suite green (1014 passed, 4 pre-existing skips, 0 failures)
- [x] `GumFull.sln` builds clean, 0 errors, no new warnings

Manual test: not needed — behavior-preserving extraction, covered by unit tests + full green regression suite.
FRB canary: not needed — only touches `Gum/CommonFormsAndControls` (tool-only, not `GumCommon`/`MonoGameGum` shared source).