### PR TITLE
Formalize IRenderDeviceHost contract around SystemManagers.Initialize(GraphicsDevice)

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -172,8 +172,14 @@ public class WireframeControl : GraphicsDeviceControl
         {
             LoaderManager.Self.ContentLoader = new ContentLoader();
 
+            // Route the GPU device/content-service lookup through IRenderDeviceHost rather than
+            // reading GraphicsDevice/Services directly off this control, so the initialization
+            // sequence below only depends on the render-host contract, not on GraphicsDeviceControl.
+            var graphicsDeviceService = (IGraphicsDeviceService)Services.GetService(typeof(IGraphicsDeviceService));
+            IRenderDeviceHost renderHost = new GraphicsDeviceServiceRenderHostAdapter(graphicsDeviceService, Services);
+
             SystemManagers.Default = new SystemManagers();
-            SystemManagers.Default.Initialize(GraphicsDevice);
+            SystemManagers.Default.Initialize(renderHost.GraphicsDevice);
 
             // Touching a type from KniGumShapes here forces the assembly to load, which fires its
             // [ModuleInitializer] -> AposShapeRuntime.RegisterRuntimeTypes (registers Apos.Shapes-backed
@@ -185,8 +191,8 @@ public class WireframeControl : GraphicsDeviceControl
             // <tool-bin>\Content\apos-shapes.xnb (see EditorTabPlugin_XNA.csproj PostBuild).
             if (!ShapeRenderer.Self.IsInitialized)
             {
-                ContentManager shapesContentManager = new ContentManager(Services, "Content");
-                ShapeRenderer.Self.Initialize(GraphicsDevice, shapesContentManager);
+                ContentManager shapesContentManager = new ContentManager(renderHost.Services, "Content");
+                ShapeRenderer.Self.Initialize(renderHost.GraphicsDevice, shapesContentManager);
             }
 
             InitializeDefaultTypeInstantiation();

--- a/Tool/Tests/GumToolUnitTests/Rendering/GraphicsDeviceServiceRenderHostAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Rendering/GraphicsDeviceServiceRenderHostAdapterTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using XnaAndWinforms;
+
+namespace GumToolUnitTests.Rendering;
+
+public class GraphicsDeviceServiceRenderHostAdapterTests : BaseTestClass
+{
+    private class FakeGraphicsDeviceService : IGraphicsDeviceService
+    {
+        public GraphicsDevice? GraphicsDevice { get; set; }
+
+#pragma warning disable CS0067 // required by IGraphicsDeviceService, never raised by this fake
+        public event EventHandler<EventArgs>? DeviceCreated;
+        public event EventHandler<EventArgs>? DeviceDisposing;
+        public event EventHandler<EventArgs>? DeviceReset;
+        public event EventHandler<EventArgs>? DeviceResetting;
+#pragma warning restore CS0067
+    }
+
+    private class FakeServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    [Fact]
+    public void Constructor_NullGraphicsDeviceService_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new GraphicsDeviceServiceRenderHostAdapter(null!, new FakeServiceProvider()));
+    }
+
+    [Fact]
+    public void Constructor_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new GraphicsDeviceServiceRenderHostAdapter(new FakeGraphicsDeviceService(), null!));
+    }
+
+    [Fact]
+    public void GraphicsDevice_ForwardsToWrappedGraphicsDeviceService()
+    {
+        FakeGraphicsDeviceService graphicsDeviceService = new FakeGraphicsDeviceService
+        {
+            GraphicsDevice = null
+        };
+        GraphicsDeviceServiceRenderHostAdapter adapter =
+            new GraphicsDeviceServiceRenderHostAdapter(graphicsDeviceService, new FakeServiceProvider());
+
+        adapter.GraphicsDevice.ShouldBe(graphicsDeviceService.GraphicsDevice);
+    }
+
+    [Fact]
+    public void Services_ForwardsToWrappedServiceProvider()
+    {
+        FakeServiceProvider services = new FakeServiceProvider();
+        GraphicsDeviceServiceRenderHostAdapter adapter =
+            new GraphicsDeviceServiceRenderHostAdapter(new FakeGraphicsDeviceService(), services);
+
+        adapter.Services.ShouldBeSameAs(services);
+    }
+}

