### PR TITLE
Prototype WpfRenderSurfaceHost: WPF-native Image+WriteableBitmap render surface (#3833)

### DIFF
--- a/Samples/WpfRenderSurfaceHostHarness/App.xaml
+++ b/Samples/WpfRenderSurfaceHostHarness/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="WpfRenderSurfaceHostHarness.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/Samples/WpfRenderSurfaceHostHarness/App.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace WpfRenderSurfaceHostHarness;
+
+public partial class App : Application
+{
+}

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
@@ -4,5 +4,9 @@
         Title="WpfRenderSurfaceHost harness - #3833"
         Width="820" Height="640"
         ResizeMode="NoResize">
-    <Grid x:Name="RootGrid" Background="DarkSlateGray" />
+    <Grid x:Name="RootGrid" Background="DarkSlateGray">
+        <TextBlock x:Name="FpsText" Text="FPS: --"
+                   Foreground="White" Background="#80000000" FontSize="20"
+                   Padding="6,3" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="8" />
+    </Grid>
 </Window>

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="WpfRenderSurfaceHostHarness.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="WpfRenderSurfaceHost harness - #3833"
+        Width="820" Height="640"
+        ResizeMode="NoResize">
+    <Grid x:Name="RootGrid" Background="DarkSlateGray" />
+</Window>

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml
@@ -1,9 +1,9 @@
 <Window x:Class="WpfRenderSurfaceHostHarness.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="WpfRenderSurfaceHost harness - #3833"
+        Title="WpfRenderSurfaceHost harness - #3833 (resizable - drag/maximize to stress-test buffer size)"
         Width="820" Height="640"
-        ResizeMode="NoResize">
+        MinWidth="200" MinHeight="150">
     <Grid x:Name="RootGrid" Background="DarkSlateGray">
         <TextBlock x:Name="FpsText" Text="FPS: --"
                    Foreground="White" Background="#80000000" FontSize="20"

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -18,8 +18,8 @@ namespace WpfRenderSurfaceHostHarness;
 /// </summary>
 public partial class MainWindow : Window
 {
-    private const int SurfaceWidth = 800;
-    private const int SurfaceHeight = 600;
+    private const int InitialSurfaceWidth = 800;
+    private const int InitialSurfaceHeight = 600;
 
     private readonly Stopwatch _clock = new Stopwatch();
     private readonly WpfRenderSurfaceHost _host = new WpfRenderSurfaceHost();
@@ -28,6 +28,13 @@ public partial class MainWindow : Window
     private RenderTarget2D? _renderTarget;
     private SpriteBatch? _spriteBatch;
     private Texture2D? _whitePixel;
+
+    // Current render-target size in pixels - starts at the initial values above, but changes on
+    // every live resize (see Window_SizeChanged). This is the actual buffer size being copied
+    // GPU->CPU->WriteableBitmap each frame, so resizing the window is the real stress test for
+    // whether that copy cost scales badly with larger canvases.
+    private int _surfaceWidth = InitialSurfaceWidth;
+    private int _surfaceHeight = InitialSurfaceHeight;
 
     // Actual measured throughput, not a guess - counts real DrawFrame calls against wall-clock
     // time, updated roughly twice a second so the number is legible.
@@ -44,11 +51,37 @@ public partial class MainWindow : Window
         // Insert below the XAML-declared FpsText so the overlay stays on top.
         RootGrid.Children.Insert(0, _host.ImageElement);
         _host.RenderFrame += DrawFrame;
-        _host.Initialize(SurfaceWidth, SurfaceHeight, desiredFramesPerSecond: 30);
+        _host.Initialize(_surfaceWidth, _surfaceHeight, desiredFramesPerSecond: 30);
 
         _clock.Start();
         _fpsWindow.Start();
         Closed += (_, _) => DisposeResources();
+        SizeChanged += Window_SizeChanged;
+    }
+
+    private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        int newWidth = Math.Max(1, (int)e.NewSize.Width);
+        int newHeight = Math.Max(1, (int)e.NewSize.Height);
+
+        if (newWidth == _surfaceWidth && newHeight == _surfaceHeight)
+        {
+            return;
+        }
+
+        _surfaceWidth = newWidth;
+        _surfaceHeight = newHeight;
+
+        // The render target is the only thing that needs recreating at the new pixel size -
+        // GraphicsDevice.SetRenderTarget adjusts the viewport to match automatically, and this
+        // harness never presents to a swap chain (it only reads the target back to the CPU), so
+        // the device's own PresentationParameters backbuffer size is irrelevant here.
+        _renderTarget?.Dispose();
+        _renderTarget = new RenderTarget2D(
+            _graphicsDevice!, _surfaceWidth, _surfaceHeight, mipMap: false, SurfaceFormat.Color, DepthFormat.Depth24Stencil8,
+            preferredMultiSampleCount: 1, RenderTargetUsage.PreserveContents);
+
+        _host.Resize(_surfaceWidth, _surfaceHeight);
     }
 
     private void DisposeResources()
