### PR TITLE
Relocate ProjectManager's load-repair logic + fix WinForms startup blocker, part of #3863

### DIFF
--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -2,7 +2,6 @@ using CommunityToolkit.Mvvm.Messaging;
 using Gum.CommandLine;
 using Gum.Commands;
 using Gum.DataTypes;
-using Gum.DataTypes.Variables;
 using Gum.Extensions;
 using Gum.Logic;
 using Gum.Logic.FileWatch;
@@ -24,8 +23,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Forms;
 using ToolsUtilities;
 
 namespace Gum;
@@ -51,6 +48,8 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     // rebuild-fonts path reads GumProjectSave) — deferring it breaks the construction cycle.
     private readonly Lazy<ICommandLineManager> _commandLineManager;
     private readonly IPluginManager _pluginManager;
+    private readonly IHotkeyManager _hotkeyManager;
+    private readonly IGumProjectRepairLogic _gumProjectRepairLogic;
 
     #endregion
 
@@ -124,7 +123,9 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         IStandardElementsManagerGumTool standardElementsManagerGumTool,
         IRetryService retryService,
         Lazy<ICommandLineManager> commandLineManager,
-        IPluginManager pluginManager)
+        IPluginManager pluginManager,
+        IHotkeyManager hotkeyManager,
+        IGumProjectRepairLogic gumProjectRepairLogic)
     {
         _selectedState = selectedState;
         _elementCommands = elementCommands;
@@ -137,6 +138,8 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         _retryService = retryService;
         _commandLineManager = commandLineManager;
         _pluginManager = pluginManager;
+        _hotkeyManager = hotkeyManager;
+        _gumProjectRepairLogic = gumProjectRepairLogic;
         // Default settings until LoadSettings() replaces this with the loaded (or newly-created)
         // file. Avoids a null-before-load window that every narrowed IProjectManager member above
         // would otherwise need to guard against (some plugins read these before LoadSettings runs -
@@ -155,7 +158,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
         if (!_commandLineManager.Value.ShouldExitImmediately)
         {
-            var isShift = (Control.ModifierKeys & Keys.Shift) != 0;
+            var isShift = _hotkeyManager.IsPressedInControl(KeyCombination.Shift());
 
             if (!isShift && !string.IsNullOrEmpty(_commandLineManager.Value.GlueProjectToLoad))
             {
@@ -320,13 +323,13 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
                 {
                     modifications.Add("AddNewStandardElementTypes");
                 }
-                if (FixSlashesInNames(_gumProjectSave))
+                if (_gumProjectRepairLogic.FixSlashesInNames(_gumProjectSave))
                 {
-                    modifications.Add(nameof(FixSlashesInNames));
+                    modifications.Add("FixSlashesInNames");
                 }
-                if (RemoveSpacesInVariables(_gumProjectSave))
+                if (_gumProjectRepairLogic.RemoveSpacesInVariables(_gumProjectSave))
                 {
-                    modifications.Add(nameof(RemoveSpacesInVariables));
+                    modifications.Add("RemoveSpacesInVariables");
                 }
                 if (_gumProjectSave.MigrateCircleRadiusToWidthHeight())
                 {
@@ -336,9 +339,9 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
                 {
                     modifications.Add("StripCircleRectangleGradientColor1");
                 }
-                if (RemoveDuplicateVariables(_gumProjectSave))
+                if (_gumProjectRepairLogic.RemoveDuplicateVariables(_gumProjectSave))
                 {
-                    modifications.Add(nameof(RemoveDuplicateVariables));
+                    modifications.Add("RemoveDuplicateVariables");
                 }
 
                 _gumProjectSave.FixStandardVariables();
@@ -353,9 +356,9 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
             CopyLinkedComponents();
 
-            if (FixRecursiveAssignments(_gumProjectSave))
+            if (_gumProjectRepairLogic.FixRecursiveAssignments(_gumProjectSave))
             {
-                modifications.Add(nameof(FixRecursiveAssignments));
+                modifications.Add("FixRecursiveAssignments");
             }
             _pluginManager.ProjectLoad(_gumProjectSave);
 
@@ -424,91 +427,6 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         }
     }
 
-    private bool RemoveSpacesInVariables(GumProjectSave gumProjectSave)
-    {
-        bool didChange = false;
-        foreach(var element in gumProjectSave.AllElements)
-        {
-            foreach(var state in element.AllStates)
-            {
-                foreach(var variable in state.Variables)
-                {
-                    Replace(variable, "Base Type");
-                    Replace(variable, "Children Layout");
-                    Replace(variable, "Clips Children");
-                    Replace(variable, "Contained Type");
-                    Replace(variable, "Font Scale");
-                    Replace(variable, "Height Units");
-                    Replace(variable, "Texture Address");
-                    Replace(variable, "Texture Height");
-                    Replace(variable, "Texture Height Scale");
-                    Replace(variable, "Texture Left");
-                    Replace(variable, "Texture Top");
-                    Replace(variable, "Texture Width");
-                    Replace(variable, "Texture Width Scale");
-                    Replace(variable, "Width Units");
-                    Replace(variable, "Wraps Children");
-                    Replace(variable, "X Origin");
-                    Replace(variable, "X Units");
-                    Replace(variable, "Y Origin");
-                    Replace(variable, "Y Units");
-
-                    void Replace(VariableSave variableSave, string oldName)
-                    {
-                        if(variable.Name.EndsWith(oldName))
-                        {
-                            var newName = variable.Name.Substring(0, variable.Name.Length - oldName.Length) +
-                                oldName.Replace(" ", "");
-                            variable.Name = newName;
-                            didChange = true;
-                        }
-                    }
-                }
-            }
-        }
-        return didChange;
-    }
-
-    private bool FixRecursiveAssignments(GumProjectSave gumProjectSave)
-    {
-        var toReturn = false;
-        // Instances can't be of type screen, so don't check this (unless someone messes with the XML but that's on them)
-        //foreach(var screen in mGumProjectSave.Screens)
-        //{
-        //    if(FixRecursiveAssignments(screen))
-        //    {
-        //        toReturn = true;
-        //    }
-        //}
-        foreach (var component in gumProjectSave.Components)
-        {
-            if (FixRecursiveAssignments(component))
-            {
-                toReturn = true;
-            }
-        }
-
-        return toReturn;
-    }
-
-    private bool FixRecursiveAssignments(ElementSave element)
-    {
-        var didModify = false;
-        // see if the child is either of this type, or a base type
-        foreach (var instance in element.Instances)
-        {
-            var isRecursive = ObjectFinder.Self.IsInstanceRecursivelyReferencingElement(instance, element);
-
-            if (isRecursive)
-            {
-                instance.BaseType = "Container";
-                didModify = true;
-            }
-        }
-
-        return didModify;
-    }
-
     private void CopyLinkedComponents()
     {
         var gumDirectory = new FilePath(_gumProjectSave.FullFileName).GetDirectoryContainingThis();
@@ -546,166 +464,6 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         {
             CopyReference(reference);
         }
-    }
-
-    /// <summary>
-    /// Fixes slashes in all references, component names, and instance references.
-    /// </summary>
-    /// <param name="gumProjectSave">The project for which to fix slashes.</param>
-    /// <returns>Whether any changes were made.</returns>
-    private bool FixSlashesInNames(GumProjectSave gumProjectSave)
-    {
-        var didAnythingChange = false;
-
-        foreach (var reference in gumProjectSave.ScreenReferences)
-        {
-            if (reference.Name?.Contains("\\") == true)
-            {
-                reference.Name = reference.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-        }
-
-        foreach (var reference in gumProjectSave.ComponentReferences)
-        {
-            if (reference?.Name.Contains("\\") == true)
-            {
-                reference.Name = reference.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-        }
-
-        foreach(var reference in gumProjectSave.BehaviorReferences)
-        {
-            if(reference.Name?.Contains("\\") == true)
-            {
-                reference.Name = reference.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-        }
-
-
-        foreach (var screen in gumProjectSave.Screens)
-        {
-            if (screen.Name?.Contains("\\") == true)
-            {
-                screen.Name = screen.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-            foreach (var instance in screen.Instances)
-            {
-                if (instance.BaseType?.Contains("\\") == true)
-                {
-                    instance.BaseType = instance.BaseType.Replace("\\", "/");
-                    didAnythingChange = true;
-                }
-            }
-
-            foreach (var behavior in screen.Behaviors)
-            {
-                if (behavior.BehaviorName?.Contains("\\") == true)
-                {
-                    behavior.BehaviorName = behavior.BehaviorName.Replace("\\", "/");
-                    didAnythingChange = true;
-                }
-            }
-        }
-
-        foreach (var component in gumProjectSave.Components)
-        {
-            if (component.Name?.Contains("\\") == true)
-            {
-                component.Name = component.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-
-            foreach (var instance in component.Instances)
-            {
-                if (instance.BaseType?.Contains("\\") == true)
-                {
-                    instance.BaseType = instance.BaseType.Replace("\\", "/");
-                    didAnythingChange = true;
-                }
-            }
-
-            foreach(var behavior in component.Behaviors)
-            {
-                if(behavior.BehaviorName?.Contains("\\") == true)
-                {
-                    behavior.BehaviorName = behavior.BehaviorName.Replace("\\", "/");
-                    didAnythingChange = true;
-                }
-            }
-        }
-
-        foreach (var behavior in gumProjectSave.Behaviors)
-        {
-            if(behavior.Name?.Contains("\\") == true)
-            {
-                behavior.Name = behavior.Name.Replace("\\", "/");
-                didAnythingChange = true;
-            }
-
-            foreach (var instance in behavior.RequiredInstances)
-            {
-                if (instance.BaseType?.Contains("\\") == true)
-                {
-                    instance.BaseType = instance.BaseType.Replace("\\", "/");
-                    didAnythingChange = true;
-                }
-            }
-        }
-
-        return didAnythingChange;
-    }
-
-    private bool RemoveDuplicateVariables(GumProjectSave gumProjectSave)
-    {
-        var didChange = false;
-        foreach (var screen in gumProjectSave.Screens)
-        {
-            didChange = RemoveDuplicateVariables(screen) || didChange;
-        }
-        foreach (var component in gumProjectSave.Components)
-        {
-            didChange = RemoveDuplicateVariables(component) || didChange;
-        }
-        foreach (var standard in gumProjectSave.StandardElements)
-        {
-            didChange = RemoveDuplicateVariables(standard) || didChange;
-        }
-        return didChange;
-    }
-
-    private bool RemoveDuplicateVariables(ElementSave element)
-    {
-        var didChange = false;
-        foreach (var state in element.AllStates)
-        {
-            didChange = RemoveDuplicateVariables(state) || didChange;
-        }
-        return didChange;
-    }
-
-    private bool RemoveDuplicateVariables(StateSave state)
-    {
-        var variableNames = state.Variables.Select(item => item.Name).ToHashSet();
-
-        var didChange = false;
-        if (variableNames.Count != state.Variables.Count)
-        {
-            var newVariables = new List<VariableSave>();
-            foreach (var variableName in variableNames)
-            {
-                var matchingVariable = state.Variables.FirstOrDefault(item => item.Name == variableName);
-                newVariables.Add(matchingVariable);
-            }
-
-            state.Variables.Clear();
-            state.Variables.AddRange(newVariables);
-            didChange = true;
-        }
-        return didChange;
     }
 
     internal void RecreateMissingStandardElements()

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -48,7 +48,9 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     // rebuild-fonts path reads GumProjectSave) — deferring it breaks the construction cycle.
     private readonly Lazy<ICommandLineManager> _commandLineManager;
     private readonly IPluginManager _pluginManager;
-    private readonly IHotkeyManager _hotkeyManager;
+    // Lazy because HotkeyManager depends (via ISetVariableLogic -> SetVariableLogic) back on
+    // IProjectManager — deferring it breaks the construction cycle, same as _commandLineManager above.
+    private readonly Lazy<IHotkeyManager> _hotkeyManager;
     private readonly IGumProjectRepairLogic _gumProjectRepairLogic;
 
     #endregion
@@ -124,7 +126,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         IRetryService retryService,
         Lazy<ICommandLineManager> commandLineManager,
         IPluginManager pluginManager,
-        IHotkeyManager hotkeyManager,
+        Lazy<IHotkeyManager> hotkeyManager,
         IGumProjectRepairLogic gumProjectRepairLogic)
     {
         _selectedState = selectedState;
@@ -158,7 +160,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
         if (!_commandLineManager.Value.ShouldExitImmediately)
         {
-            var isShift = _hotkeyManager.IsPressedInControl(KeyCombination.Shift());
+            var isShift = _hotkeyManager.Value.IsPressedInControl(KeyCombination.Shift());
 
             if (!isShift && !string.IsNullOrEmpty(_commandLineManager.Value.GlueProjectToLoad))
             {

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -148,6 +148,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IFavoriteComponentManager, FavoriteComponentManager>();
         services.AddSingleton<ICopyPasteLogic, CopyPasteLogic>();
         services.AddSingleton<IDeleteLogic, DeleteLogic>();
+        services.AddSingleton<IGumProjectRepairLogic, GumProjectRepairLogic>();
         services.AddSingleton<ISkiaShapeStandardsLogic, SkiaShapeStandardsLogic>();
         services.AddSingleton<FileLocations>();
         // IFileLocations: narrow headless port (ADR-0005 Phase 3) so dialog VMs that only need

--- a/Tests/Gum.Presentation.Tests/GumProjectRepairLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/GumProjectRepairLogicTests.cs
@@ -1,0 +1,139 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Logic;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="GumProjectRepairLogic"/> after its extraction from <c>ProjectManager</c> (#3863,
+/// part of the ADR-0005 headless-relocation effort) — a behavior-preserving move of the four
+/// load-time normalization passes that only ever operated on an explicit <see cref="GumProjectSave"/>
+/// parameter, so they carried no WPF/WinForms dependency in the first place.
+/// </summary>
+public class GumProjectRepairLogicTests
+{
+    private readonly GumProjectRepairLogic _repairLogic = new();
+
+    [Fact]
+    public void FixRecursiveAssignments_ForcesRecursiveInstanceToContainer()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        InstanceSave instance = new InstanceSave { Name = "SelfReferencing", BaseType = "MyComponent" };
+        component.Instances.Add(instance);
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.FixRecursiveAssignments(gumProjectSave);
+
+        didChange.ShouldBeTrue();
+        instance.BaseType.ShouldBe("Container");
+    }
+
+    [Fact]
+    public void FixRecursiveAssignments_ReturnsFalse_WhenNoInstanceIsRecursive()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        InstanceSave instance = new InstanceSave { Name = "Child", BaseType = "SomeOtherComponent" };
+        component.Instances.Add(instance);
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.FixRecursiveAssignments(gumProjectSave);
+
+        didChange.ShouldBeFalse();
+        instance.BaseType.ShouldBe("SomeOtherComponent");
+    }
+
+    [Fact]
+    public void FixSlashesInNames_ReplacesBackslashesWithForwardSlashes_InComponentAndInstanceNames()
+    {
+        ComponentSave component = new ComponentSave { Name = "Folder\\MyComponent" };
+        InstanceSave instance = new InstanceSave { Name = "Child", BaseType = "Folder\\Base" };
+        component.Instances.Add(instance);
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.FixSlashesInNames(gumProjectSave);
+
+        didChange.ShouldBeTrue();
+        component.Name.ShouldBe("Folder/MyComponent");
+        instance.BaseType.ShouldBe("Folder/Base");
+    }
+
+    [Fact]
+    public void FixSlashesInNames_ReturnsFalse_WhenNoNameContainsABackslash()
+    {
+        ComponentSave component = new ComponentSave { Name = "Folder/MyComponent" };
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.FixSlashesInNames(gumProjectSave);
+
+        didChange.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RemoveDuplicateVariables_RemovesLaterDuplicate_KeepingFirstOccurrence()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        StateSave state = new StateSave();
+        component.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "X", Value = 1f });
+        state.Variables.Add(new VariableSave { Name = "X", Value = 2f });
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.RemoveDuplicateVariables(gumProjectSave);
+
+        didChange.ShouldBeTrue();
+        state.Variables.Count(v => v.Name == "X").ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemoveDuplicateVariables_ReturnsFalse_WhenNoVariableNameIsDuplicated()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        StateSave state = new StateSave();
+        component.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "X", Value = 1f });
+        state.Variables.Add(new VariableSave { Name = "Y", Value = 2f });
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.RemoveDuplicateVariables(gumProjectSave);
+
+        didChange.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RemoveSpacesInVariables_StripsSpacesFromKnownLegacyVariableNames()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        StateSave state = new StateSave();
+        component.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "MyInstance.Base Type", Value = "Container" });
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.RemoveSpacesInVariables(gumProjectSave);
+
+        didChange.ShouldBeTrue();
+        state.Variables[0].Name.ShouldBe("MyInstance.BaseType");
+    }
+
+    [Fact]
+    public void RemoveSpacesInVariables_ReturnsFalse_WhenNoVariableEndsWithALegacySpacedName()
+    {
+        ComponentSave component = new ComponentSave { Name = "MyComponent" };
+        StateSave state = new StateSave();
+        component.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "MyInstance.Visible", Value = true });
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Components.Add(component);
+
+        bool didChange = _repairLogic.RemoveSpacesInVariables(gumProjectSave);
+
+        didChange.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
@@ -68,7 +68,7 @@ public class ProjectManagerTests : BaseTestClass
             _retryService.Object,
             new Lazy<ICommandLineManager>(() => _commandLineManager.Object),
             _pluginManager.Object,
-            _hotkeyManager.Object,
+            new Lazy<IHotkeyManager>(() => _hotkeyManager.Object),
             _gumProjectRepairLogic.Object);
     }
 

