### PR TITLE
Extract ReactToClickedNode's dispatch decision into TreeNodeClickDispatchLogic

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -29,6 +29,7 @@ namespace CommonFormsAndControls
         private readonly TreeNodeRangeSelectionLogic _rangeSelectionLogic;
         private readonly TreeNodeMouseUpSelectionLogic _mouseUpSelectionLogic;
         private readonly TreeNodeKeyNavigationLogic _keyNavigationLogic;
+        private readonly TreeNodeClickDispatchLogic _clickDispatchLogic;
         public ImageList ElementTreeImageList => _elementTreeImages;
 
         #endregion
@@ -603,6 +604,7 @@ namespace CommonFormsAndControls
             _rangeSelectionLogic = new TreeNodeRangeSelectionLogic();
             _mouseUpSelectionLogic = new TreeNodeMouseUpSelectionLogic();
             _keyNavigationLogic = new TreeNodeKeyNavigationLogic();
+            _clickDispatchLogic = new TreeNodeClickDispatchLogic();
             InitializeComponent();
             mSelectedNodes = new List<TreeNode>();
             mOriginalColors = new Dictionary<TreeNode, Color>();
@@ -786,38 +788,39 @@ namespace CommonFormsAndControls
 
                 bool shouldRaiseEvents = true;
 
-                if (node == null)
+                var reaction = _clickDispatchLogic.GetReaction(
+                    hasClickedNode: node != null,
+                    hasExistingSelection: mSelectedNode != null,
+                    AlwaysHaveOneNodeSelected,
+                    EffectiveModifiers(),
+                    MultiSelectBehavior);
+
+                switch (reaction)
                 {
-                    if (AlwaysHaveOneNodeSelected == false)
-                    {
+                    case TreeNodeClickReaction.DeselectAll:
                         for (int i = SelectedNodes.Count - 1; i > -1; i--)
                         {
                             Deselect(SelectedNodes[i]);
                         }
 
                         mSelectedNode = null;
-                    }
-                    else
-                    {
+                        break;
+                    case TreeNodeClickReaction.None:
                         shouldRaiseEvents = false;
-                    }
-                }
-                else if (mSelectedNode == null || EffectiveModifiers() == Keys.Control ||
-                         MultiSelectBehavior == MultiSelectBehavior.RegularClick)
-                {
-                    // Ctrl+Click selects an unselected node, or unselects a selected node.  
-                    bool bIsSelected = mSelectedNodes.Contains(node);
-                    SetNodeSelected(node, !bIsSelected);
-                }
-                else if (EffectiveModifiers() == Keys.Shift)
-                {
-                    // Shift+Click selects nodes between the selected node and here.
-                    _rangeSelectionLogic.SelectRange(mSelectedNode, node, n => SetNodeSelected(n, true));
-                }
-                else
-                {
-                    // Just clicked a node, select it  
-                    SelectSingleNode(node);
+                        break;
+                    case TreeNodeClickReaction.ToggleSelection:
+                        // Ctrl+Click selects an unselected node, or unselects a selected node.
+                        bool bIsSelected = mSelectedNodes.Contains(node!);
+                        SetNodeSelected(node!, !bIsSelected);
+                        break;
+                    case TreeNodeClickReaction.RangeSelect:
+                        // Shift+Click selects nodes between the selected node and here.
+                        _rangeSelectionLogic.SelectRange(mSelectedNode!, node!, n => SetNodeSelected(n, true));
+                        break;
+                    case TreeNodeClickReaction.SingleSelect:
+                        // Just clicked a node, select it
+                        SelectSingleNode(node!);
+                        break;
                 }
 
                 // August 22, 2011  

