### PR TITLE
Widen Cursor/Keyboard.Initialize off System.Windows.Forms.Control

### DIFF
--- a/FlatRedBall.SpecializedXnaControls/ImageRegionSelectionControl.cs
+++ b/FlatRedBall.SpecializedXnaControls/ImageRegionSelectionControl.cs
@@ -481,11 +481,13 @@ public class ImageRegionSelectionControl : GraphicsDeviceControl
 
             CreateNewSelector();
 
+            var inputHostControl = new ControlInputHostAdapter(this);
+
             mCursor = new InputLibrary.Cursor();
-            mCursor.Initialize(this);
+            mCursor.Initialize(inputHostControl);
 
             mKeyboard = new InputLibrary.Keyboard();
-            mKeyboard.Initialize(this);
+            mKeyboard.Initialize(inputHostControl);
 
             mCameraPanningLogic = new CameraPanningLogic(this, mManagers, mCursor, mKeyboard);
             var camera = mManagers.Renderer.Camera;

--- a/FlatRedBall.SpecializedXnaControls/Input/CameraPanningLogic.cs
+++ b/FlatRedBall.SpecializedXnaControls/Input/CameraPanningLogic.cs
@@ -31,7 +31,7 @@ namespace FlatRedBall.SpecializedXnaControls.Input
             mKeyboard = keyboard;
 
             mCursor = cursor;
-            mCursor.Initialize(graphicsControl);
+            mCursor.Initialize(new ControlInputHostAdapter(graphicsControl));
             mCamera = managers.Renderer.Camera;
             mControl = graphicsControl;
             graphicsControl.XnaUpdate += new Action(Activity);

--- a/InputLibrary/ControlInputHostAdapter.cs
+++ b/InputLibrary/ControlInputHostAdapter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using WinCursor = System.Windows.Forms.Cursor;
+
+namespace InputLibrary
+{
+    /// <summary>
+    /// Adapts a real <see cref="System.Windows.Forms.Control"/> to <see cref="IInputHostControl"/>
+    /// via 1:1 forwarding, so <see cref="Cursor"/> and <see cref="Keyboard"/> don't need to depend
+    /// on the concrete WinForms type.
+    /// </summary>
+    public class ControlInputHostAdapter : IInputHostControl
+    {
+        private readonly Control _control;
+
+        public ControlInputHostAdapter(Control control)
+        {
+            if (control == null)
+            {
+                throw new ArgumentNullException(nameof(control));
+            }
+            _control = control;
+        }
+
+        public bool Focused => _control.Focused;
+
+        public int Width => _control.Width;
+
+        public int Height => _control.Height;
+
+        public WinCursor Cursor
+        {
+            get => _control.Cursor;
+            set => _control.Cursor = value;
+        }
+
+        public Point PointToClient(Point point) => _control.PointToClient(point);
+    }
+}

--- a/InputLibrary/Cursor.cs
+++ b/InputLibrary/Cursor.cs
@@ -14,7 +14,7 @@ namespace InputLibrary
 
         MouseState mMouseState = new MouseState();
         MouseState mLastFrameMouseState = new MouseState();
-        Control mControl;
+        IInputHostControl mControl;
 
         public const float MaximumSecondsBetweenClickForDoubleClick = .25f;
         double mLastClickTime;
@@ -235,7 +235,7 @@ namespace InputLibrary
             }
         }
 