--- a/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
@@ -2,11 +2,13 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum;
 using Gum.CommandLine;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Logic;
 using Gum.Logic.FileWatch;
 using Gum.Managers;
 using Gum.Plugins;
@@ -34,6 +36,8 @@ public class ProjectManagerTests : BaseTestClass
     private readonly Mock<IRetryService> _retryService;
     private readonly Mock<ICommandLineManager> _commandLineManager;
     private readonly Mock<IPluginManager> _pluginManager;
+    private readonly Mock<IHotkeyManager> _hotkeyManager;
+    private readonly Mock<IGumProjectRepairLogic> _gumProjectRepairLogic;
     private readonly ProjectManager _projectManager;
 
     public ProjectManagerTests()
@@ -49,6 +53,8 @@ public class ProjectManagerTests : BaseTestClass
         _retryService = new Mock<IRetryService>();
         _commandLineManager = new Mock<ICommandLineManager>();
         _pluginManager = new Mock<IPluginManager>();
+        _hotkeyManager = new Mock<IHotkeyManager>();
+        _gumProjectRepairLogic = new Mock<IGumProjectRepairLogic>();
 
         _projectManager = new ProjectManager(
             _selectedState.Object,
@@ -61,7 +67,46 @@ public class ProjectManagerTests : BaseTestClass
             _standardElementsManagerGumTool.Object,
             _retryService.Object,
             new Lazy<ICommandLineManager>(() => _commandLineManager.Object),
-            _pluginManager.Object);
+            _pluginManager.Object,
+            _hotkeyManager.Object,
+            _gumProjectRepairLogic.Object);
+    }
+
+    [Fact]
+    public async Task Initialize_CallsCreateNewProject_WhenShiftHeldAtStartup()
+    {
+        // Pins the relocation of the startup shift-check off WinForms' Control.ModifierKeys
+        // (#3863) onto IHotkeyManager.IsPressedInControl, the same live-modifier-state seam
+        // already used elsewhere (e.g. SelectionManager.IsShiftDown). Holding Shift at startup
+        // must still skip loading the command-line/last project and start a new one instead.
+        _commandLineManager.Setup(c => c.ReadCommandLine()).Returns(Task.CompletedTask);
+        _commandLineManager.SetupGet(c => c.ShouldExitImmediately).Returns(false);
+        _commandLineManager.SetupGet(c => c.GlueProjectToLoad).Returns("c:/projects/MyGame.gumx");
+        _hotkeyManager
+            .Setup(h => h.IsPressedInControl(It.Is<KeyCombination>(c => c.IsShiftDown && c.Key == null)))
+            .Returns(true);
+
+        await _projectManager.Initialize();
+
+        _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Never);
+        _pluginManager.Verify(p => p.ProjectLoad(It.IsAny<GumProjectSave>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Initialize_LoadsCommandLineProject_WhenShiftNotHeldAtStartup()
+    {
+        string glueProject = "c:/projects/MyGame.gumx";
+        _commandLineManager.Setup(c => c.ReadCommandLine()).Returns(Task.CompletedTask);
+        _commandLineManager.SetupGet(c => c.ShouldExitImmediately).Returns(false);
+        _commandLineManager.SetupGet(c => c.GlueProjectToLoad).Returns(glueProject);
+        _hotkeyManager
+            .Setup(h => h.IsPressedInControl(It.Is<KeyCombination>(c => c.IsShiftDown && c.Key == null)))
+            .Returns(false);
+
+        await _projectManager.Initialize();
+
+        _fileCommands.Verify(f => f.LoadProject(glueProject), Times.Once);
+        _pluginManager.Verify(p => p.ProjectLoad(It.IsAny<GumProjectSave>()), Times.Never);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Logic/GumProjectRepairLogic.cs
+++ b/Tools/Gum.Presentation/Logic/GumProjectRepairLogic.cs
@@ -1,0 +1,249 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.Logic;
+
+/// <inheritdoc cref="IGumProjectRepairLogic"/>
+public class GumProjectRepairLogic : IGumProjectRepairLogic
+{
+    /// <inheritdoc/>
+    public bool RemoveSpacesInVariables(GumProjectSave gumProjectSave)
+    {
+        bool didChange = false;
+        foreach (ElementSave element in gumProjectSave.AllElements)
+        {
+            foreach (StateSave state in element.AllStates)
+            {
+                foreach (VariableSave variable in state.Variables)
+                {
+                    Replace(variable, "Base Type");
+                    Replace(variable, "Children Layout");
+                    Replace(variable, "Clips Children");
+                    Replace(variable, "Contained Type");
+                    Replace(variable, "Font Scale");
+                    Replace(variable, "Height Units");
+                    Replace(variable, "Texture Address");
+                    Replace(variable, "Texture Height");
+                    Replace(variable, "Texture Height Scale");
+                    Replace(variable, "Texture Left");
+                    Replace(variable, "Texture Top");
+                    Replace(variable, "Texture Width");
+                    Replace(variable, "Texture Width Scale");
+                    Replace(variable, "Width Units");
+                    Replace(variable, "Wraps Children");
+                    Replace(variable, "X Origin");
+                    Replace(variable, "X Units");
+                    Replace(variable, "Y Origin");
+                    Replace(variable, "Y Units");
+
+                    void Replace(VariableSave variableSave, string oldName)
+                    {
+                        if (variable.Name.EndsWith(oldName))
+                        {
+                            string newName = variable.Name.Substring(0, variable.Name.Length - oldName.Length) +
+                                oldName.Replace(" ", "");
+                            variable.Name = newName;
+                            didChange = true;
+                        }
+                    }
+                }
+            }
+        }
+        return didChange;
+    }
+
+    /// <inheritdoc/>
+    public bool FixRecursiveAssignments(GumProjectSave gumProjectSave)
+    {
+        bool toReturn = false;
+        // Instances can't be of type screen, so don't check this (unless someone messes with the XML but that's on them)
+        foreach (ComponentSave component in gumProjectSave.Components)
+        {
+            if (FixRecursiveAssignments(component))
+            {
+                toReturn = true;
+            }
+        }
+
+        return toReturn;
+    }
+
+    private bool FixRecursiveAssignments(ElementSave element)
+    {
+        bool didModify = false;
+        // see if the child is either of this type, or a base type
+        foreach (InstanceSave instance in element.Instances)
+        {
+            bool isRecursive = ObjectFinder.Self.IsInstanceRecursivelyReferencingElement(instance, element);
+
+            if (isRecursive)
+            {
+                instance.BaseType = "Container";
+                didModify = true;
+            }
+        }
+
+        return didModify;
+    }
+
+    /// <inheritdoc/>
+    public bool FixSlashesInNames(GumProjectSave gumProjectSave)
+    {
+        bool didAnythingChange = false;
+
+        foreach (ElementReference reference in gumProjectSave.ScreenReferences)
+        {
+            if (reference.Name?.Contains("\\") == true)
+            {
+                reference.Name = reference.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+        }
+
+        foreach (ElementReference reference in gumProjectSave.ComponentReferences)
+        {
+            if (reference?.Name.Contains("\\") == true)
+            {
+                reference.Name = reference.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+        }
+
+        foreach (BehaviorReference reference in gumProjectSave.BehaviorReferences)
+        {
+            if (reference.Name?.Contains("\\") == true)
+            {
+                reference.Name = reference.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+        }
+
+
+        foreach (ScreenSave screen in gumProjectSave.Screens)
+        {
+            if (screen.Name?.Contains("\\") == true)
+            {
+                screen.Name = screen.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+            foreach (InstanceSave instance in screen.Instances)
+            {
+                if (instance.BaseType?.Contains("\\") == true)
+                {
+                    instance.BaseType = instance.BaseType.Replace("\\", "/");
+                    didAnythingChange = true;
+                }
+            }
+
+            foreach (ElementBehaviorReference behavior in screen.Behaviors)
+            {
+                if (behavior.BehaviorName?.Contains("\\") == true)
+                {
+                    behavior.BehaviorName = behavior.BehaviorName.Replace("\\", "/");
+                    didAnythingChange = true;
+                }
+            }
+        }
+
+        foreach (ComponentSave component in gumProjectSave.Components)
+        {
+            if (component.Name?.Contains("\\") == true)
+            {
+                component.Name = component.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+
+            foreach (InstanceSave instance in component.Instances)
+            {
+                if (instance.BaseType?.Contains("\\") == true)
+                {
+                    instance.BaseType = instance.BaseType.Replace("\\", "/");
+                    didAnythingChange = true;
+                }
+            }
+
+            foreach (ElementBehaviorReference behavior in component.Behaviors)
+            {
+                if (behavior.BehaviorName?.Contains("\\") == true)
+                {
+                    behavior.BehaviorName = behavior.BehaviorName.Replace("\\", "/");
+                    didAnythingChange = true;
+                }
+            }
+        }
+
+        foreach (BehaviorSave behavior in gumProjectSave.Behaviors)
+        {
+            if (behavior.Name?.Contains("\\") == true)
+            {
+                behavior.Name = behavior.Name.Replace("\\", "/");
+                didAnythingChange = true;
+            }
+
+            foreach (InstanceSave instance in behavior.RequiredInstances)
+            {
+                if (instance.BaseType?.Contains("\\") == true)
+                {
+                    instance.BaseType = instance.BaseType.Replace("\\", "/");
+                    didAnythingChange = true;
+                }
+            }
+        }
+
+        return didAnythingChange;
+    }
+
+    /// <inheritdoc/>
+    public bool RemoveDuplicateVariables(GumProjectSave gumProjectSave)
+    {
+        bool didChange = false;
+        foreach (ScreenSave screen in gumProjectSave.Screens)
+        {
+            didChange = RemoveDuplicateVariables(screen) || didChange;
+        }
+        foreach (ComponentSave component in gumProjectSave.Components)
+        {
+            didChange = RemoveDuplicateVariables(component) || didChange;
+        }
+        foreach (StandardElementSave standard in gumProjectSave.StandardElements)
+        {
+            didChange = RemoveDuplicateVariables(standard) || didChange;
+        }
+        return didChange;
+    }
+
+    private bool RemoveDuplicateVariables(ElementSave element)
+    {
+        bool didChange = false;
+        foreach (StateSave state in element.AllStates)
+        {
+            didChange = RemoveDuplicateVariables(state) || didChange;
+        }
+        return didChange;
+    }
+
+    private bool RemoveDuplicateVariables(StateSave state)
+    {
+        HashSet<string> variableNames = state.Variables.Select(item => item.Name).ToHashSet();
+
+        bool didChange = false;
+        if (variableNames.Count != state.Variables.Count)
+        {
+            List<VariableSave> newVariables = new List<VariableSave>();
+            foreach (string variableName in variableNames)
+            {
+                VariableSave matchingVariable = state.Variables.FirstOrDefault(item => item.Name == variableName);
+                newVariables.Add(matchingVariable);
+            }
+
+            state.Variables.Clear();
+            state.Variables.AddRange(newVariables);
+            didChange = true;
+        }
+        return didChange;
+    }
+}

--- a/Tools/Gum.Presentation/Logic/IGumProjectRepairLogic.cs
+++ b/Tools/Gum.Presentation/Logic/IGumProjectRepairLogic.cs
@@ -1,0 +1,36 @@
+using Gum.DataTypes;
+
+namespace Gum.Logic;
+
+/// <summary>
+/// Load-time normalization/repair passes run against a freshly-loaded <see cref="GumProjectSave"/>.
+/// Each pass fixes up data left in an inconsistent state by an older version of Gum (stray spaces or
+/// backslashes in names, duplicate variables, recursive base-type assignments) and reports whether it
+/// changed anything, so the caller can decide whether the project needs to be re-saved.
+/// </summary>
+public interface IGumProjectRepairLogic
+{
+    /// <summary>
+    /// Strips spaces from variable names that historically contained them (e.g. "Base Type" ->
+    /// "BaseType"), so old projects match the current variable-naming convention.
+    /// </summary>
+    bool RemoveSpacesInVariables(GumProjectSave gumProjectSave);
+
+    /// <summary>
+    /// Finds instances whose base type recursively references the containing element, and forces
+    /// them to <c>Container</c> to break the cycle.
+    /// </summary>
+    bool FixRecursiveAssignments(GumProjectSave gumProjectSave);
+
+    /// <summary>
+    /// Replaces backslashes with forward slashes in element/instance/behavior names and references,
+    /// so names are consistent regardless of which OS created the project.
+    /// </summary>
+    bool FixSlashesInNames(GumProjectSave gumProjectSave);
+
+    /// <summary>
+    /// Removes variables with duplicate names from every state in the project, keeping the first
+    /// occurrence of each name.
+    /// </summary>
+    bool RemoveDuplicateVariables(GumProjectSave gumProjectSave);
+}


### PR DESCRIPTION
## Summary

Scoping + a bounded first slice for #3863 (`Gum/Managers/ProjectManager.cs`, ~1006 lines).

**Implemented (this PR):**
- Extracted the four load-time `GumProjectSave` repair passes (`RemoveSpacesInVariables`,
  `FixRecursiveAssignments`, `FixSlashesInNames`, `RemoveDuplicateVariables`) into a new
  `IGumProjectRepairLogic`/`GumProjectRepairLogic` in `Gum.Presentation` — they already only took a
  `GumProjectSave` parameter, so they carried no WPF/WinForms dependency to begin with.
- Fixed a real WinForms blocker: `Initialize()`'s startup shift-check read `Control.ModifierKeys`
  directly. Converted to `IHotkeyManager.IsPressedInControl(KeyCombination.Shift())` — the same
  live-modifier-state seam already used by `SelectionManager.IsShiftDown`. Verified logically
  identical (both reduce to `(Control.ModifierKeys & Keys.Shift) == Keys.Shift`, and `Keys.Shift`
  is a single-bit flag).

**Scope classification for the rest of `ProjectManager`:**
- **(a) Genuinely relocatable now:** the four extracted methods (done), plus `MakeAbsoluteIfNecessary`
  (already on `IProjectManager`, pure `FileManager` string logic — no blocker at all), `CopyLinkedComponents`
  and `RecreateMissingStandardElements` (both only need `_gumProjectSave` passed as a parameter instead
  of read off the field — a mechanical, not architectural, change; `RecreateMissingStandardElements`
  already has 2 pinning tests).
- **(b) Convertible with reasonable effort:**
  - `WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo` (2 call sites, `LoadProject`/
    `AskUserForProjectNameIfNecessary`) — real WPF (`WpfDataUi.csproj` is `UseWPF`/`UseWindowsForms`).
    Needs a narrow interface exposing just this folder-relative-to setter, WPF-side impl, same shape
    as the `IAppScaleProvider` gotcha in the decoupling plan.
  - `ICommandLineManager` and `IRetryService` — both interfaces are physically declared inside
    `Gum.csproj`-side files, not `Gum.Presentation`. Their own dependency closures are clean
    (`IRetryService` is trivial; `ICommandLineManager` only depends on other already-Presentation
    interfaces plus `IFontManager`, which itself lives in `Gum.csproj` too and needs the same
    physical-file move). Per the "interface relocation is the real gate" gotcha, `ProjectManager`
    can't move to `Gum.Presentation` until these interface files physically relocate — pure file
    moves, no logic change, but out of this PR's bounded scope.
- **(c) Genuinely stuck (real blockers, no clean seam yet):**
  - The `GeneralSettingsFile` property is typed as the concrete `Gum.Settings.GeneralSettingsFile`,
    which itself has WinForms-typed members (`Rectangle MainWindowBounds`, `FormWindowState
    MainWindowState`) — already documented in the class's own doc comment as the reason it's kept
    out of `IProjectManager`'s headless interface surface. This blocks the **concrete `ProjectManager`
    class** from moving even once every other blocker above is fixed, since a public member can't be
    typed against a WinForms type from a headless assembly. Splitting `GeneralSettingsFile`'s
    WinForms-only members off (or `#if`-gating them) is its own design decision — flagging, not
    implementing.

**Net:** the file is not close to fully headless-movable as a whole class yet — this PR advances the
*logic* (repair passes + the shift-check) but the *host class* (`ProjectManager` itself) still has 3
real, distinct blockers (`WpfDataUi`, `ICommandLineManager`/`IRetryService` interface location,
`GeneralSettingsFile`). Leaving #3863 open with this status; did not include `Closes`.

## Test plan
- [x] `dotnet build Tools/Gum.Presentation/Gum.Presentation.csproj` — 0 errors
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj --filter GumProjectRepairLogicTests` — 8/8 pass (new pinning tests)
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter ProjectManagerTests` (with `-p:SolutionDir`) — 10/10 pass (8 existing + 2 new)
- [x] Mutation-test proof: broke `FixRecursiveAssignments`' `Container` assignment, confirmed
      `FixRecursiveAssignments_ForcesRecursiveInstanceToContainer` went red, reverted, confirmed green.

**Manual test: not needed** — behavior-preserving extraction + one seam swap verified logically
identical to the original WinForms read, both covered by unit tests + compilation.

**FRB canary: not needed** — no FRB1-shared source touched (`ProjectManager.cs`/`GumProjectRepairLogic.cs`
aren't referenced by any `.projitems`).
