### PR TITLE
Add WpfInputHostAdapter: WPF-side IInputHostControl implementation

### DIFF
--- a/InputLibrary/InputLibrary.csproj
+++ b/InputLibrary/InputLibrary.csproj
@@ -6,6 +6,12 @@
 		<OutputType>Library</OutputType>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<UseWindowsForms>true</UseWindowsForms>
+		<!--
+			Added for WpfInputHostAdapter, the WPF-facing counterpart to ControlInputHostAdapter's
+			WinForms path (part of the WPF-native render surface work for #3833). Does not change how
+			any existing host adapter behaves.
+		-->
+		<UseWPF>true</UseWPF>
 		<ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
 		<LangVersion>12.0</LangVersion>
 

--- a/InputLibrary/WpfCursorKindConverter.cs
+++ b/InputLibrary/WpfCursorKindConverter.cs
@@ -1,0 +1,67 @@
+using System.Windows.Input;
+using WpfCursor = System.Windows.Input.Cursor;
+
+namespace InputLibrary
+{
+    /// <summary>
+    /// Converts between <see cref="CursorKind"/> (Gum's platform-neutral cursor-icon enum) and
+    /// <see cref="System.Windows.Input.Cursor"/>. The WPF counterpart to
+    /// <see cref="CursorKindConverter"/>; kept separate so only the WPF-backed pieces of InputLibrary
+    /// (<see cref="WpfInputHostAdapter"/>) need to know about the WPF cursor type.
+    /// </summary>
+    internal static class WpfCursorKindConverter
+    {
+        /// <summary>
+        /// Maps a WPF cursor to the closest <see cref="CursorKind"/>. Any cursor that isn't one of
+        /// the kinds Gum's editor sets (e.g. <see cref="Cursors.Wait"/>) falls back to
+        /// <see cref="CursorKind.Arrow"/>.
+        /// </summary>
+        public static CursorKind ToCursorKind(WpfCursor cursor)
+        {
+            if (cursor == Cursors.Cross)
+            {
+                return CursorKind.Cross;
+            }
+            if (cursor == Cursors.Hand)
+            {
+                return CursorKind.Hand;
+            }
+            if (cursor == Cursors.SizeAll)
+            {
+                return CursorKind.SizeAll;
+            }
+            if (cursor == Cursors.SizeNS)
+            {
+                return CursorKind.SizeNS;
+            }
+            if (cursor == Cursors.SizeWE)
+            {
+                return CursorKind.SizeWE;
+            }
+            if (cursor == Cursors.SizeNESW)
+            {
+                return CursorKind.SizeNESW;
+            }
+            if (cursor == Cursors.SizeNWSE)
+            {
+                return CursorKind.SizeNWSE;
+            }
+            return CursorKind.Arrow;
+        }
+
+        /// <summary>
+        /// Maps a <see cref="CursorKind"/> to the WPF cursor it represents.
+        /// </summary>
+        public static WpfCursor ToWpfCursor(CursorKind kind) => kind switch
+        {
+            CursorKind.Cross => Cursors.Cross,
+            CursorKind.Hand => Cursors.Hand,
+            CursorKind.SizeAll => Cursors.SizeAll,
+            CursorKind.SizeNS => Cursors.SizeNS,
+            CursorKind.SizeWE => Cursors.SizeWE,
+            CursorKind.SizeNESW => Cursors.SizeNESW,
+            CursorKind.SizeNWSE => Cursors.SizeNWSE,
+            _ => Cursors.Arrow,
+        };
+    }
+}

--- a/InputLibrary/WpfInputHostAdapter.cs
+++ b/InputLibrary/WpfInputHostAdapter.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Drawing;
+using WpfFrameworkElement = System.Windows.FrameworkElement;
+using WpfPoint = System.Windows.Point;
+
+namespace InputLibrary
+{
+    /// <summary>
+    /// Adapts a WPF <see cref="WpfFrameworkElement"/> to <see cref="IInputHostControl"/>, so
+    /// <see cref="Cursor"/> and <see cref="Keyboard"/> can be initialized against a WPF-native
+    /// rendering surface (e.g. a host built on <c>XnaAndWinforms.WpfRenderSurfaceHost</c>) instead of
+    /// a WinForms <see cref="System.Windows.Forms.Control"/>. The WPF counterpart to
+    /// <see cref="ControlInputHostAdapter"/>.
+    /// </summary>
+    public class WpfInputHostAdapter : IInputHostControl
+    {
+        private readonly WpfFrameworkElement _element;
+
+        public WpfInputHostAdapter(WpfFrameworkElement element)
+        {
+            if (element == null)
+            {
+                throw new ArgumentNullException(nameof(element));
+            }
+            _element = element;
+        }
+
+        // Requires _element to be connected to a live PresentationSource (i.e. hosted in a shown
+        // window) to reflect real keyboard focus - not unit-testable without spinning up a real WPF
+        // window, so this is exercised by the manual/runtime check instead.
+        public bool Focused => _element.IsFocused;
+
+        public int Width => (int)_element.ActualWidth;
+
+        public int Height => (int)_element.ActualHeight;
+
+        public CursorKind Cursor
+        {
+            get => WpfCursorKindConverter.ToCursorKind(_element.Cursor);
+            set => _element.Cursor = WpfCursorKindConverter.ToWpfCursor(value);
+        }
+
+        // Requires _element to be connected to a live PresentationSource - see the Focused remark
+        // above; same manual-check-only caveat applies here.
+        public Point PointToClient(Point point)
+        {
+            WpfPoint screenPoint = new WpfPoint(point.X, point.Y);
+            WpfPoint clientPoint = _element.PointFromScreen(screenPoint);
+            return new Point((int)clientPoint.X, (int)clientPoint.Y);
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Input/WpfInputHostAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/WpfInputHostAdapterTests.cs
@@ -1,0 +1,72 @@
+using InputLibrary;
+using Shouldly;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GumToolUnitTests.Input;
+
+public class WpfInputHostAdapterTests
+{
+    [StaFact]
+    public void Cursor_Get_ForwardsToWrappedElement()
+    {
+        Border element = new Border { Cursor = Cursors.Hand };
+        WpfInputHostAdapter adapter = new WpfInputHostAdapter(element);
+
+        adapter.Cursor.ShouldBe(CursorKind.Hand);
+    }
+
+    [StaFact]
+    public void Cursor_Get_UnmappedWpfCursorFallsBackToArrow()
+    {
+        Border element = new Border { Cursor = Cursors.Wait };
+        WpfInputHostAdapter adapter = new WpfInputHostAdapter(element);
+
+        adapter.Cursor.ShouldBe(CursorKind.Arrow);
+    }
+
+    [StaTheory]
+    [InlineData(CursorKind.Arrow)]
+    [InlineData(CursorKind.Cross)]
+    [InlineData(CursorKind.Hand)]
+    [InlineData(CursorKind.SizeAll)]
+    [InlineData(CursorKind.SizeNS)]
+    [InlineData(CursorKind.SizeWE)]
+    [InlineData(CursorKind.SizeNESW)]
+    [InlineData(CursorKind.SizeNWSE)]
+    public void Cursor_RoundTripsThroughWrappedElement(CursorKind cursorKind)
+    {
+        Border element = new Border();
+        WpfInputHostAdapter adapter = new WpfInputHostAdapter(element);
+
+        adapter.Cursor = cursorKind;
+
+        adapter.Cursor.ShouldBe(cursorKind);
+    }
+
+    [StaFact]
+    public void Cursor_Set_ForwardsToWrappedElement()
+    {
+        Border element = new Border();
+        WpfInputHostAdapter adapter = new WpfInputHostAdapter(element);
+
+        adapter.Cursor = CursorKind.Cross;
+
+        element.Cursor.ShouldBe(Cursors.Cross);
+    }
+
+    [StaFact]
+    public void WidthAndHeight_ForwardToWrappedElementAfterLayout()
+    {
+        Border element = new Border { Width = 320, Height = 240 };
+        // FrameworkElement.ActualWidth/ActualHeight are only populated after a measure+arrange
+        // pass. Both can run directly against an off-screen element - no live window is needed.
+        element.Measure(new Size(320, 240));
+        element.Arrange(new Rect(0, 0, 320, 240));
+        WpfInputHostAdapter adapter = new WpfInputHostAdapter(element);
+
+        adapter.Width.ShouldBe(320);
+        adapter.Height.ShouldBe(240);
+    }
+}


### PR DESCRIPTION
Part of #3833.

Adds `WpfInputHostAdapter`, the WPF-side `IInputHostControl` implementation (mirrors
`ControlInputHostAdapter`'s WinForms path) plus a `WpfCursorKindConverter` mapping `CursorKind` to
`System.Windows.Input.Cursor` (same 8-case shape as the existing `CursorKindConverter`). Unit
tested: cursor mapping (all 8 kinds, round-trip, unmapped-cursor fallback) and Width/Height via
explicit `Measure`/`Arrange` (no live window needed). `Focused`/`PointToClient` require a real
`PresentationSource` (a shown window) to behave correctly, so they're thin one-line forwards,
same shape as the WinForms adapter's already-proven equivalents, left for the manual/runtime check
once wired.

**Not wired into `WireframeControl` yet.** Investigating the actual swap found the wireframe
canvas's editing subsystem is far more WinForms-coupled than the rendering plumbing landed so far:
`CameraController`, `SelectionManager`, `Ruler`, `RectangleSelector`, `WireframeEditor`, and the 4
`InputHandlers` (Move/Resize/Rotation/PolygonPoint) all speak `System.Windows.Forms.MouseEventArgs`/
`KeyEventArgs` directly as their shared event currency, and `MainEditorTabPlugin` wires WinForms OLE
drag+drop (`AllowDrop`, `DragEventArgs`) straight onto the control for file/tree-node drops. Swapping
`WireframeControl`'s base class off `Control` needs that event-args surface neutralized first - a
separate, larger pass, not safe to bundle into this PR. Full plan posted on #3833.

Manual test: not needed - this adapter isn't wired into any live code path yet (pure additive,
unit-tested infra, same as the prior PRs in this effort).
