### PR TITLE
Extract MultiSelectTreeView's OnMouseDown click-reaction decision into TreeNodeMouseDownSelectionLogic

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.cs
@@ -28,6 +28,7 @@ namespace CommonFormsAndControls
         private TreeNode? nodeOnDragStart;
         private readonly TreeNodeRangeSelectionLogic _rangeSelectionLogic;
         private readonly TreeNodeMouseUpSelectionLogic _mouseUpSelectionLogic;
+        private readonly TreeNodeMouseDownSelectionLogic _mouseDownSelectionLogic;
         private readonly TreeNodeKeyNavigationLogic _keyNavigationLogic;
         private readonly TreeNodeClickDispatchLogic _clickDispatchLogic;
         public ImageList ElementTreeImageList => _elementTreeImages;
@@ -209,28 +210,21 @@ namespace CommonFormsAndControls
                 base.SelectedNode = null;
 
                 TreeNode? previousSelectedNode = mSelectedNode;
-                var previousCount = SelectedNodes.Count;
 
                 var node = this.GetNodeAtRowY(e.Location.Y);
                 if (node != null)
                 {
-                    if (mSelectedNodes.Contains(node) && e.Button == MouseButtons.Right &&
-                        EffectiveModifiers() != Keys.None)
+                    bool shouldReact = _mouseDownSelectionLogic.ShouldReactToClick(
+                        mSelectedNodes.Contains(node), e.Button, EffectiveModifiers(), MultiSelectBehavior,
+                        IsSelectingOnPush);
+
+                    if (shouldReact)
                     {
-                    }
-                    else if ((EffectiveModifiers() == Keys.None &&
-                              MultiSelectBehavior != MultiSelectBehavior.RegularClick) &&
-                             (mSelectedNodes.Contains(node)))
-                    {
-                        // Potential Drag Operation  
-                        // Let Mouse Up do select  
-                    }
-                    else if (IsSelectingOnPush || EffectiveModifiers() == Keys.Shift || EffectiveModifiers() == Keys.Control ||
-                             e.Button == MouseButtons.Right)
-                    {
-                        // For gum we want to prevent selection on a push. Should be on a click  
+                        // For gum we want to prevent selection on a push. Should be on a click
                         ReactToClickedNode(node);
                     }
+                    // Otherwise either a context-menu right-click on an already-selected node, or a
+                    // potential drag operation - let Mouse Up do the (re)select.
                 }
                 else
                 {
@@ -603,6 +597,7 @@ namespace CommonFormsAndControls
             this._components = new System.ComponentModel.Container();
             _rangeSelectionLogic = new TreeNodeRangeSelectionLogic();
             _mouseUpSelectionLogic = new TreeNodeMouseUpSelectionLogic();
+            _mouseDownSelectionLogic = new TreeNodeMouseDownSelectionLogic();
             _keyNavigationLogic = new TreeNodeKeyNavigationLogic();
             _clickDispatchLogic = new TreeNodeClickDispatchLogic();
             InitializeComponent();

--- a/Gum/CommonFormsAndControls/TreeNodeMouseDownSelectionLogic.cs
+++ b/Gum/CommonFormsAndControls/TreeNodeMouseDownSelectionLogic.cs
@@ -1,0 +1,43 @@
+using System.Windows.Forms;
+
+namespace CommonFormsAndControls;
+
+/// <summary>
+/// Decides whether pressing a mouse button over a tree node should react (select it / raise
+/// <c>ReactToClickedNode</c>) immediately, or defer to mouse-up. Extracted from
+/// <see cref="MultiSelectTreeView"/> so the decision - independent of any live control state -
+/// can be unit-tested directly instead of only through <c>OnMouseDown</c> plumbing.
+/// </summary>
+public class TreeNodeMouseDownSelectionLogic
+{
+    /// <summary>
+    /// A right-click with a modifier held on a node that's already part of a multi-selection opens
+    /// a context menu without changing selection. Otherwise, with no modifier held and a multi-select
+    /// behavior other than <see cref="MultiSelectBehavior.RegularClick"/>, pressing on an
+    /// already-multi-selected node is a potential drag - the actual (re)selection is deferred to
+    /// mouse-up. Otherwise this reacts immediately when selection normally happens on push
+    /// (<paramref name="isSelectingOnPush"/>), when Shift or Control is held (both extend/toggle
+    /// selection on press), or on a right-click (to select before showing the context menu).
+    /// </summary>
+    public bool ShouldReactToClick(
+        bool isNodeInMultiSelection,
+        MouseButtons button,
+        Keys effectiveModifiers,
+        MultiSelectBehavior multiSelectBehavior,
+        bool isSelectingOnPush)
+    {
+        if (isNodeInMultiSelection && button == MouseButtons.Right && effectiveModifiers != Keys.None)
+        {
+            return false;
+        }
+
+        if (effectiveModifiers == Keys.None && multiSelectBehavior != MultiSelectBehavior.RegularClick &&
+            isNodeInMultiSelection)
+        {
+            return false;
+        }
+
+        return isSelectingOnPush || effectiveModifiers == Keys.Shift || effectiveModifiers == Keys.Control ||
+               button == MouseButtons.Right;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeMouseDownSelectionLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/TreeNodeMouseDownSelectionLogicTests.cs
@@ -1,0 +1,115 @@
+using CommonFormsAndControls;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+public class TreeNodeMouseDownSelectionLogicTests : BaseTestClass
+{
+    private readonly TreeNodeMouseDownSelectionLogic _logic;
+
+    public TreeNodeMouseDownSelectionLogicTests()
+    {
+        _logic = new TreeNodeMouseDownSelectionLogic();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_LeftButtonNoModifierNotSelectingOnPush_ReturnsFalse()
+    {
+        // Neither IsSelectingOnPush nor a Shift/Control/right-click reason to react on press;
+        // OnMouseUp handles this case instead.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Left, Keys.None,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_LeftButtonNoModifierSelectingOnPush_ReturnsTrue()
+    {
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Left, Keys.None,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: true);
+
+        shouldReact.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_NodeAlreadyMultiSelectedNoModifier_ReturnsFalse()
+    {
+        // Potential drag operation - defer the actual (re)select to mouse-up.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: true, MouseButtons.Left, Keys.None,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: true);
+
+        shouldReact.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_NodeAlreadyMultiSelectedRegularClickBehavior_ReturnsTrue()
+    {
+        // MultiSelectBehavior.RegularClick means a click always (re)selects - no drag deferral.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: true, MouseButtons.Left, Keys.None,
+            MultiSelectBehavior.RegularClick, isSelectingOnPush: true);
+
+        shouldReact.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_ShiftHeld_ReturnsTrue()
+    {
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Left, Keys.Shift,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_ControlHeld_ReturnsTrue()
+    {
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Left, Keys.Control,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_RightButtonNoModifier_ReturnsTrue()
+    {
+        // Right-click selects before the context menu shows, even without IsSelectingOnPush.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Right, Keys.None,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_RightButtonWithModifierOnMultiSelectedNode_ReturnsFalse()
+    {
+        // Right-click with a modifier held on an already-multi-selected node opens a context menu
+        // without changing selection.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: true, MouseButtons.Right, Keys.Control,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReactToClick_RightButtonWithModifierOnNodeNotMultiSelected_ReturnsTrue()
+    {
+        // The right-click-with-modifier deferral only applies when the node is already part of a
+        // multi-selection; otherwise the right-click-selects-before-menu rule still applies.
+        bool shouldReact = _logic.ShouldReactToClick(
+            isNodeInMultiSelection: false, MouseButtons.Right, Keys.Control,
+            MultiSelectBehavior.CtrlDown, isSelectingOnPush: false);
+
+        shouldReact.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Extracts `OnMouseDown`'s click-reaction decision - previously inline branching (right-click on an already-selected node vs. potential-drag-defer-to-mouseup vs. react-now) - into a new `TreeNodeMouseDownSelectionLogic` class, taking modifiers/button/behavior/selection-state as parameters instead of reading live control state.

Same shape as the four prior extractions from this file (`TreeNodeRangeSelectionLogic`, `TreeNodeMouseUpSelectionLogic`, `TreeNodeKeyNavigationLogic`, `TreeNodeClickDispatchLogic`). Behavior-preserving; also drops an unused local (`previousCount`) noticed while touching the method.

The remaining part of `OnMouseDown` (previous-node/count bookkeeping for `mSelectedNodeChanged`, computed from state before/after `base.OnMouseDown`) is left as-is - it's simple sequential bookkeeping, not a branching decision worth its own class.

Part of #3755
