### PR TITLE
Add right-stick vertical scrolling to ScrollViewer's focused-gamepad path

### DIFF
--- a/GumRuntime/Input/GamePad.cs
+++ b/GumRuntime/Input/GamePad.cs
@@ -58,6 +58,9 @@ public class GamePad : IGamePad
     /// <inheritdoc/>
     IAnalogStick IGamePad.LeftStick => _leftStick;
 
+    /// <inheritdoc/>
+    IAnalogStick IGamePad.RightStick => _rightStick;
+
     /// <summary>
     /// Whether the controller was connected as of the last committed frame.
     /// </summary>
@@ -311,6 +314,12 @@ public class AnalogStick : IAnalogStick
     /// Recommended for top-down games.
     /// </summary>
     public bool IsMaxPositionNormalized { get; set; } = false;
+
+    /// <inheritdoc/>
+    public float X => _x;
+
+    /// <inheritdoc/>
+    public float Y => _y;
 
     float _x;
     float _y;

--- a/GumRuntime/Input/IGamePad.cs
+++ b/GumRuntime/Input/IGamePad.cs
@@ -34,6 +34,11 @@ public interface IGamePad
     /// The left analog stick. Always non-null even if the gamepad has no physical analog stick.
     /// </summary>
     IAnalogStick LeftStick { get; }
+
+    /// <summary>
+    /// The right analog stick. Always non-null even if the gamepad has no physical analog stick.
+    /// </summary>
+    IAnalogStick RightStick { get; }
 }
 
 /// <summary>
@@ -54,4 +59,14 @@ public interface IAnalogStick
     /// or has held it long enough to trigger key-repeat semantics.
     /// </summary>
     bool AsDPadPushedRepeatRate(DPadDirection direction);
+
+    /// <summary>
+    /// The stick's horizontal position after deadzone processing, from -1 (left) to +1 (right).
+    /// </summary>
+    float X { get; }
+
+    /// <summary>
+    /// The stick's vertical position after deadzone processing, from -1 (down) to +1 (up).
+    /// </summary>
+    float Y { get; }
 }

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -2,8 +2,11 @@
 using Gum.Forms.DefaultVisuals;
 using Gum.Wireframe;
 using Gum.GueDeriving;
+using Microsoft.Xna.Framework.Input;
 using MonoGameGum.Input;
+using MonoGameGum.Tests.Input;
 using Gum.Input;
+using GamePad = Gum.Input.GamePad;
 using Moq;
 using RenderingLibrary;
 using Shouldly;
@@ -1650,6 +1653,48 @@ public class ListBoxTests : BaseTestClass
         listBox.OnFocusUpdate();
 
         listBox.SelectedIndex.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ListBox_RightStickDeflection_ScrollsAtTopLevelFocus()
