### PR TITLE
Relocate AnimationTabRefreshLogic out of MainStateAnimationPlugin, part of #3866

### DIFF
--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -291,11 +291,11 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
             ? _animationFilePathService.GetAbsoluteAnimationFileNameFor(selectedElement)
             : null;
 
-        if (ShouldReloadAnimationsForChangedFile(filePath, selectedElementAnimationFile))
+        if (AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(filePath, selectedElementAnimationFile))
         {
             // Capture the selection before the rebuild replaces every animation/keyframe instance, then
             // reapply it so the external edit doesn't deselect the user's animation + keyframe (#3410).
-            var selection = CaptureAnimationSelection(_viewModel);
+            var selection = AnimationTabRefreshLogic.CaptureAnimationSelection(_viewModel);
 
             // forceReload bypasses CreateViewModel's same-element early-out: the external edit doesn't
             // change the selection, so without forcing it the stale view model would survive and the
@@ -305,26 +305,9 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
             if (_viewModel != null)
             {
-                RestoreAnimationSelection(_viewModel, selection);
+                AnimationTabRefreshLogic.RestoreAnimationSelection(_viewModel, selection);
             }
         }
-    }
-
-    /// <summary>
-    /// Decides whether an on-disk file change should live-reload the Animations tab (issue #3410):
-    /// true only when <paramref name="changedFile"/> is a <c>.ganx</c> and is the selected element's
-    /// own animation sidecar (<paramref name="selectedElementAnimationFile"/>). Other elements' .ganx
-    /// files reload lazily when that element is next selected, so they are ignored here.
-    /// </summary>
-    internal static bool ShouldReloadAnimationsForChangedFile(FilePath changedFile,
-        FilePath? selectedElementAnimationFile)
-    {
-        if (changedFile.Extension != "ganx")
-        {
-            return false;
-        }
-
-        return selectedElementAnimationFile != null && changedFile == selectedElementAnimationFile;
     }
 
     private void HandleElementSelected(ElementSave? element)
@@ -427,24 +410,12 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         var element = _selectedState.SelectedElement;
         if (element != null && _viewModel != null)
         {
-            RefreshAfterStateRename(_renameManager, _viewModel, element, stateSave, oldName);
+            AnimationTabRefreshLogic.RefreshAfterStateRename(_renameManager, _viewModel, element, stateSave, oldName);
         }
 
         // Refresh available states / DataContext and re-broadcast. RefreshErrors runs again here,
         // but it is idempotent and rename is not a hot path.
         RefreshViewModel();
-    }
-
-    /// <summary>
-    /// Applies a state rename to <paramref name="viewModel"/>'s keyframe references and then
-    /// recomputes errors, in that order. The order matters: recomputing before the rewrite leaves a
-    /// stale "references a missing state" error on the renamed keyframe (issue #3383).
-    /// </summary>
-    internal static void RefreshAfterStateRename(IRenameManager renameManager,
-        ElementAnimationsViewModel viewModel, ElementSave element, StateSave stateSave, string oldName)
-    {
-        renameManager.HandleRename(stateSave, oldName, viewModel);
-        viewModel.RefreshErrors(element);
     }
 
     private void HandleAfterUndo()
@@ -454,8 +425,8 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
         // user's animation + keyframe selection survives undo/redo — mirroring element-undo's state
         // selection restore (#3406). Index + count are captured alongside the keyframe so the reselect
         // can fall back to position when the undo reverted the selected keyframe's own value (see
-        // RestoreAnimationSelection).
-        var selection = CaptureAnimationSelection(_viewModel);
+        // AnimationTabRefreshLogic.RestoreAnimationSelection).
+        var selection = AnimationTabRefreshLogic.CaptureAnimationSelection(_viewModel);
 
         // Repaint the tab from the just-restored .ganx, then re-arm undo recording. The flag spanned
         // the .ganx write (ApplyAnimations) through this repaint so neither flushed a spurious undo.
