### PR TITLE
Route ETVM reparent/reorder + SortByName through ITreeNodeMutable

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -1360,13 +1360,13 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
         #region Sort everything
 
-        mScreensTreeNode.Nodes.SortByName(recursive:true);
+        ((ITreeNodeMutable)mScreensTreeNode).SortByName(recursive:true);
 
-        mComponentsTreeNode.Nodes.SortByName(recursive: true);
+        ((ITreeNodeMutable)mComponentsTreeNode).SortByName(recursive: true);
 
-        mStandardElementsTreeNode.Nodes.SortByName(recursive: true);
+        ((ITreeNodeMutable)mStandardElementsTreeNode).SortByName(recursive: true);
 
-        mBehaviorsTreeNode.Nodes.SortByName(recursive: true);
+        ((ITreeNodeMutable)mBehaviorsTreeNode).SortByName(recursive: true);
 
         #endregion
 
@@ -1920,11 +1920,11 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             {
                 if (parentNode != null)
                 {
-                    parentNode.Nodes.Remove(node);
+                    ((ITreeNodeMutable)node).RemoveSelf();
                 }
                 if(desiredNode != null)
                 {
-                    desiredNode.Nodes.Add(node);
+                    ((ITreeNodeMutable)desiredNode).AddChild((ITreeNodeMutable)node);
                 }
             }
         }
@@ -1948,7 +1948,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             if(hadTextBefore && node.Parent != null)
             {
-                node.Parent.Nodes.SortByName();
+                ((ITreeNodeMutable)node.Parent).SortByName();
             }
         }
 
@@ -1963,7 +1963,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
             if(instance == null || !allInstances.Contains(instance))
             {
-                instanceNode.Remove();
+                ((ITreeNodeMutable)instanceNode).RemoveSelf();
             }
         }
 
@@ -2018,22 +2018,17 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                     desiredParentNode = GetTreeNodeFor(instanceParent, node);
                 }
             }
-            if(desiredParentNode != nodeForInstance.Parent && desiredParentNode != null && 
+            if(desiredParentNode != nodeForInstance.Parent && desiredParentNode != null &&
                 // Just in case Gum gets into a weird circular reference situation.
                 // Gum should protect against this at a higher level, but in case it fails to we
                 // don't want to bring down the entire treeview so let's run a last minute check:
                 nodeForInstance != desiredParentNode)
             {
-                nodeForInstance.Remove();
-                desiredParentNode.Nodes.Add(nodeForInstance);
+                ((ITreeNodeMutable)nodeForInstance).RemoveSelf();
+                ((ITreeNodeMutable)desiredParentNode).AddChild((ITreeNodeMutable)nodeForInstance);
             }
 
-            var nodeParent = nodeForInstance.Parent;
-            if (desiredIndex != nodeParent.Nodes.IndexOf(nodeForInstance))
-            {
-                nodeParent.Nodes.Remove(nodeForInstance);
-                nodeParent.Nodes.Insert(desiredIndex, nodeForInstance);
-            }
+            ((ITreeNodeMutable)nodeForInstance).MoveToIndex(desiredIndex);
 
             var element = ObjectFinder.Self.GetElementSave(instance.BaseType);
 
@@ -2062,7 +2057,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             var instance = instanceNode.Tag as InstanceSave;
             if (instance == null || !allInstances.Contains(instance))
             {
-                instanceNode.Remove();
+                ((ITreeNodeMutable)instanceNode).RemoveSelf();
             }
         }
 
@@ -2083,11 +2078,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 nodeForInstance.ImageIndex = DerivedInstanceImageIndex;
             }
 
-            if (node.Nodes.IndexOf(nodeForInstance) != i)
-            {
-                node.Nodes.Remove(nodeForInstance);
-                node.Nodes.Insert(i, nodeForInstance);
-            }
+            ((ITreeNodeMutable)nodeForInstance).MoveToIndex(i);
         }
     }
 
@@ -2901,9 +2892,30 @@ public static class TreeNodeExtensionMethods
     }
 
     /// <summary>
-    /// Sorts the tree node collection alphabetically by name, with folders appearing before files.
+    /// Moves <paramref name="node"/> to <paramref name="desiredIndex"/> among its current parent's
+    /// children. No-op if it is already there, or if it currently has no parent.
     /// </summary>
