### PR TITLE
Formalize pixel-buffer readback behind IRenderTargetPixelBufferWriter

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Wireframe/BitmapPixelBufferWriterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/BitmapPixelBufferWriterTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using XnaAndWinforms;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+public class BitmapPixelBufferWriterTests
+{
+    private const int Width = 2;
+    private const int Height = 2;
+
+    // Fills every pixel with the same 4 raw bytes, in the order they'd appear in the buffer
+    // read back from RenderTarget2D.GetData.
+    private static byte[] CreateRawImage(byte byte0, byte byte1, byte byte2, byte byte3)
+    {
+        byte[] rawImage = new byte[Width * Height * 4];
+        for (int i = 0; i < rawImage.Length; i += 4)
+        {
+            rawImage[i + 0] = byte0;
+            rawImage[i + 1] = byte1;
+            rawImage[i + 2] = byte2;
+            rawImage[i + 3] = byte3;
+        }
+        return rawImage;
+    }
+
+    [Fact]
+    public void WriteToBitmap_Bgra32Source_CopiesBytesDirectly()
+    {
+        // Bgra32 source already matches the bitmap's BGRA memory layout, so no conversion is needed.
+        byte[] rawImage = CreateRawImage(byte0: 40, byte1: 50, byte2: 60, byte3: 255);
+        Bitmap bitmap = new Bitmap(Width, Height, PixelFormat.Format32bppArgb);
+        BitmapPixelBufferWriter writer = new BitmapPixelBufferWriter();
+
+        writer.WriteToBitmap(rawImage, SurfaceFormat.Bgra32, bitmap);
+
+        Color pixel = bitmap.GetPixel(0, 0);
+        pixel.B.ShouldBe((byte)40);
+        pixel.G.ShouldBe((byte)50);
+        pixel.R.ShouldBe((byte)60);
+        pixel.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void WriteToBitmap_ColorSource_ByteSwapsRgbaToBgra()
+    {
+        // Color source is RGBA; the bitmap's BGRA layout requires swapping R and B.
+        byte[] rawImage = CreateRawImage(byte0: 10, byte1: 20, byte2: 30, byte3: 255);
+        Bitmap bitmap = new Bitmap(Width, Height, PixelFormat.Format32bppArgb);
+        BitmapPixelBufferWriter writer = new BitmapPixelBufferWriter();
+
+        writer.WriteToBitmap(rawImage, SurfaceFormat.Color, bitmap);
+
+        Color pixel = bitmap.GetPixel(0, 0);
+        pixel.R.ShouldBe((byte)10);
+        pixel.G.ShouldBe((byte)20);
+        pixel.B.ShouldBe((byte)30);
+        pixel.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void WriteToBitmap_UnsupportedFormatCombination_Throws()
+    {
+        byte[] rawImage = CreateRawImage(byte0: 1, byte1: 2, byte2: 3, byte3: 4);
+        Bitmap bitmap = new Bitmap(Width, Height, PixelFormat.Format24bppRgb);
+        BitmapPixelBufferWriter writer = new BitmapPixelBufferWriter();
+
+        Should.Throw<NotSupportedException>(() => writer.WriteToBitmap(rawImage, SurfaceFormat.Color, bitmap));
+    }
+}

--- a/XnaAndWinforms/BitmapPixelBufferWriter.cs
+++ b/XnaAndWinforms/BitmapPixelBufferWriter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The real, GPU-independent implementation of <see cref="IRenderTargetPixelBufferWriter"/>. Locks
+/// <paramref name="bitmap"/>'s backing memory and copies/converts <c>rawImage</c> into it according
+/// to <see cref="RenderTargetPixelBufferConverter.GetStrategy"/>. Extracted from
+/// <see cref="GraphicsDeviceControl"/>'s <c>PaintRendertarget</c> method.
+/// </summary>
+public class BitmapPixelBufferWriter : IRenderTargetPixelBufferWriter
+{
+    public void WriteToBitmap(byte[] rawImage, SurfaceFormat sourceFormat, Bitmap bitmap)
+    {
+        int width = bitmap.Width;
+        int height = bitmap.Height;
+
+        PixelBufferConversionStrategy? strategy =
+            RenderTargetPixelBufferConverter.GetStrategy(sourceFormat, bitmap.PixelFormat);
+
+        if (strategy == null)
+        {
+            throw new NotSupportedException(
+                $"No pixel buffer conversion from {sourceFormat} to {bitmap.PixelFormat}.");
+        }
+
+        System.Drawing.Rectangle rect = new System.Drawing.Rectangle(0, 0, width, height);
+        BitmapData bmpData = bitmap.LockBits(rect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
+
+        try
+        {
+            if (strategy == PixelBufferConversionStrategy.ByteSwapRgbaToBgra)
+            {
+                CopyAndConvertRgbaToBgra(width, height, rawImage, bmpData.Scan0, bmpData.Stride);
+            }
+            else
+            {
+                int rowSize = width * 4;
+                int rowStride = bmpData.Stride;
+
+                Parallel.For(0, height, (y) =>
+                {
+                    int srcOffset = y * rowSize;
+                    int dstOffset = y * rowStride;
+                    Marshal.Copy(rawImage, srcOffset, bmpData.Scan0 + dstOffset, rowSize);
+                });
+            }
+        }
+        finally
+        {
+            bitmap.UnlockBits(bmpData);
+        }
+    }
+
+    private static unsafe void CopyAndConvertRgbaToBgra(int width, int height, byte[] data, IntPtr buffer, int rowStride)
+    {
+        int rowSize = width * 4;
+
+        fixed (void* pData = &data[0])
+        {
+            byte* src = (byte*)pData;
+            byte* dst = (byte*)buffer;
+
+            Parallel.For(0, height, (y) =>
+            {
+                int srcOffset = y * rowSize;
+                int dstOffset = y * rowStride;
+
+                for (int x = 0; x < width; x++)
+                {
+                    int i = x * 4;
+                    dst[dstOffset + i + 0] = src[srcOffset + i + 2];
+                    dst[dstOffset + i + 1] = src[srcOffset + i + 1];
+                    dst[dstOffset + i + 2] = src[srcOffset + i + 0];
+                    dst[dstOffset + i + 3] = src[srcOffset + i + 3];
+                }
+            });
+        }
+    }
+}

--- a/XnaAndWinforms/GraphicsDeviceControl.cs
+++ b/XnaAndWinforms/GraphicsDeviceControl.cs
@@ -11,8 +11,6 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Xna.Framework.Graphics;
 #endregion
@@ -53,6 +51,8 @@ public class GraphicsDeviceControl : Control
     private RenderTarget2D renderTarget;
     byte[] rawImage;
     Bitmap bitmap;
+
+    private readonly IRenderTargetPixelBufferWriter _pixelBufferWriter = new BitmapPixelBufferWriter();
 
     #endregion
 
@@ -454,35 +454,11 @@ public class GraphicsDeviceControl : Control
 
     private void PaintRendertarget(Graphics graphics)
     {
-        int w = Math.Max(1, ClientSize.Width);
-        int h = Math.Max(1, ClientSize.Height);
+        // Produce the pixel buffer: convert rawImage (the GPU render target readback from EndDraw)
+        // into bitmap's backing memory. This step needs no live WinForms Graphics surface.
+        _pixelBufferWriter.WriteToBitmap(rawImage, renderTarget.Format, bitmap);
 
-        var rect = new System.Drawing.Rectangle(0, 0, w, h);
-        BitmapData bmpData = bitmap.LockBits(rect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
-        PixelBufferConversionStrategy? strategy =
-            RenderTargetPixelBufferConverter.GetStrategy(renderTarget.Format, bitmap.PixelFormat);
-
-        if (strategy == PixelBufferConversionStrategy.ByteSwapRgbaToBgra)
-        {
-            CopyAndConvertRGBATOBGRA(w, h, rawImage, bmpData.Scan0, bmpData.Stride);
-        }
-        else if (strategy == PixelBufferConversionStrategy.DirectCopy)
-        {
-            int rowSize = w * 4;
-            int rowStride = bmpData.Stride;
-
-            Parallel.For(0, h, (y) =>
-            {
-                int srcOffset = y * rowSize;
-                int dstOffset = y * rowStride;
-                Marshal.Copy(rawImage, srcOffset, bmpData.Scan0 + dstOffset, rowSize);
-            });
-        }
-        else
-        {
-            throw new NotSupportedException();
-        }
-        bitmap.UnlockBits(bmpData);
+        // Blit the produced bitmap onto the WinForms Graphics surface.
         var cm = graphics.CompositingMode;
         var im = graphics.InterpolationMode;
         graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
@@ -490,32 +466,6 @@ public class GraphicsDeviceControl : Control
         graphics.DrawImageUnscaled(bitmap, 0, 0);
         graphics.CompositingMode = cm;
         graphics.InterpolationMode = im;
-    }
-
-    private unsafe void CopyAndConvertRGBATOBGRA(int w, int h, byte[] data, IntPtr buffer, int rowStride)
-    {
-        int rowSize = w * 4;
-
-        fixed (void* pData = &data[0])
-        {
-            byte* src = (byte*)pData;
-            byte* dst = (byte*)buffer;
-
-            Parallel.For(0, h, (y) =>
-            {
-                int srcOffset = y * rowSize;
-                int dstOffset = y * rowStride;
-
-                for (int x = 0; x < w; x++)
-                {
-                    int i = x * 4;
-                    dst[dstOffset + i + 0] = src[srcOffset + i + 2];
-                    dst[dstOffset + i + 1] = src[srcOffset + i + 1];
-                    dst[dstOffset + i + 2] = src[srcOffset + i + 0];
-                    dst[dstOffset + i + 3] = src[srcOffset + i + 3];
-                }
-            });
-        }
     }
 
     /// <summary>

--- a/XnaAndWinforms/IRenderTargetPixelBufferWriter.cs
+++ b/XnaAndWinforms/IRenderTargetPixelBufferWriter.cs
@@ -1,0 +1,24 @@
+using System.Drawing;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// Converts a raw pixel buffer read back from a GPU render target (via <c>RenderTarget2D.GetData</c>)
+/// into a <see cref="Bitmap"/>'s pixel format and writes it into that bitmap's backing memory. This
+/// is the "produce a pixel buffer" half of <see cref="GraphicsDeviceControl"/>'s paint sequence,
+/// deliberately kept separate from the actual blit of that bitmap onto a WinForms <see cref="Graphics"/>
+/// surface - so the conversion can be constructed and tested without a live GPU or window handle.
+/// </summary>
+public interface IRenderTargetPixelBufferWriter
+{
+    /// <summary>
+    /// Writes <paramref name="rawImage"/> (as read back in <paramref name="sourceFormat"/>) into
+    /// <paramref name="bitmap"/>'s backing memory, converting pixel byte order if needed.
+    /// </summary>
+    /// <exception cref="System.NotSupportedException">
+    /// Thrown when <paramref name="sourceFormat"/> and <paramref name="bitmap"/>'s pixel format have
+    /// no supported conversion.
+    /// </exception>
+    void WriteToBitmap(byte[] rawImage, SurfaceFormat sourceFormat, Bitmap bitmap);
+}


### PR DESCRIPTION
Part of #3756.

Extracts the CPU-side half of `GraphicsDeviceControl.PaintRendertarget` - the strategy lookup + `LockBits` + byte-swap/direct-copy that turns the `RenderTarget2D.GetData` readback (`rawImage`) into the `Bitmap`'s backing memory - into `BitmapPixelBufferWriter`, behind a new `IRenderTargetPixelBufferWriter` interface. `PaintRendertarget` now only calls the writer and then does the actual WinForms `Graphics.DrawImageUnscaled` blit.

Mirrors #3823/#3826's `IInputHostControl`/`IRenderDeviceHost` shape: narrow interface, adapter holds the real logic, unit-testable without a live `GraphicsDevice` or window handle (only needs a `System.Drawing.Bitmap`).

- `XnaAndWinforms/IRenderTargetPixelBufferWriter.cs`
- `XnaAndWinforms/BitmapPixelBufferWriter.cs` - moved `LockBits`/`CopyAndConvertRGBATOBGRA`/direct-copy logic here verbatim (byte-for-byte unchanged), now covered by unit tests for the first time.
- `XnaAndWinforms/GraphicsDeviceControl.cs` - `PaintRendertarget` shrinks to "produce pixel buffer" + "blit", each on its own line/comment.
- `Tool/Tests/GumToolUnitTests/Wireframe/BitmapPixelBufferWriterTests.cs` - covers direct-copy, byte-swap, and unsupported-format-throws.

Deliberately left alone: the `RenderTarget2D.GetData` call itself (`EndDraw`) stays untouched - it needs a live GPU-bound render target, so it isn't a clean unit-testable seam. This PR narrows to the part that genuinely is: the buffer-to-bitmap conversion.

## Testing
- `dotnet build GumFull.sln` - clean, no new warnings.
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` - new tests red (missing types) before implementation, green after; full suite 1050 passed / 4 pre-existing skips, no regressions.
- Manual verdict: not required - `PaintRendertarget`'s runtime behavior is unchanged (same calls, same order), and the moved copy logic is byte-for-byte identical to before, just under a new home with tests.