### PR TITLE
Relocate TabLocation, tab-auto-select, and theme-icon logic into Gum.Presentation

### DIFF
--- a/Gum/MainWindow.xaml.cs
+++ b/Gum/MainWindow.xaml.cs
@@ -17,18 +17,6 @@ using System.Windows.Threading;
 using ControlzEx;
 
 namespace Gum;
-#region TabLocation Enum
-public enum TabLocation
-{
-    [Obsolete("Use either CenterTop or CenterBottom")]
-    Center,
-    RightBottom,
-    RightTop,
-    CenterTop, 
-    CenterBottom,
-    Left
-}
-#endregion
 
 public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindowMessage>
 {

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -7,7 +7,7 @@ using Gum.Plugins;
 
 namespace Gum.Plugins
 {
-    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>
+    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate
     {
         private readonly IMessenger _messenger;
         public event Action? TabShown;

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -91,13 +91,7 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
     {
         if (e.NewItems?.OfType<PluginTab>() is { } newTabs)
         {
-            foreach (PluginTab newTab in newTabs)
-            {
-                if (!PluginTabs.Any(p => p.Location == newTab.Location && p.IsSelected))
-                {
-                    newTab.IsSelected = true;
-                }
-            }
+            TabAutoSelectLogic.SelectNewTabsWithNoExistingSelection(PluginTabs, newTabs);
         }
     }
 

--- a/Gum/ViewModels/MainWindowViewModel.cs
+++ b/Gum/ViewModels/MainWindowViewModel.cs
@@ -98,11 +98,7 @@ public class MainWindowViewModel : ViewModel, IRecipient<ThemeChangedMessage>, I
     void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
     {
         // todo: we should trigger this in the view instead
-        IconSource = message.settings.Mode switch
-        {
-            ThemeMode.Light => "pack://application:,,,/GumLogo64Light.png",
-            _ => "pack://application:,,,/GumLogo64.png"
-        };
+        IconSource = MainWindowIconLogic.GetIconSource(message.settings.Mode);
     }
 
     private void SaveWindowSettings()

--- a/Tests/Gum.Presentation.Tests/MainWindowIconLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/MainWindowIconLogicTests.cs
@@ -1,0 +1,36 @@
+using Gum.Dialogs;
+using Gum.ViewModels;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="MainWindowIconLogic"/>, pinning the icon-per-theme mapping
+/// relocated from <c>MainWindowViewModel.Receive(ThemeChangedMessage)</c> (#3856).
+/// </summary>
+public class MainWindowIconLogicTests
+{
+    [Fact]
+    public void GetIconSource_ReturnsLightIcon_WhenModeIsLight()
+    {
+        string iconSource = MainWindowIconLogic.GetIconSource(ThemeMode.Light);
+
+        iconSource.ShouldBe("pack://application:,,,/GumLogo64Light.png");
+    }
+
+    [Fact]
+    public void GetIconSource_ReturnsDarkIcon_WhenModeIsDark()
+    {
+        string iconSource = MainWindowIconLogic.GetIconSource(ThemeMode.Dark);
+
+        iconSource.ShouldBe("pack://application:,,,/GumLogo64.png");
+    }
+
+    [Fact]
+    public void GetIconSource_ReturnsDarkIcon_WhenModeIsSystem()
+    {
+        string iconSource = MainWindowIconLogic.GetIconSource(ThemeMode.System);
+
+        iconSource.ShouldBe("pack://application:,,,/GumLogo64.png");
+    }
+}

--- a/Tests/Gum.Presentation.Tests/TabAutoSelectLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/TabAutoSelectLogicTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Gum.Plugins;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="TabAutoSelectLogic"/>, pinning the "select a newly-added
+/// tab by default only if its location has no existing selection" behavior relocated from
+/// <c>MainPanelViewModel.PluginTabsOnCollectionChanged</c> (#3856).
+/// </summary>
+public class TabAutoSelectLogicTests
+{
+    private class FakeTab : ITabAutoSelectCandidate
+    {
+        public TabLocation Location { get; init; }
+        public bool IsSelected { get; set; }
+    }
+
+    [Fact]
+    public void SelectNewTabsWithNoExistingSelection_SelectsNewTab_WhenLocationHasNoExistingSelection()
+    {
+        FakeTab existingTab = new() { Location = TabLocation.RightBottom, IsSelected = false };
+        FakeTab newTab = new() { Location = TabLocation.RightBottom, IsSelected = false };
+        List<FakeTab> allTabs = [existingTab, newTab];
+
+        TabAutoSelectLogic.SelectNewTabsWithNoExistingSelection(allTabs, [newTab]);
+
+        newTab.IsSelected.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SelectNewTabsWithNoExistingSelection_LeavesNewTabUnselected_WhenLocationAlreadyHasSelection()
+    {
+        FakeTab existingSelectedTab = new() { Location = TabLocation.RightBottom, IsSelected = true };
+        FakeTab newTab = new() { Location = TabLocation.RightBottom, IsSelected = false };
+        List<FakeTab> allTabs = [existingSelectedTab, newTab];
+
+        TabAutoSelectLogic.SelectNewTabsWithNoExistingSelection(allTabs, [newTab]);
+
+        newTab.IsSelected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SelectNewTabsWithNoExistingSelection_OnlySelectsFirstOfMultipleNewTabsAtSameLocation()
+    {
+        FakeTab firstNewTab = new() { Location = TabLocation.Left, IsSelected = false };
+        FakeTab secondNewTab = new() { Location = TabLocation.Left, IsSelected = false };
+        List<FakeTab> allTabs = [firstNewTab, secondNewTab];
+
+        TabAutoSelectLogic.SelectNewTabsWithNoExistingSelection(allTabs, [firstNewTab, secondNewTab]);
+
+        firstNewTab.IsSelected.ShouldBeTrue();
+        secondNewTab.IsSelected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SelectNewTabsWithNoExistingSelection_DoesNotAffectTabsAtDifferentLocations()
+    {
+        FakeTab selectedElsewhere = new() { Location = TabLocation.CenterTop, IsSelected = true };
+        FakeTab newTab = new() { Location = TabLocation.RightTop, IsSelected = false };
+        List<FakeTab> allTabs = [selectedElsewhere, newTab];
+
+        TabAutoSelectLogic.SelectNewTabsWithNoExistingSelection(allTabs, [newTab]);
+
+        newTab.IsSelected.ShouldBeTrue();
+        selectedElsewhere.IsSelected.ShouldBeTrue();
+    }
+}

--- a/Tools/Gum.Presentation/ViewModels/MainWindowIconLogic.cs
+++ b/Tools/Gum.Presentation/ViewModels/MainWindowIconLogic.cs
@@ -1,0 +1,20 @@
+using Gum.Dialogs;
+
+namespace Gum.ViewModels;
+
+/// <summary>
+/// Picks the main window's title-bar/taskbar icon for a given theme. Relocated from
+/// <c>MainWindowViewModel.Receive(ThemeChangedMessage)</c> (part of #3856) — pure mapping, no WPF
+/// dependency.
+/// </summary>
+public static class MainWindowIconLogic
+{
+    /// <summary>
+    /// Returns the pack URI of the icon that should be shown for <paramref name="mode"/>.
+    /// </summary>
+    public static string GetIconSource(ThemeMode mode) => mode switch
+    {
+        ThemeMode.Light => "pack://application:,,,/GumLogo64Light.png",
+        _ => "pack://application:,,,/GumLogo64.png"
+    };
+}

--- a/Tools/Gum.Presentation/ViewModels/TabAutoSelectLogic.cs
+++ b/Tools/Gum.Presentation/ViewModels/TabAutoSelectLogic.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.Plugins;
+
+/// <summary>
+/// The subset of a docking-layout tab's state needed to decide default selection. Narrow interface
+/// so the decision logic can live in the headless assembly even though the concrete tab type
+/// (<c>PluginTab</c>) is WPF-typed and stays tool-side (part of #3856).
+/// </summary>
+public interface ITabAutoSelectCandidate
+{
+    /// <summary>The docking region this tab belongs in.</summary>
+    TabLocation Location { get; }
+
+    /// <summary>Whether this tab is the currently-active one within its <see cref="Location"/>.</summary>
+    bool IsSelected { get; set; }
+}
+
+/// <summary>
+/// Decides which newly-added docking-layout tabs should become selected by default. Relocated from
+/// <c>MainPanelViewModel.PluginTabsOnCollectionChanged</c> (part of #3856) — the decision itself
+/// never touched a WPF type, only the concrete <c>PluginTab</c> it operated on.
+/// </summary>
+public static class TabAutoSelectLogic
+{
+    /// <summary>
+    /// For each tab in <paramref name="newTabs"/>, selects it if no tab already in
+    /// <paramref name="allTabs"/> is selected at the same <see cref="ITabAutoSelectCandidate.Location"/>.
+    /// </summary>
+    /// <param name="allTabs">
+    /// The full current tab collection, including <paramref name="newTabs"/>. Evaluated live as each
+    /// new tab is processed, so selecting one new tab can prevent a later new tab at the same
+    /// location from also being auto-selected.
+    /// </param>
+    /// <param name="newTabs">The tabs that were just added.</param>
+    public static void SelectNewTabsWithNoExistingSelection<T>(IEnumerable<T> allTabs, IEnumerable<T> newTabs)
+        where T : ITabAutoSelectCandidate
+    {
+        foreach (T newTab in newTabs)
+        {
+            bool locationAlreadyHasSelection = allTabs.Any(t => t.Location == newTab.Location && t.IsSelected);
+            if (!locationAlreadyHasSelection)
+            {
+                newTab.IsSelected = true;
+            }
+        }
+    }
+}

--- a/Tools/Gum.Presentation/ViewModels/TabLocation.cs
+++ b/Tools/Gum.Presentation/ViewModels/TabLocation.cs
@@ -1,0 +1,21 @@
+namespace Gum;
+
+/// <summary>
+/// Identifies which region of the main window's docking layout a <c>PluginTab</c> belongs in.
+/// </summary>
+/// <remarks>
+/// Relocated from <c>MainWindow.xaml.cs</c> (part of #3856) — it never had any WPF dependency, it
+/// was just physically declared alongside the WPF window class that happened to be in the same
+/// file. Pure file-location move: namespace and members are unchanged, so no consumer needed an
+/// import change.
+/// </remarks>
+public enum TabLocation
+{
+    [System.Obsolete("Use either CenterTop or CenterBottom")]
+    Center,
+    RightBottom,
+    RightTop,
+    CenterTop,
+    CenterBottom,
+    Left
+}


### PR DESCRIPTION
Part of #3856.

## Categorization

**(a) Relocatable today (implemented here):**
- `TabLocation` enum — physically misplaced in `MainWindow.xaml.cs`, zero WPF dependency. Moved to `Gum.Presentation`, same namespace (`Gum`), zero consumer diff.
- `MainPanelViewModel.PluginTabsOnCollectionChanged`'s "select the new tab by default if its docking location has no existing selection" decision — the algorithm itself never touched a WPF type, only the concrete `PluginTab` it iterated. Extracted a narrow `ITabAutoSelectCandidate` interface (`Location`, `IsSelected`) + `TabAutoSelectLogic` into `Gum.Presentation`; `PluginTab` implements the interface with zero member changes.
- `MainWindowViewModel.Receive(ThemeChangedMessage)`'s theme -> icon path mapping — pure switch, `ThemeMode` already lived in `Gum.Presentation`. Extracted `MainWindowIconLogic`.

**(b) Convertible with effort, not attempted here:**
- `MainWindowViewModel.WindowState` — raw `System.Windows.WindowState`, bound `TwoWay` directly to the WPF `Window` in XAML (3 `DataTrigger`s + 2 code-behind sites). Converting to a neutral enum is mechanical but touches live window-chrome binding (maximize/minimize/restore) — real behavioral-adjacent risk, left for its own pass.
- `MainWindowViewModel.LoadWindowSettings`'s "skip restoring bounds on first launch" guard — pure decision, but its `WindowSettings`/`MainTabDimensions` parameter types live in `Gum.csproj` (`Gum/Settings/LayoutSettings.cs`), unreachable from `Gum.Presentation` in that direction. Needs the same "split the pure records out, leave the WinForms-touching `MigrateLegacyLayout` behind" pattern used elsewhere before the guard clause can move.

**(c) Genuinely stuck:**
- `WindowPlacementHelper` (`MainWindowViewModel.cs`) — real Win32/WPF monitor-placement glue (`Application.Current`, `PresentationSource`, `user32.dll`/`Shcore.dll` P/Invoke). Legitimate platform glue, same carve-out as `ResizeHandlesVisual`.
- `MainPanelViewModel`'s `ICollectionView`/`ListCollectionView`-based tab filtering (`CenterView`, `RightBottomView`, etc.) — the actual docking-layout mechanism, deeply bound to WPF's collection-view binding surface and to `PluginTab` (itself WPF-typed: `Content`/`CustomHeaderContent` are `FrameworkElement`). Converting this is a real redesign (splitting `PluginTab` into a neutral + WPF-decorated pair, or replacing `ICollectionView` with a neutral filtered-collection abstraction), not a bounded slice — the actual bulk of what "docking layout" means in these two VMs.
- `MainPanelViewModel.AddControl`'s `object` -> `FrameworkElement` cast — genuine UI-hosting glue.

## What's left

Issue stays open — the real remaining value (the docking-surface redesign) is a substantial separate effort, not a quick follow-up.

## Test plan
- New `TabAutoSelectLogicTests` (4 cases) + `MainWindowIconLogicTests` (3 cases) in `Gum.Presentation.Tests` — pin the relocated behavior.
- `Gum.Presentation.Tests`: 396/396 pass (compiles WPF/WinForms-free, direct proof of the boundary).
- `GumToolUnitTests` (full suite, `GumFull.sln`-built): 1148/1150 pass (2 pre-existing skips).
- `GumFull.sln` builds clean (0 errors).
