### PR TITLE
Relocate ElementTreeViewManager's ImageIndex constants into headless Gum.Presentation

### DIFF
--- a/.claude/skills/gum-tool-tree-view/SKILL.md
+++ b/.claude/skills/gum-tool-tree-view/SKILL.md
@@ -11,7 +11,7 @@ The element tree view is the left-hand panel listing Screens, Components, Standa
 
 - `MultiSelectTreeView` (`Gum/CommonFormsAndControls/MultiSelectTreeView.cs`) — derived from `System.Windows.Forms.TreeView`. Owns the underlying `ImageList` field `_elementTreeImages` (initialized empty in `InitializeComponent`). Exposed as `ElementTreeImageList`.
 - `ElementTreeViewCreator` (`Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewCreator.cs`) — builds the WPF `Grid` containing the tree view, search box, collapse buttons, and flat search list. Owns icon loading/tinting.
-- `ElementTreeViewManager` (`Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs`) — singleton (`Self`). Builds, refreshes, and selects nodes. Holds the `ImageIndex` constants. This is the bloated central class — most icon assignments happen here.
+- `ElementTreeViewManager` (`Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs`) — singleton (`Self`). Builds, refreshes, and selects nodes. This is the bloated central class — most icon assignments happen here, via `TreeNodeImageIndices`/`TreeNodeImageLogic` (`Tools/Gum.Presentation/Managers/`, headless — no `System.Windows.Forms`).
 - `MainTreeViewPlugin` — wires plugin events (`InstanceAdd`, `ElementSelected`, `VariableSet`, `AfterUndo`, etc.) to `ElementTreeViewManager.RefreshUi(...)` and to `UpdateErrorIndicatorsForElement(...)`.
 - `TreeViewStateService` — captures/restores expanded-node state across sessions via user project settings.
 
@@ -35,7 +35,7 @@ The icons are intentionally white/grayscale source PNGs so they can be re-tinted
 
 ### ImageIndex constants
 
-Defined as `public const int` on `ElementTreeViewManager`. They map to insertion order in `InjectDynamicIcons()` — **the order of the `TryInjectIcon` calls must match these indices**:
+Defined as `public const int` on `TreeNodeImageIndices` (`Tools/Gum.Presentation/Managers/TreeNodeImageIndices.cs`); `ElementTreeViewManager` consumes them via `using static`. They map to insertion order in `InjectDynamicIcons()` — **the order of the `TryInjectIcon` calls must match these indices**:
 
 | Index | Constant | File key |
 |---|---|---|
@@ -61,13 +61,13 @@ Defined as `public const int` on `ElementTreeViewManager`. They map to insertion
 
 1. Drop the PNG into `Gum/Content/Icons/UpdatedTreeViewIcons/`. Set the build action so it ships in the WPF resource pack.
 2. Add a `TryInjectIcon("YourKey.png", "pack://...")` call to `InjectDynamicIcons` **at the position matching the next image index**.
-3. Add a `public const int YourImageIndex = N;` to `ElementTreeViewManager`.
+3. Add a `public const int YourImageIndex = N;` to `TreeNodeImageIndices`.
 4. If the icon should be theme-colored, add an entry to `GetCurrentColorMap()` keyed by the same filename. Otherwise it falls back to `Frb.Colors.Primary`.
 5. Assign `treeNode.ImageIndex = YourImageIndex;` from wherever the node is created/refreshed.
 
 ### Icon decision logic (state → ImageIndex)
 
-The same node may swap between several icons over its lifetime. Decisions are scattered, not centralized. Hot spots:
+The same node may swap between several icons over its lifetime. Call sites are scattered across `ElementTreeViewManager`; the per-type mapping tables and decision rules they call into are centralized in `TreeNodeImageLogic` (`Tools/Gum.Presentation/Managers/TreeNodeImageLogic.cs`). Hot spots:
 
 - **Element nodes** (`UpdateErrorIndicatorsForElement`, `ElementTreeViewManager.cs` ~L447): picks `Screen / Component / StandardElement` by type, then overrides to `Exclamation` if `IsSourceFileMissing` or has errors.
 - **Instance nodes** (`AddTreeNodeForInstance` ~L1790, instance refresh ~L1720): default `Instance`; `LockedInstance` if `instance.Locked`; `Exclamation` if `BaseType` element is missing/missing source; `DerivedInstance` if `instance.DefinedByBase` (instance contributed by a base element).

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -20,6 +20,7 @@ using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
+using static Gum.Managers.TreeNodeImageIndices;
 using MaterialDesignThemes.Wpf;
 using RenderingLibrary;
 using System;
