### PR TITLE
Neutralize CameraController's mouse/key event currency off WinForms

### DIFF
--- a/Gum/Input/MouseExtensions.cs
+++ b/Gum/Input/MouseExtensions.cs
@@ -1,0 +1,33 @@
+using WinForms = System.Windows.Forms;
+
+namespace Gum.Input;
+
+/// <summary>
+/// Translates WinForms mouse event types to Gum's framework-neutral <see cref="GumMouseEventArgs"/> at
+/// the editor-host boundary (e.g. <c>WireframeControl</c>), so the wireframe editing subsystem
+/// (camera panning/zoom, etc.) need not reference WinForms.
+/// </summary>
+public static class MouseExtensions
+{
+    /// <summary>Maps a WinForms <see cref="WinForms.MouseButtons"/> value to the matching <see cref="GumMouseButton"/>.</summary>
+    public static GumMouseButton ToGumMouseButton(this WinForms.MouseButtons buttons) =>
+        buttons switch
+        {
+            WinForms.MouseButtons.Left => GumMouseButton.Left,
+            WinForms.MouseButtons.Right => GumMouseButton.Right,
+            WinForms.MouseButtons.Middle => GumMouseButton.Middle,
+            _ => GumMouseButton.None,
+        };
+
+    /// <summary>Builds a framework-neutral <see cref="GumMouseEventArgs"/> from a WinForms mouse event.</summary>
+    public static GumMouseEventArgs ToGumMouseEventArgs(this WinForms.MouseEventArgs e)
+    {
+        return new GumMouseEventArgs
+        {
+            X = e.X,
+            Y = e.Y,
+            Button = e.Button.ToGumMouseButton(),
+            Delta = e.Delta,
+        };
+    }
+}

--- a/Gum/Managers/KeyCombinationExtensions.cs
+++ b/Gum/Managers/KeyCombinationExtensions.cs
@@ -25,6 +25,20 @@ public static class KeyCombinationExtensions
         return kc.Key == null || args.KeyCode == ToWinFormsKey(kc.Key.Value);
     }
 
+    /// <summary>
+    /// Matches against Gum's framework-neutral <see cref="GumKeyEventArgs"/>, for callers that have
+    /// already translated the framework key event at the editor-host boundary (e.g.
+    /// <c>CameraController.HandleKeyPress</c>).
+    /// </summary>
+    public static bool IsPressed(this KeyCombination kc, GumKeyEventArgs args)
+    {
+        if (kc.IsCtrlDown && !args.IsCtrlDown) return false;
+        if (kc.IsShiftDown && !args.IsShiftDown) return false;
+        if (kc.IsAltDown && !args.IsAltDown) return false;
+
+        return kc.Key == null || args.Key == kc.Key;
+    }
+
     public static bool IsPressed(this KeyCombination kc, System.Windows.Input.KeyEventArgs args)
     {
         if (kc.IsCtrlDown && (args.KeyboardDevice.Modifiers & System.Windows.Input.ModifierKeys.Control) != System.Windows.Input.ModifierKeys.Control) return false;

--- a/Tool/EditorTabPlugin_XNA/Services/CameraController.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/CameraController.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Windows.Forms;
+using Gum.Input;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Gum.Managers;
@@ -17,7 +17,8 @@ public class CameraController
 
     EditorViewModel _editorViewModel;
 
-    System.Drawing.Point mLastMouseLocation;
+    int _lastMouseX;
+    int _lastMouseY;
 
     public event Action? CameraChanged;
     IHotkeyManager _hotkeyManager;
@@ -33,7 +34,7 @@ public class CameraController
         Renderer.Self.Camera.Y = - 30;
     }
 
