### PR TITLE
WriteableBitmap pixel-buffer writer + WPF-native render surface design (WireframeControl, part of #3833)

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Wireframe/RenderTargetPixelBufferConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/RenderTargetPixelBufferConverterTests.cs
@@ -41,4 +41,25 @@ public class RenderTargetPixelBufferConverterTests
         RenderTargetPixelBufferConverter.GetStrategy(SurfaceFormat.Rgba64, PixelFormat.Format32bppArgb)
             .ShouldBeNull();
     }
+
+    [Fact]
+    public void GetStrategyForBgraDestination_ColorSource_ReturnsByteSwapRgbaToBgra()
+    {
+        RenderTargetPixelBufferConverter.GetStrategyForBgraDestination(SurfaceFormat.Color)
+            .ShouldBe(PixelBufferConversionStrategy.ByteSwapRgbaToBgra);
+    }
+
+    [Fact]
+    public void GetStrategyForBgraDestination_Bgra32Source_ReturnsDirectCopy()
+    {
+        RenderTargetPixelBufferConverter.GetStrategyForBgraDestination(SurfaceFormat.Bgra32)
+            .ShouldBe(PixelBufferConversionStrategy.DirectCopy);
+    }
+
+    [Fact]
+    public void GetStrategyForBgraDestination_UnsupportedSourceFormat_ReturnsNull()
+    {
+        RenderTargetPixelBufferConverter.GetStrategyForBgraDestination(SurfaceFormat.Rgba64)
+            .ShouldBeNull();
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WriteableBitmapPixelBufferWriterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WriteableBitmapPixelBufferWriterTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Xna.Framework.Graphics;
+using Shouldly;
+using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using XnaAndWinforms;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+public class WriteableBitmapPixelBufferWriterTests
+{
+    private const int Width = 2;
+    private const int Height = 2;
+
+    // Fills every pixel with the same 4 raw bytes, in the order they'd appear in the buffer
+    // read back from RenderTarget2D.GetData.
+    private static byte[] CreateRawImage(byte byte0, byte byte1, byte byte2, byte byte3)
+    {
+        byte[] rawImage = new byte[Width * Height * 4];
+        for (int i = 0; i < rawImage.Length; i += 4)
+        {
+            rawImage[i + 0] = byte0;
+            rawImage[i + 1] = byte1;
+            rawImage[i + 2] = byte2;
+            rawImage[i + 3] = byte3;
+        }
+        return rawImage;
+    }
+
+    // WriteableBitmap has no GetPixel; read the top-left pixel's raw bytes back out via CopyPixels.
+    private static byte[] GetFirstPixelBytes(WriteableBitmap bitmap)
+    {
+        byte[] pixel = new byte[4];
+        bitmap.CopyPixels(new Int32Rect(0, 0, 1, 1), pixel, 4, 0);
+        return pixel;
+    }
+
+    [Fact]
+    public void WriteToBitmap_Bgra32Source_CopiesBytesDirectly()
+    {
+        // Bgra32 source already matches the bitmap's BGRA memory layout, so no conversion is needed.
+        byte[] rawImage = CreateRawImage(byte0: 40, byte1: 50, byte2: 60, byte3: 255);
+        WriteableBitmap bitmap = new WriteableBitmap(Width, Height, 96, 96, PixelFormats.Pbgra32, null);
+        WriteableBitmapPixelBufferWriter writer = new WriteableBitmapPixelBufferWriter();
+
+        writer.WriteToBitmap(rawImage, SurfaceFormat.Bgra32, bitmap);
+
+        byte[] pixel = GetFirstPixelBytes(bitmap);
+        pixel[0].ShouldBe((byte)40); // B
+        pixel[1].ShouldBe((byte)50); // G
+        pixel[2].ShouldBe((byte)60); // R
+        pixel[3].ShouldBe((byte)255); // A
+    }
+
+    [Fact]
+    public void WriteToBitmap_ColorSource_ByteSwapsRgbaToBgra()
+    {
+        // Color source is RGBA; the bitmap's BGRA layout requires swapping R and B.
+        byte[] rawImage = CreateRawImage(byte0: 10, byte1: 20, byte2: 30, byte3: 255);
+        WriteableBitmap bitmap = new WriteableBitmap(Width, Height, 96, 96, PixelFormats.Pbgra32, null);
+        WriteableBitmapPixelBufferWriter writer = new WriteableBitmapPixelBufferWriter();
+
+        writer.WriteToBitmap(rawImage, SurfaceFormat.Color, bitmap);
+
+        byte[] pixel = GetFirstPixelBytes(bitmap);
+        pixel[0].ShouldBe((byte)30); // B
+        pixel[1].ShouldBe((byte)20); // G
+        pixel[2].ShouldBe((byte)10); // R
+        pixel[3].ShouldBe((byte)255); // A
+    }
+
+    [Fact]
+    public void WriteToBitmap_UnsupportedSourceFormat_Throws()
+    {
+        byte[] rawImage = CreateRawImage(byte0: 1, byte1: 2, byte2: 3, byte3: 4);
+        WriteableBitmap bitmap = new WriteableBitmap(Width, Height, 96, 96, PixelFormats.Pbgra32, null);
+        WriteableBitmapPixelBufferWriter writer = new WriteableBitmapPixelBufferWriter();
+
+        Should.Throw<NotSupportedException>(() => writer.WriteToBitmap(rawImage, SurfaceFormat.Rgba64, bitmap));
+    }
+
+    [Fact]
+    public void WriteToBitmap_UnsupportedDestinationFormat_Throws()
+    {
+        byte[] rawImage = CreateRawImage(byte0: 1, byte1: 2, byte2: 3, byte3: 4);
+        WriteableBitmap bitmap = new WriteableBitmap(Width, Height, 96, 96, PixelFormats.Bgr24, null);
+        WriteableBitmapPixelBufferWriter writer = new WriteableBitmapPixelBufferWriter();
+
+        Should.Throw<NotSupportedException>(() => writer.WriteToBitmap(rawImage, SurfaceFormat.Color, bitmap));
+    }
+}

--- a/XnaAndWinforms/BitmapPixelBufferWriter.cs
+++ b/XnaAndWinforms/BitmapPixelBufferWriter.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace XnaAndWinforms;
@@ -15,6 +13,7 @@ namespace XnaAndWinforms;
 /// </summary>
 public class BitmapPixelBufferWriter : IRenderTargetPixelBufferWriter
 {
+    /// <inheritdoc/>
     public void WriteToBitmap(byte[] rawImage, SurfaceFormat sourceFormat, Bitmap bitmap)
     {
         int width = bitmap.Width;
@@ -36,50 +35,16 @@ public class BitmapPixelBufferWriter : IRenderTargetPixelBufferWriter
         {
             if (strategy == PixelBufferConversionStrategy.ByteSwapRgbaToBgra)
             {
-                CopyAndConvertRgbaToBgra(width, height, rawImage, bmpData.Scan0, bmpData.Stride);
+                RawPixelBufferCopy.CopyAndConvertRgbaToBgra(rawImage, bmpData.Scan0, bmpData.Stride, width, height);
             }
             else
             {
-                int rowSize = width * 4;
-                int rowStride = bmpData.Stride;
-
-                Parallel.For(0, height, (y) =>
-                {
-                    int srcOffset = y * rowSize;
-                    int dstOffset = y * rowStride;
-                    Marshal.Copy(rawImage, srcOffset, bmpData.Scan0 + dstOffset, rowSize);
-                });
+                RawPixelBufferCopy.CopyDirect(rawImage, bmpData.Scan0, bmpData.Stride, width, height);
             }
         }
         finally
         {
             bitmap.UnlockBits(bmpData);
-        }
-    }
-
-    private static unsafe void CopyAndConvertRgbaToBgra(int width, int height, byte[] data, IntPtr buffer, int rowStride)
-    {
-        int rowSize = width * 4;
-
-        fixed (void* pData = &data[0])
-        {
-            byte* src = (byte*)pData;
-            byte* dst = (byte*)buffer;
-
-            Parallel.For(0, height, (y) =>
-            {
-                int srcOffset = y * rowSize;
-                int dstOffset = y * rowStride;
-
-                for (int x = 0; x < width; x++)
-                {
-                    int i = x * 4;
-                    dst[dstOffset + i + 0] = src[srcOffset + i + 2];
-                    dst[dstOffset + i + 1] = src[srcOffset + i + 1];
-                    dst[dstOffset + i + 2] = src[srcOffset + i + 0];
-                    dst[dstOffset + i + 3] = src[srcOffset + i + 3];
-                }
-            });
         }
     }
 }

--- a/XnaAndWinforms/IWriteableBitmapPixelBufferWriter.cs
+++ b/XnaAndWinforms/IWriteableBitmapPixelBufferWriter.cs
@@ -1,0 +1,23 @@
+using Microsoft.Xna.Framework.Graphics;
+using System.Windows.Media.Imaging;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The WPF-native counterpart to <see cref="IRenderTargetPixelBufferWriter"/>: converts a raw pixel
+/// buffer read back from a GPU render target (via <c>RenderTarget2D.GetData</c>) into a
+/// <see cref="WriteableBitmap"/>'s backing memory, so a render surface can be displayed by a plain
+/// WPF <c>Image</c> element without going through <c>System.Drawing.Bitmap</c>/GDI+.
+/// </summary>
+public interface IWriteableBitmapPixelBufferWriter
+{
+    /// <summary>
+    /// Writes <paramref name="rawImage"/> (as read back in <paramref name="sourceFormat"/>) into
+    /// <paramref name="bitmap"/>'s backing memory, converting pixel byte order if needed.
+    /// </summary>
+    /// <exception cref="System.NotSupportedException">
+    /// Thrown when <paramref name="sourceFormat"/> has no supported conversion to a BGRA-ordered
+    /// destination.
+    /// </exception>
+    void WriteToBitmap(byte[] rawImage, SurfaceFormat sourceFormat, WriteableBitmap bitmap);
+}

--- a/XnaAndWinforms/RawPixelBufferCopy.cs
+++ b/XnaAndWinforms/RawPixelBufferCopy.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The pointer/stride-level byte copy loops shared by every <see cref="PixelBufferConversionStrategy"/>
+/// consumer (currently <see cref="BitmapPixelBufferWriter"/> and <see cref="WriteableBitmapPixelBufferWriter"/>).
+/// Neither destination type matters here - callers pass a raw pointer and stride into whatever backing
+/// memory they've already locked, so this class has no dependency on GDI+ or WPF.
+/// </summary>
+internal static class RawPixelBufferCopy
+{
+    /// <summary>
+    /// Copies <paramref name="source"/> into <paramref name="destination"/> row by row, honoring
+    /// <paramref name="destinationStride"/> (which may differ from the tightly-packed row size).
+    /// </summary>
+    public static void CopyDirect(byte[] source, IntPtr destination, int destinationStride, int width, int height)
+    {
+        int rowSize = width * 4;
+
+        Parallel.For(0, height, (y) =>
+        {
+            int srcOffset = y * rowSize;
+            int dstOffset = y * destinationStride;
+            Marshal.Copy(source, srcOffset, destination + dstOffset, rowSize);
+        });
+    }
+
+    /// <summary>
+    /// Copies <paramref name="source"/> into <paramref name="destination"/> row by row, swapping the
+    /// red and blue channels of each pixel (RGBA source -> BGRA destination).
+    /// </summary>
+    public static unsafe void CopyAndConvertRgbaToBgra(byte[] source, IntPtr destination, int destinationStride, int width, int height)
+    {
+        int rowSize = width * 4;
+
+        fixed (void* pSource = &source[0])
+        {
+            byte* src = (byte*)pSource;
+            byte* dst = (byte*)destination;
+
+            Parallel.For(0, height, (y) =>
+            {
+                int srcOffset = y * rowSize;
+                int dstOffset = y * destinationStride;
+
+                for (int x = 0; x < width; x++)
+                {
+                    int i = x * 4;
+                    dst[dstOffset + i + 0] = src[srcOffset + i + 2];
+                    dst[dstOffset + i + 1] = src[srcOffset + i + 1];
+                    dst[dstOffset + i + 2] = src[srcOffset + i + 0];
+                    dst[dstOffset + i + 3] = src[srcOffset + i + 3];
+                }
+            });
+        }
+    }
+}

--- a/XnaAndWinforms/RenderTargetPixelBufferConverter.cs
+++ b/XnaAndWinforms/RenderTargetPixelBufferConverter.cs
@@ -45,6 +45,19 @@ public static class RenderTargetPixelBufferConverter
             return null;
         }
 