@@ -157,57 +158,10 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     private readonly ISelectionHistory _selectionHistory;
     private readonly ElementTreeViewCreator _viewCreator;
 
-    public const int TransparentImageIndex = 0;
-    public const int FolderImageIndex = 1;
-    public const int ComponentImageIndex = 2;
-    public const int InstanceImageIndex = 3;
-    public const int ScreenImageIndex = 4;
-    public const int StandardElementImageIndex = 5;
-    public const int ExclamationIndex = 6;
-    public const int StateImageIndex = 7;
-    public const int BehaviorImageIndex = 8;
-    public const int DerivedInstanceImageIndex = 9;
-    public const int LockedInstanceImageIndex = 10;
-
-    // Per-type standard element icons. Indices must match the TryInjectIcon
-    // call order in ElementTreeViewCreator.InjectDynamicIcons.
-    public const int ContainerImageIndex = 11;
-    public const int SpriteImageIndex = 12;
-    public const int NineSliceImageIndex = 13;
-    public const int TextImageIndex = 14;
-    public const int RectangleImageIndex = 15;
-    public const int ColoredRectangleImageIndex = 16;
-    public const int CircleImageIndex = 17;
-    public const int ColoredCircleImageIndex = 18;
-    public const int RoundedRectangleImageIndex = 19;
-    public const int PolygonImageIndex = 20;
-    public const int ArcImageIndex = 21;
-    public const int LineImageIndex = 22;
-    public const int CanvasImageIndex = 23;
-    public const int LottieAnimationImageIndex = 24;
-    public const int SvgImageIndex = 25;
-
-    // Per-type instance icons (same shapes, blue tint instead of purple).
-    // Indices must match the TryInjectIcon call order in
-    // ElementTreeViewCreator.InjectDynamicIcons.
-    public const int ContainerInstanceImageIndex = 26;
-    public const int SpriteInstanceImageIndex = 27;
-    public const int NineSliceInstanceImageIndex = 28;
-    public const int TextInstanceImageIndex = 29;
-    public const int RectangleInstanceImageIndex = 30;
-    public const int ColoredRectangleInstanceImageIndex = 31;
-    public const int CircleInstanceImageIndex = 32;
-    public const int ColoredCircleInstanceImageIndex = 33;
-    public const int RoundedRectangleInstanceImageIndex = 34;
-    public const int PolygonInstanceImageIndex = 35;
-    public const int ArcInstanceImageIndex = 36;
-    public const int LineInstanceImageIndex = 37;
-    public const int CanvasInstanceImageIndex = 38;
-    public const int LottieAnimationInstanceImageIndex = 39;
-    public const int SvgInstanceImageIndex = 40;
-
-    // The per-type icon maps and the node icon-decision logic now live on TreeNodeImageLogic
-    // (accessed via _treeNodeImageLogic) so they can be unit-tested without the WinForms tree.
+    // The *ImageIndex constants and the node icon-decision logic now live on
+    // TreeNodeImageIndices/TreeNodeImageLogic (Gum.Presentation, accessed via
+    // _treeNodeImageLogic and the using static below) so they can be unit-tested without the
+    // WinForms tree and referenced from headless code.
 
     // Part of the phantom right-click workaround. Subscribed in Initialize(),
     // checked in ObjectTreeView_MouseClick(). See comments at both sites.

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeNodeImageLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/TreeNodeImageLogicTests.cs
@@ -7,8 +7,9 @@ using Xunit;
 namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
 
 // Characterization (pinning) tests for the icon-index decision logic extracted from