-        public void Initialize( Control control)
+        public void Initialize(IInputHostControl control)
         {
             mControl = control;
 

--- a/InputLibrary/IInputHostControl.cs
+++ b/InputLibrary/IInputHostControl.cs
@@ -1,0 +1,39 @@
+using System.Drawing;
+using WinCursor = System.Windows.Forms.Cursor;
+
+namespace InputLibrary
+{
+    /// <summary>
+    /// The subset of <see cref="System.Windows.Forms.Control"/> that <see cref="Cursor"/> and
+    /// <see cref="Keyboard"/> need in order to translate mouse/keyboard state into window-relative
+    /// coordinates and focus. Lets those classes be initialized against a host that isn't a real
+    /// WinForms control (e.g. a test double or a future non-WinForms rendering host).
+    /// </summary>
+    public interface IInputHostControl
+    {
+        /// <summary>
+        /// Whether the host control currently has input focus.
+        /// </summary>
+        bool Focused { get; }
+
+        /// <summary>
+        /// The host control's width, in pixels.
+        /// </summary>
+        int Width { get; }
+
+        /// <summary>
+        /// The host control's height, in pixels.
+        /// </summary>
+        int Height { get; }
+
+        /// <summary>
+        /// The cursor currently displayed over the host control.
+        /// </summary>
+        WinCursor Cursor { get; set; }
+
+        /// <summary>
+        /// Converts a point in screen coordinates to client (window-relative) coordinates.
+        /// </summary>
+        Point PointToClient(Point point);
+    }
+}

--- a/InputLibrary/Keyboard.cs
+++ b/InputLibrary/Keyboard.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.Xna.Framework.Input;
-using System.Windows.Forms;
 
 namespace InputLibrary
 {
@@ -11,7 +10,7 @@ namespace InputLibrary
         KeyboardState mKeyboardState;
         KeyboardState mLastKeyboardState = new KeyboardState();
 
-        Control mControl;
+        IInputHostControl mControl;
 
         public static Keyboard Self
         {
@@ -36,7 +35,7 @@ namespace InputLibrary
 
 
         
-        public void Initialize(Control control)
+        public void Initialize(IInputHostControl control)
         {
             if (control == null)
             {

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -207,7 +207,7 @@ public class WireframeControl : GraphicsDeviceControl
             _cameraController.Initialize(Camera, editorViewModel, Width, Height, hotkeyManager);
             _cameraController.CameraChanged += () => CameraChanged?.Invoke();
 
-            InputLibrary.Cursor.Self.Initialize(this);
+            InputLibrary.Cursor.Self.Initialize(new InputLibrary.ControlInputHostAdapter(this));
 
             mCanvasBounds = new LineRectangle();
             mCanvasBounds.IsDotted = true;

--- a/Tool/Tests/GumToolUnitTests/Input/ControlInputHostAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/ControlInputHostAdapterTests.cs
@@ -1,0 +1,61 @@
+using InputLibrary;
+using Shouldly;
+using System.Drawing;
+using System.Windows.Forms;
+using WinCursor = System.Windows.Forms.Cursor;
+
+namespace GumToolUnitTests.Input;
+
+public class ControlInputHostAdapterTests : BaseTestClass
+{
+    [StaFact]
+    public void Cursor_Get_ForwardsToWrappedControl()
+    {
+        using Control control = new Control { Cursor = Cursors.Hand };
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Cursor.ShouldBe(Cursors.Hand);
+    }
+
+    [StaFact]
+    public void Cursor_Set_ForwardsToWrappedControl()
+    {
+        using Control control = new Control();
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Cursor = Cursors.Cross;
+
+        control.Cursor.ShouldBe(Cursors.Cross);
+    }
+
+    [StaFact]
+    public void Focused_ForwardsToWrappedControl()
+    {
+        using Control control = new Control();
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Focused.ShouldBe(control.Focused);
+    }
+
+    [StaFact]
+    public void PointToClient_ForwardsToWrappedControl()
+    {
+        using Control control = new Control { Width = 200, Height = 100 };
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+        Point screenPoint = new Point(50, 60);
+
+        Point actual = adapter.PointToClient(screenPoint);
+
+        actual.ShouldBe(control.PointToClient(screenPoint));
+    }
+
+    [StaFact]
+    public void WidthAndHeight_ForwardToWrappedControl()
+    {
+        using Control control = new Control { Width = 320, Height = 240 };
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Width.ShouldBe(320);
+        adapter.Height.ShouldBe(240);
+    }
+}


### PR DESCRIPTION
Part of #3756 (Phase 4b) - first bounded slice.

## Summary
- Adds `IInputHostControl` (`Focused`, `Width`, `Height`, `Cursor`, `PointToClient`) capturing exactly the `Control` members `InputLibrary.Cursor` / `InputLibrary.Keyboard` use.
- Adds `ControlInputHostAdapter`: thin 1:1 forwarding wrapper from a real `System.Windows.Forms.Control` to the new interface.
- `Cursor.Initialize` / `Keyboard.Initialize` now take `IInputHostControl` instead of `Control`.
- Updates all 3 call sites (`WireframeControl`, `ImageRegionSelectionControl`, `CameraPanningLogic`) to pass a `ControlInputHostAdapter`.
- `Cursor.Self`/`Keyboard.Self` stay as sanctioned singletons - only the `Initialize` parameter type changed.

Behavior-preserving; confirmed tool-only (`InputLibrary` isn't referenced by any runtime project).

## Testing
- New `ControlInputHostAdapterTests` pins the adapter's forwarding (`Cursor` get/set, `Focused`, `Width`/`Height`, `PointToClient` coordinate translation against a real `Control`).
- `dotnet build GumFull.sln` - clean, no new warnings.
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` - full suite green (1019 passed, 4 pre-existing skips).

Manual test: not needed - behavior-preserving seam widening, covered by unit tests + compilation.