-    internal void HandleMouseWheel(object? sender, MouseEventArgs e)
+    internal void HandleMouseWheel(GumMouseEventArgs e)
     {
         float worldX, worldY;
         Camera.ScreenToWorld(e.X, e.Y, out worldX, out worldY);
@@ -59,27 +60,24 @@ public class CameraController
 
         CameraChanged?.Invoke();
 
-        var asHandleable = e as HandledMouseEventArgs;
-        if (asHandleable != null)
+        e.Handled = true;
+    }
+
+    internal void HandleMouseDown(GumMouseEventArgs e)
+    {
+        if (e.Button == GumMouseButton.Middle)
         {
-            asHandleable.Handled = true;
+            _lastMouseX = e.X;
+            _lastMouseY = e.Y;
         }
     }
 
-    internal void HandleMouseDown(object? sender, MouseEventArgs e)
+    internal void HandleMouseMove(GumMouseEventArgs e)
     {
-        if (e.Button == MouseButtons.Middle)
+        if (e.Button == GumMouseButton.Middle)
         {
-            mLastMouseLocation = e.Location;
-        }
-    }
-
-    internal void HandleMouseMove(object? sender, MouseEventArgs e)
-    {
-        if (e.Button == MouseButtons.Middle)
-        {
-            int xChange = e.X - mLastMouseLocation.X;
-            int yChange = e.Y - mLastMouseLocation.Y;
+            int xChange = e.X - _lastMouseX;
+            int yChange = e.Y - _lastMouseY;
 
             Renderer.Self.Camera.Position.X -= xChange / Renderer.Self.Camera.Zoom;
             Renderer.Self.Camera.Position.Y -= yChange / Renderer.Self.Camera.Zoom;
@@ -89,11 +87,12 @@ public class CameraController
                 CameraChanged?.Invoke();
             }
 
-            mLastMouseLocation = e.Location;
+            _lastMouseX = e.X;
+            _lastMouseY = e.Y;
         }
     }
 
