### PR TITLE
Relocate SelectedState into headless Gum.Presentation (#3875)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -27,7 +27,7 @@ using Gum.Plugins;
 
 namespace Gum.Managers;
 
-public partial class PropertyGridManager
+public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
 {
     #region Fields
 

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -139,9 +139,13 @@ file static class ServiceCollectionExtensions
         // bloated WinForms-coupled UI class whose only consumer couples to internal/UI-typed members.
         services.AddSingleton<ElementTreeViewManager>();
         // PropertyGridManager: drained from a static Self singleton (#3288), same pattern as ElementTreeViewManager.
-        // Concrete (no interface) because it is a bloated WinForms/WPF-coupled UI class. SelectedState and GuiCommands
-        // are both consumers AND dependencies of it, so they break the construction cycle by injecting Lazy<PropertyGridManager>.
+        // Concrete (no interface) because it is a bloated WinForms/WPF-coupled UI class. GuiCommands is both a
+        // consumer AND a dependency of it, so it breaks the construction cycle by injecting Lazy<PropertyGridManager>.
         services.AddSingleton<PropertyGridManager>();
+        // IBehaviorVariablePropertyGridSink: narrow headless port (issue #3875) so the relocated SelectedState
+        // (Gum.Presentation) can push the selected behavior variable into the property grid without depending on
+        // the concrete PropertyGridManager. Resolves to the same PropertyGridManager singleton.
+        services.AddSingleton<IBehaviorVariablePropertyGridSink>(provider => provider.GetRequiredService<PropertyGridManager>());
 
         // singletons
         services.AddSingleton<ICircularReferenceManager, CircularReferenceManager>();

--- a/Tests/Gum.Presentation.Tests/SelectedStateTests.cs
+++ b/Tests/Gum.Presentation.Tests/SelectedStateTests.cs
@@ -9,13 +9,14 @@ using Moq;
 using Shouldly;
 using System;
 
-namespace GumToolUnitTests.ToolStates;
+namespace Gum.Presentation.Tests;
 
 public class SelectedStateTests : BaseTestClass
 {
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<IMessenger> _messenger;
+    private readonly Mock<IBehaviorVariablePropertyGridSink> _propertyGridSink;
     private readonly SelectedState _selectedState;
 
     public SelectedStateTests()
@@ -23,13 +24,26 @@ public class SelectedStateTests : BaseTestClass
         _guiCommands = new Mock<IGuiCommands>();
         _pluginManager = new Mock<IPluginManager>();
         _messenger = new Mock<IMessenger>();
+        _propertyGridSink = new Mock<IBehaviorVariablePropertyGridSink>();
         _selectedState = new SelectedState(
             _guiCommands.Object,
             _pluginManager.Object,
             _messenger.Object,
-            // SelectedBehaviorVariable (the only PropertyGridManager use) is not exercised here,
-            // so the factory is never invoked.
-            new Lazy<PropertyGridManager>(() => null!));
+            new Lazy<IBehaviorVariablePropertyGridSink>(() => _propertyGridSink.Object));
+    }
+
+    [Fact]
+    public void SelectedBehaviorVariable_Set_PushesValueIntoPropertyGridSink()
+    {
+        // Pins the one seam that used to require a direct dependency on the concrete,
+        // WPF-coupled PropertyGridManager (issue #3875): setting SelectedBehaviorVariable
+        // must still forward the value into the property grid, now via the narrow
+        // IBehaviorVariablePropertyGridSink interface instead of the concrete class.
+        VariableSave variable = new VariableSave { Name = "X" };
+
+        _selectedState.SelectedBehaviorVariable = variable;
+
+        _propertyGridSink.VerifySet(s => s.SelectedBehaviorVariable = variable, Times.Once);
     }
 
     [Fact]
@@ -85,7 +99,7 @@ public class SelectedStateTests : BaseTestClass
         // element. If this cascade order is ever reversed, the element rebuild would no longer be
         // suppressed and the double-rebuild (and duplicate missing-file errors) would silently return.
         ScreenSave screen = CreateScreen("TestScreen");
-        var invocationOrder = new List<string>();
+        List<string> invocationOrder = new List<string>();
         _pluginManager
             .Setup(p => p.ReactToStateSaveSelected(It.IsAny<StateSave>()))
             .Callback(() => invocationOrder.Add(nameof(IPluginManager.ReactToStateSaveSelected)));

--- a/Tools/Gum.Presentation/Managers/IBehaviorVariablePropertyGridSink.cs
+++ b/Tools/Gum.Presentation/Managers/IBehaviorVariablePropertyGridSink.cs
@@ -1,0 +1,13 @@
+using Gum.DataTypes.Variables;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Narrow seam so headless selection logic (<see cref="Gum.ToolStates.SelectedState"/>) can push
+/// the newly-selected behavior variable into the property grid's view model without depending on
+/// the concrete, WPF-coupled <c>PropertyGridManager</c>. Implemented by <c>PropertyGridManager</c>.
+/// </summary>
+public interface IBehaviorVariablePropertyGridSink
+{
+    VariableSave SelectedBehaviorVariable { set; }
+}

--- a/Tools/Gum.Presentation/ToolStates/SelectedState.cs
+++ b/Tools/Gum.Presentation/ToolStates/SelectedState.cs
@@ -1,34 +1,28 @@
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Commands;
-using Gum.Controls;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Messages;
 using Gum.Plugins;
-using Gum.Services;
 using Gum.Wireframe;
-using Newtonsoft.Json.Linq;
 using RenderingLibrary;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Linq;
-using System.Windows.Forms;
 
 namespace Gum.ToolStates;
 
-[Export(typeof(ISelectedState))]
 public class SelectedState : ISelectedState
 {
     #region Fields
-    
+
     private readonly IGuiCommands _guiCommands;
     private readonly IPluginManager _pluginManager;
     private readonly IMessenger _messenger;
     // Lazy because PropertyGridManager depends on ISelectedState; this breaks the DI construction cycle.
-    private readonly Lazy<PropertyGridManager> _lazyPropertyGridManager;
+    private readonly Lazy<IBehaviorVariablePropertyGridSink> _lazyPropertyGridManager;
     SelectedStateSnapshot snapshot = new SelectedStateSnapshot();
 
     #endregion
@@ -324,7 +318,7 @@ public class SelectedState : ISelectedState
     #endregion
 
     #region Properties
-    
+
 
 
     public ITreeNode? SelectedTreeNode => SelectedTreeNodes.FirstOrDefault();
@@ -344,7 +338,7 @@ public class SelectedState : ISelectedState
     public SelectedState(IGuiCommands guiCommands,
         IPluginManager pluginManager,
         IMessenger messenger,
-        Lazy<PropertyGridManager> lazyPropertyGridManager)
+        Lazy<IBehaviorVariablePropertyGridSink> lazyPropertyGridManager)
     {
         _guiCommands = guiCommands;
         _pluginManager = pluginManager;
@@ -509,7 +503,7 @@ public class SelectedState : ISelectedState
         if (SelectedElement != null && (SelectedStateSave == null || SelectedElement.AllStates.Contains(SelectedStateSave) == false))
         {
             var shouldSelectDefault = true;
-            // This can happen on a redo where the state gets re-created, so instances are not preserved. In this case, we should 
+            // This can happen on a redo where the state gets re-created, so instances are not preserved. In this case, we should
             // check if there are any matching states in matching categories.
             if(SelectedStateCategorySave != null)
             {
@@ -731,7 +725,7 @@ public class SelectedState : ISelectedState
 
     /// <summary>
     /// Returns the name of the selected entry in the property grid.
-    /// There may not be a VariableSave backing the selection as the 
+    /// There may not be a VariableSave backing the selection as the
     /// value may be null in the StateSave
     /// </summary>
     public string SelectedVariableName
@@ -758,8 +752,3 @@ public class SelectedState : ISelectedState
 
 
 }
-
-// SelectedStateSnapshot (stores a selected-state snapshot without looking at any UI states) moved
-// to Tools/Gum.Presentation/ToolStates/SelectedStateSnapshot.cs (same Gum.ToolStates namespace, so
-// no using changes needed here) as part of relocating DragDropManager, its only other consumer,
-// into the headless Gum.Presentation assembly.


### PR DESCRIPTION
Closes #3875

`ISelectedState`/`SelectedStateSnapshot` already lived in `Gum.Presentation` (injected everywhere as `_selectedState`); the concrete `SelectedState` class was the last blocker. Full-file audit found only one real seam: a `Lazy<PropertyGridManager>` push into the property grid on `SelectedBehaviorVariable`. Narrowed it to a new `IBehaviorVariablePropertyGridSink` interface implemented by `PropertyGridManager`, so `SelectedState` no longer names the concrete WPF-coupled class. Everything else in the file (`IGuiCommands`, `IPluginManager`, `IMessenger`, `ObjectFinder.Self`, `ITreeNode`, `IStateContainer`, `SelectionChangedMessage`) was already headless-reachable.

Boyscout cleanup found while relocating:
- Unused `using System.Windows.Forms;` — confirmed dead (the issue's own suspicion).
- Unused `using Newtonsoft.Json.Linq;`.
- A `[Export(typeof(ISelectedState))]` MEF attribute that was never actually composed — the real DI bridge is `PluginManager.LoadPlugins`'s manual `AddExportedValue<ISelectedState>`. Confirmed dead by running the full `GumToolUnitTests` suite (including `AllPluginsCompositionTests`) green after removing it.

Migrated `SelectedStateTests` from `GumToolUnitTests` to `Gum.Presentation.Tests` and added a pinning test for the new sink seam (mutation-tested: commenting out the push made it red, reverted).

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` — 460/460 pass
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 1112/1112 pass (2 pre-existing skips)
- [x] Mutation-test proof on the new pinning test (broke it, confirmed red, reverted)

Manual test: not needed — pure behavior-preserving relocation + narrow-interface split, covered by pinning tests, mutation-test proof, and full solution build.