-// ElementTreeViewManager. They assert against the named ImageIndex constants, so they pin the
-// semantic type -> icon mapping and survive any renumbering of the underlying indices.
+// ElementTreeViewManager (now Gum.Presentation's TreeNodeImageLogic). They assert against the
+// named ImageIndex constants (Gum.Presentation's TreeNodeImageIndices), so they pin the semantic
+// type -> icon mapping and survive any renumbering of the underlying indices.
 public class TreeNodeImageLogicTests
 {
     private readonly TreeNodeImageLogic _logic = new TreeNodeImageLogic();
@@ -16,15 +17,15 @@ public class TreeNodeImageLogicTests
     [Fact]
     public void GetCreateImageIndex_MissingSource_ReturnsExclamation()
     {
-        _logic.GetCreateImageIndex(isSourceFileMissing: true, defaultImageIndex: ElementTreeViewManager.ComponentImageIndex)
-            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+        _logic.GetCreateImageIndex(isSourceFileMissing: true, defaultImageIndex: TreeNodeImageIndices.ComponentImageIndex)
+            .ShouldBe(TreeNodeImageIndices.ExclamationIndex);
     }
 
     [Fact]
     public void GetCreateImageIndex_PresentSource_ReturnsDefault()
     {
-        _logic.GetCreateImageIndex(isSourceFileMissing: false, defaultImageIndex: ElementTreeViewManager.ComponentImageIndex)
-            .ShouldBe(ElementTreeViewManager.ComponentImageIndex);
+        _logic.GetCreateImageIndex(isSourceFileMissing: false, defaultImageIndex: TreeNodeImageIndices.ComponentImageIndex)
+            .ShouldBe(TreeNodeImageIndices.ComponentImageIndex);
     }
 
     [Fact]
@@ -33,7 +34,7 @@ public class TreeNodeImageLogicTests
         ComponentSave component = new ComponentSave { Name = "MyComponent" };
 
         _logic.GetElementRefreshImageIndex(component, hasErrors: true)
-            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+            .ShouldBe(TreeNodeImageIndices.ExclamationIndex);
     }
 
     [Fact]
@@ -42,31 +43,31 @@ public class TreeNodeImageLogicTests
         ScreenSave screen = new ScreenSave { Name = "MyScreen" };
 
         _logic.GetElementRefreshImageIndex(screen, hasErrors: false)
-            .ShouldBe(ElementTreeViewManager.ScreenImageIndex);
+            .ShouldBe(TreeNodeImageIndices.ScreenImageIndex);
     }
 
     [Fact]
     public void GetImageIndexForInstance_KnownStandardType_ReturnsPerTypeInstanceIcon()
     {
-        _logic.GetImageIndexForInstance("Sprite").ShouldBe(ElementTreeViewManager.SpriteInstanceImageIndex);
+        _logic.GetImageIndexForInstance("Sprite").ShouldBe(TreeNodeImageIndices.SpriteInstanceImageIndex);
     }
 
     [Fact]
     public void GetImageIndexForInstance_UnknownType_ReturnsGenericInstanceIcon()
     {
-        _logic.GetImageIndexForInstance("SomeComponent").ShouldBe(ElementTreeViewManager.InstanceImageIndex);
+        _logic.GetImageIndexForInstance("SomeComponent").ShouldBe(TreeNodeImageIndices.InstanceImageIndex);
     }
 
     [Fact]
     public void GetImageIndexForStandardElement_KnownType_ReturnsPerTypeIcon()
     {
-        _logic.GetImageIndexForStandardElement("Text").ShouldBe(ElementTreeViewManager.TextImageIndex);
+        _logic.GetImageIndexForStandardElement("Text").ShouldBe(TreeNodeImageIndices.TextImageIndex);
     }
 
     [Fact]
     public void GetImageIndexForStandardElement_UnknownType_ReturnsGenericStandardIcon()
     {
-        _logic.GetImageIndexForStandardElement("NotAStandard").ShouldBe(ElementTreeViewManager.StandardElementImageIndex);
+        _logic.GetImageIndexForStandardElement("NotAStandard").ShouldBe(TreeNodeImageIndices.StandardElementImageIndex);
     }
 
     [Fact]
@@ -75,7 +76,7 @@ public class TreeNodeImageLogicTests
         InstanceSave instance = new InstanceSave { Name = "Broken", BaseType = "Missing" };
 
         _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: false, tolerateMissingTypes: false)
-            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+            .ShouldBe(TreeNodeImageIndices.ExclamationIndex);
     }
 
     [Fact]
@@ -84,7 +85,7 @@ public class TreeNodeImageLogicTests
         InstanceSave instance = new InstanceSave { Name = "Locked", BaseType = "Sprite", Locked = true };
 
         _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: true, tolerateMissingTypes: false)
