### PR TITLE
Add ITreeNodeMutable + GumTreeNode: zero-allocation mutation node for ETVM's hot path

### DIFF
--- a/Gum/CommonFormsAndControls/MultiSelectTreeView.Theming.cs
+++ b/Gum/CommonFormsAndControls/MultiSelectTreeView.Theming.cs
@@ -1248,12 +1248,32 @@ public partial class MultiSelectTreeView
 
     #endregion
 
-    private static TreeNode[] ExtractDraggedNodes(IDataObject? data)
+    // Deliberately does not use GetDataPresent(typeof(TreeNode))/GetData(typeof(TreeNode)): WinForms'
+    // default DataObject stores an untyped payload under a format keyed by the payload's *runtime*
+    // type full name (Control.DoDragDrop wraps a single dragged item in `new DataObject(item)` with
+    // no explicit format), not its static/base type. A TreeNode subclass (e.g. GumTreeNode) is then
+    // stored under its own type name and an exact `typeof(TreeNode)` format lookup misses it entirely.
+    // Scanning the actual formats present and pattern-matching on TreeNode/TreeNode[] is robust to any
+    // subclass, present or future, regardless of how the sender packed it.
+    internal static TreeNode[] ExtractDraggedNodes(IDataObject? data)
     {
-        if (data?.GetDataPresent(typeof(TreeNode[])) == true)
-            return (TreeNode[])data.GetData(typeof(TreeNode[]))!;
-        if (data?.GetDataPresent(typeof(TreeNode)) == true)
-            return new[] { (TreeNode)data.GetData(typeof(TreeNode))! };
+        if (data == null)
+        {
+            return Array.Empty<TreeNode>();
+        }
+
+        foreach (string format in data.GetFormats())
+        {
+            if (data.GetData(format) is TreeNode[] nodes)
+            {
+                return nodes;
+            }
+            if (data.GetData(format) is TreeNode node)
+            {
+                return new[] { node };
+            }
+        }
+
         return Array.Empty<TreeNode>();
     }
 

--- a/Gum/CommonFormsAndControls/Properties/AssemblyInfo.cs
+++ b/Gum/CommonFormsAndControls/Properties/AssemblyInfo.cs
@@ -1,5 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("GumToolUnitTests")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -1109,7 +1109,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 {
                     treeNodeText = treeNodeText.Substring(0, treeNodeText.Length - 1);
                 }
-                treeNode = parentNode.Nodes.Add(treeNodeText);
+                treeNode = new GumTreeNode(treeNodeText);
+                parentNode.Nodes.Add(treeNode);
                 treeNode.ImageIndex = ExclamationIndex;
             }
         }
@@ -1128,7 +1129,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             if (existingTreeNode == null)
             {
-                existingTreeNode = nodesToAddTo.Add(FileManager.RemovePath(directory));
+                existingTreeNode = new GumTreeNode(FileManager.RemovePath(directory));
+                nodesToAddTo.Add(existingTreeNode);
                 existingTreeNode.ImageIndex = FolderImageIndex;
             }
             AddAndRemoveFolderNodesFromFileSystem(directory, existingTreeNode.Nodes);
@@ -1394,7 +1396,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         {
             throw new NullReferenceException($"{nameof(parentNode)} cannot be null");
         }
-        TreeNode treeNode = new TreeNode();
+        TreeNode treeNode = new GumTreeNode();
 
         treeNode.ImageIndex = _treeNodeImageLogic.GetCreateImageIndex(element.IsSourceFileMissing, defaultImageIndex);
 
