### PR TITLE
Extract MultiSelectTreeView's Home/End/PageUp/PageDown tree-walk into a testable class

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -28,6 +28,7 @@ namespace CommonFormsAndControls
         private TreeNode? nodeOnDragStart;
         private readonly TreeNodeRangeSelectionLogic _rangeSelectionLogic;
         private readonly TreeNodeMouseUpSelectionLogic _mouseUpSelectionLogic;
+        private readonly TreeNodeKeyNavigationLogic _keyNavigationLogic;
         public ImageList ElementTreeImageList => _elementTreeImages;
 
         #endregion
@@ -531,90 +532,45 @@ namespace CommonFormsAndControls
                 }
                 else if (e.KeyCode == Keys.Home)
                 {
-                    if (bShift)
+                    TreeNode? homeTarget = _keyNavigationLogic.GetHomeTarget(
+                        mSelectedNode, this.Nodes, bShift, out bool selectHomeRange);
+                    if (homeTarget != null)
                     {
-                        if (mSelectedNode.Parent == null)
+                        if (selectHomeRange)
                         {
-                            // Select all of the root nodes up to this point   
-                            if (this.Nodes.Count > 0)
-                            {
-                                ReactToClickedNode(this.Nodes[0]);
-                            }
+                            ReactToClickedNode(homeTarget);
                         }
                         else
                         {
-                            // Select all of the nodes up to this point under this nodes parent  
-                            ReactToClickedNode(mSelectedNode.Parent.FirstNode);
-                        }
-                    }
-                    else
-                    {
-                        // Select this first node in the tree  
-                        if (this.Nodes.Count > 0)
-                        {
-                            SelectSingleNode(this.Nodes[0]);
+                            SelectSingleNode(homeTarget);
                         }
                     }
                 }
                 else if (e.KeyCode == Keys.End)
                 {
-                    if (bShift)
+                    TreeNode? endTarget = _keyNavigationLogic.GetEndTarget(
+                        mSelectedNode, this.Nodes, bShift, out bool selectEndRange);
+                    if (endTarget != null)
                     {
-                        if (mSelectedNode.Parent == null)
+                        if (selectEndRange)
                         {
-                            // Select the last ROOT node in the tree  
-                            if (this.Nodes.Count > 0)
-                            {
-                                ReactToClickedNode(this.Nodes[this.Nodes.Count - 1]);
-                            }
+                            ReactToClickedNode(endTarget);
                         }
                         else
                         {
-                            // Select the last node in this branch  
-                            ReactToClickedNode(mSelectedNode.Parent.LastNode);
-                        }
-                    }
-                    else
-                    {
-                        if (this.Nodes.Count > 0)
-                        {
-                            // Select the last node visible node in the tree.  
-                            // Don't expand branches incase the tree is virtual  
-                            TreeNode ndLast = this.Nodes[0].LastNode;
-                            while (ndLast.IsExpanded && (ndLast.LastNode != null))
-                            {
-                                ndLast = ndLast.LastNode;
-                            }
-
-                            SelectSingleNode(ndLast);
+                            SelectSingleNode(endTarget);
                         }
                     }
                 }
                 else if (e.KeyCode == Keys.PageUp)
                 {
-                    // Select the highest node in the display  
-                    int nCount = this.VisibleCount;
-                    TreeNode ndCurrent = mSelectedNode;
-                    while ((nCount) > 0 && (ndCurrent.PrevVisibleNode != null))
-                    {
-                        ndCurrent = ndCurrent.PrevVisibleNode;
-                        nCount--;
-                    }
-
-                    SelectSingleNode(ndCurrent);
+                    // Select the highest node in the display
+                    SelectSingleNode(_keyNavigationLogic.GetPageUpTarget(mSelectedNode, this.VisibleCount));
                 }
                 else if (e.KeyCode == Keys.PageDown)
                 {
-                    // Select the lowest node in the display  
-                    int nCount = this.VisibleCount;
-                    TreeNode ndCurrent = mSelectedNode;
-                    while ((nCount) > 0 && (ndCurrent.NextVisibleNode != null))
-                    {
-                        ndCurrent = ndCurrent.NextVisibleNode;
-                        nCount--;
-                    }
-
-                    SelectSingleNode(ndCurrent);
+                    // Select the lowest node in the display
+                    SelectSingleNode(_keyNavigationLogic.GetPageDownTarget(mSelectedNode, this.VisibleCount));
                 }
                 else
                 {
@@ -646,6 +602,7 @@ namespace CommonFormsAndControls
             this._components = new System.ComponentModel.Container();
             _rangeSelectionLogic = new TreeNodeRangeSelectionLogic();
             _mouseUpSelectionLogic = new TreeNodeMouseUpSelectionLogic();
+            _keyNavigationLogic = new TreeNodeKeyNavigationLogic();
             InitializeComponent();
             mSelectedNodes = new List<TreeNode>();
             mOriginalColors = new Dictionary<TreeNode, Color>();

--- a/Gum/CommonFormsAndControls/TreeNodeKeyNavigationLogic.cs
+++ b/Gum/CommonFormsAndControls/TreeNodeKeyNavigationLogic.cs
@@ -1,0 +1,104 @@
+using System.Windows.Forms;
+
+namespace CommonFormsAndControls;
+
+/// <summary>
+/// Computes the target node for the Home/End/PageUp/PageDown keys. Extracted from
+/// <see cref="MultiSelectTreeView.OnKeyDown"/> so the (pure) tree-walk logic can be
+/// unit-tested directly instead of only through key-event plumbing. Callers are responsible
+/// for actually applying the selection (single-select vs. range-select) to the returned node.
+/// </summary>
+public class TreeNodeKeyNavigationLogic
+{
+    /// <summary>
+    /// Finds the target node for the Home key. With <paramref name="shiftDown"/>, the range
+    /// should extend to the first root node (if <paramref name="selectedNode"/> is itself a
+    /// root) or to the first sibling under its parent; <paramref name="selectRange"/> is set to
+    /// true in that case. Otherwise the target is simply the first root node.
+    /// </summary>
+    public TreeNode? GetHomeTarget(
+        TreeNode selectedNode, TreeNodeCollection rootNodes, bool shiftDown, out bool selectRange)
+    {
+        selectRange = shiftDown;
+
+        if (shiftDown && selectedNode.Parent != null)
+        {
+            return selectedNode.Parent.FirstNode;
+        }
+
+        return rootNodes.Count > 0 ? rootNodes[0] : null;
+    }
+
+    /// <summary>
+    /// Finds the target node for the End key. With <paramref name="shiftDown"/>, the range
+    /// should extend to the last root node (if <paramref name="selectedNode"/> is itself a root)
+    /// or to the last sibling under its parent; <paramref name="selectRange"/> is set to true in
+    /// that case. Otherwise the target is the last visible node in the tree, walked down from the
+    /// first root through expanded last-children (without expanding any branch, in case the tree
+    /// is virtual).
+    /// </summary>
+    public TreeNode? GetEndTarget(
+        TreeNode selectedNode, TreeNodeCollection rootNodes, bool shiftDown, out bool selectRange)
+    {
+        selectRange = shiftDown;
+
+        if (shiftDown)
+        {
+            if (selectedNode.Parent != null)
+            {
+                return selectedNode.Parent.LastNode;
+            }
+
+            return rootNodes.Count > 0 ? rootNodes[rootNodes.Count - 1] : null;
+        }
+
+        if (rootNodes.Count == 0)
+        {
+            return null;
+        }
+
+        TreeNode lastNode = rootNodes[0].LastNode;
+        while (lastNode.IsExpanded && lastNode.LastNode != null)
+        {
+            lastNode = lastNode.LastNode;
+        }
+
+        return lastNode;
+    }
+
+    /// <summary>
+    /// Walks backward from <paramref name="selectedNode"/> through up to
+    /// <paramref name="visibleCount"/> visible nodes (stopping early if the top of the tree is
+    /// reached) and returns the resulting node - the target for the PageUp key.
+    /// </summary>
+    public TreeNode GetPageUpTarget(TreeNode selectedNode, int visibleCount)
+    {
+        TreeNode current = selectedNode;
+        int remaining = visibleCount;
+        while (remaining > 0 && current.PrevVisibleNode != null)
+        {
+            current = current.PrevVisibleNode;
+            remaining--;
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Walks forward from <paramref name="selectedNode"/> through up to
+    /// <paramref name="visibleCount"/> visible nodes (stopping early if the bottom of the tree is
+    /// reached) and returns the resulting node - the target for the PageDown key.
+    /// </summary>
+    public TreeNode GetPageDownTarget(TreeNode selectedNode, int visibleCount)
+    {
+        TreeNode current = selectedNode;
+        int remaining = visibleCount;
+        while (remaining > 0 && current.NextVisibleNode != null)
+        {
+            current = current.NextVisibleNode;
+            remaining--;
+        }
+
+        return current;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeKeyNavigationLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeKeyNavigationLogicTests.cs
@@ -1,0 +1,177 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class TreeNodeKeyNavigationLogicTests : BaseTestClass
+{
+    private readonly MultiSelectTreeView _treeView;
+    private readonly TreeNodeKeyNavigationLogic _logic;
+
+    public TreeNodeKeyNavigationLogicTests()
+    {
+        _treeView = new MultiSelectTreeView();
+        _logic = new TreeNodeKeyNavigationLogic();
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _treeView.Dispose();
+    }
+
+    // TreeNode.Expand()/PrevVisibleNode/NextVisibleNode can force the underlying native window
+    // handle to be created, which requires an STA thread (see TreeViewStateServiceTests); xUnit's
+    // default runner is MTA.
+
+    [StaFact]
+    public void GetHomeTarget_NoShift_ReturnsFirstRootNode()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        second.Nodes.Add("Child");
+
+        TreeNode? target = _logic.GetHomeTarget(
+            second, _treeView.Nodes, shiftDown: false, out bool selectRange);
+
+        target.ShouldBe(first);
+        selectRange.ShouldBeFalse();
+    }
+
+    [StaFact]
+    public void GetHomeTarget_ShiftAndSelectedNodeIsRoot_ReturnsFirstRootNode()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+
+        TreeNode? target = _logic.GetHomeTarget(
+            second, _treeView.Nodes, shiftDown: true, out bool selectRange);
+
+        target.ShouldBe(first);
+        selectRange.ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void GetHomeTarget_ShiftAndSelectedNodeHasParent_ReturnsFirstSibling()
+    {
+        TreeNode parent = _treeView.Nodes.Add("Parent");
+        TreeNode firstChild = parent.Nodes.Add("FirstChild");
+        TreeNode secondChild = parent.Nodes.Add("SecondChild");
+
+        TreeNode? target = _logic.GetHomeTarget(
+            secondChild, _treeView.Nodes, shiftDown: true, out bool selectRange);
+
+        target.ShouldBe(firstChild);
+        selectRange.ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void GetEndTarget_NoShift_WalksDownExpandedLastChildren()
+    {
+        TreeNode root = _treeView.Nodes.Add("Root");
+        TreeNode child = root.Nodes.Add("Child");
+        TreeNode grandchild = child.Nodes.Add("Grandchild");
+        root.Expand();
+        child.Expand();
+
+        TreeNode? target = _logic.GetEndTarget(
+            root, _treeView.Nodes, shiftDown: false, out bool selectRange);
+
+        target.ShouldBe(grandchild);
+        selectRange.ShouldBeFalse();
+    }
+
+    [StaFact]
+    public void GetEndTarget_NoShiftAndGrandchildLevelCollapsed_DoesNotDescendPastFirstUnexpandedNode()
+    {
+        // Matches the original behavior exactly: only descends further while the current node
+        // (not its ancestor) is itself expanded, so it stops one level short of a deeper,
+        // unexpanded grandchild.
+        TreeNode root = _treeView.Nodes.Add("Root");
+        TreeNode child = root.Nodes.Add("Child");
+        child.Nodes.Add("Grandchild");
+
+        TreeNode? target = _logic.GetEndTarget(
+            root, _treeView.Nodes, shiftDown: false, out bool selectRange);
+
+        target.ShouldBe(child);
+        selectRange.ShouldBeFalse();
+    }
+
+    [StaFact]
+    public void GetEndTarget_ShiftAndSelectedNodeIsRoot_ReturnsLastRootNode()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+
+        TreeNode? target = _logic.GetEndTarget(
+            first, _treeView.Nodes, shiftDown: true, out bool selectRange);
+
+        target.ShouldBe(second);
+        selectRange.ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void GetEndTarget_ShiftAndSelectedNodeHasParent_ReturnsLastSibling()
+    {
+        TreeNode parent = _treeView.Nodes.Add("Parent");
+        TreeNode firstChild = parent.Nodes.Add("FirstChild");
+        TreeNode secondChild = parent.Nodes.Add("SecondChild");
+
+        TreeNode? target = _logic.GetEndTarget(
+            firstChild, _treeView.Nodes, shiftDown: true, out bool selectRange);
+
+        target.ShouldBe(secondChild);
+        selectRange.ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void GetPageUpTarget_VisibleCountExceedsAvailableNodes_StopsAtTopmostNode()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+
+        TreeNode target = _logic.GetPageUpTarget(third, visibleCount: 10);
+
+        target.ShouldBe(first);
+    }
+
+    [StaFact]
+    public void GetPageUpTarget_VisibleCountLessThanAvailableNodes_StopsPartway()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+
+        TreeNode target = _logic.GetPageUpTarget(third, visibleCount: 1);
+
+        target.ShouldBe(second);
+    }
+
+    [StaFact]
+    public void GetPageDownTarget_VisibleCountExceedsAvailableNodes_StopsAtBottommostNode()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+
+        TreeNode target = _logic.GetPageDownTarget(first, visibleCount: 10);
+
+        target.ShouldBe(third);
+    }
+
+    [StaFact]
+    public void GetPageDownTarget_VisibleCountLessThanAvailableNodes_StopsPartway()
+    {
+        TreeNode first = _treeView.Nodes.Add("First");
+        TreeNode second = _treeView.Nodes.Add("Second");
+        TreeNode third = _treeView.Nodes.Add("Third");
+
+        TreeNode target = _logic.GetPageDownTarget(first, visibleCount: 1);
+
+        target.ShouldBe(second);
+    }
+}


### PR DESCRIPTION
Extracts `MultiSelectTreeView.OnKeyDown`'s Home/End/PageUp/PageDown tree-walk logic into `TreeNodeKeyNavigationLogic` - a plain class taking the current node, root nodes, shift-state, and visible-count as parameters instead of reading live control state. Same shape as `TreeNodeRangeSelectionLogic` (#3821) and `TreeNodeMouseUpSelectionLogic` (#3822).

- `GetHomeTarget`/`GetEndTarget` return the target node plus an `out bool` for whether the caller should range-select (`ReactToClickedNode`) or single-select (`SelectSingleNode`) - mirrors the original branching exactly, including the pre-existing quirk where PageUp/PageDown ignore Shift.
- `GetPageUpTarget`/`GetPageDownTarget` walk `PrevVisibleNode`/`NextVisibleNode` up to `VisibleCount` times.
- 11 new unit tests in `TreeNodeKeyNavigationLogicTests`, including one pinning a subtle existing quirk: End's non-shift descent only checks `IsExpanded` on the node it's currently at, so it stops one level short of a deeper unexpanded grandchild even when the root itself isn't "expanded."

Behavior-preserving. `Gum/CommonFormsAndControls/` is tool-only WinForms code, not part of `GumCoreShared.projitems`, so no FRB1 sync needed (confirmed via grep).

Part of #3755.

Manual test: not needed - behavior-preserving, covered by unit tests + full `GumToolUnitTests` suite (1037 passed, 0 failed).
