### PR TITLE
Route ETVM's add/remove diff-refresh + folder sync through ITreeNodeMutable

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -1037,10 +1037,12 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
 
             // add folders to the screens, entities, and standard elements
-            AddAndRemoveFolderNodesFromFileSystem(mStandardElementsTreeNode.GetFullFilePath()!.FullPath, mStandardElementsTreeNode.Nodes);
-            AddAndRemoveFolderNodesFromFileSystem(mScreensTreeNode.GetFullFilePath()!.FullPath, mScreensTreeNode.Nodes);
-            AddAndRemoveFolderNodesFromFileSystem(mComponentsTreeNode.GetFullFilePath()!.FullPath, mComponentsTreeNode.Nodes);
-            AddAndRemoveFolderNodesFromFileSystem(mBehaviorsTreeNode.GetFullFilePath()!.FullPath, mBehaviorsTreeNode.Nodes);
+            // Every node ETVM constructs is a GumTreeNode, which implements ITreeNodeMutable
+            // directly, so these are free reference casts (not wraps).
+            AddAndRemoveFolderNodesFromFileSystem(mStandardElementsTreeNode.GetFullFilePath()!.FullPath, (ITreeNodeMutable)mStandardElementsTreeNode);
+            AddAndRemoveFolderNodesFromFileSystem(mScreensTreeNode.GetFullFilePath()!.FullPath, (ITreeNodeMutable)mScreensTreeNode);
+            AddAndRemoveFolderNodesFromFileSystem(mComponentsTreeNode.GetFullFilePath()!.FullPath, (ITreeNodeMutable)mComponentsTreeNode);
+            AddAndRemoveFolderNodesFromFileSystem(mBehaviorsTreeNode.GetFullFilePath()!.FullPath, (ITreeNodeMutable)mBehaviorsTreeNode);
 
 
             AddNeededButMissingFromFileSystemFolderNodes();
@@ -1110,7 +1112,9 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                     treeNodeText = treeNodeText.Substring(0, treeNodeText.Length - 1);
                 }
                 treeNode = new GumTreeNode(treeNodeText);
-                parentNode.Nodes.Add(treeNode);
+                // parentNode is always a GumTreeNode (implements ITreeNodeMutable directly), same
+                // as every other node ETVM constructs, so this is a free reference cast.
+                ((ITreeNodeMutable)parentNode).AddChild((ITreeNodeMutable)treeNode);
                 treeNode.ImageIndex = ExclamationIndex;
             }
         }
@@ -1118,27 +1122,31 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
         return treeNode!;
     }
 
-    private void AddAndRemoveFolderNodesFromFileSystem(string currentDirectory, TreeNodeCollection nodesToAddTo)
+    // nodesToAddTo is ITreeNodeMutable rather than TreeNodeCollection so this method's own
+    // add/remove decisions are expressed through the mutation interface. GetTreeNodeFor (the
+    // directory-path search) stays TreeNode-typed by design (see gum-tool-tree-view skill) - its
+    // result is cast at the point of use, same pattern as the rest of ETVM's node construction.
+    private void AddAndRemoveFolderNodesFromFileSystem(string currentDirectory, ITreeNodeMutable nodesToAddTo)
     {
         // todo: removes
         var directories = Directory.EnumerateDirectories(currentDirectory).ToArray();
 
         foreach (string directory in directories)
         {
-            TreeNode existingTreeNode = GetTreeNodeFor(directory);
+            ITreeNodeMutable existingTreeNode = (ITreeNodeMutable)GetTreeNodeFor(directory);
 
             if (existingTreeNode == null)
             {
                 existingTreeNode = new GumTreeNode(FileManager.RemovePath(directory));
-                nodesToAddTo.Add(existingTreeNode);
+                nodesToAddTo.AddChild(existingTreeNode);
                 existingTreeNode.ImageIndex = FolderImageIndex;
             }
-            AddAndRemoveFolderNodesFromFileSystem(directory, existingTreeNode.Nodes);
+            AddAndRemoveFolderNodesFromFileSystem(directory, existingTreeNode);
         }
 
-        for(int i = nodesToAddTo.Count - 1; i > -1; i--)
+        for(int i = nodesToAddTo.ChildCount - 1; i > -1; i--)
         {
-            TreeNode node = nodesToAddTo[i];
+            ITreeNodeMutable node = nodesToAddTo.GetChildAt(i);
 
             bool found = false;
 
@@ -1156,8 +1164,8 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             // only remove nodes if they are directory nodes (aka they have a null tag)
             if (!found && node.Tag == null)
             {
-                nodesToAddTo.RemoveAt(i);
-            }               
+                nodesToAddTo.RemoveChildAt(i);
+            }
         }
     }
 