-    internal void HandleKeyPress(KeyEventArgs e)
+    internal void HandleKeyPress(GumKeyEventArgs e)
     {
         if (_hotkeyManager.MoveCameraLeft.IsPressed(e))
         {

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -120,7 +120,26 @@ public class WireframeControl : GraphicsDeviceControl
         _hotkeyManager.HandleEditorKeyDown(keyArgs);
         e.Handled = keyArgs.Handled;
         e.SuppressKeyPress = keyArgs.SuppressKeyPress;
-        _cameraController.HandleKeyPress(e);
+        _cameraController.HandleKeyPress(keyArgs);
+    }
+
+    void HandleMouseDown(object? sender, MouseEventArgs e) =>
+        _cameraController.HandleMouseDown(e.ToGumMouseEventArgs());
+
+    void HandleMouseMove(object? sender, MouseEventArgs e) =>
+        _cameraController.HandleMouseMove(e.ToGumMouseEventArgs());
+
+    void HandleMouseWheel(object? sender, MouseEventArgs e)
+    {
+        var gumMouseArgs = e.ToGumMouseEventArgs();
+        _cameraController.HandleMouseWheel(gumMouseArgs);
+
+        // WinForms reports MouseWheel via a HandledMouseEventArgs; read the neutral Handled
+        // back to suppress the container's default scroll behavior, mirroring HandleKeyDown above.
+        if (gumMouseArgs.Handled && e is HandledMouseEventArgs handledArgs)
+        {
+            handledArgs.Handled = true;
+        }
     }
 
     private void HandleKeyUp(object? sender, KeyEventArgs e)
@@ -228,9 +247,9 @@ public class WireframeControl : GraphicsDeviceControl
 
             KeyDown += HandleKeyDown;
             KeyUp += HandleKeyUp;
-            MouseDown += _cameraController.HandleMouseDown;
-            MouseMove += _cameraController.HandleMouseMove;
-            MouseWheel += _cameraController.HandleMouseWheel;
+            MouseDown += HandleMouseDown;
+            MouseMove += HandleMouseMove;
+            MouseWheel += HandleMouseWheel;
 
             MouseEnter += (_, _) =>
             {

--- a/Tool/Tests/GumToolUnitTests/Input/MouseExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Input/MouseExtensionsTests.cs
@@ -1,0 +1,58 @@
+using Gum.Input;
+using Shouldly;
+using WinFormsMouseButtons = System.Windows.Forms.MouseButtons;
+using WinFormsMouseEventArgs = System.Windows.Forms.MouseEventArgs;
+
+namespace GumToolUnitTests.Input;
+
+public class MouseExtensionsTests : BaseTestClass
+{
+    [Fact]
+    public void ToGumMouseButton_Left_MapsToLeft()
+    {
+        WinFormsMouseButtons.Left.ToGumMouseButton().ShouldBe(GumMouseButton.Left);
+    }
+
+    [Fact]
+    public void ToGumMouseButton_Middle_MapsToMiddle()
+    {
+        WinFormsMouseButtons.Middle.ToGumMouseButton().ShouldBe(GumMouseButton.Middle);
+    }
+
+    [Fact]
+    public void ToGumMouseButton_None_MapsToNone()
+    {
+        WinFormsMouseButtons.None.ToGumMouseButton().ShouldBe(GumMouseButton.None);
+    }
+
+    [Fact]
+    public void ToGumMouseButton_Right_MapsToRight()
+    {
+        WinFormsMouseButtons.Right.ToGumMouseButton().ShouldBe(GumMouseButton.Right);
+    }
+
+    [Fact]
+    public void ToGumMouseEventArgs_ExtractsPositionButtonAndDelta()
+    {
+        var original = new WinFormsMouseEventArgs(WinFormsMouseButtons.Middle, clicks: 1, x: 42, y: 17, delta: -120);
+
+        GumMouseEventArgs neutral = original.ToGumMouseEventArgs();
+
+        neutral.X.ShouldBe(42);
+        neutral.Y.ShouldBe(17);
+        neutral.Button.ShouldBe(GumMouseButton.Middle);
+        neutral.Delta.ShouldBe(-120);
+    }
+
+    [Fact]
+    public void ToGumMouseEventArgs_DoesNotMarkHandled()
+    {
+        // Handled is written by the handler and read back at the boundary; the initial conversion
+        // must not pre-set it, or a handler that never touches it would look "handled" by default.
+        var original = new WinFormsMouseEventArgs(WinFormsMouseButtons.Left, clicks: 1, x: 0, y: 0, delta: 0);
+
+        GumMouseEventArgs neutral = original.ToGumMouseEventArgs();
+
+        neutral.Handled.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/KeyCombinationExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/KeyCombinationExtensionsTests.cs
@@ -1,0 +1,45 @@
+using Gum.Input;
+using Gum.Managers;
+using Shouldly;
+
+namespace GumToolUnitTests.Managers;
+
+public class KeyCombinationExtensionsTests : BaseTestClass
+{
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_KeyAndModifiersMatch_ReturnsTrue()
+    {
+        var combo = KeyCombination.Ctrl(GumKey.Z);
+        var args = new GumKeyEventArgs { Key = GumKey.Z, IsCtrlDown = true };
+
+        combo.IsPressed(args).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_KeyMatchesButRequiredModifierMissing_ReturnsFalse()
+    {
+        var combo = KeyCombination.Ctrl(GumKey.Z);
+        var args = new GumKeyEventArgs { Key = GumKey.Z, IsCtrlDown = false };
+
+        combo.IsPressed(args).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_ModifiersMatchButKeyDiffers_ReturnsFalse()
+    {
+        var combo = KeyCombination.Ctrl(GumKey.Z);
+        var args = new GumKeyEventArgs { Key = GumKey.Y, IsCtrlDown = true };
+
+        combo.IsPressed(args).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_NoKeyOnCombination_MatchesOnModifiersAlone()
+    {
+        // e.g. KeyCombination.Alt() with no key - used for "is Alt held" checks.
+        var combo = KeyCombination.Alt();
+        var args = new GumKeyEventArgs { Key = GumKey.Up, IsAltDown = true };
+
+        combo.IsPressed(args).ShouldBeTrue();
+    }
+}

--- a/Tools/Gum.Presentation/Input/GumMouseButton.cs
+++ b/Tools/Gum.Presentation/Input/GumMouseButton.cs
@@ -1,0 +1,13 @@
+namespace Gum.Input;
+
+/// <summary>
+/// Gum's framework-neutral mouse button identity, used by <see cref="GumMouseEventArgs"/> so mouse
+/// handling code (e.g. camera panning) does not need to reference WinForms or WPF button types.
+/// </summary>
+public enum GumMouseButton
+{
+    None,
+    Left,
+    Right,
+    Middle,
+}

--- a/Tools/Gum.Presentation/Input/GumMouseEventArgs.cs
+++ b/Tools/Gum.Presentation/Input/GumMouseEventArgs.cs
@@ -1,0 +1,33 @@
+namespace Gum.Input;
+
+/// <summary>
+/// Gum's framework-neutral mouse event payload, used as the shared currency between a host control
+/// (e.g. <c>WireframeControl</c>) and framework-agnostic mouse handling code (e.g. camera panning).
+/// </summary>
+/// <remarks>
+/// Mirrors the read/write shape of the framework mouse-event args it replaces: callers at the
+/// WinForms/WPF boundary populate position/button/wheel-delta on the way in, and read
+/// <see cref="Handled"/> back out to decide whether to suppress the framework's own default handling
+/// (e.g. WinForms' <c>HandledMouseEventArgs.Handled</c> on mouse wheel). Because it is consumed
+/// in/out, it is a reference type.
+/// </remarks>
+public class GumMouseEventArgs
+{
+    /// <summary>Cursor X position, in the host control's client coordinates.</summary>
+    public int X { get; set; }
+
+    /// <summary>Cursor Y position, in the host control's client coordinates.</summary>
+    public int Y { get; set; }
+
+    /// <summary>The button associated with this event, if any (e.g. the button held during a move/drag).</summary>
+    public GumMouseButton Button { get; set; }
+
+    /// <summary>Mouse wheel delta. Positive is away from the user (zoom in); negative is toward the user (zoom out).</summary>
+    public int Delta { get; set; }
+
+    /// <summary>
+    /// Set by the handler when it consumes the event; read back by the boundary caller to suppress the
+    /// framework's own default handling (e.g. container scroll on mouse wheel).
+    /// </summary>
+    public bool Handled { get; set; }
+}


### PR DESCRIPTION
## Summary

Part of #3833's step 1 (neutralize the mouse/key event currency). Investigating the 11 files named in the issue found the coupling is much narrower than the issue text suggested: only `CameraController` actually takes `System.Windows.Forms.MouseEventArgs`/`KeyEventArgs` as parameters. `SelectionManager`, `Ruler`, `RectangleSelector`, `WireframeEditor`, and the 4 `InputHandlers` already consume mouse state exclusively via the polled `InputLibrary.Cursor.Self` abstraction and `IHotkeyManager.IsPressedInControl(KeyCombination)` — none of them reference `MouseEventArgs`/`KeyEventArgs`. (They do return `System.Windows.Forms.Cursor` cursor-image values from `GetCursorToShow`, but that's the separately-scoped, already-noted-out-of-scope cursor-image widening, not event-arg currency.)

- Added `GumMouseEventArgs`/`GumMouseButton` (`Tools/Gum.Presentation/Input/`), mirroring the existing `GumKeyEventArgs` design.
- Added `MouseExtensions.ToGumMouseEventArgs`/`ToGumMouseButton` (`Gum/Input/`), mirroring `KeysExtensions`.
- Added `KeyCombination.IsPressed(GumKeyEventArgs)` overload alongside the existing WinForms/WPF ones.
- Converted `CameraController.HandleMouseWheel/HandleMouseDown/HandleMouseMove/HandleKeyPress` to the neutral types; it no longer references `System.Windows.Forms`.
- `WireframeControl` now translates WinForms mouse/key events to the neutral type at its own boundary before calling `CameraController` (mirroring the existing `GumKeyEventArgs` translation already done for `HandleKeyDown`).

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] New tests (`MouseExtensionsTests`, `KeyCombinationExtensionsTests`) pass
- [x] Full `GumToolUnitTests` suite green (1149 passed, 4 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