+    {
+        // Pins that ListBox.DoTopLevelFocusUpdate calls the same ApplyGamepadStickScroll
+        // that ScrollViewer.DoTopLevelFocusUpdate uses, rather than duplicating the
+        // stick-scroll code (issue #3839).
+        ListBox listBox = new ListBox();
+        listBox.Visual.Height = 200;
+        listBox.AddToRoot();
+
+        for (int i = 0; i < 50; i++)
+        {
+            listBox.Items!.Add($"Item {i}");
+        }
+
+        listBox.VerticalScrollBarMaximum.ShouldBeGreaterThan(0,
+            "the test needs scrollable content to observe the scroll");
+
+        listBox.GamepadStickScrollSpeed = 100;
+        listBox.VerticalScrollBarValue = 500;
+        listBox.DoListItemsHaveFocus = false;
+
+        GamePad gamepad = new();
+        // Right stick pushed fully up (XNA/Gum convention: +1 is up).
+        gamepad.Activity(
+            new GamePadState(
+                new GamePadThumbSticks(new Microsoft.Xna.Framework.Vector2(0, 0), new Microsoft.Xna.Framework.Vector2(0, 1f)),
+                new GamePadTriggers(0, 0),
+                new GamePadButtons(0),
+                new GamePadDPad()),
+            0);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        InteractiveGue.CurrentGameTime = 0;
+        listBox.OnFocusUpdate();
+
+        InteractiveGue.CurrentGameTime = 1;
+        listBox.OnFocusUpdate();
+
+        listBox.VerticalScrollBarValue.ShouldBe(400, tolerance: 0.01);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
@@ -3,7 +3,9 @@ using Gum.Wireframe;
 using Microsoft.Xna.Framework.Input;
 using Gum.GueDeriving;
 using MonoGameGum.Input;
+using MonoGameGum.Tests.Input;
 using Gum.Input;
+using GamePad = Gum.Input.GamePad;
 using Moq;
 using Shouldly;
 using System;
@@ -196,6 +198,45 @@ public class ScrollViewerTests : BaseTestClass
         scrollViewer.AddChild(button1);
         scrollViewer.RemoveChild(button1);
         scrollViewer.Visual.Children.ShouldNotContain(button1.Visual);
+    }
+
+    [Fact]
+    public void OnFocusUpdate_ShouldScrollByRightStickDeflection_WhenTopLevelFocused()
+    {
+        ScrollViewer scrollViewer = new();
+        scrollViewer.Visual.Width = 200;
+        scrollViewer.Visual.Height = 200;
+
+        ContainerRuntime tallContent = new();
+        tallContent.Width = 0;
+        tallContent.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        tallContent.Height = 1000;
+        tallContent.HeightUnits = global::Gum.DataTypes.DimensionUnitType.Absolute;
+        scrollViewer.AddChild(tallContent);
+
+        scrollViewer.GamepadStickScrollSpeed = 100;
+        scrollViewer.VerticalScrollBarValue = 500;
+        scrollViewer.IsFocused = true;
+
+        GamePad gamepad = new();
+        // Right stick pushed fully up (XNA/Gum convention: +1 is up).
+        gamepad.Activity(
+            new GamePadState(
+                new GamePadThumbSticks(new Microsoft.Xna.Framework.Vector2(0, 0), new Microsoft.Xna.Framework.Vector2(0, 1f)),
+                new GamePadTriggers(0, 0),
+                new GamePadButtons(0),
+                new GamePadDPad()),
+            0);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        InteractiveGue.CurrentGameTime = 0;
+        scrollViewer.OnFocusUpdate();
+
+        InteractiveGue.CurrentGameTime = 1;
+        scrollViewer.OnFocusUpdate();
+
+        // Up on the stick scrolls toward the top of the content, so the value decreases.
+        scrollViewer.VerticalScrollBarValue.ShouldBe(400, tolerance: 0.01);
     }
 
     [Fact]

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -2035,6 +2035,12 @@ public class ListBox : ItemsControl, IInputReceiver
 
             HandleGamepadNavigation(gamepad);
 
+#if !FRB
+            // Shared with ScrollViewer.DoTopLevelFocusUpdate so the right-stick scroll code
+            // isn't duplicated between the two copies (issue #3839).
+            ApplyGamepadStickScroll(gamepad);
+#endif
+
             if (gamepad.ButtonPushed(GamepadButton.A))
             {
                 DoListItemsHaveFocus = true;

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -198,6 +198,15 @@ public class ScrollViewer :
     /// </remarks>
     public double MouseWheelScrollSpeed { get; set; } = 30;
 
+#if !FRB
+    /// <summary>
+    /// Units per second that <see cref="VerticalScrollBarValue"/> changes when the gamepad's
+    /// right stick is fully deflected vertically (scaled linearly for partial deflection).
+    /// Defaults to 600.
+    /// </summary>
+    public double GamepadStickScrollSpeed { get; set; } = 600;
+#endif
+
     /// <summary>
     /// The vertical scroll bar value. Assigning this automatically scrolls
     /// the ScrollViewer to the desired location. Percentage-based scrolling
@@ -1079,6 +1088,10 @@ public class ScrollViewer :
 
             HandleGamepadNavigation(gamepad);
 
+#if !FRB
+            ApplyGamepadStickScroll(gamepad);
+#endif
+
             if (gamepad.ButtonPushed(GamepadButton.A))
             {
                 DoItemsHaveFocus = true;
@@ -1124,6 +1137,36 @@ public class ScrollViewer :
         }
 #endif
     }
