### PR TITLE
Fix dead WindowsFormsHost airspace margin hack (#3756 scoping)

### DIFF
--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Data;
-using System.Windows.Forms.Integration;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Controls;
 using Gum.Managers;
@@ -109,12 +108,6 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
         PluginTab newPluginTab = _pluginTabFactory(frameworkElement);
         newPluginTab.Title = tabTitle;
         newPluginTab.Location = tabLocation;
-
-        if (frameworkElement is WindowsFormsHost host && tabTitle == "Editor")
-        {   // this is kind of a hack to deal with the the airspace issue
-            // blocking mouse interaction with the grid splitter and window resize handle
-            host.Margin = new Thickness(4, 0, 4, 0);
-        }
 
         PluginTabs.Add(newPluginTab);
         return newPluginTab;

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -1409,6 +1409,13 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         WindowsFormsHost host = new WindowsFormsHost();
         host.Child = gumEditorPanel;
 
+        // This is kind of a hack to deal with the airspace issue blocking mouse
+        // interaction with the grid splitter and window resize handle: WindowsFormsHost
+        // hosts a real HWND, which always paints on top of WPF siblings regardless of
+        // z-order, so without this margin the grid splitter can't receive mouse input
+        // right at the edge of this tab.
+        host.Margin = new Thickness(4, 0, 4, 0);
+
         wpfGrid.Children.Add(host);
         Grid.SetRow(host, 1);
 


### PR DESCRIPTION
## Summary
Scoping pass on #3756's remaining ask (revisit the `WindowsFormsHost` margin hack in `MainPanelViewModel.AddControl`). The recent `IInputHostControl`/`IRenderDeviceHost` work is orthogonal to that hack - it abstracts what `WireframeControl`/`ImageRegionSelectionControl` talk to internally, not the fact that they're still `System.Windows.Forms.Control` subclasses that must be embedded via `WindowsFormsHost`. So `WindowsFormsHost` itself stays.

What I did find: the hack's type check (`frameworkElement is WindowsFormsHost host && tabTitle == "Editor"`) has been **dead since #1874** - the Editor tab now passes a WPF `Grid` wrapping the host, not the host itself, so the check never matches. That silently regressed the airspace mouse-hit-testing fix for the grid splitter/window-resize handle around the Editor tab.

Fix: apply the margin where `WindowsFormsHost` is actually constructed (`MainEditorTabPlugin.HandleWireframeInitialized`), instead of type-sniffing for it after the fact in the generic `MainPanelViewModel.AddControl`. Removes the now-pointless `WindowsFormsHost` type dependency (and `using System.Windows.Forms.Integration;`) from the ViewModel, and actually restores the intended mouse-hit-testing behavior.

## Test plan
- `dotnet build GumFull.sln` - 0 errors.
- No unit test added: this is a WPF layout workaround (a `Margin` assignment), not testable logic, matching the original hack (also untested).
- Manual test needed - visual/interop behavior. Steps in the issue thread / PR comment.

Part of #3756.