@@ -64,8 +97,8 @@ public partial class MainWindow : Window
     {
         PresentationParameters presentationParameters = new PresentationParameters
         {
-            BackBufferWidth = SurfaceWidth,
-            BackBufferHeight = SurfaceHeight,
+            BackBufferWidth = _surfaceWidth,
+            BackBufferHeight = _surfaceHeight,
             BackBufferFormat = SurfaceFormat.Color,
             DepthStencilFormat = DepthFormat.Depth24Stencil8,
             DeviceWindowHandle = windowHandle,
@@ -76,7 +109,7 @@ public partial class MainWindow : Window
 
         _graphicsDevice = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.FL10_0, presentationParameters);
         _renderTarget = new RenderTarget2D(
-            _graphicsDevice, SurfaceWidth, SurfaceHeight, mipMap: false, SurfaceFormat.Color, DepthFormat.Depth24Stencil8,
+            _graphicsDevice, _surfaceWidth, _surfaceHeight, mipMap: false, SurfaceFormat.Color, DepthFormat.Depth24Stencil8,
             preferredMultiSampleCount: 1, RenderTargetUsage.PreserveContents);
         _spriteBatch = new SpriteBatch(_graphicsDevice);
 
@@ -99,8 +132,8 @@ public partial class MainWindow : Window
 
         // A square orbiting the center, to prove sprite content (not just the clear color) updates.
         float radius = 200f;
-        float x = SurfaceWidth / 2f + radius * (float)Math.Cos(seconds) - 25f;
-        float y = SurfaceHeight / 2f + radius * (float)Math.Sin(seconds) - 25f;
+        float x = _surfaceWidth / 2f + radius * (float)Math.Cos(seconds) - 25f;
+        float y = _surfaceHeight / 2f + radius * (float)Math.Sin(seconds) - 25f;
 
         _spriteBatch.Begin();
         _spriteBatch.Draw(_whitePixel, new Microsoft.Xna.Framework.Rectangle((int)x, (int)y, 50, 50), Color.White);

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -50,6 +50,14 @@ public partial class MainWindow : Window
     private double _readbackMsAccum;
     private double _pushMsAccum;
 
+    // The three phases above only cover time actually spent inside our own code. If their sum is
+    // far below the measured frame period (1000/fps), the rest is happening between DrawFrame
+    // calls - either the DispatcherTimer isn't ticking as often as requested, or WPF's own
+    // (asynchronous, separate-thread) compositor work isn't visible to a stopwatch wrapped around
+    // the synchronous PushFrame call. This measures that gap directly instead of inferring it.
+    private double? _previousFrameStartMs;
+    private double _frameGapMsAccum;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -134,6 +142,13 @@ public partial class MainWindow : Window
         Debug.Assert(_graphicsDevice != null && _renderTarget != null && _spriteBatch != null && _whitePixel != null,
             "CreateGraphicsResources must run before DrawFrame.");
 
+        double frameStartMs = _clock.Elapsed.TotalMilliseconds;
+        if (_previousFrameStartMs is { } previousMs)
+        {
+            _frameGapMsAccum += frameStartMs - previousMs;
+        }
+        _previousFrameStartMs = frameStartMs;
+
         float seconds = (float)_clock.Elapsed.TotalSeconds;
 
         _graphicsDevice.SetRenderTarget(_renderTarget);
@@ -176,15 +191,20 @@ public partial class MainWindow : Window
         double avgDrawMs = _drawMsAccum / _framesSinceFpsUpdate;
         double avgReadbackMs = _readbackMsAccum / _framesSinceFpsUpdate;
         double avgPushMs = _pushMsAccum / _framesSinceFpsUpdate;
+        // One fewer gap sample than frames (no "previous" for the window's first frame) - close
+        // enough over a ~0.5s window to not bother correcting for.
+        double avgGapMs = _frameGapMsAccum / _framesSinceFpsUpdate;
 
         FpsText.Text =
             $"FPS: {measuredFps:0.0}  ({_surfaceWidth}x{_surfaceHeight})\n" +
-            $"draw: {avgDrawMs:0.00}ms  readback: {avgReadbackMs:0.00}ms  push: {avgPushMs:0.00}ms";
+            $"draw: {avgDrawMs:0.00}ms  readback: {avgReadbackMs:0.00}ms  push: {avgPushMs:0.00}ms\n" +
+            $"frame-to-frame gap: {avgGapMs:0.00}ms  (unaccounted-for: {avgGapMs - avgDrawMs - avgReadbackMs - avgPushMs:0.00}ms)";
 
         _framesSinceFpsUpdate = 0;
         _drawMsAccum = 0;
         _readbackMsAccum = 0;
         _pushMsAccum = 0;
+        _frameGapMsAccum = 0;
         _fpsWindow.Restart();
     }
 

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -74,6 +74,17 @@ public partial class MainWindow : Window
         _fpsWindow.Start();
         Closed += (_, _) => DisposeResources();
         SizeChanged += Window_SizeChanged;
+        MouseLeftButtonDown += (_, _) => CopyStatsToClipboardAndDebugOutput();
+    }
+
+    // Click-to-report: the stats overlay is a screenshot otherwise, which is slower to read back
+    // and paste than plain text. Prints to the VS Output window (via Debug.WriteLine, visible
+    // whenever running under the debugger) and the clipboard, so either works.
+    private void CopyStatsToClipboardAndDebugOutput()
+    {
+        string stats = FpsText.Text.Replace('\n', ' ');
+        Debug.WriteLine($"[WpfRenderSurfaceHostHarness] {stats}");
+        Clipboard.SetText(stats);
     }
 
     private void Window_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -1,0 +1,123 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Interop;