@@ -466,122 +437,10 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         if (_viewModel != null)
         {
-            RestoreAnimationSelection(_viewModel, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(_viewModel, selection);
         }
 
         _isApplyingUndo = false;
-    }
-
-    /// <summary>
-    /// The animation/keyframe selection captured before a forced view-model rebuild (undo/redo or an
-    /// external .ganx reload). Carries both the identity (animation name + keyframe content) and the
-    /// position (animation/keyframe index + sibling counts) so <see cref="RestoreAnimationSelection"/>
-    /// can fall back to the slot when the identity changed — e.g. the selected animation was renamed.
-    /// </summary>
-    internal readonly record struct AnimationSelectionState(
-        string? AnimationName,
-        AnimatedKeyframeViewModel? Keyframe,
-        int KeyframeIndex,
-        int KeyframeCount,
-        int AnimationIndex = -1,
-        int AnimationCount = 0);
-
-    /// <summary>
-    /// Snapshots the currently-selected animation and keyframe (identity + position) so the selection
-    /// can be reapplied after a forced view-model rebuild replaces every animation/keyframe instance.
-    /// Pairs with <see cref="RestoreAnimationSelection"/>.
-    /// </summary>
-    internal static AnimationSelectionState CaptureAnimationSelection(ElementAnimationsViewModel? viewModel)
-    {
-        var selectedAnimation = viewModel?.SelectedAnimation;
-        var selectedKeyframe = selectedAnimation?.SelectedKeyframe;
-        return new AnimationSelectionState(
-            selectedAnimation?.Name,
-            selectedKeyframe,
-            selectedKeyframe != null ? selectedAnimation!.Keyframes.IndexOf(selectedKeyframe) : -1,
-            selectedAnimation?.Keyframes.Count ?? 0,
-            selectedAnimation != null && viewModel != null ? viewModel.Animations.IndexOf(selectedAnimation) : -1,
-            viewModel?.Animations.Count ?? 0);
-    }
-
-    /// <summary>
-    /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation and keyframe captured
-    /// in <paramref name="selection"/>. The animation is matched by name; if that fails because it was
-    /// renamed (e.g. an external .ganx edit), it falls back to the captured animation index when the
-    /// animation count is unchanged. The keyframe is then matched by content; if that fails because the
-    /// undo reverted the selected keyframe's <em>own</em> value (e.g. its time), it falls back to the
-    /// captured index — but only when the keyframe count is unchanged, so an add/delete (which
-    /// changes the count) drops that selection rather than grabbing a neighbor. Returns the matched
-    /// keyframe (or null). Best-effort, mirroring element-undo's silent selection drop when the selected
-    /// object no longer exists.
-    /// </summary>
-    /// <remarks>
-    /// The keyframe is selected on the animation <em>before</em> the animation is made the active
-    /// SelectedAnimation. That ordering matters: setting SelectedAnimation rebinds the keyframes
-    /// ListBox's ItemsSource, and the ListBox initializes its SelectedItem from the (two-way) bound
-    /// SelectedKeyframe at bind time. If SelectedKeyframe is still null then, the ListBox settles on no
-    /// selection and a later assignment gets reset; pre-setting it means the ListBox binds straight to
-    /// the right, already-present keyframe — so the selection (and the right-side property panel) sticks
-    /// without any dispatcher timing games (#3406).
-    /// </remarks>
-    internal static AnimatedKeyframeViewModel? RestoreAnimationSelection(ElementAnimationsViewModel viewModel,
-        AnimationSelectionState selection)
-    {
-        if (selection.AnimationName == null)
-        {
-            return null;
-        }
-
-        var animation = viewModel.Animations.FirstOrDefault(item => item.Name == selection.AnimationName);
-
-        // The selected animation may have been renamed by an external .ganx edit, so the captured name
-        // matches nothing. Fall back to the captured slot when the animation count is unchanged, keeping
-        // the same row selected through the rename (#3410). A count change means an add/delete, where
-        // grabbing a neighbor by index would be wrong, so the selection drops instead.
-        if (animation == null
-            && viewModel.Animations.Count == selection.AnimationCount
-            && selection.AnimationIndex >= 0
-            && selection.AnimationIndex < viewModel.Animations.Count)
-        {
-            animation = viewModel.Animations[selection.AnimationIndex];
-        }
-
-        if (animation == null)
-        {
-            return null;
-        }
-
-        AnimatedKeyframeViewModel? matched = null;
-        if (selection.Keyframe != null)
-        {
-            matched = animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, selection.Keyframe));
-
-            if (matched == null
-                && animation.Keyframes.Count == selection.KeyframeCount
-                && selection.KeyframeIndex >= 0
-                && selection.KeyframeIndex < animation.Keyframes.Count)
-            {
-                matched = animation.Keyframes[selection.KeyframeIndex];
-            }
-        }
-
-        animation.SelectedKeyframe = matched;
-        viewModel.SelectedAnimation = animation;
-
-        return matched;
-    }
-
-    /// <summary>
-    /// Identity match for a keyframe across a view-model rebuild: same discriminator (state /
-    /// sub-animation / event name) and time. Used to reselect the previously-selected keyframe on the
-    /// new instances after an undo/redo reload.
-    /// </summary>
-    private static bool AreSameKeyframe(AnimatedKeyframeViewModel first, AnimatedKeyframeViewModel second)
-    {
-        return first.StateName == second.StateName
-            && first.AnimationName == second.AnimationName
-            && first.EventName == second.EventName
-            && first.Time == second.Time;
     }
 
     private void HandleStateAdd(StateSave state)
