### PR TITLE
Relocate SelectionManager into headless Gum.Presentation, part of #3846

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -224,6 +224,39 @@ changelog — update this list when a *new kind* of gotcha is discovered, not fo
   (undesigned as of this writing), not a quick wrapper interface, so it's a legitimate scope cut
   to leave that one handler (and any wireframe-editor subclass that only exists to host it) tool
   side while relocating the rest of an otherwise-clean family.
+- **A coordinator class that directly `new`s a family it hands off to a headless consumer can be
+  the real blocker, even after every dependency it reads is fixed.** `SelectionManager` injected
+  `Camera`/`IGumCursorState` cleanly, but still directly constructed
+  `StandardWireframeEditor`/`PolygonWireframeEditor` (tool-only concrete types, needing a tool-only
+  font service and project-settings colors) and the XNALIKE rendering-primitive visuals
+  (`GraphicalOutline`, `HighlightManager`, `SelectionRectangleVisual`). The fix is a factory
+  interface (`IWireframeEditorFactory`) the tool side implements and the headless coordinator calls
+  — the same "push construction behind a seam" shape as the visual interfaces, just one level up
+  the object graph. A side effect worth naming: once construction moves behind the factory, a
+  `WireframeEditor is ConcreteToolType` check the coordinator used to decide "do I already have the
+  right kind" can no longer name that type either — track the decision explicitly (a small enum
+  field set alongside each construction call) instead of re-deriving it via a type check. This is a
+  *new* branch the compiler won't catch a regression in — it needs its own pinning test, not just a
+  build-passes check.
+- **A dependency injected as a full interface can be blocked by returning one non-portable type on
+  a member the consumer never even reads.** `SelectionManager` took `IEditingManager` only to read
+  `.ContextMenu?.IsOpen` — `ContextMenu` itself is `System.Windows.Controls.ContextMenu` (WPF),
+  so the whole interface was unreachable regardless of which member was actually used. Splitting
+  a same-shaped-problem interface (see the `IEditVariableService`/`WpfDataUi` bullet above) isn't
+  always right when the *interface itself* is what's blocked, not one member on an otherwise-clean
+  interface: here the fix was a second, narrower interface (`IContextMenuState`, just
+  `IsContextMenuOpen`) implemented by the same concrete class alongside the original, unmodified
+  `IEditingManager` — cheaper than splitting when nothing else consumes the interface being
+  narrowed (confirm via grep before choosing this over a split).
+- **Two type-check branches that look identical can differ in whether they're dead code — check
+  reachability, don't assume.** `SelectionManager`'s `IsIpsoVisible` had an `is IVisible` branch
+  followed by `is Sprite`/`is Text` branches for the same `.AbsoluteVisible` read; since both
+  `Sprite` and `Text` already implement `IVisible`, the later branches were unreachable and safe to
+  delete outright (removing the blocker, not just relocating it) — a `LinePolygon` branch doing a
+  *different* check (`IsPointInside` vs. the generic bounding-box `HasCursorOver`) right next to it
+  in the same class was live and needed the narrow-interface treatment instead. Don't pattern-match
+  "type-check on a renderable" to one fix; check what each branch actually does before choosing
+  delete vs. seam.
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
 - *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated

--- a/InputLibrary/Cursor.cs
+++ b/InputLibrary/Cursor.cs
@@ -262,6 +262,27 @@ namespace InputLibrary
             }
         }
 
