### PR TITLE
Relocate FileCommands into headless Gum.Presentation, completing #3862

### DIFF
--- a/Gum/Managers/CsvLocalizationLoader.cs
+++ b/Gum/Managers/CsvLocalizationLoader.cs
@@ -1,0 +1,14 @@
+using Gum.Localization;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Thin wrapper around <see cref="LocalizationServiceExtensions.AddDatabaseFromCsv"/> (which
+/// depends on CsvLibrary) so headless callers can reach it via <see cref="ICsvLocalizationLoader"/>.
+/// </summary>
+public class CsvLocalizationLoader : ICsvLocalizationLoader
+{
+    /// <inheritdoc/>
+    public void AddDatabaseFromCsv(ILocalizationService service, string fileName, char delimiter) =>
+        service.AddDatabaseFromCsv(fileName, delimiter);
+}

--- a/Gum/Managers/RecycleBinService.cs
+++ b/Gum/Managers/RecycleBinService.cs
@@ -1,0 +1,17 @@
+using ToolsUtilities;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Moves files to the OS recycle bin via <see cref="Microsoft.VisualBasic.FileIO.FileSystem"/>,
+/// which requires the Windows desktop runtime (<c>UseWindowsForms</c>). See
+/// <see cref="IRecycleBinService"/> for why this is kept behind an interface.
+/// </summary>
+public class RecycleBinService : IRecycleBinService
+{
+    /// <inheritdoc/>
+    public void MoveToRecycleBin(FilePath filePath) =>
+        Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(filePath.FullPath,
+            Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
+            Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+}

--- a/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchIgnoreList.cs
+++ b/Gum/Plugins/InternalPlugins/FileWatchPlugin/FileWatchIgnoreList.cs
@@ -5,22 +5,6 @@ using ToolsUtilities;
 
 namespace Gum.Logic.FileWatch;
 
-/// <summary>
-/// Holds the set of file paths whose next change(s) should be ignored by
-/// the file watcher. Extracted from FileWatchManager so that components
-/// which only need to mute the watcher (e.g. FileCommands when saving an
-/// element) can depend on this small surface without introducing a DI
-/// cycle through FileWatchManager.
-/// </summary>
-public interface IFileWatchIgnoreList
-{
-    IReadOnlyDictionary<FilePath, DateTime> TimedChangesToIgnore { get; }
-
-    void IgnoreNextChangeUntil(FilePath filePath, DateTime? time = null);
-    void ClearIgnoredFiles();
-    bool TryGetIgnoreFileChange(FilePath fileName);
-}
-
 public class FileWatchIgnoreList : IFileWatchIgnoreList
 {
     private readonly ConcurrentDictionary<FilePath, int> _changesToIgnore = new();

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -200,6 +200,8 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IOutputManager>(provider => provider.GetRequiredService<MainOutputViewModel>());
         services.AddSingleton<FileWatchIgnoreList>();
         services.AddSingleton<IFileWatchIgnoreList>(provider => provider.GetRequiredService<FileWatchIgnoreList>());
+        services.AddSingleton<IRecycleBinService, RecycleBinService>();
+        services.AddSingleton<ICsvLocalizationLoader, CsvLocalizationLoader>();
         services.AddSingleton<FileWatchManager>();
         services.AddSingleton<IFileWatchManager>(provider => provider.GetRequiredService<FileWatchManager>());
         services.AddSingleton<ReorderLogic>();

--- a/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
@@ -83,13 +83,19 @@ public class FileCommandsTests : BaseTestClass
     [Fact]
     public void GetFullFileName_ShouldReturnPathUnderProjectDirectory()
     {
-        _gumProject.FullFileName = @"C:\MyProject\MyProject.gumx";
+        // A real, OS-native temp directory is used here (rather than a hardcoded "C:\..." literal)
+        // because FilePath's path-rooting logic (FileManager.IsRelative -> Path.IsPathRooted) is
+        // platform-specific: a Windows-style drive-letter path is not rooted on macOS/Linux, so a
+        // hardcoded literal computes a different (wrong) FullPath there.
+        _tempDirectory = CreateTempDirectory();
+        _gumProject.FullFileName = Path.Combine(_tempDirectory, "MyProject.gumx");
         ComponentSave component = new() { Name = "MyComponent" };
 
         FilePath result = _fileCommands.GetFullFileName(component);
 
         FilePath expectedDirectory = FileManager.GetDirectory(_gumProject.FullFileName);
-        result.FullPath.ShouldBe(expectedDirectory.Original + "Components\\MyComponent.gucx");
+        FilePath expected = expectedDirectory.Original + "Components\\MyComponent.gucx";
+        result.FullPath.ShouldBe(expected.FullPath);
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
@@ -1,0 +1,307 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ToolStates;
+using Moq;
+using Moq.AutoMock;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ToolsUtilities;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Covers FileCommands aside from CSV-loading, which requires the real, concrete
+/// CsvLocalizationLoader (depends on CsvLibrary, net8.0-windows) and so stays in
+/// Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs.
+/// </summary>
+public class FileCommandsTests : BaseTestClass
+{
+    private readonly AutoMocker _mocker;
+    private readonly FileCommands _fileCommands;
+    private readonly Mock<IProjectManager> _projectManager;
+    private readonly Mock<IProjectState> _projectState;
+    private readonly Mock<IOutputManager> _outputManager;
+    private readonly Mock<IRecycleBinService> _recycleBinService;
+    private readonly LocalizationService _localizationService;
+    private readonly GumProjectSave _gumProject;
+    private readonly List<string> _outputCalls;
+    private readonly List<string> _errorCalls;
+    private string? _tempDirectory;
+
+    public FileCommandsTests()
+    {
+        _mocker = new AutoMocker();
+
+        _localizationService = new LocalizationService();
+        _mocker.Use<ILocalizationService>(_localizationService);
+
+        _recycleBinService = _mocker.GetMock<IRecycleBinService>();
+
+        _outputCalls = new List<string>();
+        _errorCalls = new List<string>();
+        _outputManager = _mocker.GetMock<IOutputManager>();
+        _outputManager.Setup(o => o.AddOutput(It.IsAny<string>()))
+            .Callback<string>(s => _outputCalls.Add(s));
+        _outputManager.Setup(o => o.AddError(It.IsAny<string>()))
+            .Callback<string>(s => _errorCalls.Add(s));
+
+        _gumProject = new GumProjectSave();
+        _projectManager = _mocker.GetMock<IProjectManager>();
+        _projectManager.Setup(p => p.GumProjectSave).Returns(_gumProject);
+        _projectState = _mocker.GetMock<IProjectState>();
+        _projectState.Setup(p => p.GumProjectSave).Returns(_gumProject);
+        _projectState.Setup(p => p.ProjectDirectory).Returns(() =>
+            _tempDirectory == null ? null : _tempDirectory + Path.DirectorySeparatorChar);
+
+        _fileCommands = _mocker.CreateInstance<FileCommands>();
+    }
+
+    public override void Dispose()
+    {
+        if (_tempDirectory != null && Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+        base.Dispose();
+    }
+
+    [Fact]
+    public void MoveToRecycleBin_ShouldDelegateToInjectedRecycleBinService()
+    {
+        FilePath filePath = @"C:\MyProject\Component.gucx";
+
+        _fileCommands.MoveToRecycleBin(filePath);
+
+        _recycleBinService.Verify(x => x.MoveToRecycleBin(filePath), Times.Once);
+    }
+
+    [Fact]
+    public void GetFullFileName_ShouldReturnPathUnderProjectDirectory()
+    {
+        _gumProject.FullFileName = @"C:\MyProject\MyProject.gumx";
+        ComponentSave component = new() { Name = "MyComponent" };
+
+        FilePath result = _fileCommands.GetFullFileName(component);
+
+        FilePath expectedDirectory = FileManager.GetDirectory(_gumProject.FullFileName);
+        result.FullPath.ShouldBe(expectedDirectory.Original + "Components\\MyComponent.gucx");
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldDoNothing_WhenLocalizationFilesIsEmpty()
+    {
+        bool raised = false;
+        _fileCommands.LocalizationLoaded += () => raised = true;
+
+        _fileCommands.LoadLocalizationFile();
+
+        _outputCalls.Count.ShouldBe(0);
+        _errorCalls.Count.ShouldBe(0);
+        _localizationService.HasDatabase.ShouldBeFalse();
+        raised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldLoadMultipleResx_WhenMultipleResxEntries()
+    {
+        _tempDirectory = CreateTempDirectory();
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
+            new Dictionary<string, string> { { "T_OK", "OK" } });
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"),
+            new Dictionary<string, string> { { "B_Save", "Save" } });
+        _gumProject.LocalizationFiles.Add("Strings.resx");
+        _gumProject.LocalizationFiles.Add("Buttons.resx");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.CurrentLanguage = 1;
+        _localizationService.Translate("T_OK").ShouldBe("OK");
+        _localizationService.Translate("B_Save").ShouldBe("Save");
+        _errorCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldLoadSingleResx_WhenOneResxEntry()
+    {
+        _tempDirectory = CreateTempDirectory();
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
+            new Dictionary<string, string> { { "T_OK", "OK" } });
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"),
+            new Dictionary<string, string> { { "T_OK", "Aceptar" } });
+        _gumProject.LocalizationFiles.Add("Strings.resx");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.Languages.Count.ShouldBe(2);
+        _localizationService.CurrentLanguage = 2;
+        _localizationService.Translate("T_OK").ShouldBe("Aceptar");
+        _errorCalls.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldReportError_WhenMixingCsvAndResx()
+    {
+        _tempDirectory = CreateTempDirectory();
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
+            new Dictionary<string, string> { { "T_OK", "OK" } });
+        File.WriteAllText(Path.Combine(_tempDirectory, "Strings.csv"),
+            "StringId,English\nT_OK,OK\n");
+        _gumProject.LocalizationFiles.Add("Strings.resx");
+        _gumProject.LocalizationFiles.Add("Strings.csv");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _errorCalls.Count.ShouldBe(1);
+        _errorCalls[0].ShouldContain("not all are .resx");
+        _localizationService.HasDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldReportError_WhenMultipleCsvEntries()
+    {
+        _tempDirectory = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(_tempDirectory, "A.csv"), "StringId,English\nT_OK,OK\n");
+        File.WriteAllText(Path.Combine(_tempDirectory, "B.csv"), "StringId,English\nT_Cancel,Cancel\n");
+        _gumProject.LocalizationFiles.Add("A.csv");
+        _gumProject.LocalizationFiles.Add("B.csv");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _errorCalls.Count.ShouldBe(1);
+        _localizationService.HasDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldRouteCollisionToOutputTab_WhenMultipleResxFilesDefineSameKey()
+    {
+        _tempDirectory = CreateTempDirectory();
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
+            new Dictionary<string, string> { { "T_Shared", "FromStrings" } });
+        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"),
+            new Dictionary<string, string> { { "T_Shared", "FromButtons" } });
+        _gumProject.LocalizationFiles.Add("Strings.resx");
+        _gumProject.LocalizationFiles.Add("Buttons.resx");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _outputCalls.Count.ShouldBe(1);
+        _outputCalls[0].ShouldContain("T_Shared");
+        _outputCalls[0].ShouldContain("Strings.resx");
+        _outputCalls[0].ShouldContain("Buttons.resx");
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldReportError_WhenSingleCsvFileMissing()
+    {
+        _tempDirectory = CreateTempDirectory();
+        _gumProject.LocalizationFiles.Add("DoesNotExist.csv");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _errorCalls.Count.ShouldBe(1);
+        _errorCalls[0].ShouldContain("DoesNotExist.csv");
+        _localizationService.HasDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldReportError_WhenSingleResxFileMissing()
+    {
+        // Single-RESX now flows through the multi-file path, so a missing file is reported
+        // via AddError rather than silently no-opping (prior behavior).
+        _tempDirectory = CreateTempDirectory();
+        _gumProject.LocalizationFiles.Add("DoesNotExist.resx");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _errorCalls.Count.ShouldBe(1);
+        _errorCalls[0].ShouldContain("DoesNotExist.resx");
+        _localizationService.HasDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldWarnAndSkip_WhenBaseFileMissing()
+    {
+        // Production behavior: in the multi-file branch, missing files are reported via
+        // AddError (not AddOutput), and remaining existing files still load.
+        _tempDirectory = CreateTempDirectory();
+        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
+            new Dictionary<string, string> { { "T_OK", "OK" } });
+        _gumProject.LocalizationFiles.Add("Strings.resx");
+        _gumProject.LocalizationFiles.Add("DoesNotExist.resx");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _errorCalls.Count.ShouldBe(1);
+        _errorCalls[0].ShouldContain("DoesNotExist.resx");
+        _localizationService.HasDatabase.ShouldBeTrue();
+        _localizationService.CurrentLanguage = 1;
+        _localizationService.Translate("T_OK").ShouldBe("OK");
+    }
+
+    // Pins a second half of the case-only-rename bug (see RenameFolderDialogViewModelTests):
+    // even once the "already exists" guard is fixed, MoveDirectory's manual recursive
+    // copy-then-delete-source approach fails for a rename that only changes casing, because
+    // source and destination are the same physical directory on a case-insensitive filesystem
+    // (Windows) - CreateDirectory(destination) is a no-op, the files "move" to themselves, and
+    // Directory.Delete(source) then throws because the directory is (still) not empty.
+    [Fact]
+    public void MoveDirectory_WhenSourceAndDestinationDifferOnlyByCase_ShouldRenameDirectoryOnDisk()
+    {
+        _tempDirectory = CreateTempDirectory();
+        string oldDir = Path.Combine(_tempDirectory, "GameMenuScreens");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "DialogueScreen.gusx"), "content");
+
+        string newDir = Path.Combine(_tempDirectory, "gamemenuscreens");
+
+        _fileCommands.MoveDirectory(oldDir, newDir);
+
+        Directory.GetDirectories(_tempDirectory)
+            .Select(Path.GetFileName)
+            .ShouldBe(new[] { "gamemenuscreens" });
+        File.Exists(Path.Combine(newDir, "DialogueScreen.gusx")).ShouldBeTrue();
+    }
+
+    #region Helpers
+
+    private static string CreateResxContent(Dictionary<string, string> entries)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        sb.AppendLine("<root>");
+        sb.AppendLine("  <resheader name=\"resmimetype\"><value>text/microsoft-resx</value></resheader>");
+        sb.AppendLine("  <resheader name=\"version\"><value>2.0</value></resheader>");
+
+        foreach (KeyValuePair<string, string> entry in entries)
+        {
+            sb.AppendLine($"  <data name=\"{entry.Key}\" xml:space=\"preserve\">");
+            sb.AppendLine($"    <value>{entry.Value}</value>");
+            sb.AppendLine("  </data>");
+        }
+
+        sb.AppendLine("</root>");
+        return sb.ToString();
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(),
+            "GumFileCommandsTests_" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void WriteResxFile(string filePath, Dictionary<string, string> entries)
+    {
+        File.WriteAllText(filePath, CreateResxContent(entries));
+    }
+
+    #endregion
+}

--- a/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
@@ -6,24 +6,23 @@ using Gum.ToolStates;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace GumToolUnitTests.Commands;
 
+/// <summary>
+/// Covers only the FileCommands behavior that requires the real, concrete CsvLocalizationLoader
+/// (which depends on CsvLibrary and can't be referenced from the headless
+/// Gum.Presentation.Tests project). Every other FileCommands test lives in
+/// Tests/Gum.Presentation.Tests/FileCommandsTests.cs, alongside the class itself.
+/// </summary>
 public class FileCommandsTests : BaseTestClass
 {
     private readonly AutoMocker _mocker;
     private readonly FileCommands _fileCommands;
     private readonly Mock<IProjectState> _projectState;
-    private readonly Mock<IOutputManager> _outputManager;
     private readonly LocalizationService _localizationService;
     private readonly GumProjectSave _gumProject;
-    private readonly List<string> _outputCalls;
-    private readonly List<string> _errorCalls;
     private string? _tempDirectory;
 
     public FileCommandsTests()
@@ -33,13 +32,10 @@ public class FileCommandsTests : BaseTestClass
         _localizationService = new LocalizationService();
         _mocker.Use<ILocalizationService>(_localizationService);
 
-        _outputCalls = new List<string>();
-        _errorCalls = new List<string>();
-        _outputManager = _mocker.GetMock<IOutputManager>();
-        _outputManager.Setup(o => o.AddOutput(It.IsAny<string>()))
-            .Callback<string>(s => _outputCalls.Add(s));
-        _outputManager.Setup(o => o.AddError(It.IsAny<string>()))
-            .Callback<string>(s => _errorCalls.Add(s));
+        // Real (not mocked) CsvLocalizationLoader - this class depends on CsvLibrary, which can't
+        // be referenced from the headless Gum.Presentation.Tests project, so this is the one test
+        // that stays here rather than moving with the rest of FileCommandsTests.
+        _mocker.Use<ICsvLocalizationLoader>(new CsvLocalizationLoader());
 
         _gumProject = new GumProjectSave();
         _projectState = _mocker.GetMock<IProjectState>();
@@ -60,40 +56,6 @@ public class FileCommandsTests : BaseTestClass
     }
 
     [Fact]
-    public void LoadLocalizationFile_ShouldDoNothing_WhenLocalizationFilesIsEmpty()
-    {
-        bool raised = false;
-        _fileCommands.LocalizationLoaded += () => raised = true;
-
-        _fileCommands.LoadLocalizationFile();
-
-        _outputCalls.Count.ShouldBe(0);
-        _errorCalls.Count.ShouldBe(0);
-        _localizationService.HasDatabase.ShouldBeFalse();
-        raised.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldLoadMultipleResx_WhenMultipleResxEntries()
-    {
-        _tempDirectory = CreateTempDirectory();
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
-            new Dictionary<string, string> { { "T_OK", "OK" } });
-        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"),
-            new Dictionary<string, string> { { "B_Save", "Save" } });
-        _gumProject.LocalizationFiles.Add("Strings.resx");
-        _gumProject.LocalizationFiles.Add("Buttons.resx");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _localizationService.HasDatabase.ShouldBeTrue();
-        _localizationService.CurrentLanguage = 1;
-        _localizationService.Translate("T_OK").ShouldBe("OK");
-        _localizationService.Translate("B_Save").ShouldBe("Save");
-        _errorCalls.Count.ShouldBe(0);
-    }
-
-    [Fact]
     public void LoadLocalizationFile_ShouldLoadSingleCsv_WhenOneCsvEntry()
     {
         _tempDirectory = CreateTempDirectory();
@@ -108,185 +70,13 @@ public class FileCommandsTests : BaseTestClass
         _localizationService.Translate("T_OK").ShouldBe("OK");
         _localizationService.CurrentLanguage = 2;
         _localizationService.Translate("T_OK").ShouldBe("Aceptar");
-        _errorCalls.Count.ShouldBe(0);
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldLoadSingleResx_WhenOneResxEntry()
-    {
-        _tempDirectory = CreateTempDirectory();
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
-            new Dictionary<string, string> { { "T_OK", "OK" } });
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.es.resx"),
-            new Dictionary<string, string> { { "T_OK", "Aceptar" } });
-        _gumProject.LocalizationFiles.Add("Strings.resx");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _localizationService.HasDatabase.ShouldBeTrue();
-        _localizationService.Languages.Count.ShouldBe(2);
-        _localizationService.CurrentLanguage = 2;
-        _localizationService.Translate("T_OK").ShouldBe("Aceptar");
-        _errorCalls.Count.ShouldBe(0);
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldReportError_WhenMixingCsvAndResx()
-    {
-        _tempDirectory = CreateTempDirectory();
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
-            new Dictionary<string, string> { { "T_OK", "OK" } });
-        File.WriteAllText(Path.Combine(_tempDirectory, "Strings.csv"),
-            "StringId,English\nT_OK,OK\n");
-        _gumProject.LocalizationFiles.Add("Strings.resx");
-        _gumProject.LocalizationFiles.Add("Strings.csv");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _errorCalls.Count.ShouldBe(1);
-        _errorCalls[0].ShouldContain("not all are .resx");
-        _localizationService.HasDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldReportError_WhenMultipleCsvEntries()
-    {
-        _tempDirectory = CreateTempDirectory();
-        File.WriteAllText(Path.Combine(_tempDirectory, "A.csv"), "StringId,English\nT_OK,OK\n");
-        File.WriteAllText(Path.Combine(_tempDirectory, "B.csv"), "StringId,English\nT_Cancel,Cancel\n");
-        _gumProject.LocalizationFiles.Add("A.csv");
-        _gumProject.LocalizationFiles.Add("B.csv");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _errorCalls.Count.ShouldBe(1);
-        _localizationService.HasDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldRouteCollisionToOutputTab_WhenMultipleResxFilesDefineSameKey()
-    {
-        _tempDirectory = CreateTempDirectory();
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
-            new Dictionary<string, string> { { "T_Shared", "FromStrings" } });
-        WriteResxFile(Path.Combine(_tempDirectory, "Buttons.resx"),
-            new Dictionary<string, string> { { "T_Shared", "FromButtons" } });
-        _gumProject.LocalizationFiles.Add("Strings.resx");
-        _gumProject.LocalizationFiles.Add("Buttons.resx");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _outputCalls.Count.ShouldBe(1);
-        _outputCalls[0].ShouldContain("T_Shared");
-        _outputCalls[0].ShouldContain("Strings.resx");
-        _outputCalls[0].ShouldContain("Buttons.resx");
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldReportError_WhenSingleCsvFileMissing()
-    {
-        _tempDirectory = CreateTempDirectory();
-        _gumProject.LocalizationFiles.Add("DoesNotExist.csv");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _errorCalls.Count.ShouldBe(1);
-        _errorCalls[0].ShouldContain("DoesNotExist.csv");
-        _localizationService.HasDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldReportError_WhenSingleResxFileMissing()
-    {
-        // Single-RESX now flows through the multi-file path, so a missing file is reported
-        // via AddError rather than silently no-opping (prior behavior).
-        _tempDirectory = CreateTempDirectory();
-        _gumProject.LocalizationFiles.Add("DoesNotExist.resx");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _errorCalls.Count.ShouldBe(1);
-        _errorCalls[0].ShouldContain("DoesNotExist.resx");
-        _localizationService.HasDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void LoadLocalizationFile_ShouldWarnAndSkip_WhenBaseFileMissing()
-    {
-        // Production behavior: in the multi-file branch, missing files are reported via
-        // AddError (not AddOutput), and remaining existing files still load.
-        _tempDirectory = CreateTempDirectory();
-        WriteResxFile(Path.Combine(_tempDirectory, "Strings.resx"),
-            new Dictionary<string, string> { { "T_OK", "OK" } });
-        _gumProject.LocalizationFiles.Add("Strings.resx");
-        _gumProject.LocalizationFiles.Add("DoesNotExist.resx");
-
-        _fileCommands.LoadLocalizationFile();
-
-        _errorCalls.Count.ShouldBe(1);
-        _errorCalls[0].ShouldContain("DoesNotExist.resx");
-        _localizationService.HasDatabase.ShouldBeTrue();
-        _localizationService.CurrentLanguage = 1;
-        _localizationService.Translate("T_OK").ShouldBe("OK");
-    }
-
-    // Pins a second half of the case-only-rename bug (see RenameFolderDialogViewModelTests):
-    // even once the "already exists" guard is fixed, MoveDirectory's manual recursive
-    // copy-then-delete-source approach fails for a rename that only changes casing, because
-    // source and destination are the same physical directory on a case-insensitive filesystem
-    // (Windows) - CreateDirectory(destination) is a no-op, the files "move" to themselves, and
-    // Directory.Delete(source) then throws because the directory is (still) not empty.
-    [Fact]
-    public void MoveDirectory_WhenSourceAndDestinationDifferOnlyByCase_ShouldRenameDirectoryOnDisk()
-    {
-        _tempDirectory = CreateTempDirectory();
-        string oldDir = Path.Combine(_tempDirectory, "GameMenuScreens");
-        Directory.CreateDirectory(oldDir);
-        File.WriteAllText(Path.Combine(oldDir, "DialogueScreen.gusx"), "content");
-
-        string newDir = Path.Combine(_tempDirectory, "gamemenuscreens");
-
-        _fileCommands.MoveDirectory(oldDir, newDir);
-
-        Directory.GetDirectories(_tempDirectory)
-            .Select(Path.GetFileName)
-            .ShouldBe(new[] { "gamemenuscreens" });
-        File.Exists(Path.Combine(newDir, "DialogueScreen.gusx")).ShouldBeTrue();
-    }
-
-    #region Helpers
-
-    private static string CreateResxContent(Dictionary<string, string> entries)
-    {
-        StringBuilder sb = new StringBuilder();
-        sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-        sb.AppendLine("<root>");
-        sb.AppendLine("  <resheader name=\"resmimetype\"><value>text/microsoft-resx</value></resheader>");
-        sb.AppendLine("  <resheader name=\"version\"><value>2.0</value></resheader>");
-
-        foreach (KeyValuePair<string, string> entry in entries)
-        {
-            sb.AppendLine($"  <data name=\"{entry.Key}\" xml:space=\"preserve\">");
-            sb.AppendLine($"    <value>{entry.Value}</value>");
-            sb.AppendLine("  </data>");
-        }
-
-        sb.AppendLine("</root>");
-        return sb.ToString();
     }
 
     private static string CreateTempDirectory()
     {
         string tempDir = Path.Combine(Path.GetTempPath(),
-            "GumFileCommandsTests_" + Guid.NewGuid().ToString("N"));
+            "GumFileCommandsTests_" + System.Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
         return tempDir;
     }
-
-    private static void WriteResxFile(string filePath, Dictionary<string, string> entries)
-    {
-        File.WriteAllText(filePath, CreateResxContent(entries));
-    }
-
-    #endregion
 }

--- a/Tools/Gum.Presentation/Commands/FileCommands.cs
+++ b/Tools/Gum.Presentation/Commands/FileCommands.cs
@@ -4,15 +4,14 @@ using Gum.Localization;
 using Gum.Logic.FileWatch;
 using Gum.Managers;
 using Gum.Plugins;
-using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
-using System.Windows.Forms;
 using ToolsUtilities;
 
 namespace Gum.Commands;
@@ -29,6 +28,8 @@ public class FileCommands : IFileCommands
     private readonly IProjectManager _projectManager;
     private readonly IProjectState _projectState;
     private readonly IPluginManager _pluginManager;
+    private readonly IRecycleBinService _recycleBinService;
+    private readonly ICsvLocalizationLoader _csvLocalizationLoader;
 
     public FileCommands(ISelectedState selectedState,
         Lazy<IUndoManager> undoManager,
@@ -39,7 +40,9 @@ public class FileCommands : IFileCommands
         IFileWatchIgnoreList fileWatchIgnoreList,
         IProjectManager projectManager,
         IProjectState projectState,
-        IPluginManager pluginManager)
+        IPluginManager pluginManager,
+        IRecycleBinService recycleBinService,
+        ICsvLocalizationLoader csvLocalizationLoader)
     {
         _selectedState = selectedState;
         _undoManager = undoManager;
@@ -51,6 +54,8 @@ public class FileCommands : IFileCommands
         _projectManager = projectManager;
         _projectState = projectState;
         _pluginManager = pluginManager;
+        _recycleBinService = recycleBinService;
+        _csvLocalizationLoader = csvLocalizationLoader;
 
     }
 
@@ -64,9 +69,7 @@ public class FileCommands : IFileCommands
         FileManager.DeleteDirectory(directory.FullPath);
 
     public void MoveToRecycleBin(FilePath filePath) =>
-        Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(filePath.FullPath,
-            Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs,
-            Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+        _recycleBinService.MoveToRecycleBin(filePath);
 
     public string[] GetFiles(string path) => System.IO.Directory.GetFiles(path);
 
@@ -290,10 +293,10 @@ public class FileCommands : IFileCommands
             {
                 _pluginManager.BeforeSavingElementSave(elementSave);
 
-                var fileName = elementSave.GetFullPathXmlFile();
+                var fileName = GetFullPathXmlFileForElement(elementSave, elementSave.Name);
 
                 // if it's readonly, let's warn the user
-                bool isReadOnly = ProjectManager.IsFileReadOnly(fileName.FullPath);
+                bool isReadOnly = IsFileReadOnly(fileName.FullPath);
 
                 if (isReadOnly)
                 {
@@ -352,13 +355,56 @@ public class FileCommands : IFileCommands
 
     public FilePath GetFullFileName(ElementSave element)
     {
-        return element.GetFullPathXmlFile();
+        return GetFullPathXmlFileForElement(element, element.Name);
     }
 
     public FilePath? GetFullPathXmlFile(ElementSave element, string elementName)
     {
-        return element.GetFullPathXmlFile(elementName);
+        return GetFullPathXmlFileForElement(element, elementName);
     }
+
+    /// <summary>
+    /// Computes the full path to <paramref name="elementSave"/>'s XML file, using
+    /// <paramref name="elementSaveName"/> for the file name and Subfolder path. Inlined from the
+    /// (Locator-based) <c>ElementSave.GetFullPathXmlFile(string)</c> extension method - that method
+    /// resolves <see cref="IProjectManager"/> via <c>Locator</c>, which is a WinForms-tool-only
+    /// static and can't be referenced from this headless assembly, so this uses the already-injected
+    /// <see cref="_projectManager"/> instead. Behavior is identical. Mirrors the private duplicate in
+    /// <c>DragDropManager</c>.
+    /// </summary>
+    private FilePath? GetFullPathXmlFileForElement(ElementSave elementSave, string elementSaveName)
+    {
+        var gumProject = _projectManager.GumProjectSave;
+        if (string.IsNullOrEmpty(gumProject?.FullFileName))
+        {
+            return null;
+        }
+
+        var extension = elementSave.FileExtension;
+
+        var reference =
+            gumProject.ScreenReferences.FirstOrDefault(item => item.Name == elementSave.Name) ??
+            gumProject.ComponentReferences.FirstOrDefault(item => item.Name == elementSave.Name) ??
+            gumProject.StandardElementReferences.FirstOrDefault(item => item.Name == elementSave.Name);
+
+        FilePath gumDirectory = FileManager.GetDirectory(gumProject.FullFileName);
+        if (!string.IsNullOrWhiteSpace(reference?.Link))
+        {
+            return gumDirectory.Original + reference.Link;
+        }
+        else
+        {
+            return gumDirectory.Original + elementSave.Subfolder + "\\" + elementSaveName + "." + extension;
+        }
+    }
+
+    /// <summary>
+    /// Inlined from the static <c>ProjectManager.IsFileReadOnly</c> helper - a pure, stateless
+    /// check that doesn't need DI, so it's duplicated here rather than referencing the concrete
+    /// (still tool-side) <c>ProjectManager</c> class from this headless assembly.
+    /// </summary>
+    private static bool IsFileReadOnly(string fileName) =>
+        File.Exists(fileName) && new FileInfo(fileName).IsReadOnly;
 
 
     public void LoadLocalizationFile()
@@ -417,7 +463,7 @@ public class FileCommands : IFileCommands
                 FilePath file = resolvedFiles[0];
                 if (file.Exists())
                 {
-                    _localizationService.AddDatabaseFromCsv(file.FullPath, ',');
+                    _csvLocalizationLoader.AddDatabaseFromCsv(_localizationService, file.FullPath, ',');
                 }
                 else
                 {
@@ -511,7 +557,7 @@ public class FileCommands : IFileCommands
                 string fileName = GetFullPathXmlFile( behavior).FullPath;
                 _fileWatchIgnoreList.IgnoreNextChangeUntil(fileName);
                 // if it's readonly, let's warn the user
-                bool isReadOnly = ProjectManager.IsFileReadOnly(fileName);
+                bool isReadOnly = IsFileReadOnly(fileName);
 
                 if (isReadOnly)
                 {

--- a/Tools/Gum.Presentation/FileWatchPlugin/IFileWatchIgnoreList.cs
+++ b/Tools/Gum.Presentation/FileWatchPlugin/IFileWatchIgnoreList.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using ToolsUtilities;
+
+namespace Gum.Logic.FileWatch;
+
+/// <summary>
+/// Holds the set of file paths whose next change(s) should be ignored by
+/// the file watcher. Extracted from FileWatchManager so that components
+/// which only need to mute the watcher (e.g. FileCommands when saving an
+/// element) can depend on this small surface without introducing a DI
+/// cycle through FileWatchManager.
+/// </summary>
+public interface IFileWatchIgnoreList
+{
+    IReadOnlyDictionary<FilePath, DateTime> TimedChangesToIgnore { get; }
+
+    void IgnoreNextChangeUntil(FilePath filePath, DateTime? time = null);
+    void ClearIgnoredFiles();
+    bool TryGetIgnoreFileChange(FilePath fileName);
+}

--- a/Tools/Gum.Presentation/Managers/ICsvLocalizationLoader.cs
+++ b/Tools/Gum.Presentation/Managers/ICsvLocalizationLoader.cs
@@ -1,0 +1,17 @@
+using Gum.Localization;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Loads a localization database from a CSV file into an <see cref="ILocalizationService"/>. The
+/// only implementation depends on CsvLibrary, which targets net8.0-windows and can't be
+/// referenced from this headless assembly, so this interface exists to keep that dependency out
+/// of headless callers (e.g. FileCommands).
+/// </summary>
+public interface ICsvLocalizationLoader
+{
+    /// <summary>
+    /// Parses <paramref name="fileName"/> as a CSV and adds its entries to <paramref name="service"/>.
+    /// </summary>
+    void AddDatabaseFromCsv(ILocalizationService service, string fileName, char delimiter);
+}

--- a/Tools/Gum.Presentation/Managers/IRecycleBinService.cs
+++ b/Tools/Gum.Presentation/Managers/IRecycleBinService.cs
@@ -1,0 +1,16 @@
+using ToolsUtilities;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Moves a file to the OS recycle bin/trash instead of permanently deleting it. The only
+/// implementation requires the Windows desktop runtime's recycle-bin UI APIs, so this interface
+/// exists to keep that platform dependency out of headless callers (e.g. FileCommands).
+/// </summary>
+public interface IRecycleBinService
+{
+    /// <summary>
+    /// Moves the file at <paramref name="filePath"/> to the OS recycle bin/trash.
+    /// </summary>
+    void MoveToRecycleBin(FilePath filePath);
+}


### PR DESCRIPTION
Part of #3862 (already auto-closed when #3867 merged — see note below). Follow-up to #3867/#3869 — relocates `FileCommands`, the last of the four classes in the issue's original scope.

## What changed

- **Extracted `IFileWatchIgnoreList`** out of `FileWatchIgnoreList.cs`, where it was declared inline with its concrete implementation (both still in `Gum.csproj`), into its own file in `Gum.Presentation`. The concrete class stays put.
- **New `IRecycleBinService` seam for `MoveToRecycleBin`** — the one genuinely-stuck piece flagged in #3867/#3869: `Microsoft.VisualBasic.FileIO.FileSystem.DeleteFile(..., UIOption, RecycleOption)` needs the Windows desktop runtime (`UseWindowsForms`). Same shape as the existing `IGumCursorState`/`IResizeHandlesVisual` pattern — narrow interface in `Gum.Presentation`, concrete implementation (`RecycleBinService`) stays in `Gum.csproj`.
- **New `ICsvLocalizationLoader` seam** for the CSV branch of `LoadLocalizationFile` — this one wasn't on the radar in #3867's scoping pass. `AddDatabaseFromCsv` depends on `CsvLibrary`, which targets `net8.0-windows`; referencing a `net8.0-windows` project from the plain-`net8.0` `Gum.Presentation` is a hard NuGet TFM-compatibility error (`NU1201`), not just a WPF/WinForms flag to route around. Same seam shape as the recycle-bin one.
- **Inlined two more Locator-based/concrete-class calls**, reusing dependencies `FileCommands` already has injected:
  - `ElementSave.GetFullPathXmlFile()`'s extension method resolves `IProjectManager` via `Locator`, which isn't reachable from this headless assembly. Mirrors an identical fix already present in `DragDropManager` — a private method using the already-injected `_projectManager` instead.
  - `ProjectManager.IsFileReadOnly` is a pure, stateless one-liner (`File.Exists && FileInfo.IsReadOnly`) on the concrete, still-tool-side `ProjectManager` class — duplicated locally rather than pulling in a dependency for one line.
- Physically relocated `FileCommands.cs` into `Gum.Presentation`.

## Tests

- Split `FileCommandsTests`: the one test needing real CSV parsing (`LoadLocalizationFile_ShouldLoadSingleCsv_WhenOneCsvEntry`) stays in `GumToolUnitTests`, wired to the real `CsvLocalizationLoader` — `CsvLibrary` can't be referenced from the headless test project either. The other 11 existing tests moved to `Gum.Presentation.Tests` unchanged.
- Added 2 new tests in `Gum.Presentation.Tests`: `MoveToRecycleBin` delegates to the injected `IRecycleBinService`; `GetFullFileName` computes the right path via the inlined `GetFullPathXmlFileForElement`. Both mutation-tested (breaking the call/logic under test turned each test red; reverted).
- `dotnet build GumFull.sln`: 0 errors. `Gum.Presentation.Tests`: 461/461. `GumToolUnitTests`: 1106/1108 (2 pre-existing skips).

## Issue #3862 scope — now fully done

This completes all four classes named in #3862's original scope: `ElementCommands` (#3867), `EditCommands`/`ProjectCommands` (#3869), `FileCommands` (here). Everything moved; nothing was left stuck as a permanent WPF-only carve-out — the recycle-bin and CSV-loading platform dependencies both got the same narrow-interface treatment already established for other platform glue in this campaign.

**Note on issue state:** #3862 is already `CLOSED` — `gh issue develop`-linking all three PRs to it means merging the *first* one (#3867) auto-closed it immediately, per the documented gotcha (closing keywords in a PR body don't prevent this; only the first merge matters). The closure reads as accurate now that this PR lands, but wasn't when #3867 alone had merged. Posting a status comment on the closed issue for the record.

## New gotcha for `Direction/ui-decoupling-plan.md` (maintainer to fold in)

A platform dependency doesn't have to be WPF/WinForms to block a class from `Gum.Presentation` — a **NuGet-level target-framework incompatibility** blocks the same way. `CsvLibrary` (`net8.0-windows`, no `UseWindowsForms`/`UseWPF`) can't be referenced from `Gum.Presentation` (plain `net8.0`) any more than an actual WPF assembly could; the fix is the identical narrow-interface seam. Worth generalizing the "platform glue" bullet beyond WPF/WinForms to "any dependency whose own TFM/flags are incompatible with net8.0."

## Manual test

Not needed — behavior-preserving move, proven by build + mutation-tested pinning tests + the compiler-enforced headless boundary.

## Skill tool availability

Not available in my tool list this session — read `refactoring-direction`/`tdd` SKILL.md directly and followed their rules; did a manual self-review instead of `/code-review`.