-            .ShouldBe(ElementTreeViewManager.LockedInstanceImageIndex);
+            .ShouldBe(TreeNodeImageIndices.LockedInstanceImageIndex);
     }
 
     [Fact]
@@ -93,7 +94,7 @@ public class TreeNodeImageLogicTests
         InstanceSave instance = new InstanceSave { Name = "Text", BaseType = "Text" };
 
         _logic.GetInstanceCreateImageIndex(instance, baseTypeValid: true, tolerateMissingTypes: false)
-            .ShouldBe(ElementTreeViewManager.TextInstanceImageIndex);
+            .ShouldBe(TreeNodeImageIndices.TextInstanceImageIndex);
     }
 
     [Fact]
@@ -103,7 +104,7 @@ public class TreeNodeImageLogicTests
         ComponentSave baseElement = new ComponentSave { Name = "Sprite" };
 
         _logic.GetInstanceRefreshImageIndex(instance, baseElement)
-            .ShouldBe(ElementTreeViewManager.LockedInstanceImageIndex);
+            .ShouldBe(TreeNodeImageIndices.LockedInstanceImageIndex);
     }
 
     [Fact]
@@ -112,7 +113,7 @@ public class TreeNodeImageLogicTests
         InstanceSave instance = new InstanceSave { Name = "Orphan", BaseType = "Sprite" };
 
         _logic.GetInstanceRefreshImageIndex(instance, baseElement: null)
-            .ShouldBe(ElementTreeViewManager.ExclamationIndex);
+            .ShouldBe(TreeNodeImageIndices.ExclamationIndex);
     }
 
     [Fact]
@@ -122,6 +123,6 @@ public class TreeNodeImageLogicTests
         ComponentSave baseElement = new ComponentSave { Name = "Sprite" };
 
         _logic.GetInstanceRefreshImageIndex(instance, baseElement)
-            .ShouldBe(ElementTreeViewManager.SpriteInstanceImageIndex);
+            .ShouldBe(TreeNodeImageIndices.SpriteInstanceImageIndex);
     }
 }

--- a/Tools/Gum.Presentation/Managers/TreeNodeImageIndices.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeImageIndices.cs
@@ -1,0 +1,61 @@
+namespace Gum.Managers;
+
+/// <summary>
+/// ImageList index constants for the element tree view's icons (Screens/Components/Standard/
+/// Behaviors panel). Relocated from <see cref="ElementTreeViewManager"/> (ADR-0005 Phase 3) so
+/// <see cref="TreeNodeImageLogic"/> and other non-WinForms consumers can reference them without
+/// depending on the WinForms-coupled ElementTreeViewManager. Values map to the insertion order of
+/// the <c>TryInjectIcon</c> calls in <c>ElementTreeViewCreator.InjectDynamicIcons</c> — renumbering
+/// requires reordering those calls to match (see the gum-tool-tree-view skill).
+/// </summary>
+public static class TreeNodeImageIndices
+{
+    public const int TransparentImageIndex = 0;
+    public const int FolderImageIndex = 1;
+    public const int ComponentImageIndex = 2;
+    public const int InstanceImageIndex = 3;
+    public const int ScreenImageIndex = 4;
+    public const int StandardElementImageIndex = 5;
+    public const int ExclamationIndex = 6;
+    public const int StateImageIndex = 7;
+    public const int BehaviorImageIndex = 8;
+    public const int DerivedInstanceImageIndex = 9;
+    public const int LockedInstanceImageIndex = 10;
+
+    // Per-type standard element icons. Indices must match the TryInjectIcon
+    // call order in ElementTreeViewCreator.InjectDynamicIcons.
+    public const int ContainerImageIndex = 11;
+    public const int SpriteImageIndex = 12;
+    public const int NineSliceImageIndex = 13;
+    public const int TextImageIndex = 14;
+    public const int RectangleImageIndex = 15;
+    public const int ColoredRectangleImageIndex = 16;
+    public const int CircleImageIndex = 17;
+    public const int ColoredCircleImageIndex = 18;
+    public const int RoundedRectangleImageIndex = 19;
+    public const int PolygonImageIndex = 20;
+    public const int ArcImageIndex = 21;
+    public const int LineImageIndex = 22;
+    public const int CanvasImageIndex = 23;
+    public const int LottieAnimationImageIndex = 24;
+    public const int SvgImageIndex = 25;
+
+    // Per-type instance icons (same shapes, blue tint instead of purple).
+    // Indices must match the TryInjectIcon call order in
+    // ElementTreeViewCreator.InjectDynamicIcons.
+    public const int ContainerInstanceImageIndex = 26;
+    public const int SpriteInstanceImageIndex = 27;
+    public const int NineSliceInstanceImageIndex = 28;
+    public const int TextInstanceImageIndex = 29;
+    public const int RectangleInstanceImageIndex = 30;
+    public const int ColoredRectangleInstanceImageIndex = 31;
+    public const int CircleInstanceImageIndex = 32;
+    public const int ColoredCircleInstanceImageIndex = 33;
+    public const int RoundedRectangleInstanceImageIndex = 34;
+    public const int PolygonInstanceImageIndex = 35;
+    public const int ArcInstanceImageIndex = 36;
+    public const int LineInstanceImageIndex = 37;
+    public const int CanvasInstanceImageIndex = 38;
+    public const int LottieAnimationInstanceImageIndex = 39;
+    public const int SvgInstanceImageIndex = 40;
+}