+
+#if !FRB
+    // Elapsed-time source for ApplyGamepadStickScroll, so scroll speed is frame-rate independent.
+    // Null until the first call so the initial frame only records a baseline instead of jumping
+    // by a spurious large delta.
+    double? _lastGamepadStickScrollTime;
+
+    /// <summary>
+    /// Applies continuous vertical scrolling from the gamepad's right analog stick, scaled by
+    /// elapsed time. Shared by <see cref="ScrollViewer"/> and <see cref="ListBox"/> so the two
+    /// separate <c>DoTopLevelFocusUpdate</c> copies don't each need their own stick-scroll code.
+    /// Horizontal (X) scrolling is not wired up yet.
+    /// </summary>
+    protected void ApplyGamepadStickScroll(IGamePad gamepad)
+    {
+        var currentTime = InteractiveGue.CurrentGameTime;
+        var y = gamepad.RightStick.Y;
+
+        if (y != 0 && _lastGamepadStickScrollTime.HasValue)
+        {
+            var elapsedSeconds = currentTime - _lastGamepadStickScrollTime.Value;
+            if (elapsedSeconds > 0)
+            {
+                VerticalScrollBarValue -= y * GamepadStickScrollSpeed * elapsedSeconds;
+            }
+        }
+
+        _lastGamepadStickScrollTime = currentTime;
+    }
+#endif
 
     private void DoItemFocusUpdate()
     {

--- a/Tests/RaylibGum.Tests/Inputs/AnalogStickTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/AnalogStickTests.cs
@@ -6,12 +6,33 @@ namespace RaylibGum.Tests.Inputs;
 /// <summary>
 /// Parity tests for the deadzone/interpolation configuration ported onto the
 /// platform-neutral <see cref="AnalogStick"/> in GumCommon (issue #3137, Phase 1).
-/// The stick exposes no public Position, so the deadzone math is observable only
-/// through whether the (post-deadzone) position crosses the DPad on/off thresholds
-/// (0.55 / 0.45) surfaced by <see cref="AnalogStick.AsDPadDown"/>.
+/// Most of the deadzone math predates <see cref="AnalogStick.X"/>/<see cref="AnalogStick.Y"/>
+/// (issue #3839) and is still exercised indirectly, through whether the (post-deadzone)
+/// position crosses the DPad on/off thresholds (0.55 / 0.45) surfaced by
+/// <see cref="AnalogStick.AsDPadDown"/>.
 /// </summary>
 public class AnalogStickTests : BaseTestClass
 {
+    [Fact]
+    public void XY_ShouldReturnZero_WhenStickWithinDeadzone()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0.2f };
+        sut.Update(0.1f, -0.1f, 1);
+
+        sut.X.ShouldBe(0f);
+        sut.Y.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void XY_ShouldReturnPostDeadzonePosition_WhenStickBeyondDeadzone()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0f };
+        sut.Update(0.3f, -0.6f, 1);
+
+        sut.X.ShouldBe(0.3f);
+        sut.Y.ShouldBe(-0.6f);
+    }
+
     [Fact]
     public void AsDPadDown_Right_False_WhenStickWithinRadialDeadzone()
     {

--- a/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/GamePadTests.cs
@@ -86,6 +86,25 @@ public class GamePadTests : BaseTestClass
         ((IAnalogStick)sut.LeftStick).AsDPadPushed(DPadDirection.Down).ShouldBeFalse();
     }
 
+    [Fact]
+    public void IGamePad_RightStick_ReturnsSameInstance_AsConcreteRightStick()
+    {
+        GamePad sut = new GamePad();
+
+        ((IGamePad)sut).RightStick.ShouldBeSameAs(sut.RightStick);
+    }
+
+    [Fact]
+    public void RightStick_XY_ReflectsSetRightStickPosition()
+    {
+        GamePad sut = new GamePad();
+        sut.SetRightStickPosition(0.4f, -0.8f);
+        sut.Activity(1);
+
+        sut.RightStick.X.ShouldBe(0.4f);
+        sut.RightStick.Y.ShouldBe(-0.8f);
+    }
+
     // ---- Phase 1 member-parity additions (issue #3137) ----
 
     [Fact]

