### PR TITLE
Convert MainWindowViewModel.WindowState to a neutral GumWindowState

### DIFF
--- a/Gum/Converters/GumWindowStateConverter.cs
+++ b/Gum/Converters/GumWindowStateConverter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Gum.ViewModels;
+using WpfWindowState = System.Windows.WindowState;
+
+namespace Gum.Converters;
+
+/// <summary>
+/// Converts between the headless <see cref="GumWindowState"/> used on <see cref="MainWindowViewModel"/>
+/// (ADR-0004) and the WPF <see cref="WpfWindowState"/> required by <c>Window.WindowState</c>. This is
+/// the "thin conversion at the View/binding boundary" for the VM's TwoWay-bound window-chrome state
+/// (part of #3856).
+/// </summary>
+public class GumWindowStateConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is GumWindowState state
+            ? state switch
+            {
+                GumWindowState.Minimized => WpfWindowState.Minimized,
+                GumWindowState.Maximized => WpfWindowState.Maximized,
+                _ => WpfWindowState.Normal
+            }
+            : WpfWindowState.Normal;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is WpfWindowState state
+            ? state switch
+            {
+                WpfWindowState.Minimized => GumWindowState.Minimized,
+                WpfWindowState.Maximized => GumWindowState.Maximized,
+                _ => GumWindowState.Normal
+            }
+            : GumWindowState.Normal;
+}

--- a/Gum/MainWindow.xaml
+++ b/Gum/MainWindow.xaml
@@ -31,7 +31,7 @@
   Top="{Binding Top, Mode=TwoWay}"
   UseLayoutRounding="True"
   WindowStartupLocation="CenterScreen"
-  WindowState="{Binding WindowState, Mode=TwoWay}"
+  WindowState="{Binding WindowState, Mode=TwoWay, Converter={StaticResource GumWindowStateConverter}}"
   mc:Ignorable="d">
   <Border
     Background="{DynamicResource Frb.Brushes.Background}"
@@ -42,7 +42,7 @@
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="BorderThickness" Value="1" />
         <Style.Triggers>
-          <DataTrigger Binding="{Binding WindowState}" Value="{x:Static WindowState.Maximized}">
+          <DataTrigger Binding="{Binding IsMaximized}" Value="True">
             <Setter Property="CornerRadius" Value="0" />
             <Setter Property="BorderThickness" Value="0" />
           </DataTrigger>
@@ -125,7 +125,7 @@
                         </Setter.Value>
                       </Setter>
                       <Style.Triggers>
-                        <DataTrigger Binding="{Binding WindowState}" Value="{x:Static WindowState.Maximized}">
+                        <DataTrigger Binding="{Binding IsMaximized}" Value="True">
                           <Setter Property="Content">
                             <Setter.Value>
                               <materialDesign:PackIcon Height="16" Kind="WindowRestore" />
@@ -157,7 +157,7 @@
                   <Style TargetType="Grid">
                     <Setter Property="Visibility" Value="Visible" />
                     <Style.Triggers>
-                      <DataTrigger Binding="{Binding WindowState}" Value="{x:Static WindowState.Maximized}">
+                      <DataTrigger Binding="{Binding IsMaximized}" Value="True">
                         <Setter Property="Visibility" Value="Collapsed" />
                       </DataTrigger>
                     </Style.Triggers>

--- a/Gum/Settings/LayoutSettings.cs
+++ b/Gum/Settings/LayoutSettings.cs
@@ -20,17 +20,3 @@ public class LayoutSettings
         }
     }
 }
-
-public record WindowSettings(
-    double Width = 1280,
-    double Height = 720,
-    double? Top = null,
-    double? Left = null,
-    bool IsMaximized = false
-);
-
-public record MainTabDimensions(
-    double LeftColumnWidth = 250,
-    double CenterColumnWidth = 320,
-    double BottomRightHeight = 200
-);