-    /// <param name="treeNodeCollection">The collection of tree nodes to sort.</param>
+    /// <remarks>
+    /// Shared by ElementTreeViewManager's element/instance and behavior-instance reorder paths
+    /// (<c>RefreshElementTreeNode</c>/<c>RefreshBehaviorTreeNode</c>), which both reorder a node
+    /// within its already-correct parent after any reparenting has already happened.
+    /// </remarks>
+    public static void MoveToIndex(this ITreeNodeMutable node, int desiredIndex)
+    {
+        ITreeNodeMutable? parent = node.Parent;
+        if (parent == null || parent.IndexOfChild(node) == desiredIndex)
+        {
+            return;
+        }
+
+        parent.RemoveChild(node);
+        parent.InsertChild(desiredIndex, node);
+    }
+
+    /// <summary>
+    /// Sorts a node's direct children alphabetically by name, with folders appearing before files.
+    /// </summary>
+    /// <param name="parentNode">The node whose children should be sorted.</param>
     /// <param name="recursive">
     /// If true, recursively sorts all child node collections (except within Screen, Component, Standard, or Behavior element nodes).
     /// Default is false.
@@ -2914,41 +2926,41 @@ public static class TreeNodeExtensionMethods
     /// When recursive is true, the method will not sort children of element nodes (Screen, Component, Standard, Behavior)
     /// as these typically contain instances and states that should maintain their specific order.
     /// </remarks>