@@ -775,64 +634,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
     private void RefreshAvailableStates()
     {
-        AvailableStates.ReplaceWith(GetAvailableStates(_selectedState.SelectedElement, _viewModel));
-    }
-
-    /// <summary>
-    /// Builds the state names shown in each keyframe's state ComboBox: every state on the element,
-    /// plus any state still referenced by a keyframe even though it no longer exists on the element.
-    /// Keeping a referenced-but-missing state in the list matters because the ComboBox is editable
-    /// with its Text bound to the keyframe's StateName — if the referenced item left the ItemsSource,
-    /// the ComboBox would coerce its Text (and thus StateName) to empty, collapsing a broken state
-    /// keyframe into an event (issue #3392). The keyframe stays flagged as broken via
-    /// HasValidState/RefreshErrors, which is computed against the element, not this list.
-    /// </summary>
-    internal static List<string> GetAvailableStates(ElementSave? element, ElementAnimationsViewModel? viewModel)
-    {
-        var states = new List<string>();
-
-        if (element != null)
-        {
-            states.AddRange(element.States.Select(item => item.Name));
-
-            foreach (var category in element.Categories)
-            {
-                states.AddRange(category.States.Select(item => category.Name + "/" + item.Name));
-            }
-        }
-
-        // Keep any state still referenced by a keyframe even though it no longer exists on the
-        // element (e.g. its category was just deleted). The editable state ComboBox binds its Text to
-        // the keyframe's StateName; if the referenced item left this list it would coerce StateName to
-        // empty, collapsing the broken state keyframe into an event (issue #3392).
-        if (viewModel != null)
-        {
-            foreach (var animation in viewModel.Animations)
-            {
-                foreach (var keyframe in animation.Keyframes)
-                {
-                    if (!string.IsNullOrEmpty(keyframe.StateName) && !states.Contains(keyframe.StateName))
-                    {
-                        states.Add(keyframe.StateName);
-                    }
-                }
-            }
-        }
-
-        return states;
-    }
-
-    /// <summary>
-    /// Decides whether <see cref="CreateViewModel"/> should rebuild the view model from the element's
-    /// .ganx. Normally the view model is only reloaded when the selected element changes; an in-place
-    /// undo/redo restores the .ganx without changing the selection, so the after-undo path passes
-    /// <paramref name="forceReload"/> to repaint the tab immediately rather than keeping the stale view
-    /// model until the element is reselected (#3406).
-    /// </summary>
-    internal static bool ShouldReloadViewModel(ElementSave? currentlyReferencedElement,
-        ElementSave? selectedElement, bool forceReload)
-    {
-        return currentlyReferencedElement != selectedElement || forceReload;
+        AvailableStates.ReplaceWith(AnimationTabRefreshLogic.GetAvailableStates(_selectedState.SelectedElement, _viewModel));
     }
 
     private void CreateViewModel(bool forceReload = false)
@@ -845,7 +647,7 @@ public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
 
         var element = _selectedState.SelectedElement;
 