@@ -1243,81 +1251,39 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
         #region Remove nodes that are no longer needed
 
-        void RemoveScreenRecursively(TreeNode treeNode, int i, TreeNode container)
-        {
-            ScreenSave? screen = treeNode.Tag as ScreenSave;
+        // Every node ETVM constructs is a GumTreeNode, which implements ITreeNodeMutable directly,
+        // so these are free reference casts (not wraps).
+        ((ITreeNodeMutable)mScreensTreeNode).RemoveRecursivelyIfStale<ScreenSave>(
+            screen => gumProject.Screens.Contains(screen) && ShouldShow(screen));
 
-            // If the screen is null, that means that it's a folder TreeNode, so we don't want to remove it
-            if (screen != null)
-            {
-                if (!gumProject.Screens.Contains(screen) || !ShouldShow(screen))
-                {
-                    container.Nodes.RemoveAt(i);
-                }
-            }
-            else if(treeNode.Nodes != null)
-            {
-                for(int subI = treeNode.Nodes.Count - 1; subI > -1; subI--)
-                {
-                    var subnode = treeNode.Nodes[subI];
-                    RemoveScreenRecursively(subnode, subI, treeNode);
-                }
-            }
-        }
+        ((ITreeNodeMutable)mComponentsTreeNode).RemoveRecursivelyIfStale<ComponentSave>(
+            component => gumProject.Components.Contains(component) && ShouldShow(component));
 
-        for (int i = mScreensTreeNode.Nodes.Count - 1; i > -1; i--)
-        {
-            RemoveScreenRecursively(mScreensTreeNode.Nodes[i] as TreeNode, i, mScreensTreeNode);
-        }
-
-        void RemoveComponentRecursively(TreeNode treeNode, int i, TreeNode container)
-        {
-            ComponentSave? component = treeNode.Tag as ComponentSave;
-
-            // If the component is null, that means that it's a folder TreeNode, so we don't want to remove it
-            if (component != null)
-            {
-                if (!gumProject.Components.Contains(component) || !ShouldShow(component))
-                {
-                    container.Nodes.RemoveAt(i);
-                }
-            }
-            else if (treeNode.Nodes != null)
-            {
-                for (int subI = treeNode.Nodes.Count - 1; subI > -1; subI--)
-                {
-                    var subnode = treeNode.Nodes[subI];
-                    RemoveComponentRecursively(subnode, subI, treeNode);
-                }
-            }
-        }
-
-        for (int i = mComponentsTreeNode.Nodes.Count - 1; i > -1; i--)
-        {
-            RemoveComponentRecursively(mComponentsTreeNode.Nodes[i], i, mComponentsTreeNode);
-        }
-
-        for (int i = mStandardElementsTreeNode.Nodes.Count - 1; i > -1; i-- )
+        // Standard elements don't support subfolders, so this pass is flat (non-recursive) and,
+        // unlike the screen/component pass above, removes any non-StandardElementSave-tagged node
+        // outright rather than recursing into it.
+        ITreeNodeMutable mutableStandardElementsNode = (ITreeNodeMutable)mStandardElementsTreeNode;
+        for (int i = mutableStandardElementsNode.ChildCount - 1; i > -1; i--)
         {
             // Do we want to support folders here?
-            StandardElementSave? standardElement = mStandardElementsTreeNode.Nodes[i].Tag as StandardElementSave;
+            StandardElementSave? standardElement = mutableStandardElementsNode.GetChildAt(i).Tag as StandardElementSave;
 
             if (standardElement == null || !gumProject.StandardElements.Contains(standardElement) || !ShouldShow(standardElement))
             {
-                mStandardElementsTreeNode.Nodes.RemoveAt(i);
+                mutableStandardElementsNode.RemoveChildAt(i);
             }
         }
 