+        return GetStrategyForBgraDestination(sourceFormat);
+    }
+
+    /// <summary>
+    /// Returns the conversion strategy for a destination whose byte order is already known to be
+    /// BGRA-ordered 32bpp (e.g. a GDI+ <see cref="PixelFormat.Format32bppPArgb"/>
+    /// <see cref="System.Drawing.Bitmap"/>, or a WPF <c>WriteableBitmap</c> using
+    /// <c>PixelFormats.Pbgra32</c>/<c>PixelFormats.Bgra32</c> - both share the same in-memory byte
+    /// layout as their GDI+ counterparts), or <see langword="null"/> if <paramref name="sourceFormat"/>
+    /// isn't supported.
+    /// </summary>
+    public static PixelBufferConversionStrategy? GetStrategyForBgraDestination(SurfaceFormat sourceFormat)
+    {
         if (sourceFormat == SurfaceFormat.Color)
         {
             return PixelBufferConversionStrategy.ByteSwapRgbaToBgra;

--- a/XnaAndWinforms/WriteableBitmapPixelBufferWriter.cs
+++ b/XnaAndWinforms/WriteableBitmapPixelBufferWriter.cs
@@ -1,0 +1,58 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The real implementation of <see cref="IWriteableBitmapPixelBufferWriter"/>. Locks
+/// <paramref name="bitmap"/>'s back buffer and copies/converts <c>rawImage</c> into it using the
+/// same <see cref="RawPixelBufferCopy"/> primitives <see cref="BitmapPixelBufferWriter"/> uses for
+/// GDI+ - the only difference is the destination's locking API and pixel format check.
+/// </summary>
+public class WriteableBitmapPixelBufferWriter : IWriteableBitmapPixelBufferWriter
+{
+    /// <inheritdoc/>
+    public void WriteToBitmap(byte[] rawImage, SurfaceFormat sourceFormat, WriteableBitmap bitmap)
+    {
+        if (bitmap.Format != PixelFormats.Pbgra32 && bitmap.Format != PixelFormats.Bgra32)
+        {
+            throw new NotSupportedException(
+                $"No pixel buffer conversion from {sourceFormat} to {bitmap.Format}.");
+        }
+
+        int width = bitmap.PixelWidth;
+        int height = bitmap.PixelHeight;
+
+        PixelBufferConversionStrategy? strategy =
+            RenderTargetPixelBufferConverter.GetStrategyForBgraDestination(sourceFormat);
+
+        if (strategy == null)
+        {
+            throw new NotSupportedException(
+                $"No pixel buffer conversion from {sourceFormat} to {bitmap.Format}.");
+        }
+
+        bitmap.Lock();
+
+        try
+        {
+            if (strategy == PixelBufferConversionStrategy.ByteSwapRgbaToBgra)
+            {
+                RawPixelBufferCopy.CopyAndConvertRgbaToBgra(rawImage, bitmap.BackBuffer, bitmap.BackBufferStride, width, height);
+            }
+            else
+            {
+                RawPixelBufferCopy.CopyDirect(rawImage, bitmap.BackBuffer, bitmap.BackBufferStride, width, height);
+            }
+
+            bitmap.AddDirtyRect(new Int32Rect(0, 0, width, height));
+        }
+        finally
+        {
+            bitmap.Unlock();
+        }
+    }
+}

--- a/XnaAndWinforms/XnaAndWinforms.csproj
+++ b/XnaAndWinforms/XnaAndWinforms.csproj
@@ -6,6 +6,13 @@
 		<OutputType>Library</OutputType>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<UseWindowsForms>true</UseWindowsForms>
+		<!--
+			Added for WriteableBitmapPixelBufferWriter, part of the WPF-native render surface work for
+			#3833 - the WPF-facing counterpart to BitmapPixelBufferWriter's GDI+ path. This does not
+			change how WireframeControl/ImageRegionSelectionControl render today; both are still
+			WinForms controls embedded via WindowsFormsHost.
+		-->
+		<UseWPF>true</UseWPF>
 		<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
 		<CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
 		<LangVersion>12.0</LangVersion>


### PR DESCRIPTION
Part of #3833 (WireframeControl only; `ImageRegionSelectionControl` deferred to a follow-up round).

## What this PR does

Adds `WriteableBitmapPixelBufferWriter` (`XnaAndWinforms/`) - the WPF-native counterpart to the
existing `BitmapPixelBufferWriter` (GDI+). Extracted the shared pointer/stride byte-copy loops into
`RawPixelBufferCopy` so both writers use the same tested primitives, and split
`RenderTargetPixelBufferConverter.GetStrategy` into a destination-format-agnostic
`GetStrategyForBgraDestination` core (pure extract, existing `GetStrategy` behavior unchanged).

**Does not touch `WireframeControl` or the live editor** - this proves the existing GPU-readback ->
pixel-buffer path (#3825/#3829) is genuinely framework-agnostic and gives the eventual conversion a
tested WPF-side writer to build on, with zero risk to the shipping tool.

## Design investigation (the actual ask for this round)

**D3DImage (WPF's DX9-surface interop bitmap) - not recommended.** `D3DImage.SetBackBuffer` only
accepts an `IDirect3DSurface9` pointer. The tool's render backend
(`nkast.Kni.Platform.WinForms.DX11`) is DX11. Bridging DX11 -> WPF via `D3DImage` requires the
well-known-but-fragile trick: create a DX11 texture with a shared NT handle, open it in a
side-channel DX9Ex device, and hand `D3DImage` that DX9Ex surface. KNI, like MonoGame, does not
publicly expose the native `ID3D11Device`/`ID3D11Texture2D` pointers `GraphicsDevice` wraps - the
only way to get them is reflection into KNI's private internals, which is exactly the kind of
private-API-surface risk this repo's own "never decompile third-party libraries" guidance warns
against (not literal decompilation, but the same fragility: breaks silently on any KNI update, no
supported contract). Not a good target for a first implementation PR.

**WriteableBitmap (CPU readback + blit) - the right direction**, and this PR's writer is the first
piece of it. This also matches the project's own `Direction/ui-decoupling-plan.md`: *"the renderer
is render-to-texture + CPU readback... it already hands any host a portable CPU pixel buffer... any
framework that can blit a bitmap can host the Gum canvas."* Slower than a true GPU interop path,
but the tool already pays the `RenderTarget2D.GetData` CPU-readback cost today for the WinForms
path - a WPF `Image`+`WriteableBitmap` host reuses that same cost, not a new one.

**Converting `WireframeControl` itself is NOT a bounded slice - genuine open design work remains:**
- `GraphicsDeviceControl`'s entire lifecycle (WinForms `Timer`-driven `Invalidate`/`OnPaint`,
  `ProcessCmdKey`, mouse capture/focus) is WinForms-`Control`-owned and has no WPF equivalent to
  drop in - it needs a parallel WPF-native host class (e.g. driven by `CompositionTarget.Rendering`
  or a `DispatcherTimer`), not a small edit to the existing one.
- `IInputHostControl.Cursor` is typed as `System.Windows.Forms.Cursor` (`InputLibrary/IInputHostControl.cs`).
  A WPF `FrameworkElement`-backed host can't satisfy that type - WPF's cursor type is
  `System.Windows.Input.Cursor`. Widening/changing this interface affects `InputLibrary.Cursor`/`Keyboard`
  (shared, sanctioned-singleton runtime code) and the other 2 real call sites
  (`ImageRegionSelectionControl`, `CameraPanningLogic`), so it needs its own scoped design, not a
  drive-by change buried in a rendering PR.
- The `WindowsFormsHost` embedding site itself (`MainEditorTabPlugin.HandleWireframeInitialized`,
  `MainPanelViewModel.AddControl`'s airspace margin hack) only comes out once `WireframeControl`
  is a real `FrameworkElement` - i.e. after both of the above land.

## What the next real implementation PR should do

1. Build a small WPF-native host class (own `Image` + `WriteableBitmap`, own render-loop timer)
   that uses this PR's `WriteableBitmapPixelBufferWriter` to display KNI's readback output - proven
   with a manual visual check before it's wired into the live tool.
2. Separately, scope `IInputHostControl`'s WPF-compatibility gap (the `Cursor` type) - likely a
   widened interface or a parallel WPF-side host contract, decided on its own before it blocks the
   control swap.
3. Only then swap `WireframeControl`'s base class and delete the `WindowsFormsHost`/margin hack.

`ImageRegionSelectionControl` should mirror this exact design once step 1-3 above are proven on
`WireframeControl` - no reason to invent a second approach for it.

## Testing

- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` - full suite green (1073 passed,
  4 pre-existing skips, 0 failures).
- `dotnet build GumFull.sln` - clean, 0 errors.

Manual test: not needed - this PR adds an unused-by-the-live-tool writer class covered by unit
tests; `WireframeControl` behavior is unchanged (confirmed by the untouched full test suite).