-        if (ShouldReloadViewModel(currentlyReferencedElement, element, forceReload))
+        if (AnimationTabRefreshLogic.ShouldReloadViewModel(currentlyReferencedElement, element, forceReload))
         {
             if (_projectState.GumProjectSave?.FullFileName == null)
             {

--- a/Gum/StateAnimationPlugin/Properties/AssemblyInfo.cs
+++ b/Gum/StateAnimationPlugin/Properties/AssemblyInfo.cs
@@ -14,11 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Exposes internal members (e.g. the animation view models' RefreshErrors/GetErrors error
-// computation) to the tool unit test project so the rename/error logic can be characterized
-// without driving the WPF plugin.
-[assembly: InternalsVisibleTo("GumToolUnitTests")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationFileReloadTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationFileReloadTests.cs
@@ -10,7 +10,7 @@ namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
 /// disk (issue #3410): only the currently-selected element's animation sidecar should trigger a
 /// repaint, and only for the <c>.ganx</c> extension. The plugin subscribes to the file-watch
 /// <c>ReactToFileChanged</c> event for every changed file, so the extension and per-element gates
-/// both live in <see cref="MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile"/>.
+/// both live in <see cref="AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile"/>.
 /// </summary>
 public class AnimationFileReloadTests
 {
@@ -20,7 +20,7 @@ public class AnimationFileReloadTests
         FilePath changed = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
         FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
 
-        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
             .ShouldBeTrue();
     }
 
@@ -30,7 +30,7 @@ public class AnimationFileReloadTests
         FilePath changed = new FilePath(@"C:\Proj\Components\OtherAnimations.ganx");
         FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
 
-        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
             .ShouldBeFalse();
     }
 
@@ -40,7 +40,7 @@ public class AnimationFileReloadTests
         FilePath changed = new FilePath(@"C:\Proj\Components\MyButton.gucx");
         FilePath selectedElementAnimationFile = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
 
-        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, selectedElementAnimationFile)
             .ShouldBeFalse();
     }
 
@@ -49,7 +49,7 @@ public class AnimationFileReloadTests
     {
         FilePath changed = new FilePath(@"C:\Proj\Components\MyButtonAnimations.ganx");
 
-        MainStateAnimationPlugin.ShouldReloadAnimationsForChangedFile(changed, null)
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, null)
             .ShouldBeFalse();
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
@@ -65,7 +65,7 @@ public class AnimationStateRenameErrorTests : BaseTestClass
 
         element.Categories.Clear();  // delete the whole category, as DeleteLogic does
 
-        List<string> availableStates = MainStateAnimationPlugin.GetAvailableStates(element, viewModel);
+        List<string> availableStates = AnimationTabRefreshLogic.GetAvailableStates(element, viewModel);
 
         availableStates.ShouldContain("Cat/Idle");
     }
@@ -109,7 +109,7 @@ public class AnimationStateRenameErrorTests : BaseTestClass
             CreateAnimationWithKeyframes(Keyframe(stateName: "Cat/Idle")));
 
         idle.Name = "Walk";  // state already renamed when the plugin event fires
