### PR TITLE
Extract render-target pixel-buffer conversion strategy into a testable class

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Wireframe/RenderTargetPixelBufferConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/RenderTargetPixelBufferConverterTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using System.Drawing.Imaging;
+using XnaAndWinforms;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+public class RenderTargetPixelBufferConverterTests
+{
+    [Theory]
+    [InlineData(SurfaceFormat.Color, PixelFormat.Format32bppArgb)]
+    [InlineData(SurfaceFormat.Color, PixelFormat.Format32bppPArgb)]
+    public void GetStrategy_ColorSourceWithArgbDestination_ReturnsByteSwapRgbaToBgra(
+        SurfaceFormat sourceFormat, PixelFormat destinationFormat)
+    {
+        RenderTargetPixelBufferConverter.GetStrategy(sourceFormat, destinationFormat)
+            .ShouldBe(PixelBufferConversionStrategy.ByteSwapRgbaToBgra);
+    }
+
+    [Theory]
+    [InlineData(SurfaceFormat.Bgra32, PixelFormat.Format32bppArgb)]
+    [InlineData(SurfaceFormat.Bgra32, PixelFormat.Format32bppPArgb)]
+    public void GetStrategy_Bgra32SourceWithArgbDestination_ReturnsDirectCopy(
+        SurfaceFormat sourceFormat, PixelFormat destinationFormat)
+    {
+        RenderTargetPixelBufferConverter.GetStrategy(sourceFormat, destinationFormat)
+            .ShouldBe(PixelBufferConversionStrategy.DirectCopy);
+    }
+
+    [Fact]
+    public void GetStrategy_UnsupportedDestinationFormat_ReturnsNull()
+    {
+        RenderTargetPixelBufferConverter.GetStrategy(SurfaceFormat.Color, PixelFormat.Format24bppRgb)
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetStrategy_UnsupportedSourceFormat_ReturnsNull()
+    {
+        RenderTargetPixelBufferConverter.GetStrategy(SurfaceFormat.Rgba64, PixelFormat.Format32bppArgb)
+            .ShouldBeNull();
+    }
+}

--- a/XnaAndWinforms/GraphicsDeviceControl.cs
+++ b/XnaAndWinforms/GraphicsDeviceControl.cs
@@ -459,11 +459,14 @@ public class GraphicsDeviceControl : Control
 
         var rect = new System.Drawing.Rectangle(0, 0, w, h);
         BitmapData bmpData = bitmap.LockBits(rect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
-        if (renderTarget.Format == SurfaceFormat.Color && (bitmap.PixelFormat == PixelFormat.Format32bppArgb || bitmap.PixelFormat == PixelFormat.Format32bppPArgb))
+        PixelBufferConversionStrategy? strategy =
+            RenderTargetPixelBufferConverter.GetStrategy(renderTarget.Format, bitmap.PixelFormat);
+
+        if (strategy == PixelBufferConversionStrategy.ByteSwapRgbaToBgra)
         {
             CopyAndConvertRGBATOBGRA(w, h, rawImage, bmpData.Scan0, bmpData.Stride);
         }
-        else if (renderTarget.Format == SurfaceFormat.Bgra32 && (bitmap.PixelFormat == PixelFormat.Format32bppArgb || bitmap.PixelFormat == PixelFormat.Format32bppPArgb))
+        else if (strategy == PixelBufferConversionStrategy.DirectCopy)
         {
             int rowSize = w * 4;
             int rowStride = bmpData.Stride;

--- a/XnaAndWinforms/RenderTargetPixelBufferConverter.cs
+++ b/XnaAndWinforms/RenderTargetPixelBufferConverter.cs
@@ -1,0 +1,60 @@
+using Microsoft.Xna.Framework.Graphics;
+using System.Drawing.Imaging;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The way a render target's raw pixel buffer must be transformed before it can be blitted into
+/// a <see cref="System.Drawing.Bitmap"/> of a given <see cref="PixelFormat"/>.
+/// </summary>
+public enum PixelBufferConversionStrategy
+{
+    /// <summary>
+    /// The source and destination byte orders differ (RGBA vs BGRA), so each pixel's color
+    /// channels must be swapped while copying.
+    /// </summary>
+    ByteSwapRgbaToBgra,
+
+    /// <summary>
+    /// The source and destination byte orders already match, so the raw bytes can be copied
+    /// straight across.
+    /// </summary>
+    DirectCopy
+}
+
+/// <summary>
+/// Decides how to convert the raw byte buffer read back from a <see cref="RenderTarget2D"/>
+/// (via <c>GetData</c>) into the pixel layout a <see cref="System.Drawing.Bitmap"/> expects.
+/// Extracted from <c>GraphicsDeviceControl</c> so this format-driven decision - independent of
+/// any live <see cref="GraphicsDevice"/> or bitmap - can be unit-tested directly.
+/// </summary>
+public static class RenderTargetPixelBufferConverter
+{
+    /// <summary>
+    /// Returns the conversion strategy for the given source/destination format pair, or
+    /// <see langword="null"/> if the combination isn't supported.
+    /// </summary>
+    public static PixelBufferConversionStrategy? GetStrategy(SurfaceFormat sourceFormat, PixelFormat destinationFormat)
+    {
+        bool destinationIsArgbOrPArgb =
+            destinationFormat == PixelFormat.Format32bppArgb ||
+            destinationFormat == PixelFormat.Format32bppPArgb;
+
+        if (!destinationIsArgbOrPArgb)
+        {
+            return null;
+        }
+
+        if (sourceFormat == SurfaceFormat.Color)
+        {
+            return PixelBufferConversionStrategy.ByteSwapRgbaToBgra;
+        }
+
+        if (sourceFormat == SurfaceFormat.Bgra32)
+        {
+            return PixelBufferConversionStrategy.DirectCopy;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #3756. Continues #3823's input-side decouple with the pixel-buffer-out side of `GraphicsDeviceControl`.

## What
`GraphicsDeviceControl.PaintRendertarget` decided between a byte-swap copy and a direct copy via inline `SurfaceFormat`/`PixelFormat` checks. Extracted that decision into `RenderTargetPixelBufferConverter.GetStrategy` (`XnaAndWinforms/RenderTargetPixelBufferConverter.cs`) - a pure, format-driven lookup that needs no live `GraphicsDevice`/`Bitmap`/WinForms handle, so it's directly unit-testable. `PaintRendertarget` now calls it and switches on the returned `PixelBufferConversionStrategy`. The actual byte-copy code (unsafe pointer math, `Marshal.Copy`) is untouched.

## Tests
New `RenderTargetPixelBufferConverterTests` covers all four supported format combos plus unsupported source/destination formats. Full `GumToolUnitTests` suite green (1032 passed, 4 pre-existing skips).

## Manual test
Not needed - behavior-preserving extraction; the byte-copy code paths are unchanged, only the branch condition was factored out.

## Next candidate
Formalize `EndDraw`'s `RenderTarget2D.GetData` readback + `OnPaint`'s `BeginDraw`/`Draw`/`EndDraw`/`PaintRendertarget` sequence behind a small "produce a pixel buffer" interface, separate from the WinForms `Graphics` blit - the bigger structural piece of "pixel-buffer-out" this PR intentionally left alone.
