### PR TITLE
Add framework-neutral wireframe drop payload + WPF reader (#3833)

### DIFF
--- a/Gum/Managers/WireframeDropAction.cs
+++ b/Gum/Managers/WireframeDropAction.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// The action a wireframe drop should perform, resolved from a <see cref="WireframeDropPayload"/>
+/// by <see cref="WireframeDropPayload.ResolveAction"/>. Each variant carries exactly the data its
+/// handler needs — mirrors the <see cref="Gum.Plugins.InternalPlugins.TreeView.DropPosition"/>
+/// pattern used elsewhere for drag-and-drop.
+/// </summary>
+public abstract record WireframeDropAction
+{
+    private WireframeDropAction() { }
+
+    /// <summary>No recognized payload was present in the drag data; nothing should happen.</summary>
+    public sealed record None : WireframeDropAction;
+
+    /// <summary>
+    /// A Standards-palette chip was dropped; create an instance of the named standard type at the
+    /// drop position.
+    /// </summary>
+    public sealed record StandardChip(string StandardElementTypeName) : WireframeDropAction;
+
+    /// <summary>
+    /// One or more tree nodes were dropped; create/reparent an instance for each dragged node's
+    /// <c>Tag</c>.
+    /// </summary>
+    public sealed record Nodes(IReadOnlyList<object> Tags) : WireframeDropAction;
+
+    /// <summary>One or more files were dropped; import/create instances from the dropped files.</summary>
+    public sealed record FileDrop(string[] Files) : WireframeDropAction;
+}

--- a/Gum/Managers/WireframeDropPayload.cs
+++ b/Gum/Managers/WireframeDropPayload.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// The framework-neutral contents of a drag payload dropped onto (or dragged over) the wireframe
+/// canvas. Extracted from a native drag-and-drop data object by a framework-specific reader — see
+/// <see cref="WpfWireframeDropPayloadReader"/> for the WPF side. Mirrors the three drop kinds the
+/// WinForms wireframe glue in <c>MainEditorTabPlugin</c> recognizes: a Standards-palette chip, one
+/// or more dragged tree nodes (by their <c>Tag</c>), or dropped files.
+/// </summary>
+public sealed record WireframeDropPayload(
+    string? StandardElementTypeName,
+    IReadOnlyList<object>? NodeTags,
+    string[]? Files)
+{
+    /// <summary>True when the payload is a Standards-palette chip drag.</summary>
+    public bool HasStandardChip => StandardElementTypeName != null;
+
+    /// <summary>True when the payload carries one or more dragged tree nodes.</summary>
+    public bool HasNodes => NodeTags is { Count: > 0 };
+
+    /// <summary>True when the payload carries one or more dropped files.</summary>
+    public bool HasFileDrop => Files is { Length: > 0 };
+
+    /// <summary>
+    /// Resolves which of the payload's drop kinds should be acted on, in the same precedence the
+    /// WinForms wireframe glue applies (<c>MainEditorTabPlugin.OnWireframeDrop</c>): a
+    /// Standards-palette chip wins, then dragged tree nodes, then a file drop.
+    /// </summary>
+    public WireframeDropAction ResolveAction()
+    {
+        if (HasStandardChip)
+        {
+            return new WireframeDropAction.StandardChip(StandardElementTypeName!);
+        }
+        if (HasNodes)
+        {
+            return new WireframeDropAction.Nodes(NodeTags!);
+        }
+        if (HasFileDrop)
+        {
+            return new WireframeDropAction.FileDrop(Files!);
+        }
+        return new WireframeDropAction.None();
+    }
+}

--- a/Gum/Managers/WpfWireframeDropPayloadReader.cs
+++ b/Gum/Managers/WpfWireframeDropPayloadReader.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using WinFormsTreeNode = System.Windows.Forms.TreeNode;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Reads a WPF drag payload (<see cref="IDataObject"/>) into a framework-neutral
+/// <see cref="WireframeDropPayload"/>. The WPF counterpart to the WinForms extraction that lives
+/// inline in <c>MainEditorTabPlugin.OnWireframeDragEnter</c>/<c>OnWireframeDrop</c> (which uses
+/// <c>DragEventArgsExt.GetData</c>/<c>HasData</c> against
+/// <see cref="System.Windows.Forms.DataFormats.FileDrop"/> and
+/// <see cref="DragDropManager.StandardElementNameDataFormat"/>).
+///
+/// Not yet wired to a live control — <c>WireframeControl</c> is still a
+/// <see cref="System.Windows.Forms.Control"/> (issue #3833). This exists so a future WPF-native
+/// <c>WireframeControl</c>, or any other WPF element that needs the same drop payloads, can wire
+/// <c>AllowDrop</c>/<c>DragEnter</c>/<c>DragOver</c>/<c>Drop</c> to it directly. Tree-node drops
+/// still carry WinForms <see cref="WinFormsTreeNode"/> objects because the element tree view itself
+/// hasn't moved to WPF yet — this reader's node extraction will need to move with it when it does.
+/// </summary>
+public static class WpfWireframeDropPayloadReader
+{
+    /// <summary>Extracts the framework-neutral drop payload from a WPF drag data object.</summary>
+    public static WireframeDropPayload Read(IDataObject? data)
+    {
+        if (data == null)
+        {
+            return new WireframeDropPayload(null, null, null);
+        }
+
+        string? standardElementTypeName =
+            data.GetDataPresent(DragDropManager.StandardElementNameDataFormat)
+                ? data.GetData(DragDropManager.StandardElementNameDataFormat) as string
+                : null;
+
+        List<object>? nodeTags = ReadNodeTags(data);
+
+        string[]? files = data.GetDataPresent(DataFormats.FileDrop)
+            ? data.GetData(DataFormats.FileDrop) as string[]
+            : null;
+
+        return new WireframeDropPayload(standardElementTypeName, nodeTags, files);
+    }
+
+    // Deliberately does not use GetDataPresent(typeof(WinFormsTreeNode[]))/GetDataPresent(typeof(WinFormsTreeNode)):
+    // the drag source (MultiSelectTreeView.Theming's native reorder path, which starts the OLE drag
+    // this WPF drop target ultimately receives) wraps the payload with no explicit format, so the
+    // underlying OLE data object keys it by the payload's *runtime* type full name. A TreeNode
+    // subclass (GumTreeNode, which is what the element tree view actually constructs) is then stored
+    // under its own type name, so an exact typeof(TreeNode) lookup misses every dragged node - the
+    // same failure mode MultiSelectTreeView.ExtractDraggedNodes fixes for the tree's own internal
+    // reorder drop. Scanning the actual formats present and pattern-matching on TreeNode[]/TreeNode is
+    // robust to any subclass. Note the multi-select shape is an array (SelectedNodes.ToArray(), i.e.
+    // WinFormsTreeNode[]), not a List<WinFormsTreeNode> - matching MultiSelectTreeView.Theming's
+    // actual DoDragDrop payload, not the container type the data started in.
+    private static List<object>? ReadNodeTags(IDataObject data)
+    {
+        foreach (string format in data.GetFormats())
+        {
+            if (data.GetData(format) is WinFormsTreeNode[] nodes)
+            {
+                return nodes.Select(node => node.Tag).ToList();
+            }
+            if (data.GetData(format) is WinFormsTreeNode singleNode)
+            {
+                return new List<object> { singleNode.Tag };
+            }
+        }
+
+        return null;
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/WireframeDropPayloadTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/WireframeDropPayloadTests.cs
@@ -1,0 +1,57 @@
+using Gum.Managers;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GumToolUnitTests.Managers;
+
+public class WireframeDropPayloadTests
+{
+    [Fact]
+    public void ResolveAction_ChipAndNodesAndFilesPresent_ChipWins()
+    {
+        WireframeDropPayload payload = new WireframeDropPayload(
+            "Button",
+            new List<object> { "NodeTag" },
+            new[] { "C:\\file.png" });
+
+        WireframeDropAction action = payload.ResolveAction();
+
+        action.ShouldBeOfType<WireframeDropAction.StandardChip>()
+            .StandardElementTypeName.ShouldBe("Button");
+    }
+
+    [Fact]
+    public void ResolveAction_FilesOnly_ReturnsFileDrop()
+    {
+        string[] files = { "C:\\file.png" };
+        WireframeDropPayload payload = new WireframeDropPayload(null, null, files);
+
+        WireframeDropAction action = payload.ResolveAction();
+
+        action.ShouldBeOfType<WireframeDropAction.FileDrop>()
+            .Files.ShouldBe(files);
+    }
+
+    [Fact]
+    public void ResolveAction_NoData_ReturnsNone()
+    {
+        WireframeDropPayload payload = new WireframeDropPayload(null, null, null);
+
+        WireframeDropAction action = payload.ResolveAction();
+
+        action.ShouldBeOfType<WireframeDropAction.None>();
+    }
+
+    [Fact]
+    public void ResolveAction_NodesAndFilesPresent_NodesWinOverFiles()
+    {
+        List<object> tags = new List<object> { "NodeTag" };
+        WireframeDropPayload payload = new WireframeDropPayload(null, tags, new[] { "C:\\file.png" });
+
+        WireframeDropAction action = payload.ResolveAction();
+
+        action.ShouldBeOfType<WireframeDropAction.Nodes>()
+            .Tags.ShouldBe(tags);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/WpfWireframeDropPayloadReaderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/WpfWireframeDropPayloadReaderTests.cs
@@ -1,0 +1,90 @@
+using Gum.Managers;
+using Shouldly;
+using System.Windows;
+using WinFormsTreeNode = System.Windows.Forms.TreeNode;
+
+namespace GumToolUnitTests.Managers;
+
+// Regression coverage for the same bug MultiSelectTreeViewExtractDraggedNodesTests pins: WinForms
+// (and the WPF DataObject that receives the same OLE payload across the WindowsFormsHost boundary)
+// keys stored data by the payload's *runtime* type full name, not its static/base type. A dragged
+// node is always a GumTreeNode (ElementTreeViewManager never constructs a plain TreeNode) and a
+// multi-select drag boxes a WinFormsTreeNode[] array (MultiSelectTreeView.Theming's
+// SelectedNodes.ToArray()), not a List<WinFormsTreeNode> - an exact-type format lookup for either
+// the wrong container type or the base TreeNode type would silently drop every dragged node.
+public class WpfWireframeDropPayloadReaderTests
+{
+    [StaFact]
+    public void Read_FileDropFormatPresent_SetsFiles()
+    {
+        string[] files = { "C:\\texture.png" };
+        DataObject data = new DataObject(DataFormats.FileDrop, files);
+
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(data);
+
+        payload.Files.ShouldBe(files);
+        payload.StandardElementTypeName.ShouldBeNull();
+        payload.NodeTags.ShouldBeNull();
+    }
+
+    [StaFact]
+    public void Read_NoRecognizedFormats_ReturnsEmptyPayload()
+    {
+        DataObject data = new DataObject("SomeUnrelatedFormat", "value");
+
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(data);
+
+        payload.StandardElementTypeName.ShouldBeNull();
+        payload.NodeTags.ShouldBeNull();
+        payload.Files.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Read_NullData_ReturnsEmptyPayload()
+    {
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(null);
+
+        payload.StandardElementTypeName.ShouldBeNull();
+        payload.NodeTags.ShouldBeNull();
+        payload.Files.ShouldBeNull();
+    }
+
+    [StaFact]
+    public void Read_SingleGumTreeNodeBoxedAsPlainObject_ReturnsItsTagInNodeTags()
+    {
+        GumTreeNode draggedNode = new GumTreeNode("Circle1") { Tag = "InstanceCircle1" };
+        // Mirrors MultiSelectTreeView.Theming.cs's single-node drag start: DoDragDrop((object)nodeToDrag, ...).
+        DataObject data = new DataObject((object)draggedNode);
+
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(data);
+
+        payload.NodeTags.ShouldHaveSingleItem();
+        payload.NodeTags![0].ShouldBe("InstanceCircle1");
+    }
+
+    [StaFact]
+    public void Read_StandardChipFormatPresent_SetsStandardElementTypeName()
+    {
+        DataObject data = new DataObject(DragDropManager.StandardElementNameDataFormat, "Button");
+
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(data);
+
+        payload.StandardElementTypeName.ShouldBe("Button");
+        payload.NodeTags.ShouldBeNull();
+        payload.Files.ShouldBeNull();
+    }
+
+    [StaFact]
+    public void Read_TreeNodeArrayBoxed_ReturnsEachNodesTagInOrder()
+    {
+        GumTreeNode first = new GumTreeNode("Circle1") { Tag = "InstanceCircle1" };
+        GumTreeNode second = new GumTreeNode("Circle2") { Tag = "InstanceCircle2" };
+        // Mirrors MultiSelectTreeView.Theming.cs's multi-select drag start: DoDragDrop(SelectedNodes.ToArray(), ...).
+        WinFormsTreeNode[] dragged = { first, second };
+        DataObject data = new DataObject((object)dragged);
+
+        WireframeDropPayload payload = WpfWireframeDropPayloadReader.Read(data);
+
+        payload.NodeTags.ShouldBe(new object[] { "InstanceCircle1", "InstanceCircle2" });
+    }
+}


### PR DESCRIPTION
Part of #3833.

Adds a framework-neutral wireframe drop-payload abstraction and its WPF-side reader — the WPF counterpart to the WinForms drag+drop handling currently inline in `MainEditorTabPlugin.OnWireframeDragEnter`/`OnWireframeDrop`.

- `WireframeDropPayload` / `WireframeDropAction` — the drop-kind precedence (Standards-palette chip > dragged tree nodes > file drop > none), independent of WinForms or WPF.
- `WpfWireframeDropPayloadReader.Read(IDataObject)` — extracts that payload from a WPF drag data object.

**Additive infra only** — not wired into `WireframeControl` (still WinForms), same posture as the already-merged `WpfInputHostAdapter`/`WpfCursorKindConverter` (#3842).

**Fix vs. the version left by the interrupted prior run:** `ReadNodeTags` did an exact-type `DataObject` format lookup (`typeof(List<TreeNode>)`/`typeof(TreeNode)`). WinForms/WPF's shared OLE data object keys a boxed payload by its *runtime* type's full name, so a `TreeNode` subclass (`GumTreeNode`, which is what the element tree view actually constructs) or an array (`TreeNode[]`, the actual multi-select drag shape from `MultiSelectTreeView.Theming`'s `SelectedNodes.ToArray()`) would silently miss that check — the identical failure mode `MultiSelectTreeView.ExtractDraggedNodes` already fixes for the tree's own internal reorder drop. Reworked to scan `GetFormats()` and pattern-match `TreeNode[]`/`TreeNode` instead.

## Tests

- `WireframeDropPayloadTests` — `ResolveAction()` precedence (chip wins over nodes+files, nodes win over files, files-only, none).
- `WpfWireframeDropPayloadReaderTests` — `Read()` extraction for chip/file-drop/null/no-format cases, plus the regression cases: a single `GumTreeNode` boxed as `object`, and a `TreeNode[]` array of `GumTreeNode`s.

Full `GumToolUnitTests` suite green (1149 passed, 4 pre-existing skips, 0 failures).