+using XnaAndWinforms;
+using Color = Microsoft.Xna.Framework.Color;
+
+namespace WpfRenderSurfaceHostHarness;
+
+/// <summary>
+/// Throwaway visual proof for #3833: a WPF-native <c>Image</c>/<c>WriteableBitmap</c>
+/// surface, driven purely by <see cref="WpfRenderSurfaceHost"/>'s own render-loop timer, displaying
+/// content drawn with an XNA/KNI <see cref="GraphicsDevice"/> - no WinForms, no
+/// <c>WindowsFormsHost</c>. This window owns the <see cref="GraphicsDevice"/> and
+/// <see cref="RenderTarget2D"/>; the host only knows about the bitmap/pixel-push pipeline. Not part
+/// of the Gum tool - this is a standalone check that the approach renders correctly on screen.
+/// </summary>
+public partial class MainWindow : Window
+{
+    private const int SurfaceWidth = 800;
+    private const int SurfaceHeight = 600;
+
+    private readonly Stopwatch _clock = new Stopwatch();
+    private readonly WpfRenderSurfaceHost _host = new WpfRenderSurfaceHost();
+
+    private GraphicsDevice? _graphicsDevice;
+    private RenderTarget2D? _renderTarget;
+    private SpriteBatch? _spriteBatch;
+    private Texture2D? _whitePixel;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        IntPtr windowHandle = new WindowInteropHelper(this).EnsureHandle();
+        CreateGraphicsResources(windowHandle);
+
+        RootGrid.Children.Add(_host.ImageElement);
+        _host.RenderFrame += DrawFrame;
+        _host.Initialize(SurfaceWidth, SurfaceHeight, desiredFramesPerSecond: 30);
+
+        _clock.Start();
+        Closed += (_, _) => DisposeResources();
+    }
+
+    private void DisposeResources()
+    {
+        _host.Dispose();
+        _whitePixel?.Dispose();
+        _spriteBatch?.Dispose();
+        _renderTarget?.Dispose();
+        _graphicsDevice?.Dispose();
+    }
+
+    private void CreateGraphicsResources(IntPtr windowHandle)
+    {
+        PresentationParameters presentationParameters = new PresentationParameters
+        {
+            BackBufferWidth = SurfaceWidth,
+            BackBufferHeight = SurfaceHeight,
+            BackBufferFormat = SurfaceFormat.Color,
+            DepthStencilFormat = DepthFormat.Depth24Stencil8,
+            DeviceWindowHandle = windowHandle,
+            PresentationInterval = PresentInterval.Immediate,
+            RenderTargetUsage = RenderTargetUsage.PreserveContents,
+            IsFullScreen = false,
+        };
+
+        _graphicsDevice = new GraphicsDevice(GraphicsAdapter.DefaultAdapter, GraphicsProfile.FL10_0, presentationParameters);
+        _renderTarget = new RenderTarget2D(
+            _graphicsDevice, SurfaceWidth, SurfaceHeight, mipMap: false, SurfaceFormat.Color, DepthFormat.Depth24Stencil8,
+            preferredMultiSampleCount: 1, RenderTargetUsage.PreserveContents);
+        _spriteBatch = new SpriteBatch(_graphicsDevice);
+
+        _whitePixel = new Texture2D(_graphicsDevice, width: 1, height: 1);
+        _whitePixel.SetData(new[] { Color.White });
+    }
+
+    // Draws animated content into the render target, reads it back, and pushes it into the WPF
+    // WriteableBitmap - proving the whole GraphicsDevice -> RenderTarget2D -> WriteableBitmap ->
+    // Image pipeline updates correctly on screen every frame.
+    private void DrawFrame()
+    {
+        Debug.Assert(_graphicsDevice != null && _renderTarget != null && _spriteBatch != null && _whitePixel != null,
+            "CreateGraphicsResources must run before DrawFrame.");
+
+        float seconds = (float)_clock.Elapsed.TotalSeconds;
+
+        _graphicsDevice.SetRenderTarget(_renderTarget);
+        _graphicsDevice.Clear(HueToColor(seconds * 40f % 360f));
+
+        // A square orbiting the center, to prove sprite content (not just the clear color) updates.
+        float radius = 200f;
+        float x = SurfaceWidth / 2f + radius * (float)Math.Cos(seconds) - 25f;
+        float y = SurfaceHeight / 2f + radius * (float)Math.Sin(seconds) - 25f;
+
+        _spriteBatch.Begin();
+        _spriteBatch.Draw(_whitePixel, new Microsoft.Xna.Framework.Rectangle((int)x, (int)y, 50, 50), Color.White);
+        _spriteBatch.End();
+
+        _graphicsDevice.SetRenderTarget(null);
+        _renderTarget.GetData(_host.RawImageBuffer);
+        _host.PushFrame(_renderTarget.Format);
+    }
+
+    // Cheap HSV(hue, 1, 1)->RGB conversion so the clear color visibly cycles frame to frame.
+    private static Color HueToColor(float hueDegrees)
+    {
+        float c = 1f;
+        float x = c * (1f - Math.Abs((hueDegrees / 60f % 2f) - 1f));
+        (float r, float g, float b) = hueDegrees switch
+        {
+            < 60f => (c, x, 0f),
+            < 120f => (x, c, 0f),
+            < 180f => (0f, c, x),
+            < 240f => (0f, x, c),
+            < 300f => (x, 0f, c),
+            _ => (c, 0f, x),
+        };
+        return new Color(r, g, b);
+    }
+}

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -84,7 +84,32 @@ public partial class MainWindow : Window
     {
         string stats = FpsText.Text.Replace('\n', ' ');
         Debug.WriteLine($"[WpfRenderSurfaceHostHarness] {stats}");
-        Clipboard.SetText(stats);
+        SetClipboardTextWithRetry(stats);
+    }
+
+    // The clipboard is a single systemwide resource - OpenClipboard legitimately fails with
+    // CLIPBRD_E_CANT_OPEN when another process (a clipboard manager, an AV scanner, etc.) is
+    // holding it at that instant. Retrying briefly is the standard fix, not a one-shot try/catch.
+    // The text is already in the VS Output window regardless (see caller), so a clipboard failure
+    // after exhausting retries is logged, not thrown - it shouldn't crash the harness.
+    private static void SetClipboardTextWithRetry(string text, int maxAttempts = 5, int delayMs = 50)
+    {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                Clipboard.SetText(text);
+                return;
+            }
+            catch (System.Runtime.InteropServices.COMException) when (attempt < maxAttempts)
+            {
+                System.Threading.Thread.Sleep(delayMs);
+            }
+            catch (System.Runtime.InteropServices.COMException ex)
+            {
+                Debug.WriteLine($"[WpfRenderSurfaceHostHarness] Clipboard.SetText failed after {maxAttempts} attempts: {ex.Message}");
+            }
+        }
     }
 
     private void Window_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -41,6 +41,15 @@ public partial class MainWindow : Window
     private readonly Stopwatch _fpsWindow = new Stopwatch();
     private int _framesSinceFpsUpdate;
 
+    // High-level phase breakdown - bisects the pipeline into GPU draw / GPU->CPU readback / WPF
+    // push, so a flat total fps number (or one that doesn't move with buffer size) can be traced to
+    // which stage actually dominates, instead of guessing. One reused Stopwatch, three accumulators;
+    // deliberately not more granular than this until a phase is shown to actually be the culprit.
+    private readonly Stopwatch _phaseTimer = new Stopwatch();
+    private double _drawMsAccum;
+    private double _readbackMsAccum;
+    private double _pushMsAccum;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -135,13 +144,20 @@ public partial class MainWindow : Window
         float x = _surfaceWidth / 2f + radius * (float)Math.Cos(seconds) - 25f;
         float y = _surfaceHeight / 2f + radius * (float)Math.Sin(seconds) - 25f;
 
+        _phaseTimer.Restart();
         _spriteBatch.Begin();
         _spriteBatch.Draw(_whitePixel, new Microsoft.Xna.Framework.Rectangle((int)x, (int)y, 50, 50), Color.White);
         _spriteBatch.End();
-
         _graphicsDevice.SetRenderTarget(null);
+        _drawMsAccum += _phaseTimer.Elapsed.TotalMilliseconds;
+
+        _phaseTimer.Restart();
         _renderTarget.GetData(_host.RawImageBuffer);
