### PR TITLE
Relocate MainPanelViewModel's tab-docking filter decision into Gum.Presentation

### DIFF
--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -7,7 +7,7 @@ using Gum.Plugins;
 
 namespace Gum.Plugins
 {
-    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate
+    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate, ITabDockingCandidate
     {
         private readonly IMessenger _messenger;
         public event Action? TabShown;

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -81,7 +81,7 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
             view.LiveFilteringProperties.Add(nameof(PluginTab.IsVisible));
             view.LiveFilteringProperties.Add(nameof(PluginTab.Location));
 
-            view.Filter = o => o is PluginTab tab && tab.Location == location && tab.IsVisible;
+            view.Filter = o => o is PluginTab tab && TabDockingLogic.ShouldAppearInLocation(tab, location);
         
             return view;
         }

--- a/Tests/Gum.Presentation.Tests/TabDockingLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/TabDockingLogicTests.cs
@@ -1,0 +1,58 @@
+using Gum.Plugins;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="TabDockingLogic"/>, pinning the "a tab appears in a
+/// docking region's view only when its own location matches and it is visible" behavior relocated
+/// from <c>MainPanelViewModel</c>'s <c>ListCollectionView.Filter</c> predicates (#3856).
+/// </summary>
+public class TabDockingLogicTests
+{
+    private class FakeTab : ITabDockingCandidate
+    {
+        public TabLocation Location { get; init; }
+        public bool IsVisible { get; init; }
+    }
+
+    [Fact]
+    public void ShouldAppearInLocation_ReturnsFalse_WhenLocationDiffersAndTabIsVisible()
+    {
+        FakeTab tab = new() { Location = TabLocation.Left, IsVisible = true };
+
+        bool result = TabDockingLogic.ShouldAppearInLocation(tab, TabLocation.RightTop);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldAppearInLocation_ReturnsFalse_WhenLocationMatchesButTabIsNotVisible()
+    {
+        FakeTab tab = new() { Location = TabLocation.CenterTop, IsVisible = false };
+
+        bool result = TabDockingLogic.ShouldAppearInLocation(tab, TabLocation.CenterTop);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldAppearInLocation_ReturnsFalse_WhenLocationDiffersAndTabIsNotVisible()
+    {
+        FakeTab tab = new() { Location = TabLocation.Left, IsVisible = false };
+
+        bool result = TabDockingLogic.ShouldAppearInLocation(tab, TabLocation.RightTop);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldAppearInLocation_ReturnsTrue_WhenLocationMatchesAndTabIsVisible()
+    {
+        FakeTab tab = new() { Location = TabLocation.RightBottom, IsVisible = true };
+
+        bool result = TabDockingLogic.ShouldAppearInLocation(tab, TabLocation.RightBottom);
+
+        result.ShouldBeTrue();
+    }
+}

--- a/Tools/Gum.Presentation/ViewModels/TabDockingLogic.cs
+++ b/Tools/Gum.Presentation/ViewModels/TabDockingLogic.cs
@@ -1,0 +1,33 @@
+namespace Gum.Plugins;
+
+/// <summary>
+/// The subset of a docking-layout tab's state needed to decide whether it belongs in a given
+/// docking region's view. Narrow interface so the decision logic can live in the headless assembly
+/// even though the concrete tab type (<c>PluginTab</c>) is WPF-typed and stays tool-side (part of
+/// #3856).
+/// </summary>
+public interface ITabDockingCandidate
+{
+    /// <summary>The docking region this tab belongs in.</summary>
+    TabLocation Location { get; }
+
+    /// <summary>Whether this tab is currently shown (not closed/hidden).</summary>
+    bool IsVisible { get; }
+}
+
+/// <summary>
+/// Decides whether a tab should appear in a given docking region's view. Relocated from
+/// <c>MainPanelViewModel</c>'s <c>ListCollectionView.Filter</c> predicates (part of #3856) — the
+/// decision itself never touched a WPF type, only the concrete <c>PluginTab</c> it operated on and
+/// the WPF <c>ICollectionView</c>/<c>ListCollectionView</c> mechanism that applies it.
+/// </summary>
+public static class TabDockingLogic
+{
+    /// <summary>
+    /// True if <paramref name="tab"/> belongs in <paramref name="location"/>'s view: its own
+    /// <see cref="ITabDockingCandidate.Location"/> matches and it is currently visible.
+    /// </summary>
+    public static bool ShouldAppearInLocation<T>(T tab, TabLocation location)
+        where T : ITabDockingCandidate
+        => tab.Location == location && tab.IsVisible;
+}


### PR DESCRIPTION
Relocates the last piece of `MainPanelViewModel`'s tab-docking logic that was still inline WPF code.

## What changed
`CreateView`'s `ListCollectionView.Filter` predicates turned out to be the *entire* docking decision — there's no sort/group logic anywhere in the class, just a one-line "tab's location matches and it's visible" check per region. Extracted it behind a narrow `ITabDockingCandidate` interface (same shape as `ITabAutoSelectCandidate` from #3857) into a new `TabDockingLogic.ShouldAppearInLocation`, implemented by `PluginTab`. WPF's `ListCollectionView` mechanism itself stays tool-side (legitimate platform glue) — only the decision moved into `Gum.Presentation`.

## Tests
`TabDockingLogicTests` (4 cases, mutation-verified — inverting the equality check flips 2 of 4 red).

Part of #3856.