-    public static void SortByName(this TreeNodeCollection treeNodeCollection, bool recursive = false)
+    public static void SortByName(this ITreeNodeMutable parentNode, bool recursive = false)
     {
-        int lastObjectExclusive = treeNodeCollection.Count;
+        int lastObjectExclusive = parentNode.ChildCount;
         int whereObjectBelongs;
         for (int i = 0 + 1; i < lastObjectExclusive; i++)
         {
-            TreeNode first = treeNodeCollection[i];
-            TreeNode second = treeNodeCollection[i - 1];
+            ITreeNodeMutable first = parentNode.GetChildAt(i);
+            ITreeNodeMutable second = parentNode.GetChildAt(i - 1);
             if (FirstComesBeforeSecond(first, second))
             {
                 if (i == 1)
                 {
-                    TreeNode treeNode = treeNodeCollection[i];
-                    treeNodeCollection.RemoveAt(i);
+                    ITreeNodeMutable movingNode = parentNode.GetChildAt(i);
+                    parentNode.RemoveChildAt(i);
 
-                    treeNodeCollection.Insert(0, treeNode);
+                    parentNode.InsertChild(0, movingNode);
                     continue;
                 }
 
                 for (whereObjectBelongs = i - 2; whereObjectBelongs > -1; whereObjectBelongs--)
                 {
-                    second = treeNodeCollection[whereObjectBelongs];
-                    if (!FirstComesBeforeSecond(treeNodeCollection[i], second))
+                    second = parentNode.GetChildAt(whereObjectBelongs);
+                    if (!FirstComesBeforeSecond(parentNode.GetChildAt(i), second))
                     {
-                        TreeNode treeNode = treeNodeCollection[i];
+                        ITreeNodeMutable movingNode = parentNode.GetChildAt(i);
 
-                        treeNodeCollection.RemoveAt(i);
-                        treeNodeCollection.Insert(whereObjectBelongs + 1, treeNode);
+                        parentNode.RemoveChildAt(i);
+                        parentNode.InsertChild(whereObjectBelongs + 1, movingNode);
                         break;
                     }
-                    else if (whereObjectBelongs == 0 && FirstComesBeforeSecond(treeNodeCollection[i], treeNodeCollection[0]))
+                    else if (whereObjectBelongs == 0 && FirstComesBeforeSecond(parentNode.GetChildAt(i), parentNode.GetChildAt(0)))
                     {
-                        TreeNode treeNode = treeNodeCollection[i];
-                        treeNodeCollection.RemoveAt(i);
-                        treeNodeCollection.Insert(0, treeNode);
+                        ITreeNodeMutable movingNode = parentNode.GetChildAt(i);
+                        parentNode.RemoveChildAt(i);
+                        parentNode.InsertChild(0, movingNode);
                         break;
                     }
                 }
@@ -2957,26 +2969,24 @@ public static class TreeNodeExtensionMethods
 
         if(recursive)
         {
-            foreach(var node in treeNodeCollection)
+            for (int i = 0; i < parentNode.ChildCount; i++)
             {
-                var asTreeNode = node as TreeNode;
-                if(asTreeNode != null)
-                {
-                    var sortInner = asTreeNode.IsScreenTreeNode() == false &&
-                        asTreeNode.IsComponentTreeNode() == false &&
-                        asTreeNode.IsStandardElementTreeNode() == false &&
-                        asTreeNode.IsBehaviorTreeNode() == false;
+                ITreeNodeMutable childNode = parentNode.GetChildAt(i);
 
-                    if(sortInner)
-                    {
-                        asTreeNode.Nodes.SortByName(recursive);
-                    }
+                var sortInner = childNode.IsScreenTreeNode() == false &&
+                    childNode.IsComponentTreeNode() == false &&
+                    childNode.IsStandardElementTreeNode() == false &&
+                    childNode.IsBehaviorTreeNode() == false;
+
+                if(sortInner)
+                {
+                    childNode.SortByName(recursive);
                 }
             }
         }
     }
 
-    private static bool FirstComesBeforeSecond(TreeNode first, TreeNode second)
+    private static bool FirstComesBeforeSecond(ITreeNodeMutable first, ITreeNodeMutable second)
     {
         bool isFirstDirectory = first.IsComponentsFolderTreeNode() || first.IsScreensFolderTreeNode();
         bool isSecondDirectory = second.IsComponentsFolderTreeNode() || second.IsScreensFolderTreeNode();

--- a/Gum/Plugins/InternalPlugins/TreeView/GumTreeNode.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/GumTreeNode.cs
@@ -39,11 +39,18 @@ public class GumTreeNode : TreeNode, ITreeNodeMutable
 
     object? ITreeNode.Tag => Tag;
 
-    ITreeNode? ITreeNode.Parent => Parent switch
+    ITreeNode? ITreeNode.Parent => base.Parent switch
     {
         null => null,
         ITreeNode alreadyImplementsInterface => alreadyImplementsInterface,
         TreeNode plainNode => new TreeNodeWrapper(plainNode)
+    };
+
+    /// <inheritdoc/>
+    public new ITreeNodeMutable? Parent => base.Parent switch
+    {
+        null => null,
+        TreeNode winFormsParent => RequireMutableNode(winFormsParent)
     };
 
     /// <inheritdoc/>
@@ -80,6 +87,18 @@ public class GumTreeNode : TreeNode, ITreeNodeMutable
     /// <inheritdoc/>
     public void ClearChildren() => Nodes.Clear();
 
+    /// <inheritdoc/>
+    public void RemoveSelf() => Remove();
+
+    /// <inheritdoc/>
+    public int IndexOfChild(ITreeNodeMutable child) => Nodes.IndexOf(RequireWinFormsNode(child));
+
+    /// <inheritdoc/>
+    public int ChildCount => Nodes.Count;
+
+    /// <inheritdoc/>
+    public ITreeNodeMutable GetChildAt(int index) => RequireMutableNode(Nodes[index]);
+
     private static TreeNode RequireWinFormsNode(ITreeNodeMutable node)
     {
         if (node is TreeNode treeNode)
@@ -90,5 +109,16 @@ public class GumTreeNode : TreeNode, ITreeNodeMutable
         throw new ArgumentException(
             $"{nameof(node)} must be a WinForms {nameof(TreeNode)} (e.g. {nameof(GumTreeNode)}) to be added under a WinForms tree.",
             nameof(node));
+    }
+
+    private static ITreeNodeMutable RequireMutableNode(TreeNode node)
+    {
+        if (node is ITreeNodeMutable mutableNode)
+        {
+            return mutableNode;
+        }
+
+        throw new InvalidOperationException(
+            $"{node} must implement {nameof(ITreeNodeMutable)} (e.g. be a {nameof(GumTreeNode)}) to be used as one.");
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/GumTreeNodeTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/GumTreeNodeTests.cs
@@ -1,5 +1,6 @@
 using Gum.Managers;
 using Shouldly;
+using System;
 using System.Linq;
 using System.Windows.Forms;
 using Xunit;
@@ -153,5 +154,91 @@ public class GumTreeNodeTests
         children.ShouldHaveSingleItem();
         children[0].Text.ShouldBe("PlainChild");
         children[0].ShouldNotBeSameAs(plainChild);
+    }
+
+    [Fact]
+    public void ChildCount_ReturnsNumberOfDirectChildren()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        parent.AddChild("First");
+        parent.AddChild("Second");
+
+        ((ITreeNodeMutable)parent).ChildCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetChildAt_ReturnsChildAtIndex()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable first = parent.AddChild("First");
+        ITreeNodeMutable second = parent.AddChild("Second");
+
+        ((ITreeNodeMutable)parent).GetChildAt(0).ShouldBeSameAs(first);
+        ((ITreeNodeMutable)parent).GetChildAt(1).ShouldBeSameAs(second);
+    }
+
+    [Fact]
+    public void IndexOfChild_ReturnsPositionOfChild()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        parent.AddChild("First");
+        ITreeNodeMutable second = parent.AddChild("Second");
+
+        ((ITreeNodeMutable)parent).IndexOfChild(second).ShouldBe(1);
+    }
+
+    [Fact]
+    public void IndexOfChild_ChildNotPresent_ReturnsNegativeOne()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode notAChild = new GumTreeNode("NotAChild");
+
+        ((ITreeNodeMutable)parent).IndexOfChild(notAChild).ShouldBe(-1);
+    }
+
+    [Fact]
+    public void Parent_AsMutableInterface_ChildOfGumTreeNode_ReturnsSameParentInstance()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable child = parent.AddChild("Child");
+
+        child.Parent.ShouldBeSameAs(parent);
+    }
+
+    [Fact]
+    public void Parent_AsMutableInterface_RootNode_ReturnsNull()
+    {
+        GumTreeNode root = new GumTreeNode("Root");
+
+        ((ITreeNodeMutable)root).Parent.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Parent_AsMutableInterface_PlainWinFormsParent_Throws()
+    {
+        TreeNode plainParent = new TreeNode("Parent");
+        GumTreeNode child = new GumTreeNode("Child");
+        plainParent.Nodes.Add(child);
+
+        Should.Throw<InvalidOperationException>(() => _ = ((ITreeNodeMutable)child).Parent);
+    }
+
+    [Fact]
+    public void RemoveSelf_RemovesNodeFromParent()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable child = parent.AddChild("Child");
+
+        child.RemoveSelf();
+
+        parent.Nodes.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveSelf_NodeWithNoParent_DoesNotThrow()
+    {
+        GumTreeNode node = new GumTreeNode("Node");
+
+        Should.NotThrow(() => ((ITreeNodeMutable)node).RemoveSelf());
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodeMutationExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodeMutationExtensionsTests.cs
@@ -1,0 +1,153 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Managers;
+
+// Pins ElementTreeViewManager's ITreeNodeMutable-based reorder/sort helpers (MoveToIndex,
+// SortByName), which used to operate directly on WinForms TreeNodeCollection. These previously had
+// no test coverage at all - the algorithm itself is unchanged, only its indexing surface moved from
+// TreeNodeCollection to ITreeNodeMutable, so these tests pin the translated behavior via real
+// GumTreeNode trees (no ETVM construction required).
+public class TreeNodeMutationExtensionsTests
+{
+    [Fact]
+    public void MoveToIndex_NodeAlreadyAtIndex_LeavesOrderUnchanged()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable a = parent.AddChild("A");
+        ITreeNodeMutable b = parent.AddChild("B");
+
+        a.MoveToIndex(0);
+
+        parent.Nodes[0].ShouldBeSameAs(a);
+        parent.Nodes[1].ShouldBeSameAs(b);
+    }
+
+    [Fact]
+    public void MoveToIndex_NodeHasNoParent_DoesNotThrow()
+    {
+        GumTreeNode orphan = new GumTreeNode("Orphan");
+
+        Should.NotThrow(() => ((ITreeNodeMutable)orphan).MoveToIndex(0));
+    }
+
+    [Fact]
+    public void MoveToIndex_NodeOutOfPosition_MovesToDesiredIndex()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable a = parent.AddChild("A");
+        ITreeNodeMutable b = parent.AddChild("B");
+        ITreeNodeMutable c = parent.AddChild("C");
+
+        c.MoveToIndex(0);
+
+        parent.Nodes[0].ShouldBeSameAs(c);
+        parent.Nodes[1].ShouldBeSameAs(a);
+        parent.Nodes[2].ShouldBeSameAs(b);
+    }
+
+    [Fact]
+    public void SortByName_AlreadySorted_LeavesOrderUnchanged()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable alpha = parent.AddChild("Alpha");
+        ITreeNodeMutable bravo = parent.AddChild("Bravo");
+        ITreeNodeMutable charlie = parent.AddChild("Charlie");
+
+        ((ITreeNodeMutable)parent).SortByName();
+
+        parent.Nodes[0].ShouldBeSameAs(alpha);
+        parent.Nodes[1].ShouldBeSameAs(bravo);
+        parent.Nodes[2].ShouldBeSameAs(charlie);
+    }
+
+    [Fact]
+    public void SortByName_FoldersComeBeforeFilesRegardlessOfName()
+    {
+        GumTreeNode componentsRoot = new GumTreeNode("Components");
+        GumTreeNode subfolder = (GumTreeNode)componentsRoot.AddChild("ZFolder");
+        GumTreeNode fileNode = (GumTreeNode)componentsRoot.AddChild("AFile");
+        fileNode.Tag = new ComponentSave();
+
+        ((ITreeNodeMutable)componentsRoot).SortByName();
+
+        componentsRoot.Nodes[0].ShouldBeSameAs(subfolder);
+        componentsRoot.Nodes[1].ShouldBeSameAs(fileNode);
+    }
+
+    [Fact]
+    public void SortByName_LastNodeBelongsAtStart_MovesAllTheWayToFront()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable bravo = parent.AddChild("Bravo");
+        ITreeNodeMutable charlie = parent.AddChild("Charlie");
+        ITreeNodeMutable alpha = parent.AddChild("Alpha");
+
+        ((ITreeNodeMutable)parent).SortByName();
+
+        parent.Nodes[0].ShouldBeSameAs(alpha);
+        parent.Nodes[1].ShouldBeSameAs(bravo);
+        parent.Nodes[2].ShouldBeSameAs(charlie);
+    }
+
+    [Fact]
+    public void SortByName_LastNodeBelongsInMiddle_MovesToMiddle()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable alpha = parent.AddChild("Alpha");
+        ITreeNodeMutable bravo = parent.AddChild("Bravo");
+        ITreeNodeMutable delta = parent.AddChild("Delta");
+        ITreeNodeMutable charlie = parent.AddChild("Charlie");
+
+        ((ITreeNodeMutable)parent).SortByName();
+
+        parent.Nodes[0].ShouldBeSameAs(alpha);
+        parent.Nodes[1].ShouldBeSameAs(bravo);
+        parent.Nodes[2].ShouldBeSameAs(charlie);
+        parent.Nodes[3].ShouldBeSameAs(delta);
+    }
+
+    [Fact]
+    public void SortByName_Recursive_DoesNotSortChildrenOfElementNode()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode componentChild = (GumTreeNode)parent.AddChild("Comp");
+        componentChild.Tag = new ComponentSave();
+        componentChild.AddChild("Zed");
+        componentChild.AddChild("Alpha");
+
+        ((ITreeNodeMutable)parent).SortByName(recursive: true);
+
+        componentChild.Nodes[0].Text.ShouldBe("Zed");
+        componentChild.Nodes[1].Text.ShouldBe("Alpha");
+    }
+
+    [Fact]
+    public void SortByName_Recursive_SortsChildrenOfNonElementNodes()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode folderChild = (GumTreeNode)parent.AddChild("Folder");
+        folderChild.AddChild("Zed");
+        folderChild.AddChild("Alpha");
+
+        ((ITreeNodeMutable)parent).SortByName(recursive: true);
+
+        folderChild.Nodes[0].Text.ShouldBe("Alpha");
+        folderChild.Nodes[1].Text.ShouldBe("Zed");
+    }
+
+    [Fact]
+    public void SortByName_TwoNodesOutOfOrder_Swaps()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        ITreeNodeMutable bravo = parent.AddChild("Bravo");
+        ITreeNodeMutable alpha = parent.AddChild("Alpha");
+
+        ((ITreeNodeMutable)parent).SortByName();
+
+        parent.Nodes[0].ShouldBeSameAs(alpha);
+        parent.Nodes[1].ShouldBeSameAs(bravo);
+    }
+}