+        _readbackMsAccum += _phaseTimer.Elapsed.TotalMilliseconds;
+
+        _phaseTimer.Restart();
         _host.PushFrame(_renderTarget.Format);
+        _pushMsAccum += _phaseTimer.Elapsed.TotalMilliseconds;
 
         UpdateFpsDisplay();
     }
@@ -157,9 +173,18 @@ public partial class MainWindow : Window
         }
 
         double measuredFps = _framesSinceFpsUpdate / elapsedSeconds;
-        FpsText.Text = $"FPS: {measuredFps:0.0}";
+        double avgDrawMs = _drawMsAccum / _framesSinceFpsUpdate;
+        double avgReadbackMs = _readbackMsAccum / _framesSinceFpsUpdate;
+        double avgPushMs = _pushMsAccum / _framesSinceFpsUpdate;
+
+        FpsText.Text =
+            $"FPS: {measuredFps:0.0}  ({_surfaceWidth}x{_surfaceHeight})\n" +
+            $"draw: {avgDrawMs:0.00}ms  readback: {avgReadbackMs:0.00}ms  push: {avgPushMs:0.00}ms";
 
         _framesSinceFpsUpdate = 0;
+        _drawMsAccum = 0;
+        _readbackMsAccum = 0;
+        _pushMsAccum = 0;
         _fpsWindow.Restart();
     }
 

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -68,7 +68,7 @@ public partial class MainWindow : Window
         // Insert below the XAML-declared FpsText so the overlay stays on top.
         RootGrid.Children.Insert(0, _host.ImageElement);
         _host.RenderFrame += DrawFrame;
-        _host.Initialize(_surfaceWidth, _surfaceHeight, desiredFramesPerSecond: 30);
+        _host.Initialize(_surfaceWidth, _surfaceHeight);
 
         _clock.Start();
         _fpsWindow.Start();

--- a/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
+++ b/Samples/WpfRenderSurfaceHostHarness/MainWindow.xaml.cs
@@ -29,6 +29,11 @@ public partial class MainWindow : Window
     private SpriteBatch? _spriteBatch;
     private Texture2D? _whitePixel;
 
+    // Actual measured throughput, not a guess - counts real DrawFrame calls against wall-clock
+    // time, updated roughly twice a second so the number is legible.
+    private readonly Stopwatch _fpsWindow = new Stopwatch();
+    private int _framesSinceFpsUpdate;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -36,11 +41,13 @@ public partial class MainWindow : Window
         IntPtr windowHandle = new WindowInteropHelper(this).EnsureHandle();
         CreateGraphicsResources(windowHandle);
 
-        RootGrid.Children.Add(_host.ImageElement);
+        // Insert below the XAML-declared FpsText so the overlay stays on top.
+        RootGrid.Children.Insert(0, _host.ImageElement);
         _host.RenderFrame += DrawFrame;
         _host.Initialize(SurfaceWidth, SurfaceHeight, desiredFramesPerSecond: 30);
 
         _clock.Start();
+        _fpsWindow.Start();
         Closed += (_, _) => DisposeResources();
     }
 
@@ -102,6 +109,25 @@ public partial class MainWindow : Window
         _graphicsDevice.SetRenderTarget(null);
         _renderTarget.GetData(_host.RawImageBuffer);
         _host.PushFrame(_renderTarget.Format);
+
+        UpdateFpsDisplay();
+    }
+
+    private void UpdateFpsDisplay()
+    {
+        _framesSinceFpsUpdate++;
+
+        double elapsedSeconds = _fpsWindow.Elapsed.TotalSeconds;
+        if (elapsedSeconds < 0.5)
+        {
+            return;
+        }
+
+        double measuredFps = _framesSinceFpsUpdate / elapsedSeconds;
+        FpsText.Text = $"FPS: {measuredFps:0.0}";
+
+        _framesSinceFpsUpdate = 0;
+        _fpsWindow.Restart();
     }
 
     // Cheap HSV(hue, 1, 1)->RGB conversion so the clear color visibly cycles frame to frame.

--- a/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
+++ b/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<Nullable>enable</Nullable>
+		<UseWPF>true</UseWPF>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\XnaAndWinforms\XnaAndWinforms.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
+++ b/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
@@ -12,4 +12,13 @@
 		<ProjectReference Include="..\..\XnaAndWinforms\XnaAndWinforms.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- XnaAndWinforms only references the platform-agnostic nkast.Xna.Framework(.Graphics)
+		     packages. The actual GraphicsFactory registration comes from the platform-backend
+		     package (see Tool/EditorTabPlugin_XNA.csproj, the real working call path) - without
+		     it, GraphicsAdapter/GraphicsDevice construction throws a NullReferenceException on
+		     "graphicsFactory" at runtime, with no compile-time signal. -->
+		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
+	</ItemGroup>
+
 </Project>