--- a/Tools/Gum.Presentation/Managers/TreeNodeImageLogic.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeImageLogic.cs
@@ -1,15 +1,16 @@
 using Gum.DataTypes;
-using static Gum.Managers.ElementTreeViewManager;
+using static Gum.Managers.TreeNodeImageIndices;
 
 namespace Gum.Managers;
 
 /// <summary>
 /// Resolves the tree-view ImageList index for element, behavior, and instance nodes.
-/// Extracted from <see cref="ElementTreeViewManager"/> so the (pure, WinForms-free) icon-decision
-/// logic can be unit-tested directly. The ImageIndex constants themselves still live on
-/// <see cref="ElementTreeViewManager"/> because non-tree code (e.g. ElementTreeViewCreator) references them.
+/// Extracted from ElementTreeViewManager (Gum.csproj, WinForms-coupled) so the (pure,
+/// WinForms-free) icon-decision logic can be unit-tested directly and referenced from headless
+/// code (ADR-0005 Phase 3). The ImageIndex constants live alongside it on
+/// <see cref="TreeNodeImageIndices"/>, relocated off ElementTreeViewManager for the same reason.
 /// </summary>
-class TreeNodeImageLogic
+public class TreeNodeImageLogic
 {
     /// <summary>
     /// Returns the per-type (blue-tinted) icon for an instance whose BaseType is a standard element.


### PR DESCRIPTION
## What

Unblocks moving `TreeNodeImageLogic` (icon-index decision logic) into `Gum.Presentation`: it `using static`d `ElementTreeViewManager` to reach ~40 `*ImageIndex`/`ExclamationIndex` constants declared on ETVM itself.

- New `Tools/Gum.Presentation/Managers/TreeNodeImageIndices.cs` — the constants, same values/order.
- `TreeNodeImageLogic.cs` moved from `Gum/Plugins/InternalPlugins/TreeView/` into `Tools/Gum.Presentation/Managers/`, now `public` (was `internal`, needed for cross-assembly access from `ElementTreeViewManager`).
- `ElementTreeViewManager` no longer declares the constants; consumes them via `using static Gum.Managers.TreeNodeImageIndices;`.
- `TreeNodeImageLogicTests` updated to reference `TreeNodeImageIndices` instead of `ElementTreeViewManager` for the constants (mechanical qualifier rename only).
- `gum-tool-tree-view` skill's file pointers updated (was stale: said constants live on ETVM).

## North-star check

`Tools/Gum.Presentation/Managers/TreeNodeImageIndices.cs` and `TreeNodeImageLogic.cs`: 0 `System.Windows.*`/`System.Windows.Forms.*` references, and `Gum.Presentation.csproj` declares neither `UseWPF` nor `UseWindowsForms`.

## Tests

Pure relocation — pinned by the existing 14 `TreeNodeImageLogicTests` (unchanged assertions, only the constant qualifier renamed), all green. Full `GumToolUnitTests` (1163 passed) and `Gum.Presentation.Tests` (347 passed) both green.

Part of #3845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