--- a/XnaAndWinforms/GraphicsDeviceServiceRenderHostAdapter.cs
+++ b/XnaAndWinforms/GraphicsDeviceServiceRenderHostAdapter.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// Adapts an <see cref="IGraphicsDeviceService"/> and a service provider to
+/// <see cref="IRenderDeviceHost"/> via 1:1 forwarding, so render-initialization code doesn't need
+/// to depend on the concrete <see cref="GraphicsDeviceControl"/> type.
+/// </summary>
+public class GraphicsDeviceServiceRenderHostAdapter : IRenderDeviceHost
+{
+    private readonly IGraphicsDeviceService _graphicsDeviceService;
+    private readonly IServiceProvider _services;
+
+    public GraphicsDeviceServiceRenderHostAdapter(IGraphicsDeviceService graphicsDeviceService, IServiceProvider services)
+    {
+        if (graphicsDeviceService == null)
+        {
+            throw new ArgumentNullException(nameof(graphicsDeviceService));
+        }
+        if (services == null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        _graphicsDeviceService = graphicsDeviceService;
+        _services = services;
+    }
+
+    public GraphicsDevice GraphicsDevice => _graphicsDeviceService.GraphicsDevice;
+
+    public IServiceProvider Services => _services;
+}

--- a/XnaAndWinforms/IRenderDeviceHost.cs
+++ b/XnaAndWinforms/IRenderDeviceHost.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The render-side subset of a rendering host that <c>SystemManagers.Initialize</c> and its
+/// callers need: a GPU device to register against, and a service provider for constructing
+/// <c>ContentManager</c>s. Lets that initialization run against a host that isn't a real WinForms
+/// <see cref="GraphicsDeviceControl"/> (e.g. a test double or a future non-WinForms rendering host).
+/// </summary>
+public interface IRenderDeviceHost
+{
+    /// <summary>
+    /// The GPU device to initialize rendering against.
+    /// </summary>
+    GraphicsDevice GraphicsDevice { get; }
+
+    /// <summary>
+    /// The service provider used to construct <c>ContentManager</c>s for loading fonts/textures.
+    /// </summary>
+    IServiceProvider Services { get; }
+}


### PR DESCRIPTION
Part of #3756 (Phase 4b). Follows the same shape as #3823's `IInputHostControl`, but for the render side of the host contract.

## What changed
- `XnaAndWinforms/IRenderDeviceHost.cs` — new interface: `GraphicsDevice` + `IServiceProvider Services`, the exact pair `SystemManagers.Initialize(GraphicsDevice)` and the shape-renderer/font ContentManager construction need from a host.
- `XnaAndWinforms/GraphicsDeviceServiceRenderHostAdapter.cs` — adapts the standard MonoGame `IGraphicsDeviceService` (already registered in `GraphicsDeviceControl.Services`) + `IServiceProvider` to `IRenderDeviceHost` via 1:1 forwarding. No dependency on the concrete `GraphicsDeviceControl` type, so it's constructible with a fake in tests (no GPU needed).
- `WireframeControl.cs` — `Initialize()` now resolves `IRenderDeviceHost` once and routes `SystemManagers.Default.Initialize(...)` / the shapes `ContentManager` construction through it instead of reading `GraphicsDevice`/`Services` directly off the WinForms base class.

## Why this shape
`GraphicsDeviceControl` itself (render-target/pixel-buffer readback) is being extracted separately in parallel. This PR only touches the *inputs* to `SystemManagers.Initialize` — the actual GPU-init call is a single line and too GPU-entangled to unit test directly, so the seam that's actually testable is the host-contract adapter, mirroring #3823's approach.

## Tests
- `GraphicsDeviceServiceRenderHostAdapterTests` (4 tests): forwarding + null-arg guards, using a fake `IGraphicsDeviceService`/`IServiceProvider` — no GPU required.
- Full `GumToolUnitTests`: 1030 passed, 4 skipped (pre-existing), 0 failed.

Manual test: not needed — behavior-preserving (same GraphicsDevice/Services values flow through, just via the interface), covered by the adapter's unit tests + a clean `GumFull.sln` build.

FRB canary: not needed — `XnaAndWinforms` isn't referenced by `GumCoreShared.projitems` or FRB1's Forms shared project; this file isn't shared with FRB1.

Closes nothing on its own; part of the ongoing #3756 decoupling effort.