-        for(int i = mBehaviorsTreeNode.Nodes.Count - 1; i > -1; i--)
+        // Also flat (non-recursive): unlike standard elements above, a non-BehaviorSave-tagged node
+        // (a behavior subfolder) is left alone rather than removed.
+        ITreeNodeMutable mutableBehaviorsNode = (ITreeNodeMutable)mBehaviorsTreeNode;
+        for (int i = mutableBehaviorsNode.ChildCount - 1; i > -1; i--)
         {
-            BehaviorSave? behavior = mBehaviorsTreeNode.Nodes[i].Tag as BehaviorSave;
+            BehaviorSave? behavior = mutableBehaviorsNode.GetChildAt(i).Tag as BehaviorSave;
 
-            if(behavior != null)
+            if (behavior != null && (!gumProject.Behaviors.Contains(behavior) || !ShouldShow(behavior)))
             {
-                if(behavior == null || !gumProject.Behaviors.Contains(behavior) || !ShouldShow(behavior))
-                {
-                    mBehaviorsTreeNode.Nodes.RemoveAt(i);
-                }
+                mutableBehaviorsNode.RemoveChildAt(i);
             }
         }
 

--- a/Tool/Tests/GumToolUnitTests/Managers/TreeNodeMutationExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/TreeNodeMutationExtensionsTests.cs
@@ -5,11 +5,11 @@ using Xunit;
 
 namespace GumToolUnitTests.Managers;
 