--- a/Gum/Themes/Frb.Converters.xaml
+++ b/Gum/Themes/Frb.Converters.xaml
@@ -12,5 +12,6 @@
     <converters1:BoolToVisibilityConverter x:Key="BoolToVisibilityHiddenConverter" Collapse="False" />
     <converters1:InverseBoolConverter x:Key="InverseBoolConverter" />
     <converters1:DrawingColorToMediaColorConverter x:Key="DrawingColorToMediaColorConverter" />
+    <converters1:GumWindowStateConverter x:Key="GumWindowStateConverter" />
     <controls:MultiplyConverter x:Key="MultiplyConverter" />
 </ResourceDictionary>

--- a/Gum/ViewModels/MainWindowViewModel.cs
+++ b/Gum/ViewModels/MainWindowViewModel.cs
@@ -5,12 +5,10 @@ using Gum.Mvvm;
 using Gum.Properties;
 using Gum.Settings;
 using System;
-using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Media;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using Window = System.Windows.Window;
 
 namespace Gum.ViewModels;
@@ -56,11 +54,18 @@ public class MainWindowViewModel : ViewModel, IRecipient<ThemeChangedMessage>, I
         set => Set(value);
     }
 
-    public WindowState WindowState
+    public GumWindowState WindowState
     {
-        get => Get<WindowState>();
+        get => Get<GumWindowState>();
         set => Set(value);
     }
+
+    /// <summary>
+    /// Pure boolean projection of <see cref="WindowState"/> for XAML DataTriggers, so the view
+    /// doesn't need to reference <see cref="GumWindowState"/> directly (ADR-0004).
+    /// </summary>
+    [DependsOn(nameof(WindowState))]
+    public bool IsMaximized => WindowState == GumWindowState.Maximized;
 
     public MainWindowViewModel(MainPanelViewModel mainPanelViewModel, IMessenger messenger, IWritableOptions<LayoutSettings> layoutSettings)
     {
@@ -74,14 +79,11 @@ public class MainWindowViewModel : ViewModel, IRecipient<ThemeChangedMessage>, I
     // and, we need to ensure ProjectManager.GeneralSettings has been loaded and migrated first.
     public void LoadWindowSettings(WindowSettings settings)
     {
-        
-        if (settings is { Left: null, Top: null } or {Width: 0} or {Height: 0})
+        if (WindowSettingsLogic.IsFirstLaunch(settings))
         {
-            // nulls should imply this is the first launch -- let wpf center the window
-            // width or height 0 is invalid (how'd that happen?), so also just return
+            // let wpf center the window
             return;
         }
-
 
         Rectangle constrained = // monitor setup may have changed since last run
             WindowPlacementHelper.ConstrainIntoWorkingArea(new Rectangle((int)settings.Left!.Value, (int)settings.Top!.Value,
@@ -92,7 +94,7 @@ public class MainWindowViewModel : ViewModel, IRecipient<ThemeChangedMessage>, I
         Width = constrained.Width;
         Height = constrained.Height;
 
-        WindowState = settings.IsMaximized ? WindowState.Maximized : WindowState.Normal;
+        WindowState = settings.IsMaximized ? GumWindowState.Maximized : GumWindowState.Normal;
     }
 
     void IRecipient<ThemeChangedMessage>.Receive(ThemeChangedMessage message)
@@ -111,7 +113,7 @@ public class MainWindowViewModel : ViewModel, IRecipient<ThemeChangedMessage>, I
                 Top = this.Top,
                 Width = this.Width ?? 0,
                 Height = this.Height ?? 0,
-                IsMaximized = this.WindowState == WindowState.Maximized
+                IsMaximized = this.WindowState == GumWindowState.Maximized
             };
         });
     }