-        MainStateAnimationPlugin.RefreshAfterStateRename(
+        AnimationTabRefreshLogic.RefreshAfterStateRename(
             RenameManagerFor(element), viewModel, element, idle, "Idle");
 
         viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("Cat/Walk");

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationUndoTests.cs
@@ -89,7 +89,7 @@ public class AnimationUndoTests : BaseTestClass
         // .ganx even when the selected element is the same one already loaded (issue #3406 follow-up).
         ComponentSave element = new();
 
-        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+        bool shouldReload = AnimationTabRefreshLogic.ShouldReloadViewModel(
             currentlyReferencedElement: element,
             selectedElement: element,
             forceReload: true);
@@ -103,7 +103,7 @@ public class AnimationUndoTests : BaseTestClass
         // The stale-VM early-out the normal refresh path relies on: same element, no reload.
         ComponentSave element = new();
 
-        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+        bool shouldReload = AnimationTabRefreshLogic.ShouldReloadViewModel(
             currentlyReferencedElement: element,
             selectedElement: element,
             forceReload: false);
@@ -117,7 +117,7 @@ public class AnimationUndoTests : BaseTestClass
         ComponentSave currentElement = new();
         ComponentSave selectedElement = new();
 
-        bool shouldReload = MainStateAnimationPlugin.ShouldReloadViewModel(
+        bool shouldReload = AnimationTabRefreshLogic.ShouldReloadViewModel(
             currentlyReferencedElement: currentElement,
             selectedElement: selectedElement,
             forceReload: false);
@@ -134,11 +134,11 @@ public class AnimationUndoTests : BaseTestClass
         // across the reload when the selected keyframe itself was unchanged by the undo.
         ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
             Keyframe("Default", 0f), Keyframe("Highlighted", 1f));
-        var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+        var selection = new AnimationTabRefreshLogic.AnimationSelectionState(
             "Anim", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2);
 
         AnimatedKeyframeViewModel? matched =
-            MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(rebuilt, selection);
 
         rebuilt.SelectedAnimation.ShouldBe(animation);
         matched.ShouldNotBeNull();
@@ -157,11 +157,11 @@ public class AnimationUndoTests : BaseTestClass
         // selected (with its time showing 5 again).
         ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
             Keyframe("Default", 0f), Keyframe("Highlighted", 5f));
-        var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+        var selection = new AnimationTabRefreshLogic.AnimationSelectionState(
             "Anim", Keyframe("Highlighted", 4f), KeyframeIndex: 1, KeyframeCount: 2);
 
         AnimatedKeyframeViewModel? matched =
-            MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(rebuilt, selection);
 
         matched.ShouldNotBeNull();
         matched!.Time.ShouldBe(5f);
@@ -176,11 +176,11 @@ public class AnimationUndoTests : BaseTestClass
         // rather than grabbing a neighbor. The animation is still reselected.
         ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("Anim", out AnimationViewModel animation,
             Keyframe("Default", 0f));
-        var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+        var selection = new AnimationTabRefreshLogic.AnimationSelectionState(
             "Anim", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2);
 
         AnimatedKeyframeViewModel? matched =
-            MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(rebuilt, selection);
 
         rebuilt.SelectedAnimation.ShouldBe(animation);
         matched.ShouldBeNull();
@@ -196,12 +196,12 @@ public class AnimationUndoTests : BaseTestClass
         // keyframe is re-matched on it by content.
         ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("NewName", out AnimationViewModel animation,
             Keyframe("Default", 0f), Keyframe("Highlighted", 1f));
-        var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+        var selection = new AnimationTabRefreshLogic.AnimationSelectionState(
             "OldName", Keyframe("Highlighted", 1f), KeyframeIndex: 1, KeyframeCount: 2,
             AnimationIndex: 0, AnimationCount: 1);
 
         AnimatedKeyframeViewModel? matched =
-            MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(rebuilt, selection);
 
         rebuilt.SelectedAnimation.ShouldBe(animation);
         matched.ShouldNotBeNull();
@@ -217,12 +217,12 @@ public class AnimationUndoTests : BaseTestClass
         // Drop the selection cleanly instead.
         ElementAnimationsViewModel rebuilt = ViewModelWithAnimation("NewName", out AnimationViewModel _,
             Keyframe("Default", 0f));