-// Pins ElementTreeViewManager's ITreeNodeMutable-based reorder/sort helpers (MoveToIndex,
-// SortByName), which used to operate directly on WinForms TreeNodeCollection. These previously had
-// no test coverage at all - the algorithm itself is unchanged, only its indexing surface moved from
-// TreeNodeCollection to ITreeNodeMutable, so these tests pin the translated behavior via real
-// GumTreeNode trees (no ETVM construction required).
+// Pins ElementTreeViewManager's ITreeNodeMutable-based reorder/sort/removal helpers (MoveToIndex,
+// SortByName, RemoveRecursivelyIfStale), which used to operate directly on WinForms
+// TreeNodeCollection. These previously had no test coverage at all - the algorithms are unchanged,
+// only their indexing surface moved from TreeNodeCollection to ITreeNodeMutable, so these tests pin
+// the translated behavior via real GumTreeNode trees (no ETVM construction required).
 public class TreeNodeMutationExtensionsTests
 {
     [Fact]
@@ -46,6 +46,59 @@ public class TreeNodeMutationExtensionsTests
         parent.Nodes[0].ShouldBeSameAs(c);
         parent.Nodes[1].ShouldBeSameAs(a);
         parent.Nodes[2].ShouldBeSameAs(b);
+    }
+
+    [Fact]
+    public void RemoveRecursivelyIfStale_NestedFolders_RemovesDeeplyNestedStaleDescendant()
+    {
+        GumTreeNode root = new GumTreeNode("Root");
+        GumTreeNode outerFolder = (GumTreeNode)root.AddChild("Outer");
+        GumTreeNode innerFolder = (GumTreeNode)outerFolder.AddChild("Inner");
+        GumTreeNode staleScreen = (GumTreeNode)innerFolder.AddChild("StaleScreen");
+        staleScreen.Tag = new ScreenSave();
+
+        ((ITreeNodeMutable)root).RemoveRecursivelyIfStale<ScreenSave>(_ => false);
+
+        outerFolder.Nodes.Contains(innerFolder).ShouldBeTrue();
+        innerFolder.Nodes.Contains(staleScreen).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RemoveRecursivelyIfStale_TaggedChildFailsShouldKeep_RemovesChild()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode staleScreen = (GumTreeNode)parent.AddChild("StaleScreen");
+        staleScreen.Tag = new ScreenSave();
+
+        ((ITreeNodeMutable)parent).RemoveRecursivelyIfStale<ScreenSave>(_ => false);
+
+        parent.Nodes.Contains(staleScreen).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RemoveRecursivelyIfStale_TaggedChildPassesShouldKeep_KeepsChild()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode liveScreen = (GumTreeNode)parent.AddChild("LiveScreen");
+        liveScreen.Tag = new ScreenSave();
+
+        ((ITreeNodeMutable)parent).RemoveRecursivelyIfStale<ScreenSave>(_ => true);
+
+        parent.Nodes.Contains(liveScreen).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RemoveRecursivelyIfStale_UntaggedFolderChild_IsNeverRemovedItself()
+    {
+        GumTreeNode parent = new GumTreeNode("Parent");
+        GumTreeNode folder = (GumTreeNode)parent.AddChild("Folder");
+        GumTreeNode staleScreen = (GumTreeNode)folder.AddChild("StaleScreen");
+        staleScreen.Tag = new ScreenSave();
+
+        ((ITreeNodeMutable)parent).RemoveRecursivelyIfStale<ScreenSave>(_ => false);
+
+        parent.Nodes.Contains(folder).ShouldBeTrue();
+        folder.Nodes.Contains(staleScreen).ShouldBeFalse();
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Managers/TreeNodeMutationExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeMutationExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Gum.Managers;
 
 /// <summary>
@@ -101,6 +103,38 @@ public static class TreeNodeMutationExtensions
                 {
                     childNode.SortByName(recursive);
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recursively removes children tagged with <typeparamref name="T"/> that fail
+    /// <paramref name="shouldKeep"/>. A child not tagged <typeparamref name="T"/> (e.g. a folder
+    /// node) is never removed itself, but is recursed into so stale descendants are still pruned.
+    /// </summary>
+    /// <remarks>
+    /// Relocated from ElementTreeViewManager's <c>AddAndRemoveScreensComponentsStandardsAndBehaviors</c>,
+    /// where it existed as two near-identical local functions (<c>RemoveScreenRecursively</c>,
+    /// <c>RemoveComponentRecursively</c>) differing only by save type - this generic version
+    /// replaces both call sites.
+    /// </remarks>
+    public static void RemoveRecursivelyIfStale<T>(this ITreeNodeMutable containerNode, Func<T, bool> shouldKeep)
+        where T : class
+    {
+        for (int i = containerNode.ChildCount - 1; i > -1; i--)
+        {
+            ITreeNodeMutable child = containerNode.GetChildAt(i);
+
+            if (child.Tag is T tag)
+            {
+                if (!shouldKeep(tag))
+                {
+                    containerNode.RemoveChildAt(i);
+                }
+            }
+            else
+            {
+                child.RemoveRecursivelyIfStale(shouldKeep);
             }
         }
     }


### PR DESCRIPTION
Part of #3845.

## What this does

Converts the next scoped slice of ElementTreeViewManager off raw `TreeNode`/`TreeNodeCollection`
mutation, onto `ITreeNodeMutable` - following the #3841 recipe: node search (`GetTreeNodeFor`)
stays `TreeNode`-typed by design (per #3832), only the add/remove mutation calls convert.

- **`AddAndRemoveScreensComponentsStandardsAndBehaviors`'s removal region.** The screens/components
  passes were two near-identical local functions (`RemoveScreenRecursively`/`RemoveComponentRecursively`)
  differing only by save type - genuinely duplicated logic with zero WinForms coupling beyond typing,
  so it's **relocated** to a new generic `RemoveRecursivelyIfStale<T>` extension in
  `Tools/Gum.Presentation/Managers/TreeNodeMutationExtensions.cs`, replacing both call sites.
- The Standard/Behaviors removal loops **stay** on `ElementTreeViewManager` (single-use, and their
  null-tag semantics genuinely differ between the two - Standard removes untagged nodes, Behaviors
  preserves them - not worth generalizing into a shared API two call sites can misuse), but now go
  through `ITreeNodeMutable.RemoveChildAt` instead of `TreeNodeCollection.RemoveAt`. Also drops a
  dead redundant `behavior == null` check inside an already-null-gated block (behavior-preserving
  simplification).
- **`AddAndRemoveFolderNodesFromFileSystem`/`CreateNodeIfNecessary`** (filesystem-backed folder
  sync) - signature changed from `TreeNodeCollection` to `ITreeNodeMutable`, body converted to
  `AddChild`/`GetChildAt`/`RemoveChildAt`/`ChildCount`. Stays on `ElementTreeViewManager`.

## What stayed out of scope

Per the issue's option (b): the search dependency (`GetTreeNodeFor`) and the neighboring
Add/Update/Sort regions/`RefreshUi` stay as-is - they're inherently mixed with WinForms search/
expand-state concerns the interface intentionally excludes. None of the converted methods
physically relocate to `Gum.Presentation` except the genuinely pure, duplicated recursive-removal
logic.

## Tests

`RemoveRecursivelyIfStale<T>` is a new unit - pinned per the extraction rule with 4 tests against
real `GumTreeNode` trees (tagged-child removed/kept, folder-child never removed itself, nested
folders pruned recursively). Red-verified by temporarily inverting the keep condition and
confirming all 4 fail, then restoring.

The in-place ITreeNodeMutable conversions (Standard/Behaviors loops, folder sync) aren't new units -
behavior-preserving retyping of already-untested `ElementTreeViewManager` methods, same as #3841's
own scoping; the compiler + full test suite are the safety net.

Full `GumToolUnitTests` suite: 1163 passed, 4 pre-existing skips, 0 failed.

Manual test: not needed - pure logic relocation/retyping, pinned by new + existing unit tests and
compiler-checked signature changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