--- a/Tests/Gum.Presentation.Tests/WindowSettingsLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/WindowSettingsLogicTests.cs
@@ -1,0 +1,52 @@
+using Gum.Settings;
+using Gum.ViewModels;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="WindowSettingsLogic.IsFirstLaunch"/>, pinning the
+/// first-launch guard relocated from <c>MainWindowViewModel.LoadWindowSettings</c> (#3856).
+/// </summary>
+public class WindowSettingsLogicTests
+{
+    [Fact]
+    public void IsFirstLaunch_ShouldReturnFalse_WhenSettingsAreFullyPopulated()
+    {
+        WindowSettings settings = new(Width: 1280, Height: 720, Top: 10, Left: 20, IsMaximized: false);
+
+        bool result = WindowSettingsLogic.IsFirstLaunch(settings);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFirstLaunch_ShouldReturnTrue_WhenLeftAndTopAreNull()
+    {
+        WindowSettings settings = new(Width: 1280, Height: 720, Top: null, Left: null);
+
+        bool result = WindowSettingsLogic.IsFirstLaunch(settings);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFirstLaunch_ShouldReturnTrue_WhenWidthIsZero()
+    {
+        WindowSettings settings = new(Width: 0, Height: 720, Top: 10, Left: 20);
+
+        bool result = WindowSettingsLogic.IsFirstLaunch(settings);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFirstLaunch_ShouldReturnTrue_WhenHeightIsZero()
+    {
+        WindowSettings settings = new(Width: 1280, Height: 0, Top: 10, Left: 20);
+
+        bool result = WindowSettingsLogic.IsFirstLaunch(settings);
+
+        result.ShouldBeTrue();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Converters/GumWindowStateConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Converters/GumWindowStateConverterTests.cs
@@ -1,0 +1,38 @@
+using Gum.Converters;
+using Gum.ViewModels;
+using Shouldly;
+using WpfWindowState = System.Windows.WindowState;
+
+namespace GumToolUnitTests.Converters;
+
+/// <summary>
+/// Pins <see cref="GumWindowStateConverter"/>'s boundary conversion between the headless
+/// <see cref="GumWindowState"/> (VM side, ADR-0004) and the WPF <see cref="WpfWindowState"/>
+/// (<c>Window.WindowState</c> binding side), part of #3856.
+/// </summary>
+public class GumWindowStateConverterTests
+{
+    private readonly GumWindowStateConverter _sut = new();
+
+    [Theory]
+    [InlineData(GumWindowState.Normal, WpfWindowState.Normal)]
+    [InlineData(GumWindowState.Minimized, WpfWindowState.Minimized)]
+    [InlineData(GumWindowState.Maximized, WpfWindowState.Maximized)]
+    public void Convert_ShouldMapGumWindowStateToMatchingWpfWindowState(GumWindowState gumState, WpfWindowState expected)
+    {
+        object? result = _sut.Convert(gumState, typeof(WpfWindowState), null, null!);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(WpfWindowState.Normal, GumWindowState.Normal)]
+    [InlineData(WpfWindowState.Minimized, GumWindowState.Minimized)]
+    [InlineData(WpfWindowState.Maximized, GumWindowState.Maximized)]
+    public void ConvertBack_ShouldMapWpfWindowStateToMatchingGumWindowState(WpfWindowState wpfState, GumWindowState expected)
+    {
+        object? result = _sut.ConvertBack(wpfState, typeof(GumWindowState), null, null!);
+
+        result.ShouldBe(expected);
+    }
+}

--- a/Tools/Gum.Presentation/Settings/WindowSettings.cs
+++ b/Tools/Gum.Presentation/Settings/WindowSettings.cs
@@ -1,0 +1,22 @@
+namespace Gum.Settings;
+
+/// <summary>
+/// Relocated from <c>Gum/Settings/LayoutSettings.cs</c> (part of #3856) — pure data records, no WPF
+/// dependency. <see cref="LayoutSettings"/> itself stays in <c>Gum.csproj</c> because
+/// <c>LayoutSettings.MigrateLegacyLayout</c> reads WinForms-typed legacy settings
+/// (<c>GeneralSettingsFile.MainWindowBounds</c>/<c>MainWindowState</c>). Pure file-location move:
+/// namespace and members are unchanged, so no consumer needed an import change.
+/// </summary>
+public record WindowSettings(
+    double Width = 1280,
+    double Height = 720,
+    double? Top = null,
+    double? Left = null,
+    bool IsMaximized = false
+);
+
+public record MainTabDimensions(
+    double LeftColumnWidth = 250,
+    double CenterColumnWidth = 320,
+    double BottomRightHeight = 200
+);

--- a/Tools/Gum.Presentation/ViewModels/GumWindowState.cs
+++ b/Tools/Gum.Presentation/ViewModels/GumWindowState.cs
@@ -1,0 +1,19 @@
+namespace Gum.ViewModels;
+
+/// <summary>
+/// Mirrors the 3 values of <c>System.Windows.WindowState</c> so <see cref="MainWindowViewModel"/>
+/// can expose window-chrome state (ADR-0004) without a WPF type on the property (part of #3856).
+/// </summary>
+/// <remarks>
+/// All 3 values are load-bearing, not just Normal/Maximized: the main window's chrome is
+/// <c>TwoWay</c>-bound to this property, so minimizing the real window pushes
+/// <see cref="Minimized"/> back into the ViewModel. A 2-state (bool) representation would lose that
+/// distinction and cause the binding to re-push <see cref="Normal"/> back down, un-minimizing the
+/// window the user just minimized.
+/// </remarks>
+public enum GumWindowState
+{
+    Normal,
+    Minimized,
+    Maximized
+}

--- a/Tools/Gum.Presentation/ViewModels/WindowSettingsLogic.cs
+++ b/Tools/Gum.Presentation/ViewModels/WindowSettingsLogic.cs
@@ -1,0 +1,18 @@
+using Gum.Settings;
+
+namespace Gum.ViewModels;
+
+/// <summary>
+/// Relocated from <c>MainWindowViewModel.LoadWindowSettings</c>'s first-launch guard (part of
+/// #3856) — pure decision, no WPF dependency.
+/// </summary>
+public static class WindowSettingsLogic
+{
+    /// <summary>
+    /// True when <paramref name="settings"/> looks like it was never actually saved (first launch,
+    /// or a corrupt 0-sized save) and the window should be left at its WPF-chosen default
+    /// position/size instead of being placed from <paramref name="settings"/>.
+    /// </summary>
+    public static bool IsFirstLaunch(WindowSettings settings) =>
+        settings is { Left: null, Top: null } or { Width: 0 } or { Height: 0 };
+}


### PR DESCRIPTION
Part of #3856.

## What changed
- New `GumWindowState` enum (`Gum.Presentation`, mirrors `System.Windows.WindowState`'s 3 values) replaces the WPF type on `MainWindowViewModel.WindowState`, keeping the VM's public surface free of `System.Windows.*` (ADR-0004).
- New `GumWindowStateConverter` bridges the neutral VM type to the real `Window.WindowState` at the live `TwoWay` binding (the one place a real WPF type is unavoidable).
- The 3 XAML `DataTrigger`s that compared `WindowState == Maximized` now bind to a derived VM bool (`IsMaximized`) instead of referencing the enum from markup.
- Companion fix: relocated `WindowSettings`/`MainTabDimensions` (pure records, no WPF dependency) into `Gum.Presentation`, and extracted `LoadWindowSettings`'s first-launch guard into `WindowSettingsLogic.IsFirstLaunch` — this was flagged as blocked-only-by-record-location in the prior round and turned out to be a small, in-scope addition.
- `MainWindowViewModel` itself stays in `Gum.csproj` — `WindowPlacementHelper` (Win32 monitor placement, real platform glue) lives in the same file and keeps the class WPF-coupled; only the `WindowState` property's *type* moved.

## Tests
- `WindowSettingsLogicTests` (`Gum.Presentation.Tests`) — pins the first-launch guard.
- `GumWindowStateConverterTests` (`GumToolUnitTests`) — pins both conversion directions for all 3 states.
- Full `Gum.Presentation.Tests` (420/420) and `GumToolUnitTests` (1140/1140, 2 pre-existing skips) green; `GumFull.sln` builds clean.

## Manual test
Needed — this is a live window-chrome binding. See PR/issue comment for numbered steps.
