### PR TITLE
Widen IInputHostControl.Cursor off System.Windows.Forms.Cursor

### DIFF
--- a/InputLibrary/ControlInputHostAdapter.cs
+++ b/InputLibrary/ControlInputHostAdapter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
 using System.Windows.Forms;
-using WinCursor = System.Windows.Forms.Cursor;
 
 namespace InputLibrary
 {
@@ -29,10 +28,10 @@ namespace InputLibrary
 
         public int Height => _control.Height;
 
-        public WinCursor Cursor
+        public CursorKind Cursor
         {
-            get => _control.Cursor;
-            set => _control.Cursor = value;
+            get => CursorKindConverter.ToCursorKind(_control.Cursor);
+            set => _control.Cursor = CursorKindConverter.ToWinCursor(value);
         }
 
         public Point PointToClient(Point point) => _control.PointToClient(point);

--- a/InputLibrary/Cursor.cs
+++ b/InputLibrary/Cursor.cs
@@ -22,7 +22,6 @@ namespace InputLibrary
         bool mHasBeenSet = false;
 
         WinCursor mSetCursor = Cursors.Arrow;
-        WinCursor mLastSet = Cursors.Arrow;
 
         #endregion
 
@@ -267,12 +266,12 @@ namespace InputLibrary
         {
             if (mHasBeenSet)
             {
-                mControl.Cursor = mSetCursor;
+                mControl.Cursor = CursorKindConverter.ToCursorKind(mSetCursor);
                 WinCursor.Current = mSetCursor;
             }
-            else if (mControl.Cursor != Cursors.Arrow)
+            else if (mControl.Cursor != CursorKind.Arrow)
             {
-                mControl.Cursor = Cursors.Arrow;
+                mControl.Cursor = CursorKind.Arrow;
                 WinCursor.Current = Cursors.Arrow;
             }
         }

--- a/InputLibrary/CursorKind.cs
+++ b/InputLibrary/CursorKind.cs
@@ -1,0 +1,20 @@
+namespace InputLibrary
+{
+    /// <summary>
+    /// The set of cursor icons the Gum tool's editor surfaces can display over an
+    /// <see cref="IInputHostControl"/>. Gum-owned and platform-neutral, so the host contract
+    /// doesn't require a WinForms-specific <see cref="System.Windows.Forms.Cursor"/> and can be
+    /// implemented by a non-WinForms host (e.g. a future WPF-native rendering surface).
+    /// </summary>
+    public enum CursorKind
+    {
+        Arrow,
+        Cross,
+        Hand,
+        SizeAll,
+        SizeNS,
+        SizeWE,
+        SizeNESW,
+        SizeNWSE
+    }
+}

--- a/InputLibrary/CursorKindConverter.cs
+++ b/InputLibrary/CursorKindConverter.cs
@@ -1,0 +1,67 @@
+using System.Windows.Forms;
+using WinCursor = System.Windows.Forms.Cursor;
+
+namespace InputLibrary
+{
+    /// <summary>
+    /// Converts between <see cref="CursorKind"/> (Gum's platform-neutral cursor-icon enum) and
+    /// <see cref="System.Windows.Forms.Cursor"/>. Kept separate from <see cref="IInputHostControl"/>
+    /// so only the WinForms-backed pieces of InputLibrary (<see cref="ControlInputHostAdapter"/>,
+    /// <see cref="Cursor"/>) need to know about the WinForms cursor type.
+    /// </summary>
+    internal static class CursorKindConverter
+    {
+        /// <summary>
+        /// Maps a WinForms cursor to the closest <see cref="CursorKind"/>. Any cursor that isn't
+        /// one of the kinds Gum's editor sets (e.g. <see cref="Cursors.Default"/>) falls back to
+        /// <see cref="CursorKind.Arrow"/>.
+        /// </summary>
+        public static CursorKind ToCursorKind(WinCursor cursor)
+        {
+            if (cursor == Cursors.Cross)
+            {
+                return CursorKind.Cross;
+            }
+            if (cursor == Cursors.Hand)
+            {
+                return CursorKind.Hand;
+            }
+            if (cursor == Cursors.SizeAll)
+            {
+                return CursorKind.SizeAll;
+            }
+            if (cursor == Cursors.SizeNS)
+            {
+                return CursorKind.SizeNS;
+            }
+            if (cursor == Cursors.SizeWE)
+            {
+                return CursorKind.SizeWE;
+            }
+            if (cursor == Cursors.SizeNESW)
+            {
+                return CursorKind.SizeNESW;
+            }
+            if (cursor == Cursors.SizeNWSE)
+            {
+                return CursorKind.SizeNWSE;
+            }
+            return CursorKind.Arrow;
+        }
+
+        /// <summary>
+        /// Maps a <see cref="CursorKind"/> to the WinForms cursor it represents.
+        /// </summary>
+        public static WinCursor ToWinCursor(CursorKind kind) => kind switch
+        {
+            CursorKind.Cross => Cursors.Cross,
+            CursorKind.Hand => Cursors.Hand,
+            CursorKind.SizeAll => Cursors.SizeAll,
+            CursorKind.SizeNS => Cursors.SizeNS,
+            CursorKind.SizeWE => Cursors.SizeWE,
+            CursorKind.SizeNESW => Cursors.SizeNESW,
+            CursorKind.SizeNWSE => Cursors.SizeNWSE,
+            _ => Cursors.Arrow,
+        };
+    }
+}

--- a/InputLibrary/IInputHostControl.cs
+++ b/InputLibrary/IInputHostControl.cs
@@ -1,5 +1,4 @@
 using System.Drawing;
-using WinCursor = System.Windows.Forms.Cursor;
 
 namespace InputLibrary
 {
@@ -27,9 +26,9 @@ namespace InputLibrary
         int Height { get; }
 
         /// <summary>
-        /// The cursor currently displayed over the host control.
+        /// The cursor icon currently displayed over the host control.
         /// </summary>
-        WinCursor Cursor { get; set; }
+        CursorKind Cursor { get; set; }
 
         /// <summary>
         /// Converts a point in screen coordinates to client (window-relative) coordinates.

--- a/Tool/Tests/GumToolUnitTests/Input/ControlInputHostAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/ControlInputHostAdapterTests.cs
@@ -2,7 +2,6 @@ using InputLibrary;
 using Shouldly;
 using System.Drawing;
 using System.Windows.Forms;
-using WinCursor = System.Windows.Forms.Cursor;
 
 namespace GumToolUnitTests.Input;
 
@@ -14,7 +13,35 @@ public class ControlInputHostAdapterTests : BaseTestClass
         using Control control = new Control { Cursor = Cursors.Hand };
         ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
 
-        adapter.Cursor.ShouldBe(Cursors.Hand);
+        adapter.Cursor.ShouldBe(CursorKind.Hand);
+    }
+
+    [StaFact]
+    public void Cursor_Get_UnmappedWinFormsCursorFallsBackToArrow()
+    {
+        using Control control = new Control { Cursor = Cursors.Default };
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Cursor.ShouldBe(CursorKind.Arrow);
+    }
+
+    [StaTheory]
+    [InlineData(CursorKind.Arrow)]
+    [InlineData(CursorKind.Cross)]
+    [InlineData(CursorKind.Hand)]
+    [InlineData(CursorKind.SizeAll)]
+    [InlineData(CursorKind.SizeNS)]
+    [InlineData(CursorKind.SizeWE)]
+    [InlineData(CursorKind.SizeNESW)]
+    [InlineData(CursorKind.SizeNWSE)]
+    public void Cursor_RoundTripsThroughWrappedControl(CursorKind cursorKind)
+    {
+        using Control control = new Control();
+        ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
+
+        adapter.Cursor = cursorKind;
+
+        adapter.Cursor.ShouldBe(cursorKind);
     }
 
     [StaFact]
@@ -23,7 +50,7 @@ public class ControlInputHostAdapterTests : BaseTestClass
         using Control control = new Control();
         ControlInputHostAdapter adapter = new ControlInputHostAdapter(control);
 
-        adapter.Cursor = Cursors.Cross;
+        adapter.Cursor = CursorKind.Cross;
 
         control.Cursor.ShouldBe(Cursors.Cross);
     }