--- a/docs/code/events-and-interactivity/gamepad-support.md
+++ b/docs/code/events-and-interactivity/gamepad-support.md
@@ -106,6 +106,32 @@ for (int i = 0; i < gamepads.Count; i++)
 
 <figure><img src="../../.gitbook/assets/09_10 56 13.png" alt=""><figcaption></figcaption></figure>
 
+## ScrollViewer Right-Stick Scrolling
+
+When a `ScrollViewer` (or a control built on it, such as `ItemsControl`, `ListBox`, or `Menu`) has top-level focus, tilting the right stick up or down scrolls the content vertically. The scroll speed is proportional to how far the stick is tilted and scales with elapsed time, so it feels the same regardless of frame rate. Horizontal scrolling from the stick is not yet supported.
+
+The following example creates a `ScrollViewer` with tall content and enables gamepad input:
+
+```csharp
+// Initialize
+var scrollViewer = new ScrollViewer();
+scrollViewer.Width = 200;
+scrollViewer.Height = 200;
+
+var tallContent = new ContainerRuntime();
+tallContent.Width = 0;
+tallContent.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+tallContent.Height = 1000;
+scrollViewer.AddChild(tallContent);
+scrollViewer.AddToRoot();
+
+FrameworkElement.GamePadsForUiControl.Clear();
+FrameworkElement.GamePadsForUiControl.AddRange(GumUI.Gamepads);
+scrollViewer.IsFocused = true;
+```
+
+Tilting the right stick up scrolls toward the top of the content; tilting it down scrolls toward the bottom. The default speed can be adjusted with `GamepadStickScrollSpeed`, which is measured in the same units as `VerticalScrollBarValue` per second at full stick deflection.
+
 ## ListBox Navigation
 
 When a `ListBox` is focused, press the A button to move focus into the items. Once the items have focus, pressing up or down on the D-pad (or tilting the left stick up or down) moves the highlighted selection through the list, and the `SelectionChanged` event fires each time the selected item changes. Pressing A again selects the highlighted item and returns focus to the top level; pressing B returns focus to the top level without selecting.


### PR DESCRIPTION
Closes #3839

## Summary
- Adds `IGamePad.RightStick` and `IAnalogStick.X`/`Y` (post-deadzone continuous position) to the platform-neutral gamepad abstraction — the concrete `GamePad`/`AnalogStick` already tracked this internally, it just wasn't exposed.
- `ScrollViewer.DoTopLevelFocusUpdate` now applies continuous vertical scroll from the right stick, scaled by elapsed time via a new `GamepadStickScrollSpeed` property. `ItemsControl`/`Menu` inherit it for free.
- `ListBox`'s separate `DoTopLevelFocusUpdate` copy calls the same shared `ApplyGamepadStickScroll` method instead of duplicating the stick-scroll code.
- Implemented for MonoGame/KNI/FNA and Raylib — both drivers already push `RightStick` position into the shared `GamePad` holder, so no driver changes were needed. Silk.NET has no gamepad driver at all yet (#3564), so the feature compiles there but stays inert until that's implemented — out of scope here.
- Horizontal (X) scroll from the stick is deferred per the issue.

## Test plan
- [x] New unit tests: `AnalogStick.X`/`Y`, `IGamePad.RightStick`, `ScrollViewer`/`ListBox` right-stick scroll behavior (frame-rate-independent, top-level-focus-gated)
- [x] `MonoGameGum.Tests` full suite green (1886 tests)
- [x] `RaylibGum.Tests` full suite green (519 tests)
- [x] `KniGum`, `SilkNetGum` build clean
- [x] FRB canary (`FlatRedBall.Forms.DesktopGlNet6`, net6.0 + net8.0): 0 errors
- Manual test: not needed — behavior is proven by the frame-stepped unit tests (fake gamepad + `InteractiveGue.CurrentGameTime`); no new visual/rendering path to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)