### PR TITLE
Relocate CameraController into headless Gum.Presentation, part of #3846

### DIFF
--- a/Gum/Managers/KeyCombinationExtensions.cs
+++ b/Gum/Managers/KeyCombinationExtensions.cs
@@ -25,19 +25,9 @@ public static class KeyCombinationExtensions
         return kc.Key == null || args.KeyCode == ToWinFormsKey(kc.Key.Value);
     }
 
-    /// <summary>
-    /// Matches against Gum's framework-neutral <see cref="GumKeyEventArgs"/>, for callers that have
-    /// already translated the framework key event at the editor-host boundary (e.g.
-    /// <c>CameraController.HandleKeyPress</c>).
-    /// </summary>
-    public static bool IsPressed(this KeyCombination kc, GumKeyEventArgs args)
-    {
-        if (kc.IsCtrlDown && !args.IsCtrlDown) return false;
-        if (kc.IsShiftDown && !args.IsShiftDown) return false;
-        if (kc.IsAltDown && !args.IsAltDown) return false;
-
-        return kc.Key == null || args.Key == kc.Key;
-    }
+    // The GumKeyEventArgs overload of IsPressed is framework-neutral (ADR-0005) and lives in
+    // Gum.Presentation (Tools/Gum.Presentation/Managers/KeyCombinationGumEventArgsExtensions.cs)
+    // alongside KeyCombination itself, not here — see CameraController, its first consumer.
 
     public static bool IsPressed(this KeyCombination kc, System.Windows.Input.KeyEventArgs args)
     {

--- a/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
+++ b/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
@@ -1,0 +1,163 @@
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.EditorTab.Services;
+using Moq;
+using RenderingLibrary;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="CameraController"/>'s pan/zoom/hotkey math after its relocation to
+/// Gum.Presentation (ADR-0005, part of #3846) — it previously read/wrote the camera through the
+/// XNALIKE-only <c>Renderer.Self</c>/<c>SystemManagers.Default</c> singletons instead of its own
+/// injected <see cref="Camera"/>, which is what actually blocked the move.
+/// </summary>
+public class CameraControllerTests
+{
+    private static Mock<IHotkeyManager> CreateHotkeyManagerMock()
+    {
+        // Every combo the class reads must resolve to a non-null KeyCombination distinct from the
+        // one under test, since IsPressed() is an extension method that dereferences a null "this"
+        // instance rather than short-circuiting.
+        var hotkeyManager = new Mock<IHotkeyManager>();
+        hotkeyManager.SetupGet(h => h.MoveCameraLeft).Returns(KeyCombination.Pressed(GumKey.Left));
+        hotkeyManager.SetupGet(h => h.MoveCameraRight).Returns(KeyCombination.Pressed(GumKey.Right));
+        hotkeyManager.SetupGet(h => h.MoveCameraUp).Returns(KeyCombination.Pressed(GumKey.Up));
+        hotkeyManager.SetupGet(h => h.MoveCameraDown).Returns(KeyCombination.Pressed(GumKey.Down));
+        hotkeyManager.SetupGet(h => h.ZoomCameraIn).Returns(KeyCombination.Pressed(GumKey.Add));
+        hotkeyManager.SetupGet(h => h.ZoomCameraInAlternative).Returns(KeyCombination.Pressed(GumKey.F2));
+        hotkeyManager.SetupGet(h => h.ZoomCameraOut).Returns(KeyCombination.Pressed(GumKey.Subtract));
+        hotkeyManager.SetupGet(h => h.ZoomCameraOutAlternative).Returns(KeyCombination.Pressed(GumKey.F12));
+        return hotkeyManager;
+    }
+
+    private static (CameraController Controller, Camera Camera, Mock<IHotkeyManager> HotkeyManager, Mock<IZoomController> ZoomController)
+        CreateSut()
+    {
+        var camera = new Camera { ClientWidth = 800, ClientHeight = 600 };
+        var hotkeyManager = CreateHotkeyManagerMock();
+        var zoomController = new Mock<IZoomController>();
+
+        var controller = new CameraController();
+        controller.Initialize(camera, zoomController.Object, defaultWidth: 800, defaultHeight: 600, hotkeyManager.Object);
+
+        return (controller, camera, hotkeyManager, zoomController);
+    }
+
+    [Fact]
+    public void HandleKeyPress_MoveCameraLeft_MovesCameraByStepDividedByZoomAndRaisesCameraChanged()
+    {
+        var (controller, camera, hotkeyManager, _) = CreateSut();
+        camera.Zoom = 2f;
+        var originalX = camera.X;
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        controller.HandleKeyPress(new GumKeyEventArgs { Key = GumKey.Left });
+
+        camera.X.ShouldBe(originalX - 10 / 2f);
+        raised.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HandleKeyPress_ZoomCameraIn_CallsZoomControllerZoomInAndRaisesCameraChanged()
+    {
+        var (controller, _, _, zoomController) = CreateSut();
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        controller.HandleKeyPress(new GumKeyEventArgs { Key = GumKey.Add });
+
+        zoomController.Verify(z => z.ZoomIn(), Times.Once);
+        zoomController.Verify(z => z.ZoomOut(), Times.Never);
+        raised.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HandleKeyPress_UnrelatedKey_DoesNothing()
+    {
+        var (controller, camera, _, zoomController) = CreateSut();
+        var originalX = camera.X;
+        var originalY = camera.Y;
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        controller.HandleKeyPress(new GumKeyEventArgs { Key = GumKey.Z });
+
+        camera.X.ShouldBe(originalX);
+        camera.Y.ShouldBe(originalY);
+        zoomController.Verify(z => z.ZoomIn(), Times.Never);
+        zoomController.Verify(z => z.ZoomOut(), Times.Never);
+        raised.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HandleMouseDown_ThenHandleMouseMove_WithMiddleButton_PansCameraOppositeToMouseDeltaAndRaisesCameraChanged()
+    {
+        var (controller, camera, _, _) = CreateSut();
+        camera.Zoom = 2f;
+        var originalX = camera.X;
+        var originalY = camera.Y;
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        controller.HandleMouseDown(new GumMouseEventArgs { X = 100, Y = 100, Button = GumMouseButton.Middle });
+        controller.HandleMouseMove(new GumMouseEventArgs { X = 130, Y = 90, Button = GumMouseButton.Middle });
+
+        // Dragging the mouse right/up should move the world (camera position) left/down relative
+        // to the drag, scaled by zoom - i.e. content appears to follow the cursor.
+        camera.X.ShouldBe(originalX - (130 - 100) / 2f);
+        camera.Y.ShouldBe(originalY - (90 - 100) / 2f);
+        raised.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HandleMouseMove_WithLeftButton_DoesNotPanCameraOrRaiseCameraChanged()
+    {
+        var (controller, camera, _, _) = CreateSut();
+        var originalX = camera.X;
+        var originalY = camera.Y;
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        controller.HandleMouseDown(new GumMouseEventArgs { X = 100, Y = 100, Button = GumMouseButton.Left });
+        controller.HandleMouseMove(new GumMouseEventArgs { X = 200, Y = 200, Button = GumMouseButton.Left });
+
+        camera.X.ShouldBe(originalX);
+        camera.Y.ShouldBe(originalY);
+        raised.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HandleMouseWheel_ScrollUp_ZoomsInAndKeepsWorldPointUnderCursorFixed()
+    {
+        var (controller, camera, _, zoomController) = CreateSut();
+        zoomController.Setup(z => z.ZoomIn()).Callback(() => camera.Zoom = 2f);
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        var mouseArgs = new GumMouseEventArgs { X = 300, Y = 200, Delta = 120 };
+        camera.ScreenToWorld(mouseArgs.X, mouseArgs.Y, out var worldXBefore, out var worldYBefore);
+
+        controller.HandleMouseWheel(mouseArgs);
+
+        zoomController.Verify(z => z.ZoomIn(), Times.Once);
+        camera.ScreenToWorld(mouseArgs.X, mouseArgs.Y, out var worldXAfter, out var worldYAfter);
+        worldXAfter.ShouldBe(worldXBefore, tolerance: 0.001);
+        worldYAfter.ShouldBe(worldYBefore, tolerance: 0.001);
+        mouseArgs.Handled.ShouldBeTrue();
+        raised.ShouldBe(1);
+    }
+
+    [Fact]
+    public void HandleMouseWheel_ScrollDown_CallsZoomOut()
+    {
+        var (controller, camera, _, zoomController) = CreateSut();
+
+        controller.HandleMouseWheel(new GumMouseEventArgs { X = 300, Y = 200, Delta = -120 });
+
+        zoomController.Verify(z => z.ZoomOut(), Times.Once);
+        zoomController.Verify(z => z.ZoomIn(), Times.Never);
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
+++ b/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Mvvm;
 using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.EditorTab.Services;
 using Gum.Plugins.InternalPlugins.EditorTab.Views;
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -17,7 +18,11 @@ using System.Threading.Tasks;
 
 namespace EditorTabPlugin_XNA.ViewModels;
 
-public partial class EditorViewModel : ViewModel
+/// <summary>
+/// Implements <see cref="IZoomController"/> so <c>CameraController</c> (headless, Gum.Presentation)
+/// can drive zoom without depending on this concrete, still-WPF/WinForms-side ViewModel.
+/// </summary>
+public partial class EditorViewModel : ViewModel, IZoomController
 {
     private readonly IPluginManager _pluginManager;
     private readonly IFileCommands _fileCommands;

--- a/Tools/Gum.Presentation/Managers/KeyCombinationGumEventArgsExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/KeyCombinationGumEventArgsExtensions.cs
@@ -1,0 +1,23 @@
+using Gum.Input;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Matches a <see cref="KeyCombination"/> against Gum's framework-neutral <see cref="GumKeyEventArgs"/>.
+/// Framework-neutral (ADR-0005), unlike the WinForms/WPF <c>IsPressed</c> overloads in
+/// <c>Gum.csproj</c>'s <c>KeyCombinationExtensions</c> — those match against the raw framework key
+/// event types and so must stay in the tool layer, while this one is safe to live in Gum.Presentation
+/// alongside <see cref="KeyCombination"/> itself. Used by callers that have already translated the
+/// framework key event at the editor-host boundary (e.g. <c>CameraController.HandleKeyPress</c>).
+/// </summary>
+public static class KeyCombinationGumEventArgsExtensions
+{
+    public static bool IsPressed(this KeyCombination kc, GumKeyEventArgs args)
+    {
+        if (kc.IsCtrlDown && !args.IsCtrlDown) return false;
+        if (kc.IsShiftDown && !args.IsShiftDown) return false;
+        if (kc.IsAltDown && !args.IsAltDown) return false;
+
+        return kc.Key == null || args.Key == kc.Key;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using Gum.Input;
 using RenderingLibrary;
-using RenderingLibrary.Graphics;
 using Gum.Managers;
-using EditorTabPlugin_XNA.ViewModels;
 
 namespace Gum.Plugins.InternalPlugins.EditorTab.Services;
 
@@ -15,7 +13,7 @@ public class CameraController
         set;
     }
 
-    EditorViewModel _editorViewModel;
+    IZoomController _zoomController;
 
     int _lastMouseX;
     int _lastMouseY;
@@ -23,18 +21,18 @@ public class CameraController
     public event Action? CameraChanged;
     IHotkeyManager _hotkeyManager;
 
-    public void Initialize(Camera camera, 
-        EditorViewModel viewModel, int defaultWidth, int defaultHeight, IHotkeyManager hotkeyManager)
+    public void Initialize(Camera camera,
+        IZoomController zoomController, int defaultWidth, int defaultHeight, IHotkeyManager hotkeyManager)
     {
         _hotkeyManager = hotkeyManager;
-        _editorViewModel = viewModel;
+        _zoomController = zoomController;
         Camera = camera;
 
-        Renderer.Self.Camera.X = - 30;
-        Renderer.Self.Camera.Y = - 30;
+        Camera.X = -30;
+        Camera.Y = -30;
     }
 
-    internal void HandleMouseWheel(GumMouseEventArgs e)
+    public void HandleMouseWheel(GumMouseEventArgs e)
     {
         float worldX, worldY;
         Camera.ScreenToWorld(e.X, e.Y, out worldX, out worldY);
@@ -45,11 +43,11 @@ public class CameraController
 
         if (e.Delta < 0)
         {
-            _editorViewModel.ZoomOut();
+            _zoomController.ZoomOut();
         }
         else
         {
-            _editorViewModel.ZoomIn();
+            _zoomController.ZoomIn();
         }
 
         float newDifferenceX = differenceX * oldZoom / Camera.Zoom;
@@ -63,7 +61,7 @@ public class CameraController
         e.Handled = true;
     }
 
-    internal void HandleMouseDown(GumMouseEventArgs e)
+    public void HandleMouseDown(GumMouseEventArgs e)
     {
         if (e.Button == GumMouseButton.Middle)
         {
@@ -72,15 +70,15 @@ public class CameraController
         }
     }
 
-    internal void HandleMouseMove(GumMouseEventArgs e)
+    public void HandleMouseMove(GumMouseEventArgs e)
     {
         if (e.Button == GumMouseButton.Middle)
         {
             int xChange = e.X - _lastMouseX;
             int yChange = e.Y - _lastMouseY;
 
-            Renderer.Self.Camera.Position.X -= xChange / Renderer.Self.Camera.Zoom;
-            Renderer.Self.Camera.Position.Y -= yChange / Renderer.Self.Camera.Zoom;
+            Camera.Position.X -= xChange / Camera.Zoom;
+            Camera.Position.Y -= yChange / Camera.Zoom;
 
             if (xChange != 0 || yChange != 0)
             {
@@ -92,38 +90,38 @@ public class CameraController
         }
     }
 
-    internal void HandleKeyPress(GumKeyEventArgs e)
+    public void HandleKeyPress(GumKeyEventArgs e)
     {
         if (_hotkeyManager.MoveCameraLeft.IsPressed(e))
         {
-            SystemManagers.Default.Renderer.Camera.X -= 10 / SystemManagers.Default.Renderer.Camera.Zoom;
+            Camera.X -= 10 / Camera.Zoom;
             CameraChanged?.Invoke();
         }
         if (_hotkeyManager.MoveCameraRight.IsPressed(e))
         {
-            SystemManagers.Default.Renderer.Camera.X += 10 / SystemManagers.Default.Renderer.Camera.Zoom;
+            Camera.X += 10 / Camera.Zoom;
             CameraChanged?.Invoke();
         }
         if (_hotkeyManager.MoveCameraUp.IsPressed(e))
         {
-            SystemManagers.Default.Renderer.Camera.Y -= 10 / SystemManagers.Default.Renderer.Camera.Zoom;
+            Camera.Y -= 10 / Camera.Zoom;
             CameraChanged?.Invoke();
         }
         if (_hotkeyManager.MoveCameraDown.IsPressed(e))
         {
-            SystemManagers.Default.Renderer.Camera.Y += 10 / SystemManagers.Default.Renderer.Camera.Zoom;
+            Camera.Y += 10 / Camera.Zoom;
             CameraChanged?.Invoke();
         }
 
         if (_hotkeyManager.ZoomCameraIn.IsPressed(e) || _hotkeyManager.ZoomCameraInAlternative.IsPressed(e))
         {
-            _editorViewModel.ZoomIn();
+            _zoomController.ZoomIn();
             CameraChanged?.Invoke();
         }
 
         if (_hotkeyManager.ZoomCameraOut.IsPressed(e) || _hotkeyManager.ZoomCameraOutAlternative.IsPressed(e))
         {
-            _editorViewModel.ZoomOut();
+            _zoomController.ZoomOut();
             CameraChanged?.Invoke();
         }
     }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/IZoomController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/IZoomController.cs
@@ -1,0 +1,16 @@
+namespace Gum.Plugins.InternalPlugins.EditorTab.Services;
+
+/// <summary>
+/// Narrow seam for the editor-tab zoom steps <see cref="CameraController"/> drives from mouse wheel
+/// and zoom hotkeys. Kept separate from the full <c>EditorViewModel</c> (which is still WPF/WinForms-side)
+/// so <see cref="CameraController"/> can stay headless (ADR-0005) while depending only on the zoom
+/// operations it actually calls.
+/// </summary>
+public interface IZoomController
+{
+    /// <summary>Steps the zoom level in (closer).</summary>
+    void ZoomIn();
+
+    /// <summary>Steps the zoom level out (farther).</summary>
+    void ZoomOut();
+}


### PR DESCRIPTION
## Summary

Part of #3846. This round is a scoping pass over all 6 named classes (`SelectionManager`, `CameraController`, `WireframeEditor`, `MoveInputHandler`, `ResizeInputHandler`, `RotationInputHandler`, `PolygonPointInputHandler`) plus one implemented slice: **`CameraController` moved into headless `Gum.Presentation`.**

## What moved

- `CameraController` now lives in `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs`. It was already routed through `GumMouseEventArgs`/`GumKeyEventArgs` (#3843), but two things still blocked the physical move:
  1. It read/wrote the camera via `Renderer.Self`/`SystemManagers.Default` (XNALIKE-only, unreachable from a net8.0 assembly) instead of its own injected `Camera` — same object at runtime (`WireframeControl.Camera => Renderer.Self.Camera`), so swapping is behavior-preserving.
  2. It depended on the concrete, still-WPF/WinForms-side `EditorViewModel` just for `ZoomIn()`/`ZoomOut()`. Extracted a narrow `IZoomController` interface (in Gum.Presentation) that `EditorViewModel` now implements.
- Moved the `IsPressed(GumKeyEventArgs)` `KeyCombination` extension overload out of `Gum.Managers.KeyCombinationExtensions` (tool-side, WinForms/WPF project) into a new `Gum.Presentation` file, since it's framework-neutral and was the only remaining blocker on `HandleKeyPress`.
- Zero prior test coverage on `CameraController` — added `CameraControllerTests` (7 tests) pinning pan/zoom/hotkey math, including a "cursor stays over the same world point while zooming" invariant. Confirmed the tests actually catch regressions via a manual mutation (flipped one `-=` to `+=`, watched it go red, reverted).

## Categorization of the remaining 5 classes (not done this round)

- **`WireframeEditor` + the 4 input handlers (`Move`/`Resize`/`Rotation`/`PolygonPointInputHandler`) + `InputHandlerBase`/`IInputHandler` + `RectangleSelector`/`StandardWireframeEditor`/`PolygonWireframeEditor`**: convertible with reasonable effort, one shared blocker — `IInputHandler.GetCursorToShow`/`WireframeEditor.GetWindowsCursorToShow`/`RectangleSelector.GetCursorToShow` all return `System.Windows.Forms.Cursor?`. Every other dependency (`EditorContext`, `GrabbedState`, all injected interfaces) is already headless-clean. Fix: a small neutral `GumCursorKind` enum in Gum.Presentation, WinForms mapping pushed to the one real call site (`SelectionManager.HighlightActivity`'s `Cursor.SetWinformsCursor(...)`). This has to be one PR (~9 files) since they share the `IInputHandler` interface — can't half-migrate it.
- **`SelectionManager`**: genuinely stuck today — direct `System.Windows.Forms.Control.ModifierKeys` read (`IsShiftDown`) and the WinForms-typed `Cursor.SetWinformsCursor(...)` call (note: `InputLibrary` itself declares `UseWindowsForms=true`, so this isn't just a `System.Windows.Forms` text-grep issue). Becomes convertible once the cursor-enum work above lands — its own remaining surface shrinks to just those two reads, fixable the same way `IHotkeyManager.IsPressedInControl` abstracts live modifier state.

**Parallelism: mostly no.** `CameraController` was the only truly independent slice (implemented here). The cursor-enum work and `SelectionManager` are sequential, not parallel — `SelectionManager` depends on the cursor-enum interface change landing first.

## Recommendation for round 2

Cursor-enum extraction across `IInputHandler`/`InputHandlerBase`/the 4 handlers/`WireframeEditor`/`StandardWireframeEditor`/`PolygonWireframeEditor`/`RectangleSelector` — one PR, mechanical, low risk, each handler's `GetCursorToShow` gets a pinning test. `SelectionManager` itself is round 3, after that lands.

## Manual test

Not needed — behavior-preserving relocation + math substitution, covered by the new unit tests plus green `GumFull.sln` build and full `GumToolUnitTests`/`Gum.Presentation.Tests` runs (both suites fully green, no regressions).