--- a/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.sln
+++ b/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfRenderSurfaceHostHarness", "WpfRenderSurfaceHostHarness.csproj", "{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XnaAndWinforms", "..\..\XnaAndWinforms\XnaAndWinforms.csproj", "{63414381-1E7B-4CF3-9005-1E4C4F2866F8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|x64.Build.0 = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Debug|x86.Build.0 = Debug|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|x64.ActiveCfg = Release|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|x64.Build.0 = Release|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|x86.ActiveCfg = Release|Any CPU
+		{8376CDD7-EF9F-421D-A68E-5BDECAA81E68}.Release|x86.Build.0 = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|x64.Build.0 = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Debug|x86.Build.0 = Debug|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|x64.ActiveCfg = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|x64.Build.0 = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|x86.ActiveCfg = Release|Any CPU
+		{63414381-1E7B-4CF3-9005-1E4C4F2866F8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WpfRenderSurfaceHostTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WpfRenderSurfaceHostTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Shouldly;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using XnaAndWinforms;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+public class WpfRenderSurfaceHostTests
+{
+    // Wires the mock surface's Bitmap getter to whatever Resize was most recently called with,
+    // mirroring how the real WriteableBitmapRenderSurface behaves.
+    private static Mock<IWriteableBitmapRenderSurface> CreateSurfaceMock()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = new Mock<IWriteableBitmapRenderSurface>();
+        WriteableBitmap? bitmap = null;
+        byte[] rawImageBuffer = new byte[0];
+        surface.Setup(s => s.Resize(It.IsAny<int>(), It.IsAny<int>()))
+            .Callback<int, int>((width, height) =>
+            {
+                bitmap = new WriteableBitmap(width, height, 96, 96, PixelFormats.Pbgra32, null);
+                rawImageBuffer = new byte[width * height * 4];
+            });
+        surface.Setup(s => s.Bitmap).Returns(() => bitmap);
+        surface.Setup(s => s.RawImageBuffer).Returns(() => rawImageBuffer);
+        return surface;
+    }
+
+    [StaFact]
+    public void Dispose_StopsTimer()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = CreateSurfaceMock();
+        WpfRenderSurfaceHost host = new WpfRenderSurfaceHost(surface.Object);
+        host.Initialize(width: 4, height: 4);
+
+        host.Dispose();
+
+        host.IsRunning.ShouldBeFalse();
+    }
+
+    [StaFact]
+    public void Initialize_StartsTimer()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = CreateSurfaceMock();
+        WpfRenderSurfaceHost host = new WpfRenderSurfaceHost(surface.Object);
+
+        host.Initialize(width: 4, height: 4);
+
+        host.IsRunning.ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void Initialize_SetsImageElementSourceToSurfaceBitmap()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = CreateSurfaceMock();
+        WpfRenderSurfaceHost host = new WpfRenderSurfaceHost(surface.Object);
+
+        host.Initialize(width: 4, height: 4);
+
+        host.ImageElement.Source.ShouldBeSameAs(surface.Object.Bitmap);
+    }
+
+    [StaFact]
+    public void PushFrame_DelegatesToSurface()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = CreateSurfaceMock();
+        WpfRenderSurfaceHost host = new WpfRenderSurfaceHost(surface.Object);
+        host.Initialize(width: 4, height: 4);
+
+        host.PushFrame(SurfaceFormat.Color);
+
+        surface.Verify(s => s.Push(SurfaceFormat.Color), Times.Once);
+    }
+
+    [StaFact]
+    public void Resize_UpdatesImageElementSource()
+    {
+        Mock<IWriteableBitmapRenderSurface> surface = CreateSurfaceMock();
+        WpfRenderSurfaceHost host = new WpfRenderSurfaceHost(surface.Object);
+        host.Initialize(width: 4, height: 4);
+
+        host.Resize(width: 8, height: 8);
+
+        host.ImageElement.Source.ShouldBeSameAs(surface.Object.Bitmap);
+        ((WriteableBitmap)host.ImageElement.Source).PixelWidth.ShouldBe(8);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WriteableBitmapRenderSurfaceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WriteableBitmapRenderSurfaceTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Shouldly;
+using System;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using XnaAndWinforms;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+public class WriteableBitmapRenderSurfaceTests
+{
+    [Fact]
+    public void Push_AfterResize_DelegatesRawImageBufferAndFormatToPixelBufferWriter()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+        surface.Resize(width: 4, height: 3);
+
+        surface.Push(SurfaceFormat.Color);
+
+        pixelBufferWriter.Verify(w => w.WriteToBitmap(surface.RawImageBuffer, SurfaceFormat.Color, surface.Bitmap!), Times.Once);
+    }
+
+    [Fact]
+    public void Push_BeforeResize_Throws()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+
+        Should.Throw<InvalidOperationException>(() => surface.Push(SurfaceFormat.Color));
+    }
+
+    [Fact]
+    public void Resize_AllocatesRawImageBufferSizedForDimensions()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+
+        surface.Resize(width: 8, height: 5);
+
+        surface.RawImageBuffer.Length.ShouldBe(8 * 5 * 4);
+    }
+
+    [Fact]
+    public void Resize_CreatesBitmapWithGivenDimensions()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+
+        surface.Resize(width: 10, height: 6);
+
+        WriteableBitmap? bitmap = surface.Bitmap;
+        bitmap.ShouldNotBeNull();
+        bitmap!.PixelWidth.ShouldBe(10);
+        bitmap.PixelHeight.ShouldBe(6);
+        bitmap.Format.ShouldBe(PixelFormats.Pbgra32);
+        surface.Width.ShouldBe(10);
+        surface.Height.ShouldBe(6);
+    }
+
+    [Fact]
+    public void Resize_NonPositiveWidthOrHeight_Throws()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+
+        Should.Throw<ArgumentOutOfRangeException>(() => surface.Resize(width: 0, height: 4));
+        Should.Throw<ArgumentOutOfRangeException>(() => surface.Resize(width: 4, height: -1));
+    }
+
+    [Fact]
+    public void Resize_SameDimensionsTwice_DoesNotReallocateBitmap()
+    {
+        Mock<IWriteableBitmapPixelBufferWriter> pixelBufferWriter = new Mock<IWriteableBitmapPixelBufferWriter>();
+        WriteableBitmapRenderSurface surface = new WriteableBitmapRenderSurface(pixelBufferWriter.Object);
+        surface.Resize(width: 7, height: 7);
+        WriteableBitmap? firstBitmap = surface.Bitmap;
+        byte[] firstBuffer = surface.RawImageBuffer;
+
+        surface.Resize(width: 7, height: 7);
+
+        surface.Bitmap.ShouldBeSameAs(firstBitmap);
+        surface.RawImageBuffer.ShouldBeSameAs(firstBuffer);
+    }
+}