+        /// <summary>
+        /// <see cref="IGumCursorState.SetCursor"/> implementation. Maps the neutral
+        /// <see cref="GumCursorKind"/> to a real WinForms <see cref="WinCursor"/> and forwards to
+        /// <see cref="SetWinformsCursor"/> — the one place that mapping happens, so headless callers
+        /// (e.g. <c>SelectionManager</c>) never reference <see cref="WinCursor"/> directly.
+        /// </summary>
+        public void SetCursor(GumCursorKind kind) => SetWinformsCursor(ToWinFormsCursor(kind));
+
+        private static WinCursor ToWinFormsCursor(GumCursorKind kind) => kind switch
+        {
+            GumCursorKind.Arrow => Cursors.Arrow,
+            GumCursorKind.Cross => Cursors.Cross,
+            GumCursorKind.Hand => Cursors.Hand,
+            GumCursorKind.SizeAll => Cursors.SizeAll,
+            GumCursorKind.SizeNS => Cursors.SizeNS,
+            GumCursorKind.SizeWE => Cursors.SizeWE,
+            GumCursorKind.SizeNESW => Cursors.SizeNESW,
+            GumCursorKind.SizeNWSE => Cursors.SizeNWSE,
+            _ => Cursors.Arrow
+        };
+
 
         public void EndCursorSettingFrameStart()
         {

--- a/Tests/Gum.Presentation.Tests/SelectionManagerEditorFactoryTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectionManagerEditorFactoryTests.cs
@@ -1,0 +1,164 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.PropertyGridHelpers;
+using Gum.Services;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors.Visuals;
+using Moq;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="SelectionManager"/>'s WireframeEditor-kind switching after its relocation to
+/// Gum.Presentation (ADR-0005, part of #3846). Building a <c>StandardWireframeEditor</c>/
+/// <c>PolygonWireframeEditor</c> requires XNALIKE-only dependencies (a tool font service, project
+/// guide-color settings) unreachable from headless Gum.Presentation, so construction moved behind
+/// <see cref="IWireframeEditorFactory"/> — and the "is the current editor already the right kind"
+/// check, previously a runtime type-check against those same tool-only concrete types
+/// (<c>WireframeEditor is StandardWireframeEditor</c>), had to become an explicitly-tracked kind
+/// instead. This suite pins that new tracking, not just the factory call.
+/// </summary>
+public class SelectionManagerEditorFactoryTests : BaseTestClass
+{
+    private class FakeWireframeEditor : WireframeEditor
+    {
+        public FakeWireframeEditor(ISelectionManager selectionManager)
+            : base(
+                Mock.Of<IHotkeyManager>(),
+                selectionManager,
+                Mock.Of<ISelectedState>(),
+                Mock.Of<IElementCommands>(),
+                Mock.Of<IGuiCommands>(),
+                Mock.Of<IFileCommands>(),
+                Mock.Of<ISetVariableLogic>(),
+                Mock.Of<IUndoManager>(),
+                Mock.Of<IVariableInCategoryPropagationLogic>(),
+                Mock.Of<IWireframeObjectManager>(),
+                Mock.Of<IUiSettingsService>(),
+                new Layer(),
+                System.Drawing.Color.White,
+                System.Drawing.Color.White,
+                new Camera(),
+                Mock.Of<IGumCursorState>(),
+                Mock.Of<IPluginManager>())
+        {
+        }
+
+        public bool Destroyed { get; private set; }
+
+        public override bool HasCursorOverHandles => false;
+
+        public override void Destroy()
+        {
+            Destroyed = true;
+            base.Destroy();
+        }
+    }
+
+    private readonly Mock<ISelectedState> _mockSelectedState;
+    private readonly Mock<IWireframeEditorFactory> _mockFactory;
+    private readonly SelectionManager _selectionManager;
+    private readonly List<InstanceSave> _selectedInstances = new();
+
+    public SelectionManagerEditorFactoryTests()
+    {
+        _mockSelectedState = new Mock<ISelectedState>();
+        _mockSelectedState.Setup(x => x.SelectedInstances).Returns(() => _selectedInstances);
+        _mockSelectedState.Setup(x => x.GetTopLevelElementStack()).Returns(new List<ElementWithState>());
+
+        _mockFactory = new Mock<IWireframeEditorFactory>();
+        _mockFactory
+            .Setup(f => f.CreateStandardEditor(It.IsAny<ISelectionManager>(), It.IsAny<Layer>(), It.IsAny<Camera>(), It.IsAny<IGumCursorState>()))
+            .Returns<ISelectionManager, Layer, Camera, IGumCursorState>((sm, _, _, _) => new FakeWireframeEditor(sm));
+
+        _selectionManager = new SelectionManager(
+            _mockSelectedState.Object,
+            Mock.Of<IUndoManager>(),
+            Mock.Of<IContextMenuState>(),
+            Mock.Of<Gum.Services.Dialogs.IDialogService>(),
+            Mock.Of<IHotkeyManager>(),
+            Mock.Of<IWireframeObjectManager>(),
+            Mock.Of<IGuiCommands>(),
+            _mockFactory.Object,
+            Mock.Of<INineSliceCoordinateRefresher>(),
+            Mock.Of<IPreciseHitTester>());
+
+        _selectionManager.Initialize(
+            new Layer(),
+            new Camera(),
+            Mock.Of<IGumCursorState>(),
+            Mock.Of<ISelectionRectangleVisual>(),
+            Mock.Of<IHighlightOutlineVisual>(),
+            Mock.Of<IHighlightOverlayVisual>());
+    }
+
+    private GraphicalUiElement SelectNewStandardInstance()
+    {
+        var instance = new InstanceSave { Name = "Instance" };
+        var gue = new GraphicalUiElement { Tag = instance };
+        _selectionManager.SelectedGue = gue;
+        return gue;
+    }
+
+    [Fact]
+    public void SelectingStandardElement_CreatesEditorViaFactory()
+    {
+        SelectNewStandardInstance();
+
+        _mockFactory.Verify(f => f.CreateStandardEditor(
+            _selectionManager, It.IsAny<Layer>(), It.IsAny<Camera>(), It.IsAny<IGumCursorState>()), Times.Once);
+        _selectionManager.WireframeEditor.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void SelectingAnotherStandardElement_DoesNotRecreateEditor()
+    {
+        SelectNewStandardInstance();
+        var firstEditor = _selectionManager.WireframeEditor;
+
+        // Selecting a second, different standard-kind instance should reuse the existing editor
+        // rather than destroying and rebuilding it.
+        SelectNewStandardInstance();
+
+        _mockFactory.Verify(f => f.CreateStandardEditor(
+            _selectionManager, It.IsAny<Layer>(), It.IsAny<Camera>(), It.IsAny<IGumCursorState>()), Times.Once);
+        _selectionManager.WireframeEditor.ShouldBeSameAs(firstEditor);
+        ((FakeWireframeEditor)firstEditor!).Destroyed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DeselectingAll_DestroysEditorAndClearsIt()
+    {
+        SelectNewStandardInstance();
+        var editor = (FakeWireframeEditor)_selectionManager.WireframeEditor!;
+
+        _selectionManager.DeselectAll();
+
+        editor.Destroyed.ShouldBeTrue();
+        _selectionManager.WireframeEditor.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReselectingAfterDeselect_CreatesANewEditor()
+    {
+        SelectNewStandardInstance();
+        _selectionManager.DeselectAll();
+
+        SelectNewStandardInstance();
+
+        _mockFactory.Verify(f => f.CreateStandardEditor(
+            _selectionManager, It.IsAny<Layer>(), It.IsAny<Camera>(), It.IsAny<IGumCursorState>()), Times.Exactly(2));
+        _selectionManager.WireframeEditor.ShouldNotBeNull();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/SelectionManagerHighlightTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectionManagerHighlightTests.cs
@@ -1,24 +1,19 @@
 using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Input;
 using Gum.Managers;
-using Gum.Plugins;
-using Gum.Plugins.InternalPlugins.EditorTab.Services;
-using Gum.Plugins.InternalPlugins.VariableGrid;
-using Gum.PropertyGridHelpers;
-using Gum.Services;
-using Gum.Services.Dialogs;
-using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
+using Gum.Wireframe.Editors.Visuals;
 using Moq;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System.Collections.Generic;
 
-namespace GumToolUnitTests.Wireframe;
+namespace Gum.Presentation.Tests;
 
 /// <summary>
 /// Tests for SelectionManager.HighlightedIpsoChanged callback behavior.
@@ -26,40 +21,31 @@ namespace GumToolUnitTests.Wireframe;
 public class SelectionManagerHighlightTests : BaseTestClass
 {
     private readonly SelectionManager _selectionManager;
-    private readonly Mock<LayerService> _layerService;
 
     public SelectionManagerHighlightTests()
     {
-        SystemManagers.Default = new SystemManagers();
-        SystemManagers.Default.Renderer = new Renderer();
-        SystemManagers.Default.Renderer.AddLayer();
-        SystemManagers.Default.ShapeManager = new RenderingLibrary.Math.Geometry.ShapeManager();
-        SystemManagers.Default.TextManager = new TextManager();
-
         var mockSelectedState = new Mock<ISelectedState>();
         mockSelectedState.Setup(x => x.SelectedInstances).Returns(() => new List<InstanceSave>());
-
-        var projectManager = new Mock<IProjectManager>();
 
         _selectionManager = new SelectionManager(
             mockSelectedState.Object,
             Mock.Of<IUndoManager>(),
-            Mock.Of<IEditingManager>(),
-            Mock.Of<IDialogService>(),
+            Mock.Of<IContextMenuState>(),
+            Mock.Of<Gum.Services.Dialogs.IDialogService>(),
             Mock.Of<IHotkeyManager>(),
-            Mock.Of<IVariableInCategoryPropagationLogic>(),
             Mock.Of<IWireframeObjectManager>(),
-            projectManager.Object,
             Mock.Of<IGuiCommands>(),
-            Mock.Of<IElementCommands>(),
-            Mock.Of<IFileCommands>(),
-            Mock.Of<ISetVariableLogic>(),
-            Mock.Of<IUiSettingsService>(),
-            Mock.Of<IToolFontService>(),
-            Mock.Of<IPluginManager>());
+            Mock.Of<IWireframeEditorFactory>(),
+            Mock.Of<INineSliceCoordinateRefresher>(),
+            Mock.Of<IPreciseHitTester>());
 
-        _layerService = new Mock<LayerService>();
-        _selectionManager.Initialize(_layerService.Object);
+        _selectionManager.Initialize(
+            new Layer(),
+            new Camera(),
+            Mock.Of<IGumCursorState>(),
+            Mock.Of<ISelectionRectangleVisual>(),
+            Mock.Of<IHighlightOutlineVisual>(),
+            Mock.Of<IHighlightOverlayVisual>());
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/SelectionManagerIsShiftDownTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectionManagerIsShiftDownTests.cs
@@ -1,0 +1,61 @@
+using Gum.Commands;
+using Gum.Input;
+using Gum.Managers;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="SelectionManager.IsShiftDown"/> after its relocation to Gum.Presentation
+/// (ADR-0005, part of #3846) — it previously read the live modifier state directly via WinForms
+/// <c>Control.ModifierKeys</c>, unreachable from headless code. It now delegates to
+/// <see cref="IHotkeyManager.IsPressedInControl"/>, the same live-modifier-state seam already used
+/// for the multi-select hotkey, with a Shift-only <see cref="KeyCombination"/>.
+/// </summary>
+public class SelectionManagerIsShiftDownTests
+{
+    private static (SelectionManager SelectionManager, Mock<IHotkeyManager> HotkeyManager) CreateSut()
+    {
+        var hotkeyManager = new Mock<IHotkeyManager>();
+
+        var selectionManager = new SelectionManager(
+            Mock.Of<ISelectedState>(),
+            Mock.Of<IUndoManager>(),
+            Mock.Of<IContextMenuState>(),
+            Mock.Of<Gum.Services.Dialogs.IDialogService>(),
+            hotkeyManager.Object,
+            Mock.Of<IWireframeObjectManager>(),
+            Mock.Of<IGuiCommands>(),
+            Mock.Of<IWireframeEditorFactory>(),
+            Mock.Of<INineSliceCoordinateRefresher>(),
+            Mock.Of<IPreciseHitTester>());
+
+        return (selectionManager, hotkeyManager);
+    }
+
+    [Fact]
+    public void IsShiftDown_ReturnsTrue_WhenHotkeyManagerReportsShiftHeld()
+    {
+        var (selectionManager, hotkeyManager) = CreateSut();
+        hotkeyManager
+            .Setup(h => h.IsPressedInControl(It.Is<KeyCombination>(c => c.IsShiftDown && c.Key == null)))
+            .Returns(true);
+
+        selectionManager.IsShiftDown.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsShiftDown_ReturnsFalse_WhenHotkeyManagerReportsShiftNotHeld()
+    {
+        var (selectionManager, hotkeyManager) = CreateSut();
+        hotkeyManager
+            .Setup(h => h.IsPressedInControl(It.Is<KeyCombination>(c => c.IsShiftDown && c.Key == null)))
+            .Returns(false);
+
+        selectionManager.IsShiftDown.ShouldBeFalse();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/SelectionManagerRectangleTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectionManagerRectangleTests.cs
@@ -1,17 +1,12 @@
 using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Input;
 using Gum.Managers;
-using Gum.Plugins;
-using Gum.Plugins.InternalPlugins.EditorTab.Services;
-using Gum.Plugins.InternalPlugins.VariableGrid;
-using Gum.PropertyGridHelpers;
-using Gum.Services;
-using Gum.Services.Dialogs;
-using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
+using Gum.Wireframe.Editors.Visuals;
 using Moq;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -19,7 +14,7 @@ using Shouldly;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GumToolUnitTests.Wireframe;
+namespace Gum.Presentation.Tests;
 
 /// <summary>
 /// Tests for SelectionManager methods related to rectangle selection:
@@ -30,24 +25,13 @@ public class SelectionManagerRectangleTests : BaseTestClass
     private readonly Mock<ISelectedState> _mockSelectedState;
     private readonly Mock<IWireframeObjectManager> _mockWireframeManager;
     private readonly SelectionManager _selectionManager;
-    private readonly Mock<LayerService> _layerService;
     private readonly List<InstanceSave> _selectedInstances;
-    private readonly Mock<IProjectManager> _projectManager;
 
     public SelectionManagerRectangleTests()
     {
-        SystemManagers.Default = new SystemManagers();
-        SystemManagers.Default.Renderer = new Renderer();
-        SystemManagers.Default.Renderer.AddLayer();
-        SystemManagers.Default.ShapeManager = new RenderingLibrary.Math.Geometry.ShapeManager();
-
-        SystemManagers.Default.TextManager = new TextManager();
-
         _mockSelectedState = new Mock<ISelectedState>();
         _mockWireframeManager = new Mock<IWireframeObjectManager>();
         _selectedInstances = new List<InstanceSave>();
-
-        _projectManager = new Mock<IProjectManager>();
 
         // Setup SelectedInstances to return our test list
         _mockSelectedState.Setup(x => x.SelectedInstances).Returns(() => _selectedInstances);
@@ -64,23 +48,22 @@ public class SelectionManagerRectangleTests : BaseTestClass
         _selectionManager = new SelectionManager(
             _mockSelectedState.Object,
             Mock.Of<IUndoManager>(),
-            Mock.Of<IEditingManager>(),
-            Mock.Of<IDialogService>(),
+            Mock.Of<IContextMenuState>(),
+            Mock.Of<Gum.Services.Dialogs.IDialogService>(),
             Mock.Of<IHotkeyManager>(),
-            Mock.Of<IVariableInCategoryPropagationLogic>(),
             _mockWireframeManager.Object,
-            _projectManager.Object,
             Mock.Of<IGuiCommands>(),
-            Mock.Of<IElementCommands>(),
-            Mock.Of<IFileCommands>(),
-            Mock.Of<ISetVariableLogic>(),
-            Mock.Of<IUiSettingsService>(),
-            Mock.Of<IToolFontService>(),
-            Mock.Of<IPluginManager>());
+            Mock.Of<IWireframeEditorFactory>(),
+            Mock.Of<INineSliceCoordinateRefresher>(),
+            Mock.Of<IPreciseHitTester>());
 
-        _layerService = new Mock<LayerService>();
-
-        _selectionManager.Initialize(_layerService.Object);
+        _selectionManager.Initialize(
+            new Layer(),
+            new Camera(),
+            Mock.Of<IGumCursorState>(),
+            Mock.Of<ISelectionRectangleVisual>(),
+            Mock.Of<IHighlightOutlineVisual>(),
+            Mock.Of<IHighlightOverlayVisual>());
     }
 
     #region DeselectAll Tests

--- a/Tool/EditorTabPlugin_XNA/EditingManager.RightClick.cs
+++ b/Tool/EditorTabPlugin_XNA/EditingManager.RightClick.cs
@@ -20,6 +20,8 @@ public partial class EditingManager
 
     public ContextMenu ContextMenu => _contextMenu;
 
+    public bool IsContextMenuOpen => _contextMenu?.IsOpen == true;
+
     private void RightClickInitialize(ContextMenu contextMenu)
     {
         _viewModel = new RightClickViewModel(

--- a/Tool/EditorTabPlugin_XNA/EditingManager.cs
+++ b/Tool/EditorTabPlugin_XNA/EditingManager.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace Gum.Wireframe;
 
-public partial class EditingManager : IEditingManager
+public partial class EditingManager : IEditingManager, IContextMenuState
 {
     private readonly ISelectedState _selectedState;
     private readonly IReorderLogic _reorderLogic;

--- a/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/PolygonWireframeEditor.cs
@@ -62,7 +62,7 @@ public class PolygonWireframeEditor : WireframeEditor
     public PolygonWireframeEditor(
         Layer layer,
         IHotkeyManager hotkeyManager,
-        SelectionManager selectionManager,
+        ISelectionManager selectionManager,
         ISelectedState selectedState,
         IElementCommands elementCommands,
         IGuiCommands guiCommands,

--- a/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/StandardWireframeEditor.cs
@@ -84,7 +84,7 @@ public class StandardWireframeEditor : WireframeEditor
         Color lineColor,
         Color textColor,
         global::Gum.Managers.IHotkeyManager hotkeyManager,
-        SelectionManager selectionManager,
+        ISelectionManager selectionManager,
         ISelectedState selectedState,
         IElementCommands elementCommands,
         IGuiCommands guiCommands,

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -146,6 +146,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IToolFontService _toolFontService;
     private readonly IToolLayerService _toolLayerService;
     private readonly IPluginManager _pluginManager;
+    private IWireframeEditorFactory _wireframeEditorFactory;
 
     // Suppresses the redundant second wireframe rebuild when selecting an element forces its
     // default state (state event rebuilds) and then fires the element event for the same element.
@@ -225,22 +226,32 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _toolFontService = new ToolFontService();
         _toolLayerService = new ToolLayerService();
 
+        _wireframeEditorFactory = new WireframeEditorFactory(
+            _hotkeyManager,
+            _selectedState,
+            _elementCommands,
+            _guiCommands,
+            _fileCommands,
+            _setVariableLogic,
+            undoManager,
+            _variableInCategoryPropagationLogic,
+            _wireframeObjectManager,
+            _uiSettingsService,
+            _toolFontService,
+            _pluginManager,
+            _projectManager);
+
         _selectionManager = new SelectionManager(
             _selectedState,
             undoManager,
             _editingManager,
             _dialogService,
             _hotkeyManager,
-            _variableInCategoryPropagationLogic,
             _wireframeObjectManager,
-            _projectManager,
             _guiCommands,
-            _elementCommands,
-            _fileCommands,
-            _setVariableLogic,
-            _uiSettingsService,
-            _toolFontService,
-            _pluginManager);
+            _wireframeEditorFactory,
+            new NineSliceCoordinateRefresher(),
+            new PreciseHitTester());
 
         _screenshotService = new ScreenshotService(_selectionManager, _wireframeCommands, _guiCommands);
         _singlePixelTextureService = new SinglePixelTextureService();
@@ -818,7 +829,13 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         // _layerService must be created after _wireframeControl so that the SystemManagers.Default are assigned
         _layerService.Initialize();
-        _selectionManager.Initialize(_layerService);
+        _selectionManager.Initialize(
+            _layerService.OverlayLayer,
+            Renderer.Self.Camera,
+            InputLibrary.Cursor.Self,
+            new Gum.Wireframe.Editors.Visuals.SelectionRectangleVisual(_layerService.OverlayLayer),
+            new GraphicalOutline(_layerService.OverlayLayer),
+            new HighlightManager(_layerService.OverlayLayer));
 
         _wireframeControl.ShareLayerReferences(_layerService);
 

--- a/Tool/EditorTabPlugin_XNA/Services/HighlightManager.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/HighlightManager.cs
@@ -10,7 +10,7 @@ using EditorTabPlugin_XNA.Utilities;
 
 namespace Gum.Wireframe;
 
-public class HighlightManager
+public class HighlightManager : Editors.Visuals.IHighlightOverlayVisual
 {
     SolidRectangle mOverlaySolidRectangle;
     Sprite mOverlaySprite;

--- a/Tool/EditorTabPlugin_XNA/Services/NineSliceCoordinateRefresher.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/NineSliceCoordinateRefresher.cs
@@ -1,0 +1,18 @@
+using RenderingLibrary.Graphics;
+
+namespace Gum.Wireframe;
+
+/// <inheritdoc cref="INineSliceCoordinateRefresher"/>
+public class NineSliceCoordinateRefresher : INineSliceCoordinateRefresher
+{
+    public void RefreshIfNineSlice(IRenderable? renderableComponent)
+    {
+        // This function updates the sizes and texture coordinates of the highlighted
+        // representation if it's a NineSlice. This is needed before we set the HighlightedIpso and
+        // before we update the highlight objects.
+        if (renderableComponent is NineSlice nineSlice)
+        {
+            nineSlice.RefreshTextureCoordinatesAndSpriteSizes();
+        }
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/Services/PreciseHitTester.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/PreciseHitTester.cs
@@ -1,0 +1,18 @@
+using RenderingLibrary;
+using RenderingLibrary.Math.Geometry;
+
+namespace Gum.Wireframe;
+
+/// <inheritdoc cref="IPreciseHitTester"/>
+public class PreciseHitTester : IPreciseHitTester
+{
+    public bool HasCursorOver(GraphicalUiElement element, float x, float y)
+    {
+        if (element.RenderableComponent is LinePolygon linePolygon)
+        {
+            return linePolygon.IsPointInside(x, y);
+        }
+
+        return element.HasCursorOver(x, y);
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/Services/WireframeEditorFactory.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/WireframeEditorFactory.cs
@@ -1,0 +1,115 @@
+using Gum.Commands;
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.PropertyGridHelpers;
+using Gum.Services;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Wireframe.Editors;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Color = System.Drawing.Color;
+
+namespace Gum.Wireframe;
+
+/// <inheritdoc cref="IWireframeEditorFactory"/>
+public class WireframeEditorFactory : IWireframeEditorFactory
+{
+    private readonly IHotkeyManager _hotkeyManager;
+    private readonly ISelectedState _selectedState;
+    private readonly IElementCommands _elementCommands;
+    private readonly IGuiCommands _guiCommands;
+    private readonly IFileCommands _fileCommands;
+    private readonly ISetVariableLogic _setVariableLogic;
+    private readonly IUndoManager _undoManager;
+    private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IUiSettingsService _uiSettingsService;
+    private readonly IToolFontService _toolFontService;
+    private readonly IPluginManager _pluginManager;
+    private readonly IProjectManager _projectManager;
+
+    public WireframeEditorFactory(
+        IHotkeyManager hotkeyManager,
+        ISelectedState selectedState,
+        IElementCommands elementCommands,
+        IGuiCommands guiCommands,
+        IFileCommands fileCommands,
+        ISetVariableLogic setVariableLogic,
+        IUndoManager undoManager,
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
+        IWireframeObjectManager wireframeObjectManager,
+        IUiSettingsService uiSettingsService,
+        IToolFontService toolFontService,
+        IPluginManager pluginManager,
+        IProjectManager projectManager)
+    {
+        _hotkeyManager = hotkeyManager;
+        _selectedState = selectedState;
+        _elementCommands = elementCommands;
+        _guiCommands = guiCommands;
+        _fileCommands = fileCommands;
+        _setVariableLogic = setVariableLogic;
+        _undoManager = undoManager;
+        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
+        _wireframeObjectManager = wireframeObjectManager;
+        _uiSettingsService = uiSettingsService;
+        _toolFontService = toolFontService;
+        _pluginManager = pluginManager;
+        _projectManager = projectManager;
+    }
+
+    public WireframeEditor CreateStandardEditor(ISelectionManager selectionManager, Layer layer, Camera camera, IGumCursorState cursor)
+    {
+        var lineColor = Color.FromArgb(255, _projectManager.GuideLineColorR,
+            _projectManager.GuideLineColorG,
+            _projectManager.GuideLineColorB);
+
+        var textColor = Color.FromArgb(255, _projectManager.GuideTextColorR,
+            _projectManager.GuideTextColorG,
+            _projectManager.GuideTextColorB);
+
+        return new StandardWireframeEditor(
+            layer,
+            lineColor,
+            textColor,
+            _hotkeyManager,
+            selectionManager,
+            _selectedState,
+            _elementCommands,
+            _guiCommands,
+            _fileCommands,
+            _setVariableLogic,
+            _undoManager,
+            _variableInCategoryPropagationLogic,
+            _wireframeObjectManager,
+            _uiSettingsService,
+            camera,
+            cursor,
+            _toolFontService,
+            _pluginManager);
+    }
+
+    public WireframeEditor CreatePolygonEditor(ISelectionManager selectionManager, Layer layer, Camera camera, IGumCursorState cursor)
+    {
+        return new PolygonWireframeEditor(
+            layer,
+            _hotkeyManager,
+            selectionManager,
+            _selectedState,
+            _elementCommands,
+            _guiCommands,
+            _fileCommands,
+            _setVariableLogic,
+            _undoManager,
+            _variableInCategoryPropagationLogic,
+            _wireframeObjectManager,
+            _uiSettingsService,
+            camera,
+            cursor,
+            _pluginManager);
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/Views/GraphicalOutline.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/GraphicalOutline.cs
@@ -10,7 +10,7 @@ using Matrix = System.Numerics.Matrix4x4;
 
 namespace Gum.Wireframe
 {
-    public class GraphicalOutline
+    public class GraphicalOutline : Editors.Visuals.IHighlightOutlineVisual
     {
         #region Fields
 

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -388,7 +388,7 @@ public class WireframeControl : GraphicsDeviceControl
 
                     _selectionManager.Activity(shouldForceNoHighlight);
 
-                    _selectionManager.LateActivity(this.SystemManagers);
+                    _selectionManager.LateActivity();
                 }
 
                 InputLibrary.Cursor.Self.EndCursorSettingFrameStart();

--- a/Tools/Gum.Presentation/Input/IGumCursorState.cs
+++ b/Tools/Gum.Presentation/Input/IGumCursorState.cs
@@ -24,4 +24,23 @@ public interface IGumCursorState
     bool PrimaryDown { get; }
     bool PrimaryPush { get; }
     bool PrimaryClick { get; }
+
+    /// <summary>Whether the cursor is currently positioned over the editor window.</summary>
+    bool IsInWindow { get; }
+
+    /// <summary>Whether the current <see cref="PrimaryClick"/> is the second click of a double-click.</summary>
+    bool PrimaryDoubleClick { get; }
+
+    /// <summary>Whether the secondary (right) mouse button was pushed this frame.</summary>
+    bool SecondaryPush { get; }
+
+    /// <summary>Same as <see cref="PrimaryDown"/> but does not require <see cref="IsInWindow"/> to be true.</summary>
+    bool PrimaryDownIgnoringIsInWindow { get; }
+
+    /// <summary>
+    /// Requests that the given cursor icon be shown. The mapping to a real framework cursor type
+    /// (e.g. WinForms <c>Cursor</c>) is the implementation's job, so headless callers never need to
+    /// reference a framework cursor type directly.
+    /// </summary>
+    void SetCursor(GumCursorKind kind);
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Visuals/IHighlightOutlineVisual.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Visuals/IHighlightOutlineVisual.cs
@@ -1,0 +1,23 @@
+namespace Gum.Wireframe.Editors.Visuals;
+
+/// <summary>
+/// The dashed/dotted outline rectangle <c>SelectionManager</c> draws around the currently
+/// highlighted (hovered) object, exposed without referencing the underlying XNALIKE-only drawing
+/// types (<c>LineRectangle</c>, <c>NineSlice</c>) the tool-side <c>GraphicalOutline</c> uses,
+/// unreachable from headless <c>Gum.Presentation</c>.
+/// </summary>
+public interface IHighlightOutlineVisual
+{
+    /// <summary>
+    /// The object currently being outlined, or null to clear the outline. Setting this recomputes
+    /// the outline geometry.
+    /// </summary>
+    GraphicalUiElement? HighlightedIpso { set; }
+
+    /// <summary>
+    /// Recomputes the outline (and any NineSlice split lines) around the current
+    /// <see cref="HighlightedIpso"/>. Called every frame so the outline tracks a nudge/resize
+    /// immediately.
+    /// </summary>
+    void UpdateHighlightElements();
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Visuals/IHighlightOverlayVisual.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Visuals/IHighlightOverlayVisual.cs
@@ -1,0 +1,24 @@
+using RenderingLibrary;
+
+namespace Gum.Wireframe.Editors.Visuals;
+
+/// <summary>
+/// The translucent overlay (Sprite/NineSlice/LineRectangle/LinePolygon-shaped) <c>SelectionManager</c>
+/// draws over the currently highlighted object, exposed without referencing the underlying
+/// XNALIKE-only renderable types the tool-side <c>HighlightManager</c> uses, unreachable from
+/// headless <c>Gum.Presentation</c>.
+/// </summary>
+public interface IHighlightOverlayVisual
+{
+    /// <summary>The object the overlay is currently shaped around.</summary>
+    IPositionedSizedObject? HighlightedIpso { set; }
+
+    /// <summary>Whether the overlay should be drawn at all.</summary>
+    bool AreHighlightsVisible { get; set; }
+
+    /// <summary>Hides the overlay shaped for <paramref name="highlightedIpso"/>.</summary>
+    void UnhighlightIpso(GraphicalUiElement highlightedIpso);
+
+    /// <summary>Recomputes and shows the overlay shaped around <see cref="HighlightedIpso"/>.</summary>
+    void UpdateHighlightObjects();
+}

--- a/Tools/Gum.Presentation/Wireframe/IContextMenuState.cs
+++ b/Tools/Gum.Presentation/Wireframe/IContextMenuState.cs
@@ -1,0 +1,12 @@
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Headless-safe subset of the tool-side <c>IEditingManager</c>: whether the wireframe right-click
+/// context menu is currently open. <c>IEditingManager.ContextMenu</c> itself is a WPF
+/// <c>System.Windows.Controls.ContextMenu</c>, unreachable from headless <c>Gum.Presentation</c>, but
+/// consumers here (e.g. <c>SelectionManager</c>) only ever need this one bit.
+/// </summary>
+public interface IContextMenuState
+{
+    bool IsContextMenuOpen { get; }
+}

--- a/Tools/Gum.Presentation/Wireframe/INineSliceCoordinateRefresher.cs
+++ b/Tools/Gum.Presentation/Wireframe/INineSliceCoordinateRefresher.cs
@@ -1,0 +1,17 @@
+using RenderingLibrary.Graphics;
+
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Refreshes a NineSlice's texture coordinates and sprite sizes before it is highlighted, without
+/// <c>SelectionManager</c> referencing the concrete <c>NineSlice</c> type (XNALIKE-only, unreachable
+/// from headless <c>Gum.Presentation</c>).
+/// </summary>
+public interface INineSliceCoordinateRefresher
+{
+    /// <summary>
+    /// If <paramref name="renderableComponent"/> is a NineSlice, refreshes its texture coordinates
+    /// and sprite sizes. No-op for any other type (or null).
+    /// </summary>
+    void RefreshIfNineSlice(IRenderable? renderableComponent);
+}

--- a/Tools/Gum.Presentation/Wireframe/IPreciseHitTester.cs
+++ b/Tools/Gum.Presentation/Wireframe/IPreciseHitTester.cs
@@ -1,0 +1,14 @@
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Precise (non-bounding-box) hit testing for hover/click selection. Most
+/// <see cref="GraphicalUiElement"/>s use the generic rotated-bounding-box
+/// <c>IRenderableIpso.HasCursorOver</c> extension method, but a polygon needs an actual
+/// point-in-polygon test (<c>LinePolygon.IsPointInside</c>) — a concrete, XNALIKE-only type
+/// unreachable from headless <c>Gum.Presentation</c>, so that distinction is pushed behind this
+/// seam instead of <c>SelectionManager</c> type-checking for <c>LinePolygon</c> directly.
+/// </summary>
+public interface IPreciseHitTester
+{
+    bool HasCursorOver(GraphicalUiElement element, float x, float y);
+}

--- a/Tools/Gum.Presentation/Wireframe/IWireframeEditorFactory.cs
+++ b/Tools/Gum.Presentation/Wireframe/IWireframeEditorFactory.cs
@@ -1,0 +1,19 @@
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Gum.Input;
+
+namespace Gum.Wireframe;
+
+/// <summary>
+/// Builds the concrete <see cref="WireframeEditor"/> implementation (<c>StandardWireframeEditor</c>
+/// or <c>PolygonWireframeEditor</c>) for the current selection. <c>SelectionManager</c> only decides
+/// *when* a new editor is needed (polygon vs. standard, or none) — the concrete editors are tool-side
+/// (XNALIKE rendering, a tool-only font service, project-settings colors), so building one is pushed
+/// behind this seam instead of <c>SelectionManager</c> constructing them directly.
+/// </summary>
+public interface IWireframeEditorFactory
+{
+    WireframeEditor CreateStandardEditor(ISelectionManager selectionManager, Layer layer, Camera camera, IGumCursorState cursor);
+
+    WireframeEditor CreatePolygonEditor(ISelectionManager selectionManager, Layer layer, Camera camera, IGumCursorState cursor);
+}

--- a/Tools/Gum.Presentation/Wireframe/SelectionManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/SelectionManager.cs
@@ -1,44 +1,33 @@
-﻿using Gum.Commands;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Input;
 using Gum.Managers;
-using Gum.Plugins;
-using Gum.Plugins.InternalPlugins.EditorTab.Services;
-using Gum.Plugins.InternalPlugins.VariableGrid;
-using Gum.PropertyGridHelpers;
-using Gum.Services;
 using Gum.Services.Dialogs;
-using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Undo;
-using Gum.Wireframe.Editors;
 using Gum.Wireframe.Editors.Visuals;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
-using RenderingLibrary.Math.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
-using System.Windows.Input;
-using Color = System.Drawing.Color;
-using Matrix = System.Numerics.Matrix4x4;
-using WinCursor = System.Windows.Forms.Cursor;
 
 namespace Gum.Wireframe;
-
-// ISelectionManager moved to Gum.Presentation (Tools/Gum.Presentation/Wireframe/ISelectionManager.cs)
-// so EditorContext/RectangleSelector/WireframeEditor and its input handlers (also moved) can depend
-// on it without the concrete SelectionManager, which stays here — it directly reads WinForms
-// Control.ModifierKeys and sets a WinForms Cursor. Same namespace, so no using changes needed.
 
 public class SelectionManager : ISelectionManager
 {
     #region Fields
 
-    LayerService _layerService;
-
     public WireframeEditor? WireframeEditor;
+
+    private enum WireframeEditorKind
+    {
+        None,
+        Standard,
+        Polygon
+    }
+
+    private WireframeEditorKind _currentEditorKind = WireframeEditorKind.None;
 
     /// <summary>
     /// Set on PrimaryPush when the push was on an already-selected locked instance body.
@@ -53,40 +42,28 @@ public class SelectionManager : ISelectionManager
 
     public event Action<IPositionedSizedObject?>? HighlightedIpsoChanged;
 
-    GraphicalOutline mGraphicalOutline;
+    IHighlightOutlineVisual mGraphicalOutline;
 
-
-    HighlightManager highlightManager;
+    IHighlightOverlayVisual highlightManager;
 
     #endregion
 
     #region Properties
 
-
-    public InputLibrary.Cursor Cursor
-    {
-        get
-        {
-            return InputLibrary.Cursor.Self;
-        }
-    }
-
-
     private readonly ISelectedState _selectedState;
-    private readonly IEditingManager _editingManager;
     private readonly IUndoManager _undoManager;
+    private readonly IContextMenuState _contextMenuState;
     private readonly IDialogService _dialogService;
     private readonly IHotkeyManager _hotkeyManager;
     private readonly IWireframeObjectManager _wireframeObjectManager;
-    private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
-    private readonly IProjectManager _projectManager;
     private readonly IGuiCommands _guiCommands;
-    private readonly IElementCommands _elementCommands;
-    private readonly IFileCommands _fileCommands;
-    private readonly ISetVariableLogic _setVariableLogic;
-    private readonly IUiSettingsService _uiSettingsService;
-    private readonly IToolFontService _toolFontService;
-    private readonly IPluginManager _pluginManager;
+    private readonly IWireframeEditorFactory _wireframeEditorFactory;
+    private readonly INineSliceCoordinateRefresher _nineSliceCoordinateRefresher;
+    private readonly IPreciseHitTester _preciseHitTester;
+
+    private Layer _overlayLayer;
+    private Camera _camera;
+    private IGumCursorState _cursor;
 
     public virtual bool IsOverBody
     {
@@ -166,13 +143,12 @@ public class SelectionManager : ISelectionManager
         }
     }
 
-    public bool IsShiftDown
-    {
-        get
-        {
-            return ((Control.ModifierKeys & Keys.Shift) != 0);
-        }
-    }
+    /// <summary>
+    /// Whether Shift is currently held, via the same live-modifier-state seam
+    /// (<see cref="IHotkeyManager.IsPressedInControl"/>) already used for the multi-select hotkey,
+    /// rather than reading a WinForms modifier state directly.
+    /// </summary>
+    public bool IsShiftDown => _hotkeyManager.IsPressedInControl(KeyCombination.Shift());
 
     bool restrictToUnitValues;
     public bool RestrictToUnitValues
@@ -204,45 +180,47 @@ public class SelectionManager : ISelectionManager
 
     public SelectionManager(ISelectedState selectedState,
         IUndoManager undoManager,
-        IEditingManager editingManager,
+        IContextMenuState contextMenuState,
         IDialogService dialogService,
         IHotkeyManager hotkeyManager,
-        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
         IWireframeObjectManager wireframeObjectManager,
-        IProjectManager projectManager,
         IGuiCommands guiCommands,
-        IElementCommands elementCommands,
-        IFileCommands fileCommands,
-        ISetVariableLogic setVariableLogic,
-        IUiSettingsService uiSettingsService,
-        IToolFontService toolFontService,
-        IPluginManager pluginManager)
+        IWireframeEditorFactory wireframeEditorFactory,
+        INineSliceCoordinateRefresher nineSliceCoordinateRefresher,
+        IPreciseHitTester preciseHitTester)
     {
         _selectedState = selectedState;
-        _toolFontService = toolFontService;
-        _editingManager = editingManager;
         _undoManager = undoManager;
+        _contextMenuState = contextMenuState;
         _dialogService = dialogService;
         _hotkeyManager = hotkeyManager;
         _wireframeObjectManager = wireframeObjectManager;
-        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
-        _projectManager = projectManager;
         _guiCommands = guiCommands;
-        _elementCommands = elementCommands;
-        _fileCommands = fileCommands;
-        _setVariableLogic = setVariableLogic;
-        _uiSettingsService = uiSettingsService;
-        _pluginManager = pluginManager;
+        _wireframeEditorFactory = wireframeEditorFactory;
+        _nineSliceCoordinateRefresher = nineSliceCoordinateRefresher;
+        _preciseHitTester = preciseHitTester;
     }
 
-    public void Initialize(LayerService layerService)
+    /// <summary>
+    /// Finishes construction with the live rendering-side dependencies (overlay layer, camera,
+    /// cursor, and the tool-side visuals SelectionManager decorates but doesn't build itself) —
+    /// these aren't available until the XNA host has initialized, so they're supplied here rather
+    /// than the constructor (two-stage init).
+    /// </summary>
+    public void Initialize(
+        Layer overlayLayer,
+        Camera camera,
+        IGumCursorState cursor,
+        ISelectionRectangleVisual selectionRectangleVisual,
+        IHighlightOutlineVisual highlightOutline,
+        IHighlightOverlayVisual highlightOverlay)
     {
-        _layerService = layerService;
-        var overlayLayer = layerService.OverlayLayer;
+        _overlayLayer = overlayLayer;
+        _camera = camera;
+        _cursor = cursor;
 
-        mGraphicalOutline = new GraphicalOutline(overlayLayer);
-
-        highlightManager = new HighlightManager(overlayLayer);
+        mGraphicalOutline = highlightOutline;
+        highlightManager = highlightOverlay;
 
         // Initialize rectangle selector for drag-to-select functionality
         _rectangleSelector = new RectangleSelector(
@@ -250,9 +228,9 @@ public class SelectionManager : ISelectionManager
             _wireframeObjectManager,
             this,
             _guiCommands,
-            Renderer.Self.Camera,
-            InputLibrary.Cursor.Self,
-            new SelectionRectangleVisual(overlayLayer));
+            _camera,
+            _cursor,
+            selectionRectangleVisual);
     }
 
     /// <summary>
@@ -278,18 +256,12 @@ public class SelectionManager : ISelectionManager
             // Always check this even if the cursor isn't over the window because other windows (like
             // the texture coordinate seleciton plugin window) can change the texture coordinates and we
             // want the highlight to update:
-            //if (Cursor.IsInWindow && _selectedState.SelectedElement != null)
             if (_selectedState.SelectedElement != null)
             {
                 HighlightActivity(forceNoHighlight);
 
                 SelectionActivity();
             }
-            //else if (!Cursor.IsInWindow)
-            //{
-            // the element view window can also highlight, so we don't want to do this:
-            //HighlightedIpso = null;
-            //}
         }
         catch (Exception e)
         {
@@ -297,7 +269,7 @@ public class SelectionManager : ISelectionManager
         }
     }
 
-    public void LateActivity(SystemManagers systemManagers)
+    public void LateActivity()
     {
         // Only update visuals here - input processing happens in SelectionActivity via ProcessInputForSelection
         WireframeEditor?.UpdateVisuals(SelectedGues);
@@ -417,7 +389,7 @@ public class SelectionManager : ISelectionManager
     /// to un-highlight anything if the cursor is outside of the window</param>
     void HighlightActivity(bool forceNoHighlight)
     {
-        if (!InputLibrary.Cursor.Self.PrimaryDownIgnoringIsInWindow)
+        if (!_cursor.PrimaryDownIgnoringIsInWindow)
         {
             // There is currently a known
             // bug where the user can click+drag
@@ -425,14 +397,13 @@ public class SelectionManager : ISelectionManager
             // wireframe window and the cursor will
             // change.
 
-            var cursorToSet = System.Windows.Forms.Cursors.Arrow;
+            var cursorToSet = GumCursorKind.Arrow;
 
-            float worldXAt = Cursor.GetWorldX();
-            float worldYAt = Cursor.GetWorldY();
+            _camera.ScreenToWorld(_cursor.X, _cursor.Y, out float worldXAt, out float worldYAt);
 
             GraphicalUiElement? representationOver = null;
 
-            if (_editingManager.ContextMenu?.IsOpen == true)
+            if (_contextMenuState.IsContextMenuOpen)
             {
                 // do nothing!
             }
@@ -442,7 +413,7 @@ public class SelectionManager : ISelectionManager
                 {
                     var rectangleCursor = _rectangleSelector.GetCursorToShow();
                     if (rectangleCursor != null)
-                        cursorToSet = ToWinFormsCursor(rectangleCursor.Value);
+                        cursorToSet = rectangleCursor.Value;
                 }
 
                 // Cursor and IsOverBody are determined by which of four mutually exclusive
@@ -460,7 +431,7 @@ public class SelectionManager : ISelectionManager
                     IsOverBody = false;
                     cursorToSet = ApplyHandlerCursor(cursorToSet, worldXAt, worldYAt);
                 }
-                else if (IsOverBody && Cursor.PrimaryDown)
+                else if (IsOverBody && _cursor.PrimaryDown)
                 {
                     representationOver = _wireframeObjectManager.GetSelectedRepresentation();
                     var selectedIsLocked = _selectedState.SelectedInstance?.Locked == true;
@@ -486,25 +457,19 @@ public class SelectionManager : ISelectionManager
                 }
             }
 
+            // This updates the sizes and texture coordinates of the highlighted representation if
+            // it's a NineSlice. This is needed before we set the HighlightedIpso and before we
+            // update the highlight objects. No-op for any other component type.
+            _nineSliceCoordinateRefresher.RefreshIfNineSlice(representationOver?.RenderableComponent);
 
-            if (representationOver != null && representationOver.RenderableComponent is NineSlice nineslice)
+            // We used to not check this, but we have to now because the cursor might be
+            if (_cursor.IsInWindow)
             {
-                // This function updates the sizes and texture coordinates of the 
-                // highlighted representation if it's a NineSlice.  This is needed before
-                // we set the HighlightedIpso and before we update the highlight objects
-                nineslice.RefreshTextureCoordinatesAndSpriteSizes();
-            }
-
-
-
-            // We used to not check this, but we have to now because the cursor might be 
-            if (Cursor.IsInWindow)
-            {
-                Cursor.SetWinformsCursor(cursorToSet);
+                _cursor.SetCursor(cursorToSet);
 
                 // We don't want to show the highlight when the user is performing some kind of editing.
                 // Therefore make sure the cursor isn't down.
-                if (representationOver != null && Cursor.PrimaryDown == false)
+                if (representationOver != null && _cursor.PrimaryDown == false)
                 {
                     HighlightedIpso = representationOver;
 
@@ -516,7 +481,7 @@ public class SelectionManager : ISelectionManager
                 }
             }
         }
-        else if (InputLibrary.Cursor.Self.PrimaryDown && Cursor.IsInWindow)
+        else if (_cursor.PrimaryDown && _cursor.IsInWindow)
         {
             // We only want to hide it if the user is holding the cursor down over the wireframe window.
             HighlightedIpso = null;
@@ -532,29 +497,15 @@ public class SelectionManager : ISelectionManager
 
     /// <summary>
     /// Asks <see cref="WireframeEditor"/> (headless, in Gum.Presentation) which cursor its
-    /// handlers want to show and maps the neutral <see cref="GumCursorKind"/> answer to a real
-    /// WinForms <see cref="WinCursor"/>, or returns <paramref name="defaultCursor"/> unchanged if
-    /// no handler has an opinion. This is the one place that mapping happens — WireframeEditor and
-    /// its input handlers only ever deal in <see cref="GumCursorKind"/>.
+    /// handlers want to show, falling back to <paramref name="defaultCursor"/> if no handler has an
+    /// opinion. Mapping the resulting <see cref="GumCursorKind"/> to a real framework cursor is
+    /// <see cref="IGumCursorState.SetCursor"/>'s job, not this class's.
     /// </summary>
-    private WinCursor ApplyHandlerCursor(WinCursor defaultCursor, float worldXAt, float worldYAt)
+    private GumCursorKind ApplyHandlerCursor(GumCursorKind defaultCursor, float worldXAt, float worldYAt)
     {
         var cursorKind = WireframeEditor.GetCursorToShow(worldXAt, worldYAt);
-        return cursorKind != null ? ToWinFormsCursor(cursorKind.Value) : defaultCursor;
+        return cursorKind ?? defaultCursor;
     }
-
-    private static WinCursor ToWinFormsCursor(GumCursorKind kind) => kind switch
-    {
-        GumCursorKind.Arrow => System.Windows.Forms.Cursors.Arrow,
-        GumCursorKind.Cross => System.Windows.Forms.Cursors.Cross,
-        GumCursorKind.Hand => System.Windows.Forms.Cursors.Hand,
-        GumCursorKind.SizeAll => System.Windows.Forms.Cursors.SizeAll,
-        GumCursorKind.SizeNS => System.Windows.Forms.Cursors.SizeNS,
-        GumCursorKind.SizeWE => System.Windows.Forms.Cursors.SizeWE,
-        GumCursorKind.SizeNESW => System.Windows.Forms.Cursors.SizeNESW,
-        GumCursorKind.SizeNWSE => System.Windows.Forms.Cursors.SizeNWSE,
-        _ => System.Windows.Forms.Cursors.Arrow
-    };
 
     public GraphicalUiElement GetRepresentationAt(float x, float y, bool trySkipSelected, List<ElementWithState> elementStack)
     {
@@ -582,23 +533,11 @@ public class SelectionManager : ISelectionManager
                         // If this is a container, and dotted lines are not drawn, then this has no renderable component:
                         if (selectedRepresentation?.RenderableComponent != null)
                         {
-                            var hasCursorOver = false;
-
-                            if (selectedRepresentation.RenderableComponent is LinePolygon)
-                            {
-                                hasCursorOver = (selectedRepresentation.RenderableComponent as LinePolygon).IsPointInside(x, y);
-                            }
-                            else
-                            {
-                                hasCursorOver = selectedRepresentation.HasCursorOver(x, y);
-                            }
-
-                            if (hasCursorOver)
+                            if (_preciseHitTester.HasCursorOver(selectedRepresentation, x, y))
                             {
                                 ipsoOver = selectedRepresentation;
                                 break;
                             }
-
                         }
                     }
                 }
@@ -707,16 +646,7 @@ public class SelectionManager : ISelectionManager
 
                 if (visible == visibleToCheck)
                 {
-                    var hasCursorOver = false;
-
-                    if (graphicalUiElement.RenderableComponent is LinePolygon)
-                    {
-                        hasCursorOver = (graphicalUiElement.RenderableComponent as LinePolygon).IsPointInside(x, y);
-                    }
-                    else
-                    {
-                        hasCursorOver = graphicalUiElement.HasCursorOver(x, y);
-                    }
+                    bool hasCursorOver = _preciseHitTester.HasCursorOver(graphicalUiElement, x, y);
 
                     if (hasCursorOver && (_wireframeObjectManager.IsRepresentation(graphicalUiElement)))
                     {
@@ -763,14 +693,6 @@ public class SelectionManager : ISelectionManager
         {
             isVisible = (asIVisible).AbsoluteVisible;
         }
-        else if (ipso is Sprite asSprite)
-        {
-            isVisible = (asSprite).AbsoluteVisible;
-        }
-        else if (ipso is Text asText)
-        {
-            isVisible = (asText).AbsoluteVisible;
-        }
 
         return isVisible;
     }
@@ -796,14 +718,7 @@ public class SelectionManager : ISelectionManager
         if (isPolygon)
         {
             // use the Polygon wireframe editor
-            if (WireframeEditor is PolygonWireframeEditor == false)
-            {
-                if (WireframeEditor != null)
-                {
-                    WireframeEditor.Destroy();
-                }
-                CreatePolygonWireframeEditor();
-            }
+            SwitchToPolygonEditor();
         }
         else if (SelectedGues.Count > 0 && SelectedGue?.Tag is ScreenSave == false)
         {
@@ -816,55 +731,21 @@ public class SelectionManager : ISelectionManager
 
             if (isPolygon)
             {
-                if (WireframeEditor != null)
-                {
-                    WireframeEditor.Destroy();
-                }
-                CreatePolygonWireframeEditor();
+                SwitchToPolygonEditor();
             }
-            else
+            else if (_currentEditorKind != WireframeEditorKind.Standard)
             {
-                if (WireframeEditor is StandardWireframeEditor == false)
-                {
-                    if (WireframeEditor != null)
-                    {
-                        WireframeEditor.Destroy();
-                    }
+                WireframeEditor?.Destroy();
 
-                    var lineColor = Color.FromArgb(255, _projectManager.GuideLineColorR,
-                        _projectManager.GuideLineColorG,
-                        _projectManager.GuideLineColorB);
-
-                    var textColor = Color.FromArgb(255, _projectManager.GuideTextColorR,
-                        _projectManager.GuideTextColorG,
-                        _projectManager.GuideTextColorB);
-
-                    WireframeEditor = new StandardWireframeEditor(
-                        _layerService.OverlayLayer,
-                        lineColor,
-                        textColor,
-                        _hotkeyManager,
-                        this,
-                        _selectedState,
-                        _elementCommands,
-                        _guiCommands,
-                        _fileCommands,
-                        _setVariableLogic,
-                        _undoManager,
-                        _variableInCategoryPropagationLogic,
-                        _wireframeObjectManager,
-                        _uiSettingsService,
-                        Renderer.Self.Camera,
-                        InputLibrary.Cursor.Self,
-                        _toolFontService,
-                        _pluginManager);
-                }
+                WireframeEditor = _wireframeEditorFactory.CreateStandardEditor(this, _overlayLayer, _camera, _cursor);
+                _currentEditorKind = WireframeEditorKind.Standard;
             }
         }
         else if (WireframeEditor != null)
         {
             WireframeEditor.Destroy();
             WireframeEditor = null;
+            _currentEditorKind = WireframeEditorKind.None;
         }
 
         if (WireframeEditor != null)
@@ -881,24 +762,14 @@ public class SelectionManager : ISelectionManager
         }
     }
 
-    private void CreatePolygonWireframeEditor()
+    private void SwitchToPolygonEditor()
     {
-        WireframeEditor = new PolygonWireframeEditor(
-            _layerService.OverlayLayer,
-            _hotkeyManager,
-            this,
-            _selectedState,
-            _elementCommands,
-            _guiCommands,
-            _fileCommands,
-            _setVariableLogic,
-            _undoManager,
-            _variableInCategoryPropagationLogic,
-            _wireframeObjectManager,
-            _uiSettingsService,
-            Renderer.Self.Camera,
-            InputLibrary.Cursor.Self,
-            _pluginManager);
+        if (_currentEditorKind != WireframeEditorKind.Polygon)
+        {
+            WireframeEditor?.Destroy();
+            WireframeEditor = _wireframeEditorFactory.CreatePolygonEditor(this, _overlayLayer, _camera, _cursor);
+            _currentEditorKind = WireframeEditorKind.Polygon;
+        }
     }
 
     #region New Explicit Input Processing System
@@ -942,9 +813,8 @@ public class SelectionManager : ISelectionManager
     /// </summary>
     private void ProcessInputForSelection()
     {
-        var cursor = Cursor;
-        float worldX = cursor.GetWorldX();
-        float worldY = cursor.GetWorldY();
+        var cursor = _cursor;
+        _camera.ScreenToWorld(cursor.X, cursor.Y, out float worldX, out float worldY);
 
         // ═══════════════════════════════════════════════════════════════
         // DIFFERENT ORDERING FOR PUSH vs DOWN/CLICK
@@ -1051,7 +921,7 @@ public class SelectionManager : ISelectionManager
     /// Determines what's under the cursor without changing any state.
     /// This is a pure query - no side effects.
     /// </summary>
-    private InputContext DetermineInputContext(float worldX, float worldY, InputLibrary.Cursor cursor)
+    private InputContext DetermineInputContext(float worldX, float worldY, IGumCursorState cursor)
     {
         var context = new InputContext
         {
@@ -1103,7 +973,7 @@ public class SelectionManager : ISelectionManager
     /// - PrimaryPush: Called BEFORE handlers (selection updates first)
     /// - PrimaryDown/Click: Called AFTER handlers (handlers continue operation)
     /// </summary>
-    private InputDecision MakeInputDecision(InputContext context, InputLibrary.Cursor cursor)
+    private InputDecision MakeInputDecision(InputContext context, IGumCursorState cursor)
     {
         // ═══════════════════════════════════════════════════════════════
         // PRIORITY 1: If any handler is active (dragging),
@@ -1154,7 +1024,7 @@ public class SelectionManager : ISelectionManager
     private void ExecuteInputDecision(
         InputDecision decision,
         InputContext context,
-        InputLibrary.Cursor cursor,
+        IGumCursorState cursor,
         float worldX,
         float worldY)
     {
@@ -1184,7 +1054,7 @@ public class SelectionManager : ISelectionManager
     /// Separated into its own method for clarity.
     /// If rectangle selector doesn't activate (no drag), falls back to normal selection.
     /// </summary>
-    private void ProcessRectangleSelection(InputLibrary.Cursor cursor, float worldX, float worldY, InputContext context)
+    private void ProcessRectangleSelection(IGumCursorState cursor, float worldX, float worldY, InputContext context)
     {
         if (_rectangleSelector == null)
             return;
@@ -1240,13 +1110,12 @@ public class SelectionManager : ISelectionManager
     {
         // Update hover state EVERY frame (not just when there's input)
         // This ensures hover highlights (e.g., polygon point highlights) show correctly
-        var cursor = Cursor;
-        float worldX = cursor.GetWorldX();
-        float worldY = cursor.GetWorldY();
+        var cursor = _cursor;
+        _camera.ScreenToWorld(cursor.X, cursor.Y, out float worldX, out float worldY);
         WireframeEditor?.UpdateHover(worldX, worldY);
 
         // Process input only when no context menu is visible
-        if (_editingManager.ContextMenu?.IsOpen != true)
+        if (!_contextMenuState.IsContextMenuOpen)
         {
             ProcessInputForSelection();
         }
@@ -1261,15 +1130,14 @@ public class SelectionManager : ISelectionManager
             // is already selected
             if (WireframeEditor?.HasCursorOverHandles != true)
             {
-                float x = Cursor.GetWorldX();
-                float y = Cursor.GetWorldY();
+                _camera.ScreenToWorld(_cursor.X, _cursor.Y, out float x, out float y);
 
                 List<ElementWithState> elementStack = new List<ElementWithState>();
                 elementStack.Add(new ElementWithState(_selectedState.SelectedElement));
 
 
                 IRenderableIpso representation =
-                    GetRepresentationAt(x, y, Cursor.PrimaryDoubleClick || IsComponentNoInstanceSelected, elementStack);
+                    GetRepresentationAt(x, y, _cursor.PrimaryDoubleClick || IsComponentNoInstanceSelected, elementStack);
                 bool hasChanged = true;
 
                 if (representation != null)
@@ -1282,7 +1150,7 @@ public class SelectionManager : ISelectionManager
                     {
                         throw new Exception("Either the selected element or instance should not be null");
                     }
-                    // The representation 
+                    // The representation
                     // will become invalid
                     // in the following if/else
                     // because the Wireframe view


### PR DESCRIPTION
Closes #3846.

## What changed
Relocates `SelectionManager` (the last piece of #3846) from `Tool/EditorTabPlugin_XNA` into headless `Gum.Presentation` (`Tools/Gum.Presentation/Wireframe/SelectionManager.cs`).

The two named blockers (WinForms `Control.ModifierKeys` read, `Cursor.SetWinformsCursor` call) confirmed real, but the class had more blockers than scoped:
- `Renderer.Self.Camera` / `InputLibrary.Cursor.Self` direct reads (XNALIKE singletons) — now injected via `Initialize(Layer, Camera, IGumCursorState, ...)`.
- `IGumCursorState` was too narrow for what `SelectionManager` actually polls — widened with `IsInWindow`, `PrimaryDoubleClick`, `SecondaryPush`, `PrimaryDownIgnoringIsInWindow`, and `SetCursor(GumCursorKind)`.
- Directly constructed the XNALIKE-only `GraphicalOutline`/`HighlightManager`/`SelectionRectangleVisual` — new narrow interfaces `IHighlightOutlineVisual`/`IHighlightOverlayVisual` (plus the existing `ISelectionRectangleVisual`), tool-side implementations built by the caller and injected via `Initialize`.
- Directly `new`ed the tool-only concrete `StandardWireframeEditor`/`PolygonWireframeEditor` (needing a tool-only font service and project guide-color settings) — extracted `IWireframeEditorFactory`, tool-side implementation (`WireframeEditorFactory`). The removed `WireframeEditor is StandardWireframeEditor`/`is PolygonWireframeEditor` type-checks became an explicitly-tracked `_currentEditorKind` field.
- Type-checked concrete `NineSlice`/`LinePolygon` renderables (XNALIKE-only) — new narrow interfaces `INineSliceCoordinateRefresher`/`IPreciseHitTester`, tool-side implementations.
- `Sprite`/`Text` type-check branches in `IsIpsoVisible` were dead code (already covered by the preceding `IVisible` branch, since both implement it) — deleted.
- `IEditingManager.ContextMenu` (a WPF type) — new narrow `IContextMenuState` (`IsContextMenuOpen`), implemented alongside the existing `IEditingManager` by the same concrete `EditingManager`.
- `IsShiftDown` now delegates to `IHotkeyManager.IsPressedInControl(KeyCombination.Shift())`, the same live-modifier-state seam already used for the multi-select hotkey.

## Tests
- Relocated the two existing SelectionManager test files (`SelectionManagerRectangleTests`, `SelectionManagerHighlightTests`) into `Gum.Presentation.Tests` — no longer need the `SystemManagers.Default`/`Renderer` scaffolding now that Camera/Cursor are injected mocks.
- Added `SelectionManagerIsShiftDownTests` (2 tests) and `SelectionManagerEditorFactoryTests` (4 tests) covering the new editor-kind-switching state machine.
- Mutation-tested the editor-kind-switching branch (inverted the `_currentEditorKind != WireframeEditorKind.Standard` guard, confirmed the "does not recreate" test goes red, reverted).
- Full `Gum.Presentation.Tests` suite: 409/409 passing. `GumToolUnitTests`: 1134/1136 passing (2 pre-existing unrelated skips).

## Manual test
Not needed — this is a pure extraction/relocation with pinning tests; the compiler + test suite are the proof. The class's *behavior* (input decision logic, editor-kind switching, cursor mapping) is unchanged, only *where the code lives and how it obtains its dependencies* changed.

## Direction doc
Added 3 new gotchas to `Direction/ui-decoupling-plan.md`'s "Known gotchas" list, found this round: a coordinator directly constructing a tool-only family (fix: factory interface, one level up from the existing per-visual-interface pattern) plus the new-branch-needs-a-test corollary; an interface blocked by one never-read member returning a non-portable type; and dead-vs-live type-check branches needing different fixes (delete vs. seam).