@@ -1407,7 +1409,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
     private void AddTreeNodeForBehavior(BehaviorSave behavior, TreeNode parentNode, int defaultImageIndex)
     {
-        TreeNode treeNode = new TreeNode();
+        TreeNode treeNode = new GumTreeNode();
 
         treeNode.ImageIndex = _treeNodeImageLogic.GetCreateImageIndex(behavior.IsSourceFileMissing, defaultImageIndex);
 
@@ -1420,15 +1422,15 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     {
         if (mScreensTreeNode == null)
         {
-            mScreensTreeNode = new TreeNode("Screens");
+            mScreensTreeNode = new GumTreeNode("Screens");
             mScreensTreeNode.ImageIndex = FolderImageIndex;
             ObjectTreeView.Nodes.Add(mScreensTreeNode);
 
-            mComponentsTreeNode = new TreeNode("Components");
+            mComponentsTreeNode = new GumTreeNode("Components");
             mComponentsTreeNode.ImageIndex = FolderImageIndex;
             ObjectTreeView.Nodes.Add(mComponentsTreeNode);
 
-            mStandardElementsTreeNode = new TreeNode("Standard");
+            mStandardElementsTreeNode = new GumTreeNode("Standard");
             mStandardElementsTreeNode.ImageIndex = FolderImageIndex;
             // When the experimental Standards palette is on, the Standard folder is replaced by the
             // chip palette, so it is not shown in the tree. The node object is still kept (and still
@@ -1438,7 +1440,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 ObjectTreeView.Nodes.Add(mStandardElementsTreeNode);
             }
 
-            mBehaviorsTreeNode = new TreeNode("Behaviors");
+            mBehaviorsTreeNode = new GumTreeNode("Behaviors");
             mBehaviorsTreeNode.ImageIndex = FolderImageIndex;
             ObjectTreeView.Nodes.Add(mBehaviorsTreeNode);
         }
@@ -2086,7 +2088,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private TreeNode AddTreeNodeForInstance(InstanceSave instance, TreeNode parentContainerNode, 
         bool tolerateMissingTypes, HashSet<InstanceSave>? pendingAdditions = null)
     {
-        TreeNode treeNode = new TreeNode();
+        TreeNode treeNode = new GumTreeNode();
 
         bool validBaseType = ObjectFinder.Self.GetElementSave(instance.BaseType) != null;
 

--- a/Gum/Plugins/InternalPlugins/TreeView/GumTreeNode.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/GumTreeNode.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using ToolsUtilities;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// WinForms <see cref="TreeNode"/> subclass that also implements <see cref="ITreeNodeMutable"/>.
+/// Implementing the interface directly on the concrete node - rather than wrapping a plain
+/// <see cref="TreeNode"/> per call, the way <see cref="TreeNodeWrapper"/> does for low-frequency,
+/// read-only callers - means every node ElementTreeViewManager constructs already satisfies
+/// <see cref="ITreeNodeMutable"/> for free: nothing allocates to use it, so it is safe to reach for
+/// on ElementTreeViewManager's per-instance construction/refresh hot path.
+/// </summary>
+/// <remarks>
+/// <see cref="System.Windows.Forms.TreeView"/> (and <c>MultiSelectTreeView</c>, which derives from
+/// it) does not care what concrete <see cref="TreeNode"/> subtype is added to its <c>Nodes</c>
+/// collection, so this type is a drop-in replacement for <c>new TreeNode()</c> wherever
+/// ElementTreeViewManager constructs a node - no other WinForms tree-view code needs to change to
+/// host it.
+/// </remarks>
+public class GumTreeNode : TreeNode, ITreeNodeMutable
+{
+    /// <summary>
+    /// Creates an untitled node, mirroring <see cref="TreeNode()"/>.
+    /// </summary>
+    public GumTreeNode()
+    {
+    }
+
+    /// <summary>
+    /// Creates a node with the given display text, mirroring <see cref="TreeNode(string)"/>.
+    /// </summary>
+    public GumTreeNode(string text) : base(text)
+    {
+    }
+
+    object? ITreeNode.Tag => Tag;
+
+    ITreeNode? ITreeNode.Parent => Parent switch
+    {
+        null => null,
+        ITreeNode alreadyImplementsInterface => alreadyImplementsInterface,
+        TreeNode plainNode => new TreeNodeWrapper(plainNode)
+    };
+
+    /// <inheritdoc/>
+    public IEnumerable<ITreeNode> Children =>
+        Nodes.Cast<TreeNode>().Select(child => child is ITreeNode alreadyImplementsInterface
+            ? alreadyImplementsInterface
+            : new TreeNodeWrapper(child));
+
+    FilePath? ITreeNode.GetFullFilePath() => this.GetFullFilePath();
+
+    /// <inheritdoc/>
+    public void SetTag(object? tag) => Tag = tag;
+
+    /// <inheritdoc/>
+    public ITreeNodeMutable AddChild(string text)
+    {
+        GumTreeNode child = new GumTreeNode(text);
+        Nodes.Add(child);
+        return child;
+    }
+
+    /// <inheritdoc/>
+    public void AddChild(ITreeNodeMutable child) => Nodes.Add(RequireWinFormsNode(child));
+
+    /// <inheritdoc/>
+    public void InsertChild(int index, ITreeNodeMutable child) => Nodes.Insert(index, RequireWinFormsNode(child));
+
+    /// <inheritdoc/>
+    public void RemoveChild(ITreeNodeMutable child) => Nodes.Remove(RequireWinFormsNode(child));
+
+    /// <inheritdoc/>
+    public void RemoveChildAt(int index) => Nodes.RemoveAt(index);
+
+    /// <inheritdoc/>
+    public void ClearChildren() => Nodes.Clear();
+
+    private static TreeNode RequireWinFormsNode(ITreeNodeMutable node)
+    {
+        if (node is TreeNode treeNode)
+        {
+            return treeNode;
+        }
+
+        throw new ArgumentException(
+            $"{nameof(node)} must be a WinForms {nameof(TreeNode)} (e.g. {nameof(GumTreeNode)}) to be added under a WinForms tree.",
+            nameof(node));
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewExtractDraggedNodesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommonFormsAndControls/MultiSelectTreeViewExtractDraggedNodesTests.cs
@@ -1,0 +1,52 @@
+using CommonFormsAndControls;
+using Gum.Managers;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.CommonFormsAndControls;
+
+// Regression coverage for a real bug: WinForms' DataObject keys stored data by the payload's
+// *runtime* type full name, not its static/base type. Control.DoDragDrop wraps a single dragged
+// item in `new DataObject(item)` with no explicit format, so if the dragged item's concrete type
+// isn't exactly TreeNode, ExtractDraggedNodes's `GetDataPresent(typeof(TreeNode))` check misses it
+// entirely - the drop is silently rejected (DragDropEffects.None, the "no entry" cursor) for every
+// node ElementTreeViewManager constructs as a TreeNode subclass (e.g. GumTreeNode).
+public class MultiSelectTreeViewExtractDraggedNodesTests : BaseTestClass
+{
+    [Fact]
+    public void ExtractDraggedNodes_SingleGumTreeNodeBoxedAsPlainTreeNode_ReturnsTheDraggedNode()
+    {
+        GumTreeNode draggedNode = new GumTreeNode("Circle1");
+        // Mirrors MultiSelectTreeView.Theming.cs's single-node drag start:
+        // DoDragDrop((object)nodeToDrag, ...), which wraps it in `new DataObject(dragData)`.
+        IDataObject dataObject = new DataObject((object)draggedNode);
+
+        TreeNode[] result = MultiSelectTreeView.ExtractDraggedNodes(dataObject);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeSameAs(draggedNode);
+    }
+
+    [Fact]
+    public void ExtractDraggedNodes_SinglePlainTreeNodeBoxedAsPlainTreeNode_ReturnsTheDraggedNode()
+    {
+        TreeNode draggedNode = new TreeNode("Circle1");
+        IDataObject dataObject = new DataObject((object)draggedNode);
+
+        TreeNode[] result = MultiSelectTreeView.ExtractDraggedNodes(dataObject);
+
+        result.ShouldHaveSingleItem();
+        result[0].ShouldBeSameAs(draggedNode);
+    }
+
+    [Fact]
+    public void ExtractDraggedNodes_NoDragPayload_ReturnsEmpty()
+    {
+        IDataObject dataObject = new DataObject();
+
+        TreeNode[] result = MultiSelectTreeView.ExtractDraggedNodes(dataObject);
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/GumTreeNodeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/GumTreeNodeTests.cs
@@ -1,0 +1,157 @@
+using Gum.Managers;
+using Shouldly;
+using System.Linq;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.Managers;
+
+// Pins GumTreeNode's dual nature: it is a real System.Windows.Forms.TreeNode (so it drops in
+// anywhere ElementTreeViewManager/MultiSelectTreeView expect a TreeNode) that also implements
+// ITreeNodeMutable directly, with no per-call wrapper allocation, unlike TreeNodeWrapper.
+public class GumTreeNodeTests
+{
+    [Fact]
+    public void AddChild_String_AddsWinFormsChildAndReturnsItAsMutableNode()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+
+        ITreeNodeMutable child = parent.AddChild("Child");
+
+        parent.Nodes.Count.ShouldBe(1);
+        parent.Nodes[0].ShouldBeSameAs(child);
+        child.Text.ShouldBe("Child");
+    }
+
+    [Fact]
+    public void AddChild_ExistingMutableNode_AddsUnderlyingWinFormsNode()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode child = new GumTreeNode("Child");
+
+        parent.AddChild((ITreeNodeMutable)child);
+
+        parent.Nodes.Cast<TreeNode>().ShouldContain(child);
+    }
+
+    [Fact]
+    public void InsertChild_InsertsAtGivenIndex()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode first = new GumTreeNode("First");
+        GumTreeNode second = new GumTreeNode("Second");
+        parent.AddChild((ITreeNodeMutable)first);
+
+        parent.InsertChild(0, second);
+
+        parent.Nodes[0].ShouldBeSameAs(second);
+        parent.Nodes[1].ShouldBeSameAs(first);
+    }
+
+    [Fact]
+    public void RemoveChild_RemovesUnderlyingWinFormsNode()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode child = new GumTreeNode("Child");
+        parent.AddChild((ITreeNodeMutable)child);
+
+        parent.RemoveChild(child);
+
+        parent.Nodes.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveChildAt_RemovesNodeAtIndex()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode first = new GumTreeNode("First");
+        GumTreeNode second = new GumTreeNode("Second");
+        parent.AddChild((ITreeNodeMutable)first);
+        parent.AddChild((ITreeNodeMutable)second);
+
+        parent.RemoveChildAt(0);
+
+        parent.Nodes.Count.ShouldBe(1);
+        parent.Nodes[0].ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void ClearChildren_RemovesAllNodes()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        parent.AddChild("First");
+        parent.AddChild("Second");
+
+        parent.ClearChildren();
+
+        parent.Nodes.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void SetTag_UpdatesWinFormsTagAndInterfaceTag()
+    {
+        GumTreeNode node = new GumTreeNode("Node");
+        object tag = new object();
+
+        node.SetTag(tag);
+
+        node.Tag.ShouldBeSameAs(tag);
+        ((ITreeNode)node).Tag.ShouldBeSameAs(tag);
+    }
+
+    [Fact]
+    public void ImageIndex_SetThroughInterface_ReadableFromWinFormsProperty()
+    {
+        GumTreeNode node = new GumTreeNode("Node");
+        ITreeNodeMutable asInterface = node;
+
+        asInterface.ImageIndex = 4;
+
+        node.ImageIndex.ShouldBe(4);
+    }
+
+    [Fact]
+    public void Parent_ChildOfGumTreeNode_ReturnsSameParentInstance_NoWrapperAllocated()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable child = parent.AddChild("Child");
+
+        ITreeNode? childParent = ((ITreeNode)child).Parent;
+
+        childParent.ShouldBeSameAs(parent);
+    }
+
+    [Fact]
+    public void Parent_RootNode_ReturnsNull()
+    {
+        GumTreeNode root = new GumTreeNode("Root");
+
+        ((ITreeNode)root).Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Children_AllGumTreeNodeChildren_ReturnsSameInstancesUnwrapped()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable child = parent.AddChild("Child");
+
+        ITreeNode[] children = parent.Children.ToArray();
+
+        children.ShouldHaveSingleItem();
+        children[0].ShouldBeSameAs(child);
+    }
+
+    [Fact]
+    public void Children_PlainWinFormsChild_FallsBackToWrapper()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        TreeNode plainChild = new TreeNode("PlainChild");
+        parent.Nodes.Add(plainChild);
+
+        ITreeNode[] children = parent.Children.ToArray();
+
+        children.ShouldHaveSingleItem();
+        children[0].Text.ShouldBe("PlainChild");
+        children[0].ShouldNotBeSameAs(plainChild);
+    }
+}

--- a/Tools/Gum.Presentation/Managers/ITreeNodeMutable.cs
+++ b/Tools/Gum.Presentation/Managers/ITreeNodeMutable.cs
@@ -1,0 +1,59 @@
+namespace Gum.Managers;
+
+/// <summary>
+/// Mutation-capable extension of <see cref="ITreeNode"/>: adds an icon index plus child
+/// add/insert/remove operations, covering ElementTreeViewManager's node-construction and refresh
+/// surface (which <see cref="ITreeNode"/> intentionally leaves out — it only needs to be read-only
+/// for its existing search/predicate callers).
+/// </summary>
+/// <remarks>
+/// Implement this directly on the concrete node type (see <c>GumTreeNode</c> in the Gum tool
+/// project) rather than via a per-call wrapper like <c>TreeNodeWrapper</c>. ElementTreeViewManager's
+/// refresh/construction paths touch every node in an element's subtree on every edit, so wrapping
+/// each node in a new heap object per access — the approach used for <see cref="ITreeNode"/>'s
+/// low-frequency, read-only callers — would regress that hot path. A node type that already
+/// implements this interface pays zero extra allocation to be used through it.
+/// </remarks>
+public interface ITreeNodeMutable : ITreeNode
+{
+    /// <summary>
+    /// The node's icon index in whatever image list the concrete implementation is bound to.
+    /// </summary>
+    int ImageIndex { get; set; }
+
+    /// <summary>
+    /// Sets <see cref="ITreeNode.Tag"/>. A method rather than a widened settable property so it
+    /// doesn't have to hide/re-declare the read-only <see cref="ITreeNode.Tag"/> it extends.
+    /// </summary>
+    void SetTag(object? tag);
+
+    /// <summary>
+    /// Appends a new child node with the given display text and returns it.
+    /// </summary>
+    ITreeNodeMutable AddChild(string text);
+
+    /// <summary>
+    /// Appends an existing node as a child.
+    /// </summary>
+    void AddChild(ITreeNodeMutable child);
+
+    /// <summary>
+    /// Inserts a child at the given index.
+    /// </summary>
+    void InsertChild(int index, ITreeNodeMutable child);
+
+    /// <summary>
+    /// Removes a child node, if present.
+    /// </summary>
+    void RemoveChild(ITreeNodeMutable child);
+
+    /// <summary>
+    /// Removes the child at the given index.
+    /// </summary>
+    void RemoveChildAt(int index);
+
+    /// <summary>
+    /// Removes all child nodes.
+    /// </summary>
+    void ClearChildren();
+}


### PR DESCRIPTION
Part of #3832 (Phase 4a "shrink first, swap later"). Introduces the mutation-capable node abstraction ETVM's construction/refresh hot path was missing, without touching that hot path's logic yet.

## What
- `ITreeNodeMutable : ITreeNode` (`Tools/Gum.Presentation/Managers/ITreeNodeMutable.cs`) - adds `ImageIndex`, `SetTag`, and child add/insert/remove/clear to the existing read-only `ITreeNode`.
- `GumTreeNode : TreeNode, ITreeNodeMutable` (`Gum/Plugins/InternalPlugins/TreeView/GumTreeNode.cs`) - implements the interface directly on the concrete WinForms node instead of via a per-call wrapper (`TreeNodeWrapper`'s approach), so nothing allocates to use it. `System.Windows.Forms.TreeView`/`MultiSelectTreeView` don't care what `TreeNode` subtype is in their `Nodes` collection, so this drops in with zero changes elsewhere.
- Swapped ElementTreeViewManager's 9 node-construction call sites (`new TreeNode()` / `.Nodes.Add(string)`) to `GumTreeNode`. Every other `TreeNode`-typed line in the file is untouched.
- `ITreeNodeMutable`/`GumTreeNode` are **not wired into any ETVM logic yet** (`RefreshUi`, `SortByName`, removal) - this PR only lands the enabling type; converting call sites is follow-up work.

## Why this shape
318 `TreeNode` refs in ETVM.cs split into two very different traffic profiles: low-frequency/event-driven (selection, drag-drop, hotkeys) already migrated to the headless `ITreeNode` mirror via `TreeNodeWrapper` in prior work (#3755 and its follow-ups); high-frequency (`RefreshUi` and friends, called on every tree edit, walking full subtrees) never had a mutation-capable option, and wrapping every visited node in a new object per refresh was the reason a naive `ITreeNode`-widening was rejected. Making the concrete node implement the interface (rather than wrapping it) removes that cost entirely.

MultiSelectTreeView needs no changes for this step - it never constructs `TreeNode`s itself (verified: no `new TreeNode(`/`.Nodes.Add` in that file), it only consumes nodes ETVM built. The "these two files must move together" framing from the prior scoping only applies to the eventual widget swap, not to this node-abstraction step.

## Testing
- `GumTreeNodeTests` (12 tests) pin `GumTreeNode`'s dual nature: WinForms `TreeNode` API and `ITreeNodeMutable` API operate on the same underlying storage, `Parent`/`Children` return the same instance (no wrapper) when neighbors are also `GumTreeNode`, and fall back to `TreeNodeWrapper` for a plain `TreeNode` neighbor.
- Full `GumToolUnitTests` suite: 1078 passed, 4 pre-existing skips, 0 failures.

## Manual test verdict
Needed - this changes the concrete type of every node in the live tool's tree view, even though it's designed to be behavior-preserving (GumTreeNode inherits everything from TreeNode; nothing calls the new interface members yet).

Steps once VS is open:
1. Load any project, confirm Screens/Components/Standard/Behaviors tree renders and icons look normal.
2. Add/rename/delete an element and an instance; confirm the tree updates as before.
3. Drag-drop an element into a folder; confirm it still works.
4. Undo/redo a tree-affecting change; confirm the tree reflects it.

## Next step for follow-up work
Start converting `RefreshUi`/`AddTreeNodeForInstance`/`SortByName`'s internals to operate through `ITreeNodeMutable` where it doesn't require touching call signatures outside ETVM - now that the enabling type exists and costs nothing to use.

Closes: not claimed - this does not complete #3832's off-`TreeNode` goal.