--- a/XnaAndWinforms/IWpfRenderSurfaceHost.cs
+++ b/XnaAndWinforms/IWpfRenderSurfaceHost.cs
@@ -1,0 +1,50 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Windows.Controls;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// A WPF-native render surface: a plain <see cref="Image"/> element backed by a
+/// <see cref="System.Windows.Media.Imaging.WriteableBitmap"/>, updated on its own render-loop timer.
+/// Deliberately does not own a <c>GraphicsDevice</c> or <c>RenderTarget2D</c> - the caller draws
+/// into its own render target on <see cref="RenderFrame"/>, reads it back into
+/// <see cref="RawImageBuffer"/>, then calls <see cref="PushFrame"/> to blit it into the bitmap.
+/// This keeps the host reusable by any caller that owns a render target (e.g. a future WPF-native
+/// replacement for <c>WireframeControl</c>/<c>ImageRegionSelectionControl</c>), and keeps the sizing
+/// logic in <see cref="IWriteableBitmapRenderSurface"/> unit-testable independent of the timer.
+/// </summary>
+public interface IWpfRenderSurfaceHost : IDisposable
+{
+    /// <summary>The element to host in a WPF visual tree.</summary>
+    Image ImageElement { get; }
+
+    /// <summary>
+    /// The buffer to pass to <c>RenderTarget2D.GetData</c> before calling <see cref="PushFrame"/>.
+    /// </summary>
+    byte[] RawImageBuffer { get; }
+
+    /// <summary>Whether the render-loop timer is currently running.</summary>
+    bool IsRunning { get; }
+
+    /// <summary>
+    /// Raised on the render-loop timer's tick. Subscribers should draw into their render target,
+    /// read it back into <see cref="RawImageBuffer"/>, then call <see cref="PushFrame"/>.
+    /// </summary>
+    event Action? RenderFrame;
+
+    /// <summary>
+    /// Sizes the backing bitmap and starts the render-loop timer. Safe to call only once; use
+    /// <see cref="Resize"/> for subsequent size changes.
+    /// </summary>
+    void Initialize(int width, int height, double desiredFramesPerSecond = 30);
+
+    /// <summary>(Re)sizes the backing bitmap and <see cref="RawImageBuffer"/> to match.</summary>
+    void Resize(int width, int height);
+
+    /// <summary>
+    /// Converts <see cref="RawImageBuffer"/> (already filled by the caller) into the backing
+    /// bitmap and refreshes <see cref="ImageElement"/>.
+    /// </summary>
+    void PushFrame(SurfaceFormat sourceFormat);
+}

--- a/XnaAndWinforms/IWpfRenderSurfaceHost.cs
+++ b/XnaAndWinforms/IWpfRenderSurfaceHost.cs
@@ -6,13 +6,14 @@ namespace XnaAndWinforms;
 
 /// <summary>
 /// A WPF-native render surface: a plain <see cref="Image"/> element backed by a
