### PR TITLE
Extract MultiSelectTreeView's ShouldSelectOnMouseUp into a testable class

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -27,6 +27,7 @@ namespace CommonFormsAndControls
         private System.ComponentModel.IContainer _components;
         private TreeNode? nodeOnDragStart;
         private readonly TreeNodeRangeSelectionLogic _rangeSelectionLogic;
+        private readonly TreeNodeMouseUpSelectionLogic _mouseUpSelectionLogic;
         public ImageList ElementTreeImageList => _elementTreeImages;
 
         #endregion
@@ -173,9 +174,10 @@ namespace CommonFormsAndControls
         /// </summary>
         private bool ShouldSelectOnMouseUp(TreeNode node, MouseButtons button)
         {
-            return (EffectiveModifiers() == Keys.None && MultiSelectBehavior != MultiSelectBehavior.RegularClick) &&
-                   ((mSelectedNodes.Count > 1 && mSelectedNodes.Contains(node)) || IsSelectingOnPush == false) &&
-                   button == MouseButtons.Left;
+            bool isNodeInMultiSelection = mSelectedNodes.Count > 1 && mSelectedNodes.Contains(node);
+
+            return _mouseUpSelectionLogic.ShouldSelect(
+                EffectiveModifiers(), MultiSelectBehavior, isNodeInMultiSelection, IsSelectingOnPush, button);
         }
 
         protected override void OnMouseDown(MouseEventArgs e)