### PR DESCRIPTION
Widens `IInputHostControl.Cursor` off `System.Windows.Forms.Cursor`, per the follow-up called out in #3823/#3831.

## What changed
- New `InputLibrary.CursorKind` enum (`Arrow`, `Cross`, `Hand`, `SizeAll`, `SizeNS`, `SizeWE`, `SizeNESW`, `SizeNWSE`) — the closed set of cursor icons the editor actually sets (traced through `Cursor.SetWinformsCursor`'s real callers: `Ruler`, `SelectionManager`, and the resize/move/rotate/polygon input handlers).
- `InputLibrary.CursorKindConverter` (internal) — maps `CursorKind` <-> `System.Windows.Forms.Cursor`. Unmapped WinForms cursors (e.g. `Cursors.Default`) fall back to `CursorKind.Arrow`.
- `IInputHostControl.Cursor` and `ControlInputHostAdapter.Cursor` now typed `CursorKind` instead of `WinCursor`.
- `InputLibrary.Cursor.EndCursorSettingFrameStart` converts at the boundary where it pushes onto `IInputHostControl.Cursor`.
- `SetWinformsCursor(WinCursor cursor)` is a separate, unrelated public API (not part of `IInputHostControl`) and is intentionally untouched — widening it is a much larger pass across many WinForms-coupled editor handlers, out of scope here.
- The 3 real call sites (`WireframeControl`, `ImageRegionSelectionControl`, `CameraPanningLogic`) only construct `ControlInputHostAdapter` and never read/write `.Cursor` directly, so no changes needed there.
- Boy-scout: removed unused `mLastSet` field in `Cursor.cs`.

## Tests
Extended `ControlInputHostAdapterTests`: get/set through `CursorKind`, an unmapped-WinForms-cursor fallback case, and a round-trip theory over all 8 `CursorKind` values. Full `GumToolUnitTests` suite green (1082 passed, 4 pre-existing skips, 0 failed).

Part of #3833.