-        var selection = new MainStateAnimationPlugin.AnimationSelectionState(
+        var selection = new AnimationTabRefreshLogic.AnimationSelectionState(
             "OldName", Keyframe("Default", 0f), KeyframeIndex: 0, KeyframeCount: 1,
             AnimationIndex: 1, AnimationCount: 2);
 
         AnimatedKeyframeViewModel? matched =
-            MainStateAnimationPlugin.RestoreAnimationSelection(rebuilt, selection);
+            AnimationTabRefreshLogic.RestoreAnimationSelection(rebuilt, selection);
 
         rebuilt.SelectedAnimation.ShouldBeNull();
         matched.ShouldBeNull();

--- a/Tools/Gum.Presentation/StateAnimationPlugin/AnimationTabRefreshLogic.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/AnimationTabRefreshLogic.cs
@@ -1,0 +1,217 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using StateAnimationPlugin.Managers;
+using StateAnimationPlugin.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+using ToolsUtilities;
+
+namespace StateAnimationPlugin;
+
+/// <summary>
+/// Pure decision logic for refreshing/reloading the Animations tab and reselecting the animation +
+/// keyframe across a forced view-model rebuild (undo/redo, an external <c>.ganx</c> edit, or a state
+/// rename). Extracted from <c>MainStateAnimationPlugin</c> (the WPF-hosted plugin) since none of it
+/// touches WPF types — the plugin calls into this class and only owns the WPF-side repaint
+/// (assigning the rebuilt view model to the window's DataContext).
+/// </summary>
+public static class AnimationTabRefreshLogic
+{
+    /// <summary>
+    /// Decides whether an on-disk file change should live-reload the Animations tab (issue #3410):
+    /// true only when <paramref name="changedFile"/> is a <c>.ganx</c> and is the selected element's
+    /// own animation sidecar (<paramref name="selectedElementAnimationFile"/>). Other elements' .ganx
+    /// files reload lazily when that element is next selected, so they are ignored here.
+    /// </summary>
+    public static bool ShouldReloadAnimationsForChangedFile(FilePath changedFile,
+        FilePath? selectedElementAnimationFile)
+    {
+        if (changedFile.Extension != "ganx")
+        {
+            return false;
+        }
+
+        return selectedElementAnimationFile != null && changedFile == selectedElementAnimationFile;
+    }
+
+    /// <summary>
+    /// Applies a state rename to <paramref name="viewModel"/>'s keyframe references and then
+    /// recomputes errors, in that order. The order matters: recomputing before the rewrite leaves a
+    /// stale "references a missing state" error on the renamed keyframe (issue #3383).
+    /// </summary>
+    public static void RefreshAfterStateRename(IRenameManager renameManager,
+        ElementAnimationsViewModel viewModel, ElementSave element, StateSave stateSave, string oldName)
+    {
+        renameManager.HandleRename(stateSave, oldName, viewModel);
+        viewModel.RefreshErrors(element);
+    }
+
+    /// <summary>
+    /// The animation/keyframe selection captured before a forced view-model rebuild (undo/redo or an
+    /// external .ganx reload). Carries both the identity (animation name + keyframe content) and the
+    /// position (animation/keyframe index + sibling counts) so <see cref="RestoreAnimationSelection"/>
+    /// can fall back to the slot when the identity changed — e.g. the selected animation was renamed.
+    /// </summary>
+    public readonly record struct AnimationSelectionState(
+        string? AnimationName,
+        AnimatedKeyframeViewModel? Keyframe,
+        int KeyframeIndex,
+        int KeyframeCount,
+        int AnimationIndex = -1,
+        int AnimationCount = 0);
+
+    /// <summary>
+    /// Snapshots the currently-selected animation and keyframe (identity + position) so the selection
+    /// can be reapplied after a forced view-model rebuild replaces every animation/keyframe instance.
+    /// Pairs with <see cref="RestoreAnimationSelection"/>.
+    /// </summary>
+    public static AnimationSelectionState CaptureAnimationSelection(ElementAnimationsViewModel? viewModel)
+    {
+        var selectedAnimation = viewModel?.SelectedAnimation;
+        var selectedKeyframe = selectedAnimation?.SelectedKeyframe;
+        return new AnimationSelectionState(
+            selectedAnimation?.Name,
+            selectedKeyframe,
+            selectedKeyframe != null ? selectedAnimation!.Keyframes.IndexOf(selectedKeyframe) : -1,
+            selectedAnimation?.Keyframes.Count ?? 0,
+            selectedAnimation != null && viewModel != null ? viewModel.Animations.IndexOf(selectedAnimation) : -1,
+            viewModel?.Animations.Count ?? 0);
+    }
+
+    /// <summary>
+    /// Reselects, on a freshly-rebuilt <paramref name="viewModel"/>, the animation and keyframe captured
+    /// in <paramref name="selection"/>. The animation is matched by name; if that fails because it was
+    /// renamed (e.g. an external .ganx edit), it falls back to the captured animation index when the
+    /// animation count is unchanged. The keyframe is then matched by content; if that fails because the
+    /// undo reverted the selected keyframe's <em>own</em> value (e.g. its time), it falls back to the
+    /// captured index — but only when the keyframe count is unchanged, so an add/delete (which
+    /// changes the count) drops that selection rather than grabbing a neighbor. Returns the matched
+    /// keyframe (or null). Best-effort, mirroring element-undo's silent selection drop when the selected
+    /// object no longer exists.
+    /// </summary>
+    /// <remarks>
+    /// The keyframe is selected on the animation <em>before</em> the animation is made the active
+    /// SelectedAnimation. That ordering matters: setting SelectedAnimation rebinds the keyframes
+    /// ListBox's ItemsSource, and the ListBox initializes its SelectedItem from the (two-way) bound
+    /// SelectedKeyframe at bind time. If SelectedKeyframe is still null then, the ListBox settles on no
+    /// selection and a later assignment gets reset; pre-setting it means the ListBox binds straight to
+    /// the right, already-present keyframe — so the selection (and the right-side property panel) sticks
+    /// without any dispatcher timing games (#3406).
+    /// </remarks>
+    public static AnimatedKeyframeViewModel? RestoreAnimationSelection(ElementAnimationsViewModel viewModel,
+        AnimationSelectionState selection)
+    {
+        if (selection.AnimationName == null)
+        {
+            return null;
+        }
+
+        var animation = viewModel.Animations.FirstOrDefault(item => item.Name == selection.AnimationName);
+
+        // The selected animation may have been renamed by an external .ganx edit, so the captured name
+        // matches nothing. Fall back to the captured slot when the animation count is unchanged, keeping
+        // the same row selected through the rename (#3410). A count change means an add/delete, where
+        // grabbing a neighbor by index would be wrong, so the selection drops instead.
+        if (animation == null
+            && viewModel.Animations.Count == selection.AnimationCount
+            && selection.AnimationIndex >= 0
+            && selection.AnimationIndex < viewModel.Animations.Count)
+        {
+            animation = viewModel.Animations[selection.AnimationIndex];
+        }
+
+        if (animation == null)
+        {
+            return null;
+        }
+
+        AnimatedKeyframeViewModel? matched = null;
+        if (selection.Keyframe != null)
+        {
+            matched = animation.Keyframes.FirstOrDefault(item => AreSameKeyframe(item, selection.Keyframe));
+
+            if (matched == null
+                && animation.Keyframes.Count == selection.KeyframeCount
+                && selection.KeyframeIndex >= 0
+                && selection.KeyframeIndex < animation.Keyframes.Count)
+            {
+                matched = animation.Keyframes[selection.KeyframeIndex];
+            }
+        }
+
+        animation.SelectedKeyframe = matched;
+        viewModel.SelectedAnimation = animation;
+
+        return matched;
+    }
+
+    /// <summary>
+    /// Identity match for a keyframe across a view-model rebuild: same discriminator (state /
+    /// sub-animation / event name) and time. Used to reselect the previously-selected keyframe on the
+    /// new instances after an undo/redo reload.
+    /// </summary>
+    private static bool AreSameKeyframe(AnimatedKeyframeViewModel first, AnimatedKeyframeViewModel second)
+    {
+        return first.StateName == second.StateName
+            && first.AnimationName == second.AnimationName
+            && first.EventName == second.EventName
+            && first.Time == second.Time;
+    }
+
+    /// <summary>
+    /// Builds the state names shown in each keyframe's state ComboBox: every state on the element,
+    /// plus any state still referenced by a keyframe even though it no longer exists on the element.
+    /// Keeping a referenced-but-missing state in the list matters because the ComboBox is editable
+    /// with its Text bound to the keyframe's StateName — if the referenced item left the ItemsSource,
+    /// the ComboBox would coerce its Text (and thus StateName) to empty, collapsing a broken state
+    /// keyframe into an event (issue #3392). The keyframe stays flagged as broken via
+    /// HasValidState/RefreshErrors, which is computed against the element, not this list.
+    /// </summary>
+    public static List<string> GetAvailableStates(ElementSave? element, ElementAnimationsViewModel? viewModel)
+    {
+        var states = new List<string>();
+
+        if (element != null)
+        {
+            states.AddRange(element.States.Select(item => item.Name));
+
+            foreach (var category in element.Categories)
+            {
+                states.AddRange(category.States.Select(item => category.Name + "/" + item.Name));
+            }
+        }
+
+        // Keep any state still referenced by a keyframe even though it no longer exists on the
+        // element (e.g. its category was just deleted). The editable state ComboBox binds its Text to
+        // the keyframe's StateName; if the referenced item left this list it would coerce StateName to
+        // empty, collapsing the broken state keyframe into an event (issue #3392).
+        if (viewModel != null)
+        {
+            foreach (var animation in viewModel.Animations)
+            {
+                foreach (var keyframe in animation.Keyframes)
+                {
+                    if (!string.IsNullOrEmpty(keyframe.StateName) && !states.Contains(keyframe.StateName))
+                    {
+                        states.Add(keyframe.StateName);
+                    }
+                }
+            }
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// Decides whether <c>MainStateAnimationPlugin.CreateViewModel</c> should rebuild the view model
+    /// from the element's .ganx. Normally the view model is only reloaded when the selected element
+    /// changes; an in-place undo/redo restores the .ganx without changing the selection, so the
+    /// after-undo path passes <paramref name="forceReload"/> to repaint the tab immediately rather than
+    /// keeping the stale view model until the element is reselected (#3406).
+    /// </summary>
+    public static bool ShouldReloadViewModel(ElementSave? currentlyReferencedElement,
+        ElementSave? selectedElement, bool forceReload)
+    {
+        return currentlyReferencedElement != selectedElement || forceReload;
+    }
+}


### PR DESCRIPTION
## Summary
Scoping pass for #3866 (`MainStateAnimationPlugin.cs`, ~1113 lines, WPF+WinForms plugin project). Most of the file's private handler logic is already headless-clean (delegates to already-relocated interfaces/ViewModels from prior work); the genuinely WPF-tainted surface is thin: menu items, the `MainWindow`/`CheckBox` construction, and the tab-visibility/DataContext glue.

This PR lands one bounded, TDD-pinned slice: extracts the already-static, already-pinned, zero-WPF decision helpers (`ShouldReloadAnimationsForChangedFile`, `CaptureAnimationSelection`/`RestoreAnimationSelection`/`AreSameKeyframe`, `ShouldReloadViewModel`, `GetAvailableStates`, `RefreshAfterStateRename`, `AnimationSelectionState`) into a new `AnimationTabRefreshLogic` class in `Gum.Presentation`. Production call sites and the existing pinning tests are retargeted to it; no behavior change.

Boyscout: removed the now-dead `InternalsVisibleTo("GumToolUnitTests")` from `StateAnimationPlugin`'s AssemblyInfo — these relocated members were its only reason to exist.

## Not in this PR (remaining scope)
The bulk of `MainStateAnimationPlugin`'s other handler methods (`HandleVariableSet`, `CreateViewModel`, `HandleDataChange`, `HandleAddStateKeyframe`, error-response handlers, etc.) are *also* WPF-free logic today, but they're still instance methods reading the plugin's own private fields (`_viewModel`, `_animationCollectionViewModelManager`, `_messenger`, ...) rather than free-standing/injectable — extracting them is a bigger follow-up (a real controller class taking those as ctor deps), not a same-shape drop-in move. Genuine WPF/WinForms glue (`CreateAnimationWindow`, `CreateMenuItems`, `HandleToggleTabVisibility`, `HandleTabShown/Hidden`, `HandleDeleteOptionsWindowShow/Confirmed`) stays tool-side — real platform construction with no clean seam yet, same carve-out as other `PluginBase` classes in this campaign.

## Test plan
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — full suite green (1122 passed, 2 pre-existing skips), including `AllPluginsCompositionTests`.
- `dotnet build GumFull.sln` — 0 errors.
- Mutation-test proof: broke `ShouldReloadAnimationsForChangedFile`'s equality, confirmed 2 tests went red, reverted, confirmed green again.

Manual test: not needed — pure extraction, covered by unit tests + compilation.

Part of #3866 (see issue comment for remaining scope; NOT closing — the bulk of the plugin's handler logic is still tool-side)