@@ -643,6 +645,7 @@ namespace CommonFormsAndControls
         {
             this._components = new System.ComponentModel.Container();
             _rangeSelectionLogic = new TreeNodeRangeSelectionLogic();
+            _mouseUpSelectionLogic = new TreeNodeMouseUpSelectionLogic();
             InitializeComponent();
             mSelectedNodes = new List<TreeNode>();
             mOriginalColors = new Dictionary<TreeNode, Color>();

--- a/Gum/CommonFormsAndControls/TreeNodeMouseUpSelectionLogic.cs
+++ b/Gum/CommonFormsAndControls/TreeNodeMouseUpSelectionLogic.cs
@@ -1,0 +1,32 @@
+using System.Windows.Forms;
+
+namespace CommonFormsAndControls;
+
+/// <summary>
+/// Decides whether releasing a mouse button over a tree node should (re)select it. Extracted from
+/// <see cref="MultiSelectTreeView"/> so the decision - independent of any live control state - can
+/// be unit-tested directly instead of only through <c>OnMouseUp</c> plumbing.
+/// </summary>
+public class TreeNodeMouseUpSelectionLogic
+{
+    /// <summary>
+    /// Only the left button selects - a mouse "back"/"forward" (or middle/right) release over a
+    /// node must not be treated as a click on that node. With a modifier key held, or with
+    /// <see cref="MultiSelectBehavior.RegularClick"/>, mouse-down already handled selection, so
+    /// mouse-up must not re-select. Otherwise it selects when either the node is already part of a
+    /// multi-selection (a potential drag was deferred to mouse-up) or selection normally happens on
+    /// click rather than push (<paramref name="isSelectingOnPush"/> is false).
+    /// </summary>
+    public bool ShouldSelect(
+        Keys effectiveModifiers,
+        MultiSelectBehavior multiSelectBehavior,
+        bool isNodeInMultiSelection,
+        bool isSelectingOnPush,
+        MouseButtons button)
+    {
+        return button == MouseButtons.Left &&
+               effectiveModifiers == Keys.None &&
+               multiSelectBehavior != MultiSelectBehavior.RegularClick &&
+               (isNodeInMultiSelection || !isSelectingOnPush);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeMouseUpSelectionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeMouseUpSelectionLogicTests.cs
@@ -1,0 +1,92 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class TreeNodeMouseUpSelectionLogicTests : BaseTestClass
+{
+    private readonly TreeNodeMouseUpSelectionLogic _logic;
+
+    public TreeNodeMouseUpSelectionLogicTests()
+    {
+        _logic = new TreeNodeMouseUpSelectionLogic();
+    }
+
+    [Fact]
+    public void ShouldSelect_RightButton_ReturnsFalse()
+    {
+        // Pins pre-existing behavior: right-click opens the context menu, it must not select.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: false,
+            isSelectingOnPush: false, MouseButtons.Right);
+
+        shouldSelect.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelect_XButton1_ReturnsFalse()
+    {
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: false,
+            isSelectingOnPush: false, MouseButtons.XButton1);
+
+        shouldSelect.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelect_ModifierKeyHeld_ReturnsFalse()
+    {
+        // Mouse-down already handled selection under a modifier; mouse-up must not re-select.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.Control, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: true,
+            isSelectingOnPush: false, MouseButtons.Left);
+
+        shouldSelect.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelect_RegularClickBehavior_ReturnsFalse()
+    {
+        // MultiSelectBehavior.RegularClick means mouse-down already selected; mouse-up must not.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.RegularClick, isNodeInMultiSelection: true,
+            isSelectingOnPush: false, MouseButtons.Left);
+
+        shouldSelect.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldSelect_NodeAlreadyMultiSelected_ReturnsTrue()
+    {
+        // A potential drag on an already-selected node defers the actual select to mouse-up.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: true,
+            isSelectingOnPush: true, MouseButtons.Left);
+
+        shouldSelect.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldSelect_NotSelectingOnPush_ReturnsTrue()
+    {
+        // Gum configures IsSelectingOnPush = false so clicks (not pushes) select.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: false,
+            isSelectingOnPush: false, MouseButtons.Left);
+
+        shouldSelect.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldSelect_SelectingOnPushAndNotAlreadySelected_ReturnsFalse()
+    {
+        // Selection already happened on push; mouse-up has nothing left to do.
+        bool shouldSelect = _logic.ShouldSelect(
+            Keys.None, MultiSelectBehavior.CtrlDown, isNodeInMultiSelection: false,
+            isSelectingOnPush: true, MouseButtons.Left);
+
+        shouldSelect.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Part of #3755 (not linked via `gh issue develop` — this issue has repeatedly auto-closed on the first linked PR's merge even with "Part of #N" phrasing, so this stays a plain branch off `origin/main`).

## Summary
- Extracts `MultiSelectTreeView.ShouldSelectOnMouseUp`'s decision logic (previously only reflection-tested via `MethodInfo.Invoke`, see `MultiSelectTreeViewNavigationTests`) into a new `TreeNodeMouseUpSelectionLogic` class.
- The extracted `ShouldSelect` method takes already-resolved modifiers/behavior/selection-state as parameters instead of reading live control state (`EffectiveModifiers()`) or instance fields directly — same shape as `TreeNodeRangeSelectionLogic` from #3821.
- `ShouldSelectOnMouseUp` is now a thin wrapper that resolves its inputs and delegates. Behavior-preserving.
- 7 new direct unit tests cover branches the old reflection tests didn't reach (modifier held, `RegularClick` behavior, already-multi-selected node, `IsSelectingOnPush` true/false) — the old reflection tests only ever varied `button`, since for XButton1/XButton2/Right the `button == Left` check alone already forced `false`.

## Test plan
- [x] New `TreeNodeMouseUpSelectionLogicTests` (7 tests) — all pass
- [x] Existing `MultiSelectTreeViewNavigationTests` reflection tests still pass unchanged (kept as integration-level pin on the wiring)
- [x] Full `GumToolUnitTests` suite green (1021 passed, 4 pre-existing skips, 0 failures)
- [x] `GumFull.sln` builds clean, 0 errors, no new warnings

Manual test: not needed — behavior-preserving extraction, covered by unit tests + full green regression suite.
FRB canary: not needed — only touches `Gum/CommonFormsAndControls` (tool-only, not `GumCommon`/`MonoGameGum` shared source).