--- a/Tools/Gum.Presentation/Managers/ITreeNodeMutable.cs
+++ b/Tools/Gum.Presentation/Managers/ITreeNodeMutable.cs
@@ -17,6 +17,13 @@ namespace Gum.Managers;
 public interface ITreeNodeMutable : ITreeNode
 {
     /// <summary>
+    /// Hides <see cref="ITreeNode.Parent"/> with a mutable-typed return. A concrete implementation's
+    /// parent (when it has one) is always itself an <see cref="ITreeNodeMutable"/>, so exposing it as
+    /// one here costs nothing beyond what <see cref="ITreeNode.Parent"/> already computes.
+    /// </summary>
+    new ITreeNodeMutable? Parent { get; }
+
+    /// <summary>
     /// The node's icon index in whatever image list the concrete implementation is bound to.
     /// </summary>
     int ImageIndex { get; set; }
@@ -56,4 +63,26 @@ public interface ITreeNodeMutable : ITreeNode
     /// Removes all child nodes.
     /// </summary>
     void ClearChildren();
+
+    /// <summary>
+    /// Removes this node from its parent's children (or its owning tree's root nodes), if any.
+    /// No-op if the node currently has neither.
+    /// </summary>
+    void RemoveSelf();
+
+    /// <summary>
+    /// The index of <paramref name="child"/> among this node's children, or -1 if it is not a child
+    /// of this node.
+    /// </summary>
+    int IndexOfChild(ITreeNodeMutable child);
+
+    /// <summary>
+    /// The number of direct children.
+    /// </summary>
+    int ChildCount { get; }
+
+    /// <summary>
+    /// The direct child at the given index.
+    /// </summary>
+    ITreeNodeMutable GetChildAt(int index);
 }


