### PR TITLE
Mirror IRenderDeviceHost onto ImageRegionSelectionControl

### DIFF
--- a/FlatRedBall.SpecializedXnaControls/ImageRegionSelectionControl.cs
+++ b/FlatRedBall.SpecializedXnaControls/ImageRegionSelectionControl.cs
@@ -433,8 +433,14 @@ public class ImageRegionSelectionControl : GraphicsDeviceControl
             mTimeManager = new TimeManager();
 
 
+            // Route the GPU device/content-service lookup through IRenderDeviceHost rather than
+            // reading GraphicsDevice/Services directly off this control, so the initialization
+            // sequence below only depends on the render-host contract, not on GraphicsDeviceControl.
+            var graphicsDeviceService = (IGraphicsDeviceService)Services.GetService(typeof(IGraphicsDeviceService));
+            IRenderDeviceHost renderHost = new GraphicsDeviceServiceRenderHostAdapter(graphicsDeviceService, Services);
+
             mManagers = new SystemManagers();
-            mManagers.Initialize(GraphicsDevice);
+            mManagers.Initialize(renderHost.GraphicsDevice);
             mManagers.Name = "Image Region Selection";
             Assembly assembly = Assembly.GetAssembly(typeof(GraphicsDeviceControl));// Assembly.GetCallingAssembly();
 
@@ -477,7 +483,7 @@ public class ImageRegionSelectionControl : GraphicsDeviceControl
             contentLoader.SystemManagers = mManagers;
 
             LoaderManager.Self.ContentLoader = contentLoader;
-            LoaderManager.Self.Initialize("Content/InvalidTexture.png", targetFntFileName.FullPath, Services, mManagers);
+            LoaderManager.Self.Initialize("Content/InvalidTexture.png", targetFntFileName.FullPath, renderHost.Services, mManagers);
 
             CreateNewSelector();
 


### PR DESCRIPTION
Part of #3756 (Phase 4b). Mirrors #3826's `IRenderDeviceHost` adoption onto `ImageRegionSelectionControl`, the other `SystemManagers.Initialize(GraphicsDevice)` call site left unwired in that PR.

## What changed
- `FlatRedBall.SpecializedXnaControls/ImageRegionSelectionControl.cs` — `CustomInitialize()` now resolves `IGraphicsDeviceService` from `Services`, adapts it via `GraphicsDeviceServiceRenderHostAdapter`, and routes both `SystemManagers.Initialize(...)` and `LoaderManager.Self.Initialize(...)`'s `ContentManager` service lookup through `IRenderDeviceHost.GraphicsDevice`/`.Services` instead of reading `GraphicsDevice`/`Services` directly off the `GraphicsDeviceControl` base class.

No new interface/adapter needed — `IRenderDeviceHost` and `GraphicsDeviceServiceRenderHostAdapter` already exist and are unit-tested from #3826; this PR only adds the second call site.

## Tests
- No new unit test: `ImageRegionSelectionControl` is a WinForms `Control` that needs a real GPU-backed handle to construct (same reason #3826 didn't test `WireframeControl` directly) — the adapter itself is already covered by `GraphicsDeviceServiceRenderHostAdapterTests`.
- Full `GumToolUnitTests`: 1047 passed, 4 skipped (pre-existing), 0 failed.

Manual test: not needed — behavior-preserving (same `GraphicsDevice`/`Services` values flow through, just via the interface), covered by the adapter's existing unit tests + a clean `GumFull.sln` build.

FRB canary: not needed — `FlatRedBall.SpecializedXnaControls`/`XnaAndWinforms` aren't referenced by `GumCoreShared.projitems` or FRB1's Forms shared project.