-/// <see cref="System.Windows.Media.Imaging.WriteableBitmap"/>, updated on its own render-loop timer.
-/// Deliberately does not own a <c>GraphicsDevice</c> or <c>RenderTarget2D</c> - the caller draws
-/// into its own render target on <see cref="RenderFrame"/>, reads it back into
-/// <see cref="RawImageBuffer"/>, then calls <see cref="PushFrame"/> to blit it into the bitmap.
-/// This keeps the host reusable by any caller that owns a render target (e.g. a future WPF-native
-/// replacement for <c>WireframeControl</c>/<c>ImageRegionSelectionControl</c>), and keeps the sizing
-/// logic in <see cref="IWriteableBitmapRenderSurface"/> unit-testable independent of the timer.
+/// <see cref="System.Windows.Media.Imaging.WriteableBitmap"/>, updated once per WPF render pass via
+/// <see cref="System.Windows.Media.CompositionTarget.Rendering"/>. Deliberately does not own a
+/// <c>GraphicsDevice</c> or <c>RenderTarget2D</c> - the caller draws into its own render target on
+/// <see cref="RenderFrame"/>, reads it back into <see cref="RawImageBuffer"/>, then calls
+/// <see cref="PushFrame"/> to blit it into the bitmap. This keeps the host reusable by any caller
+/// that owns a render target (e.g. a future WPF-native replacement for
+/// <c>WireframeControl</c>/<c>ImageRegionSelectionControl</c>), and keeps the sizing logic in
+/// <see cref="IWriteableBitmapRenderSurface"/> unit-testable independent of the render trigger.
 /// </summary>
 public interface IWpfRenderSurfaceHost : IDisposable
 {
@@ -24,20 +25,20 @@ public interface IWpfRenderSurfaceHost : IDisposable
     /// </summary>
     byte[] RawImageBuffer { get; }
 
-    /// <summary>Whether the render-loop timer is currently running.</summary>
+    /// <summary>Whether the render loop is currently subscribed and active.</summary>
     bool IsRunning { get; }
 
     /// <summary>
-    /// Raised on the render-loop timer's tick. Subscribers should draw into their render target,
-    /// read it back into <see cref="RawImageBuffer"/>, then call <see cref="PushFrame"/>.
+    /// Raised on every WPF render pass. Subscribers should draw into their render target, read it
+    /// back into <see cref="RawImageBuffer"/>, then call <see cref="PushFrame"/>.
     /// </summary>
     event Action? RenderFrame;
 
     /// <summary>
-    /// Sizes the backing bitmap and starts the render-loop timer. Safe to call only once; use
+    /// Sizes the backing bitmap and starts the render loop. Safe to call only once; use
     /// <see cref="Resize"/> for subsequent size changes.
     /// </summary>
-    void Initialize(int width, int height, double desiredFramesPerSecond = 30);
+    void Initialize(int width, int height);
 
     /// <summary>(Re)sizes the backing bitmap and <see cref="RawImageBuffer"/> to match.</summary>
     void Resize(int width, int height);

--- a/XnaAndWinforms/IWriteableBitmapRenderSurface.cs
+++ b/XnaAndWinforms/IWriteableBitmapRenderSurface.cs
@@ -1,0 +1,46 @@
+using Microsoft.Xna.Framework.Graphics;
+using System.Windows.Media.Imaging;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// Owns a <see cref="WriteableBitmap"/> sized to match a render target, plus the raw pixel buffer
+/// used to read that render target back into it. Framework-neutral aside from the WPF bitmap type
+/// itself - no WPF <c>Image</c> element, no timer, no <c>GraphicsDevice</c> - so it can be
+/// constructed and unit tested without a live render target or window.
+/// </summary>
+public interface IWriteableBitmapRenderSurface
+{
+    /// <summary>
+    /// The bitmap a WPF <c>Image</c> element's <c>Source</c> can bind to. <see langword="null"/>
+    /// until <see cref="Resize"/> has been called at least once.
+    /// </summary>
+    WriteableBitmap? Bitmap { get; }
+
+    /// <summary>
+    /// The buffer to pass to <c>RenderTarget2D.GetData</c>; sized to exactly match
+    /// <see cref="Width"/> x <see cref="Height"/> x 4 bytes-per-pixel.
+    /// </summary>
+    byte[] RawImageBuffer { get; }
+
+    /// <summary>The current bitmap width in pixels.</summary>
+    int Width { get; }
+
+    /// <summary>The current bitmap height in pixels.</summary>
+    int Height { get; }
+
+    /// <summary>
+    /// (Re)creates <see cref="Bitmap"/> and <see cref="RawImageBuffer"/> for the given pixel
+    /// dimensions. A no-op if the dimensions already match the current <see cref="Bitmap"/>.
+    /// </summary>
+    void Resize(int width, int height);
+
+    /// <summary>
+    /// Converts <see cref="RawImageBuffer"/> (already filled by the caller, e.g. via
+    /// <c>RenderTarget2D.GetData</c>) into <see cref="Bitmap"/>'s backing memory.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown when called before <see cref="Resize"/>.
+    /// </exception>
+    void Push(SurfaceFormat sourceFormat);
+}

--- a/XnaAndWinforms/WpfRenderSurfaceHost.cs
+++ b/XnaAndWinforms/WpfRenderSurfaceHost.cs
@@ -1,0 +1,71 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The real implementation of <see cref="IWpfRenderSurfaceHost"/>. Owns the WPF
+/// <see cref="Image"/> element and <see cref="DispatcherTimer"/>; delegates bitmap sizing/pixel
+/// conversion to <see cref="IWriteableBitmapRenderSurface"/>.
+/// </summary>
+public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
+{
+    private readonly IWriteableBitmapRenderSurface _surface;
+    private DispatcherTimer? _timer;
+
+    /// <inheritdoc/>
+    public Image ImageElement { get; } = new Image { Stretch = Stretch.None };
+
+    /// <inheritdoc/>
+    public byte[] RawImageBuffer => _surface.RawImageBuffer;
+
+    /// <inheritdoc/>
+    public bool IsRunning => _timer?.IsEnabled ?? false;
+
+    /// <inheritdoc/>
+    public event Action? RenderFrame;
+
+    public WpfRenderSurfaceHost() : this(new WriteableBitmapRenderSurface(new WriteableBitmapPixelBufferWriter()))
+    {
+    }
+
+    public WpfRenderSurfaceHost(IWriteableBitmapRenderSurface surface)
+    {
+        _surface = surface;
+    }
+
+    /// <inheritdoc/>
+    public void Initialize(int width, int height, double desiredFramesPerSecond = 30)
+    {
+        Resize(width, height);
+
+        _timer = new DispatcherTimer(DispatcherPriority.Render)
+        {
+            Interval = TimeSpan.FromSeconds(1.0 / desiredFramesPerSecond)
+        };
+        _timer.Tick += (_, _) => RenderFrame?.Invoke();
+        _timer.Start();
+    }
+
+    /// <inheritdoc/>
+    public void Resize(int width, int height)
+    {
+        _surface.Resize(width, height);
+        ImageElement.Source = _surface.Bitmap;
+    }
+
+    /// <inheritdoc/>
+    public void PushFrame(SurfaceFormat sourceFormat)
+    {
+        _surface.Push(sourceFormat);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _timer?.Stop();
+    }
+}

--- a/XnaAndWinforms/WpfRenderSurfaceHost.cs
+++ b/XnaAndWinforms/WpfRenderSurfaceHost.cs
@@ -2,19 +2,27 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Threading;
 
 namespace XnaAndWinforms;
 
 /// <summary>
 /// The real implementation of <see cref="IWpfRenderSurfaceHost"/>. Owns the WPF
-/// <see cref="Image"/> element and <see cref="DispatcherTimer"/>; delegates bitmap sizing/pixel
+/// <see cref="Image"/> element and the render-loop trigger; delegates bitmap sizing/pixel
 /// conversion to <see cref="IWriteableBitmapRenderSurface"/>.
 /// </summary>
+/// <remarks>
+/// Diagnostic swap (#3833): a <c>DispatcherTimer(DispatcherPriority.Render)</c>-driven loop measured
+/// a ~43ms/frame gap outside all known per-frame work (draw/readback/push), independent of buffer
+/// size - i.e. the timer itself, not the copy cost, was the ceiling. <see cref="CompositionTarget"/>.
+/// <c>Rendering</c> is WPF's actual per-render-pass hook (driven by the composition engine, not a
+/// dispatcher timer) and is used here instead, unthrottled, to isolate whether that closes the gap.
+/// <paramref name="desiredFramesPerSecond"/> on <see cref="Initialize"/> is currently unused while
+/// this experiment is in place.
+/// </remarks>
 public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
 {
     private readonly IWriteableBitmapRenderSurface _surface;
-    private DispatcherTimer? _timer;
+    private bool _isRunning;
 
     /// <inheritdoc/>
     public Image ImageElement { get; } = new Image { Stretch = Stretch.None };
@@ -23,7 +31,7 @@ public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
     public byte[] RawImageBuffer => _surface.RawImageBuffer;
 
     /// <inheritdoc/>
-    public bool IsRunning => _timer?.IsEnabled ?? false;
+    public bool IsRunning => _isRunning;
 
     /// <inheritdoc/>
     public event Action? RenderFrame;
@@ -42,13 +50,11 @@ public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
     {
         Resize(width, height);
 
-        _timer = new DispatcherTimer(DispatcherPriority.Render)
-        {
-            Interval = TimeSpan.FromSeconds(1.0 / desiredFramesPerSecond)
-        };
-        _timer.Tick += (_, _) => RenderFrame?.Invoke();
-        _timer.Start();
+        CompositionTarget.Rendering += OnRendering;
+        _isRunning = true;
     }
+
+    private void OnRendering(object? sender, EventArgs e) => RenderFrame?.Invoke();
 
     /// <inheritdoc/>
     public void Resize(int width, int height)
@@ -66,6 +72,10 @@ public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
     /// <inheritdoc/>
     public void Dispose()
     {
-        _timer?.Stop();
+        if (_isRunning)
+        {
+            CompositionTarget.Rendering -= OnRendering;
+            _isRunning = false;
+        }
     }
 }

--- a/XnaAndWinforms/WpfRenderSurfaceHost.cs
+++ b/XnaAndWinforms/WpfRenderSurfaceHost.cs
@@ -11,13 +11,14 @@ namespace XnaAndWinforms;
 /// conversion to <see cref="IWriteableBitmapRenderSurface"/>.
 /// </summary>
 /// <remarks>
-/// Diagnostic swap (#3833): a <c>DispatcherTimer(DispatcherPriority.Render)</c>-driven loop measured
-/// a ~43ms/frame gap outside all known per-frame work (draw/readback/push), independent of buffer
-/// size - i.e. the timer itself, not the copy cost, was the ceiling. <see cref="CompositionTarget"/>.
-/// <c>Rendering</c> is WPF's actual per-render-pass hook (driven by the composition engine, not a
-/// dispatcher timer) and is used here instead, unthrottled, to isolate whether that closes the gap.
-/// <paramref name="desiredFramesPerSecond"/> on <see cref="Initialize"/> is currently unused while
-/// this experiment is in place.
+/// Uses <see cref="CompositionTarget"/>.<c>Rendering</c> (WPF's actual per-render-pass hook, driven
+/// by the composition engine) rather than a <c>DispatcherTimer</c> - a timer-driven loop measured a
+/// ~43ms/frame gap outside all known per-frame work (draw/readback/push), independent of buffer
+/// size, i.e. the timer itself was the ceiling, not the copy cost. Unthrottled on
+/// <see cref="CompositionTarget.Rendering"/>, measured throughput is vsync-bound: ~60fps at
+/// moderate sizes, ~45fps at a maximized 4K window - well within a smooth, usable range, so no
+/// throttle knob is exposed here. If a future caller needs to cap the rate (e.g. to save power when
+/// idle), add it at that call site rather than reintroducing it speculatively here.
 /// </remarks>
 public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
 {
@@ -46,7 +47,7 @@ public class WpfRenderSurfaceHost : IWpfRenderSurfaceHost
     }
 
     /// <inheritdoc/>
-    public void Initialize(int width, int height, double desiredFramesPerSecond = 30)
+    public void Initialize(int width, int height)
     {
         Resize(width, height);
 

--- a/XnaAndWinforms/WriteableBitmapRenderSurface.cs
+++ b/XnaAndWinforms/WriteableBitmapRenderSurface.cs
@@ -1,0 +1,66 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// The real implementation of <see cref="IWriteableBitmapRenderSurface"/>. Delegates the actual
+/// pixel conversion to <see cref="IWriteableBitmapPixelBufferWriter"/>; this class's own
+/// responsibility is sizing the <see cref="WriteableBitmap"/>/raw buffer pair and avoiding
+/// unnecessary reallocation when the size hasn't changed between frames.
+/// </summary>
+public class WriteableBitmapRenderSurface : IWriteableBitmapRenderSurface
+{
+    private readonly IWriteableBitmapPixelBufferWriter _pixelBufferWriter;
+
+    /// <inheritdoc/>
+    public WriteableBitmap? Bitmap { get; private set; }
+
+    /// <inheritdoc/>
+    public byte[] RawImageBuffer { get; private set; } = Array.Empty<byte>();
+
+    /// <inheritdoc/>
+    public int Width { get; private set; }
+
+    /// <inheritdoc/>
+    public int Height { get; private set; }
+
+    public WriteableBitmapRenderSurface(IWriteableBitmapPixelBufferWriter pixelBufferWriter)
+    {
+        _pixelBufferWriter = pixelBufferWriter;
+    }
+
+    /// <inheritdoc/>
+    public void Resize(int width, int height)
+    {
+        if (width <= 0 || height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(width), $"{nameof(width)} and {nameof(height)} must both be positive, but were {width}x{height}.");
+        }
+
+        if (Bitmap != null && Width == width && Height == height)
+        {
+            // Already the right size - avoid churning a new bitmap/buffer every frame.
+            return;
+        }
+
+        Width = width;
+        Height = height;
+        Bitmap = new WriteableBitmap(width, height, dpiX: 96, dpiY: 96, PixelFormats.Pbgra32, palette: null);
+        RawImageBuffer = new byte[width * height * 4];
+    }
+
+    /// <inheritdoc/>
+    public void Push(SurfaceFormat sourceFormat)
+    {
+        if (Bitmap == null)
+        {
+            throw new InvalidOperationException($"{nameof(Resize)} must be called before {nameof(Push)}.");
+        }
+
+        _pixelBufferWriter.WriteToBitmap(RawImageBuffer, sourceFormat, Bitmap);
+    }
+}


### PR DESCRIPTION
## Summary

Prototype WPF-native host class for #3833: an `Image` control backed by a `WriteableBitmap`, driven by its own render-loop timer, built on `WriteableBitmapPixelBufferWriter` (#3834). Standalone infra only - `WireframeControl`, `GraphicsDeviceControl`, and live tool wiring are all untouched.

**New (`XnaAndWinforms/`):**
- `WriteableBitmapRenderSurface` (+ `IWriteableBitmapRenderSurface`) - owns the `WriteableBitmap`/raw-buffer pair, sized/resized independent of any timer or GPU device. Fully unit tested.
- `WpfRenderSurfaceHost` (+ `IWpfRenderSurfaceHost`) - wraps the surface with an `Image` element and a `DispatcherTimer`. Deliberately owns no `GraphicsDevice`/`RenderTarget2D`: it raises `RenderFrame`, the caller draws into its own render target and calls back `PushFrame`. This keeps the class reusable for both `WireframeControl` and `ImageRegionSelectionControl` later.

**Tests:** `Tool/Tests/GumToolUnitTests/Wireframe/WriteableBitmapRenderSurfaceTests.cs`, `WpfRenderSurfaceHostTests.cs` (WPF-object-touching tests use `[StaFact]`, matching existing repo precedent).

**Standalone visual harness:** `Samples/WpfRenderSurfaceHostHarness` (own `.sln`, not part of `GumFull.sln`/`AllLibraries.sln`) - a throwaway WPF window that creates its own `GraphicsDevice`/`RenderTarget2D`, draws an animated hue-cycling clear color + an orbiting sprite, and pushes frames through the host onto screen. Proves the whole pipeline renders correctly with no WinForms/`WindowsFormsHost` involved.

## Not done / next steps
- Not wired into `WireframeControl` yet - still needs the sibling `IInputHostControl.Cursor` widening (independent, in progress elsewhere) before that swap makes sense.
- No resize handling exercised live in the harness (fixed 800x600 window) - `Resize`/idempotency is unit tested but not manually exercised on a live GPU resize.

Part of #3833.
