### PR TITLE
Relocate ElementCommands into headless Gum.Presentation, scope EditCommands/FileCommands (#3862)

### DIFF
--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -1,36 +1,33 @@
-﻿using Gum.Commands;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers;
+using Gum.PropertyGridHelpers.Converters;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using Moq;
 using Shouldly;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace GumToolUnitTests.ToolCommands;
+namespace Gum.Presentation.Tests;
 
-public class ElementCommandsTests
+public class ElementCommandsTests : BaseTestClass
 {
-    ElementCommands _sut;
+    private readonly ElementCommands _sut;
 
-    Mock<ISelectedState> _selectedState;
-    Mock<IGuiCommands> _guiCommands;
-    Mock<IFileCommands> _fileCommands;
-    Mock<IVariableInCategoryPropagationLogic> _variableInCategoryPropagationLogic;
-    Mock<IWireframeObjectManager> _wireframeObjectManager;
-    Mock<IPluginManager> _pluginManager;
-    Mock<IProjectManager> _projectManager;
-    Mock<IProjectState> _projectState;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IVariableInCategoryPropagationLogic> _variableInCategoryPropagationLogic;
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager;
+    private readonly Mock<IPluginManager> _pluginManager;
+    private readonly Mock<IProjectManager> _projectManager;
+    private readonly Mock<IProjectState> _projectState;
 
-    ObjectFinder _objectFinder => ObjectFinder.Self;
+    private ObjectFinder ObjectFinder => ObjectFinder.Self;
 
     public ElementCommandsTests()
     {
@@ -52,6 +49,22 @@ public class ElementCommandsTests
             _pluginManager.Object,
             _projectManager.Object,
             _projectState.Object);
+    }
+
+    [Fact]
+    public void AddCategory_ShouldAddCategoryStateVariable_WithAvailableStatesConverter()
+    {
+        ComponentSave component = new();
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+
+        StateSaveCategory category = _sut.AddCategory(component, "MyCategory");
+
+        VariableSave? stateVariable = component.DefaultState.Variables
+            .FirstOrDefault(item => item.Name == "MyCategoryState");
+
+        stateVariable.ShouldNotBeNull();
+        stateVariable.CustomTypeConverter.ShouldBeOfType<AvailableStatesConverter>();
+        ((AvailableStatesConverter)stateVariable.CustomTypeConverter).CategoryName.ShouldBe("MyCategory");
     }
 
     [Fact]
@@ -82,16 +95,15 @@ public class ElementCommandsTests
     public void GetUniqueNameForNewInstance_ShouldReturnDefaultName()
     {
         GumProjectSave project = new GumProjectSave();
-        _objectFinder.GumProjectSave = project;
+        ObjectFinder.GumProjectSave = project;
 
         StandardElementSave text = new()
         {
             Name = "Text"
         };
-        _objectFinder.GumProjectSave.StandardElements.Add(text);
+        ObjectFinder.GumProjectSave.StandardElements.Add(text);
 
         ComponentSave component = new();
-
 
         // act
         string name = _sut.GetUniqueNameForNewInstance(text, component);
@@ -104,13 +116,13 @@ public class ElementCommandsTests
     public void GetUniqueNameForNewInstance_ShouldIncrement_OnMatchingName()
     {
         GumProjectSave project = new GumProjectSave();
-        _objectFinder.GumProjectSave = project;
+        ObjectFinder.GumProjectSave = project;
 
         StandardElementSave text = new()
         {
             Name = "Text"
         };
-        _objectFinder.GumProjectSave.StandardElements.Add(text);
+        ObjectFinder.GumProjectSave.StandardElements.Add(text);
 
         ComponentSave component = new();
         component.Instances.Add(new InstanceSave
@@ -129,13 +141,13 @@ public class ElementCommandsTests
     public void GetUniqueNameForNewInstance_WithBehaviorSave_ShouldReturnDefaultName()
     {
         GumProjectSave project = new GumProjectSave();
-        _objectFinder.GumProjectSave = project;
+        ObjectFinder.GumProjectSave = project;
 
         StandardElementSave text = new()
         {
             Name = "Text"
         };
-        _objectFinder.GumProjectSave.StandardElements.Add(text);
+        ObjectFinder.GumProjectSave.StandardElements.Add(text);
 
         BehaviorSave behavior = new();
 
@@ -150,13 +162,13 @@ public class ElementCommandsTests
     public void GetUniqueNameForNewInstance_WithBehaviorSave_ShouldIncrement_OnMatchingName()
     {
         GumProjectSave project = new GumProjectSave();
-        _objectFinder.GumProjectSave = project;
+        ObjectFinder.GumProjectSave = project;
 
         StandardElementSave text = new()
         {
             Name = "Text"
         };
-        _objectFinder.GumProjectSave.StandardElements.Add(text);
+        ObjectFinder.GumProjectSave.StandardElements.Add(text);
 
         BehaviorSave behavior = new();
         behavior.RequiredInstances.Add(new BehaviorInstanceSave

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -621,11 +621,11 @@ public class ElementCommands : IElementCommands
                 Name = category.Name + "State",
                 // We used to set the type with the word "State" appended but why? Gum seems to not do this everywhere, and this can add confusion, so let's omit the "State" suffix
                 Type = category.Name,
-                Value = null
-#if GUM
-,
+                Value = null,
+                // Was previously guarded by "#if GUM" from when this class lived in Gum.csproj (which
+                // always defines GUM), making the guard always-true and effectively dead. AvailableStatesConverter
+                // already lives in Gum.Presentation, so this assignment is unconditional now that the class does too.
                 CustomTypeConverter = new Gum.PropertyGridHelpers.Converters.AvailableStatesConverter(category.Name, _selectedState)
-#endif
             });
 
             elementToAddTo.DefaultState.Variables.Sort((first, second) => first.Name.CompareTo(second.Name));


### PR DESCRIPTION
Part of #3862.

## Scoping pass (per the north-star test in `Direction/ui-decoupling-plan.md`)

Read all three target files fully and classified each by whether it's reachable from `Gum.Presentation` today.

**`Gum/ToolCommands/ElementCommands.cs` — (a) genuinely relocatable, done in this PR.** Every ctor dependency (`ISelectedState`, `IGuiCommands`, `IFileCommands`, `IVariableInCategoryPropagationLogic`, `IWireframeObjectManager`, `IPluginManager`, `IProjectManager`, `IProjectState`) already lives in `Gum.Presentation`, and the concrete types it touches (`GraphicalUiElement`, `StandardElementsManager`, `UnitConverter`, `AvailableStatesConverter`, `TextureAddress`) are already reachable there via `GumCommon`'s linked-source compile. `IPositionedSizedObjectExtensionMethods.cs` (the file backing `GetFileWidthAndHeightOrDefault`/`GetParentWidthAndHeight`) is also already linked into `Gum.Presentation.csproj` — no move needed there.

One wrinkle: `AddCategory`'s `CustomTypeConverter` assignment was guarded by `#if GUM`, which is always defined in `Gum.csproj` and thus always-true, effectively dead code. Left as-is it would have silently compiled out once the class left that project. Made it unconditional and pinned it with a new test (mutation-tested: reverting to the guard turns the test red).

Moved `ElementCommandsTests` to `Tests/Gum.Presentation.Tests` to match. `Builder.cs`'s DI registration (`services.AddSingleton<IElementCommands, ElementCommands>()`) needed no change — namespace is unchanged, and `Gum.csproj` already references `Gum.Presentation.csproj`.

**`Gum/Commands/EditCommands.cs` — (b) convertible with reasonable effort, not done here.** The 3 grep "System.Windows" hits (`using System.Windows.Controls;`, `using System.Windows.Forms;`, `DialogResult = System.Windows.Forms.DialogResult`) plus `using CommonFormsAndControls;`/`using Gum.Gui.Windows;` are all **dead code** — zero call sites in the class body. The real blocker is two ctor params typed as the **concrete** `StandardElementsManagerGumTool` (WPF-typed: uses `WpfDataUi.Controls`) instead of the already-headless `IStandardElementsManagerGumTool` interface. Same issue in `Gum/ToolCommands/ProjectCommands.cs` (an `EditCommands` dependency). Fix is mechanical: swap both ctor params to the interface (already DI-registered in `Builder.cs`), drop the dead usings, then both classes move. `INameVerifier` (in `Gum/Managers/`) is clean but not yet physically relocated — needs to move too.

**`Gum/Commands/FileCommands.cs` — mostly (a)/(b), one real (c).** All DI dependencies are already headless. Two issues:
- `IFileWatchIgnoreList` is declared in the same file as its concrete `FileWatchIgnoreList` (still in `Gum.csproj`) — needs extracting to its own file before it can move to `Gum.Presentation` (mirrors the `FileWatchManager.cs` gotcha already in the decoupling doc).
- `MoveToRecycleBin` calls `Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(..., UIOption, RecycleOption)`, which needs the Windows-desktop runtime (`UseWindowsForms`) — genuine platform glue, not reachable headless without a seam (e.g. an `IRecycleBinService` the WPF side implements). This is the one **(c)** piece across all three files.

## New gotcha (for the maintainer to fold into `Direction/ui-decoupling-plan.md`)

A class can look headless-clean by grep (dependencies all interfaces already in `Gum.Presentation`) while still failing to move because a field/ctor param is typed as a **concrete**, still-WPF-tied sibling class instead of that sibling's own already-existing, already-headless interface (`StandardElementsManagerGumTool` vs. `IStandardElementsManagerGumTool` here). Same shape as the "inject the interface, not the concrete" gotcha already in the doc, but the trigger this time was auditing a *second* class's ctor params, not the field's declared type looking safe.

Also: a `#if GUM` (or similar) compile guard inside a class that's about to leave `Gum.csproj` can be **always-true dead code** if `GUM` was defined project-wide — worth grepping for stray `#if`/`#endif` blocks before/after any relocation, since removing the guard changes nothing today but preserves behavior once the define disappears.

## Manual test

Not needed — behavior-preserving move + pinning test + compiler-enforced boundary (Gum.Presentation is net8.0, no WPF/WinForms). `dotnet build GumFull.sln` is clean, `Gum.Presentation.Tests` (449/449) and `GumToolUnitTests` (1116/1118, 2 pre-existing skips) are green.

## Skill tool availability

The `Skill` tool was not available to me in this session (not in my registered tool list). Loaded `refactoring-direction` and `tdd` by reading their `SKILL.md` files directly and followed their rules; did a manual self-review of the diff instead of `/code-review`.