--- a/Gum/CommonFormsAndControls/TreeNodeClickDispatchLogic.cs
+++ b/Gum/CommonFormsAndControls/TreeNodeClickDispatchLogic.cs
@@ -1,0 +1,72 @@
+using System.Windows.Forms;
+
+namespace CommonFormsAndControls;
+
+/// <summary>
+/// Which selection strategy a click on a tree node should use. Returned by
+/// <see cref="TreeNodeClickDispatchLogic.GetReaction"/> for <see cref="MultiSelectTreeView"/>'s
+/// caller to act on.
+/// </summary>
+public enum TreeNodeClickReaction
+{
+    /// <summary>The clicked node was null and the selection may become empty: clear it.</summary>
+    DeselectAll,
+
+    /// <summary>
+    /// The clicked node was null, but <see cref="MultiSelectTreeView.AlwaysHaveOneNodeSelected"/>
+    /// forbids an empty selection: do nothing.
+    /// </summary>
+    None,
+
+    /// <summary>Toggle the clicked node's selected state, leaving other selected nodes alone.</summary>
+    ToggleSelection,
+
+    /// <summary>Select every node between the previously-selected node and the clicked node.</summary>
+    RangeSelect,
+
+    /// <summary>Clear the selection and select only the clicked node.</summary>
+    SingleSelect,
+}
+
+/// <summary>
+/// Decides which selection strategy applies to a clicked tree node. Extracted from
+/// <see cref="MultiSelectTreeView.ReactToClickedNode"/> so the dispatch decision - independent of
+/// any live control state - can be unit-tested directly instead of only through click plumbing.
+/// The caller still owns performing the actual selection mutation.
+/// </summary>
+public class TreeNodeClickDispatchLogic
+{
+    /// <summary>
+    /// A null <paramref name="hasClickedNode"/> deselects everything, unless
+    /// <paramref name="alwaysHaveOneNodeSelected"/> forbids it. Otherwise: Ctrl+Click (or no prior
+    /// selection, or <see cref="MultiSelectBehavior.RegularClick"/>) toggles the clicked node;
+    /// Shift+Click selects the range from the current selection; a plain click selects only the
+    /// clicked node.
+    /// </summary>
+    public TreeNodeClickReaction GetReaction(
+        bool hasClickedNode,
+        bool hasExistingSelection,
+        bool alwaysHaveOneNodeSelected,
+        Keys effectiveModifiers,
+        MultiSelectBehavior multiSelectBehavior)
+    {
+        if (!hasClickedNode)
+        {
+            return alwaysHaveOneNodeSelected ? TreeNodeClickReaction.None : TreeNodeClickReaction.DeselectAll;
+        }
+
+        if (!hasExistingSelection ||
+            effectiveModifiers == Keys.Control ||
+            multiSelectBehavior == MultiSelectBehavior.RegularClick)
+        {
+            return TreeNodeClickReaction.ToggleSelection;
+        }
+
+        if (effectiveModifiers == Keys.Shift)
+        {
+            return TreeNodeClickReaction.RangeSelect;
+        }
+
+        return TreeNodeClickReaction.SingleSelect;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeClickDispatchLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeClickDispatchLogicTests.cs
@@ -1,0 +1,90 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class TreeNodeClickDispatchLogicTests : BaseTestClass
+{
+    private readonly TreeNodeClickDispatchLogic _logic;
+
+    public TreeNodeClickDispatchLogicTests()
+    {
+        _logic = new TreeNodeClickDispatchLogic();
+    }
+
+    [Fact]
+    public void GetReaction_NullNodeAndAlwaysHaveOneNodeSelectedFalse_ReturnsDeselectAll()
+    {
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: false, hasExistingSelection: true, alwaysHaveOneNodeSelected: false,
+            Keys.None, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.DeselectAll);
+    }
+
+    [Fact]
+    public void GetReaction_NullNodeAndAlwaysHaveOneNodeSelectedTrue_ReturnsNone()
+    {
+        // A null node normally deselects everything, but AlwaysHaveOneNodeSelected forbids an
+        // empty selection, so nothing should happen.
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: false, hasExistingSelection: true, alwaysHaveOneNodeSelected: true,
+            Keys.None, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.None);
+    }
+
+    [Fact]
+    public void GetReaction_NoExistingSelection_ReturnsToggleSelection()
+    {
+        // With nothing currently selected, even a plain click toggles the clicked node on.
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: true, hasExistingSelection: false, alwaysHaveOneNodeSelected: false,
+            Keys.None, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.ToggleSelection);
+    }
+
+    [Fact]
+    public void GetReaction_ControlModifier_ReturnsToggleSelection()
+    {
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: true, hasExistingSelection: true, alwaysHaveOneNodeSelected: false,
+            Keys.Control, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.ToggleSelection);
+    }
+
+    [Fact]
+    public void GetReaction_RegularClickBehavior_ReturnsToggleSelection()
+    {
+        // MultiSelectBehavior.RegularClick always toggles, even without a modifier.
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: true, hasExistingSelection: true, alwaysHaveOneNodeSelected: false,
+            Keys.None, MultiSelectBehavior.RegularClick);
+
+        reaction.ShouldBe(TreeNodeClickReaction.ToggleSelection);
+    }
+
+    [Fact]
+    public void GetReaction_ShiftModifier_ReturnsRangeSelect()
+    {
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: true, hasExistingSelection: true, alwaysHaveOneNodeSelected: false,
+            Keys.Shift, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.RangeSelect);
+    }
+
+    [Fact]
+    public void GetReaction_NoModifierWithExistingSelection_ReturnsSingleSelect()
+    {
+        TreeNodeClickReaction reaction = _logic.GetReaction(
+            hasClickedNode: true, hasExistingSelection: true, alwaysHaveOneNodeSelected: false,
+            Keys.None, MultiSelectBehavior.CtrlDown);
+
+        reaction.ShouldBe(TreeNodeClickReaction.SingleSelect);
+    }
+}


### PR DESCRIPTION
Extracts `MultiSelectTreeView.ReactToClickedNode`'s dispatch decision into `TreeNodeClickDispatchLogic` - a plain class deciding which selection strategy applies (deselect all / no-op / toggle / range / single) from modifiers, `MultiSelectBehavior`, `AlwaysHaveOneNodeSelected`, and whether there's an existing selection, instead of reading live control state. Same shape as `TreeNodeRangeSelectionLogic` (#3821), `TreeNodeMouseUpSelectionLogic` (#3822), `TreeNodeKeyNavigationLogic` (#3824).

- `TreeNodeClickReaction` enum (`DeselectAll`, `None`, `ToggleSelection`, `RangeSelect`, `SingleSelect`) mirrors the original 4-way branch exactly, including the `AlwaysHaveOneNodeSelected` no-op case.
- `ReactToClickedNode` now switches on the returned reaction and still owns the actual mutation (`Deselect`, `SetNodeSelected`, `_rangeSelectionLogic.SelectRange`, `SelectSingleNode`).
- 7 new unit tests in `TreeNodeClickDispatchLogicTests` covering every branch.

Behavior-preserving. `Gum/CommonFormsAndControls/` is tool-only WinForms code, not part of `GumCoreShared.projitems`, so no FRB1 sync needed.

Part of #3755.

Manual test: not needed - behavior-preserving, covered by unit tests + full `GumToolUnitTests` suite (1054 passed, 0 failed, 4 pre-existing skips).