### PR DESCRIPTION
## Summary

Converts ElementTreeViewManager's remaining mutation-path methods off raw `TreeNodeCollection` calls, onto `ITreeNodeMutable`.

**Design call: Option A (widen the interface).** The reparent/reorder logic in `RefreshElementTreeNode`/`RefreshBehaviorTreeNode` and `SortByName` needed indexed primitives `ITreeNodeMutable` didn't have. Widened it with:
- `new ITreeNodeMutable? Parent` (hides `ITreeNode.Parent` with a mutable-typed return)
- `void RemoveSelf()`
- `int IndexOfChild(ITreeNodeMutable child)`
- `int ChildCount`
- `ITreeNodeMutable GetChildAt(int index)`

All implemented directly on `GumTreeNode` — zero allocation, same pattern as the prior PR's `AddChild`/`InsertChild`/etc.

**What converted:**
- `RefreshElementTreeNode`'s element-reparent, instance-removal, instance-reparent, and instance-reorder blocks
- `RefreshBehaviorTreeNode`'s instance-removal and reorder blocks
- `SortByName`/`FirstComesBeforeSecond` (previously an extension on `TreeNodeCollection`, now on `ITreeNodeMutable`) — its predicates resolve to the already-existing headless `ITreeNode`-typed `Is*TreeNode`/`IsComponentsFolderTreeNode` overloads (`Tools/Gum.Presentation/Managers/TreeNodeElementExtensions.cs`/`TreeNodeFolderExtensions.cs`), so no cast-back to `TreeNode` was needed there
- Extracted a shared `MoveToIndex(ITreeNodeMutable, int)` helper for the two identical reorder call sites

**What stayed `TreeNode`-typed (deliberately):** `RefreshElementTreeNode`/`RefreshBehaviorTreeNode`/`RefreshUi(TreeNode)`'s own signatures, plus their search helpers (`GetTreeNodeFor`, `GetInstanceTreeNodeByName`) and expand-state calls (`.Expand()`, `.IsExpanded`). These are inherently mixed with WinForms-specific search/expand-state concerns the interface intentionally excludes (per the prior PR's own scoping) — converting the surrounding method signatures would only relocate casts, not reduce real coupling.

**Tests:** `SortByName`/`MoveToIndex` had zero existing coverage despite being a hot, order-sensitive algorithm. Added pinning tests against real `GumTreeNode` trees (no `ElementTreeViewManager` construction needed) covering ordering, folder-before-file precedence, the `i==1` and `whereObjectBelongs==0` special-case branches, and recursive skip-on-element-node behavior. Also added tests for the 5 new `GumTreeNodeTests` primitives.

Full suite: 1116 passed, 4 skipped (pre-existing skips), 0 failed.

Part of #3832.
