### PR TITLE
Rewire StateReferencingInstanceMember to delegate to VariableGridEntry (PR 2/3 of #3860 variable-grid decoupling)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/ElementSaveDisplayer.cs
@@ -45,7 +45,7 @@ public class ElementSaveDisplayer
     private readonly CategorySortAndColorLogic _categorySortAndColorLogic;
     private readonly IPluginManager _pluginManager;
     private readonly StandardElementsManager _standardElementsManager;
-    private readonly IEditVariableMenuService _editVariableService;
+    private readonly IEditVariableService _editVariableService;
     private readonly IExposeVariableService _exposeVariableService;
     private readonly IHotkeyManager _hotkeyManager;
     private readonly IDeleteVariableService _deleteVariableService;
@@ -53,6 +53,7 @@ public class ElementSaveDisplayer
     private readonly IFileCommands _fileCommands;
     private readonly ISetVariableLogic _setVariableLogic;
     private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IClipboardService _clipboardService;
     private readonly ShapeVariableVersionGate _shapeVariableVersionGate;
 
     #endregion
@@ -80,14 +81,15 @@ public class ElementSaveDisplayer
         IUndoManager undoManager,
         IPluginManager pluginManager,
         IVariableSaveLogic variableSaveLogic,
-        IEditVariableMenuService editVariableService,
+        IEditVariableService editVariableService,
         IExposeVariableService exposeVariableService,
         IHotkeyManager hotkeyManager,
         IDeleteVariableService deleteVariableService,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         ISetVariableLogic setVariableLogic,
-        IWireframeObjectManager wireframeObjectManager)
+        IWireframeObjectManager wireframeObjectManager,
+        IClipboardService clipboardService)
     {
         _subtextLogic = subtextLogic;
         _selectedState = selectedState;
@@ -105,6 +107,7 @@ public class ElementSaveDisplayer
         _fileCommands = fileCommands;
         _setVariableLogic = setVariableLogic;
         _wireframeObjectManager = wireframeObjectManager;
+        _clipboardService = clipboardService;
         _shapeVariableVersionGate = new ShapeVariableVersionGate();
     }
 
@@ -524,18 +527,19 @@ public class ElementSaveDisplayer
                     variableName,
                     instance,
                     instanceOwner,
-                    _undoManager,
-                    _editVariableService,
-                    _exposeVariableService,
-                    _hotkeyManager,
-                    _deleteVariableService,
                     _selectedState,
+                    _undoManager,
                     _guiCommands,
                     _fileCommands,
                     _setVariableLogic,
                     _wireframeObjectManager,
+                    _pluginManager,
+                    _hotkeyManager,
+                    _deleteVariableService,
+                    _exposeVariableService,
+                    _editVariableService,
                     _typeManager,
-                    _pluginManager);
+                    _clipboardService);
 
                 // moved to internal
                 //srim.SetToDefault += (memberName) => ResetVariableToDefault(srim);
@@ -673,18 +677,19 @@ public class ElementSaveDisplayer
                     variableName,
                     instance,
                     instanceOwner,
-                    _undoManager,
-                    _editVariableService,
-                    _exposeVariableService,
-                    _hotkeyManager,
-                    _deleteVariableService,
                     _selectedState,
+                    _undoManager,
                     _guiCommands,
                     _fileCommands,
                     _setVariableLogic,
                     _wireframeObjectManager,
+                    _pluginManager,
+                    _hotkeyManager,
+                    _deleteVariableService,
+                    _exposeVariableService,
+                    _editVariableService,
                     _typeManager,
-                    _pluginManager);
+                    _clipboardService);
 
                 // Surface the behavior's declared default (FormsProperty.Value) so the grid
                 // reflects e.g. IsEnabled = true even before the user authors anything. The
@@ -735,18 +740,19 @@ public class ElementSaveDisplayer
             variableName,
             instance,
             instanceOwner,
-            _undoManager,
-            _editVariableService,
-            _exposeVariableService,
-            _hotkeyManager,
-            _deleteVariableService,
             _selectedState,
+            _undoManager,
             _guiCommands,
             _fileCommands,
             _setVariableLogic,
             _wireframeObjectManager,
+            _pluginManager,
+            _hotkeyManager,
+            _deleteVariableService,
+            _exposeVariableService,
+            _editVariableService,
             _typeManager,
-            _pluginManager
+            _clipboardService
             );
 
         // Override the display name if specified in PropertyData

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -49,7 +49,6 @@ public partial class PropertyGridManager
     private readonly INameVerifier _nameVerifier;
     private readonly IDeleteVariableService _deleteVariableService;
     private readonly IEditVariableService _editVariableService;
-    private readonly IEditVariableMenuService _editVariableMenuService;
     private readonly IHotkeyManager _hotkeyManager;
     private readonly IVariableSaveLogic _variableSaveLogic;
     private readonly IClipboardService _clipboardService;
@@ -122,7 +121,6 @@ public partial class PropertyGridManager
         INameVerifier nameVerifier,
         IDeleteVariableService deleteVariableService,
         IEditVariableService editVariableService,
-        IEditVariableMenuService editVariableMenuService,
         IHotkeyManager hotkeyManager,
         IVariableSaveLogic variableSaveLogic,
         IClipboardService clipboardService)
@@ -145,7 +143,6 @@ public partial class PropertyGridManager
         _nameVerifier = nameVerifier;
         _deleteVariableService = deleteVariableService;
         _editVariableService = editVariableService;
-        _editVariableMenuService = editVariableMenuService;
         _hotkeyManager = hotkeyManager;
         _variableSaveLogic = variableSaveLogic;
         _clipboardService = clipboardService;
@@ -173,14 +170,15 @@ public partial class PropertyGridManager
             _undoManager,
             _pluginManager,
             _variableSaveLogic,
-            _editVariableMenuService,
+            _editVariableService,
             _exposeVariableService,
             _hotkeyManager,
             _deleteVariableService,
             _guiCommands,
             _fileCommands,
             _setVariableLogic,
-            _wireframeObjectManager);
+            _wireframeObjectManager,
+            _clipboardService);
 
         mainControl = new Gum.MainPropertyGrid();
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -1,9 +1,7 @@
-using CommonFormsAndControls;
-using ExCSS;
+using Gum.Commands;
 using Gum.DataTypes;
-using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
-using Gum.Logic;
+using Gum.Input;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -12,46 +10,49 @@ using Gum.Services;
 using Gum.ToolStates;
 using Gum.Undo;
 using Gum.Wireframe;
-using GumRuntime;
-using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json.Linq;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Windows.Forms;
-using Gum.Commands;
 using ToolsUtilities;
 using WpfDataUi.Controls;
 using WpfDataUi.DataTypes;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Gum.PropertyGridHelpers;
 
+/// <summary>
+/// Thin WPF adapter over <see cref="VariableGridEntry"/> - the headless heir holding this class's
+/// former decision logic (see ADR-0005 and the "ui-decoupling-plan.md" known-gotchas list). This
+/// class still derives from WpfDataUi's <see cref="InstanceMember"/> (required so the live
+/// Variables tab grid can render it) and owns the WPF-only glue that has no headless equivalent -
+/// the go-to-definition <c>KeyDown</c> wiring and <see cref="HandleUiCreated"/> - while every other
+/// member forwards to <see cref="_entry"/>, translating only at the WPF boundary
+/// (<see cref="VariableDisplayerKind"/> &lt;-&gt; <see cref="Type"/>,
+/// <see cref="VariablePropertyCommitType"/> &lt;-&gt; <see cref="SetPropertyCommitType"/>,
+/// <see cref="VariableContextMenuAction"/> -&gt; <see cref="InstanceMember.ContextMenuEvents"/>).
+/// </summary>
 public class StateReferencingInstanceMember : InstanceMember
 {
     #region Fields
 
-    ObjectFinder _objectFinder;
-    private readonly ITypeManager _typeManager;
-    private readonly IHotkeyManager _hotkeyManager;
-    private readonly IUndoManager _undoManager;
-    private readonly IDeleteVariableService _deleteVariableLogic;
-    private readonly IGuiCommands _guiCommands;
-    private readonly IFileCommands _fileCommands;
-    private readonly IEditVariableMenuService _editVariablesService;
-    private readonly IExposeVariableService _exposeVariableService;
-    private readonly ISelectedState _selectedState;
-    private readonly ISetVariableLogic _setVariableLogic;
-    private readonly IWireframeObjectManager _wireframeObjectManager;
-    private readonly IPluginManager _pluginManager;
-    StateSave mStateSave;
-    string mVariableName;
-    public InstanceSave? InstanceSave { get; private set; }
-    public ElementSave? ElementSave { get; private set; }
+    private readonly VariableGridEntry _entry;
 
-    public object LastOldFullCommitValue { get; private set; }
+    #endregion
+
+    #region Properties
+
+    public StateSaveCategory? StateSaveCategory
+    {
+        get => _entry.StateSaveCategory;
+        set => _entry.StateSaveCategory = value;
+    }
+
+    public StateSave StateSave => _entry.StateSave;
+
+    public InstanceSave? InstanceSave => _entry.InstanceSave;
+
+    public ElementSave? ElementSave => _entry.ElementSave;
+
+    public object? LastOldFullCommitValue => _entry.LastOldFullCommitValue;
 
     /// <summary>
     /// Optional fallback consulted by the value getter when neither the selected
@@ -59,187 +60,77 @@ public class StateReferencingInstanceMember : InstanceMember
     /// behavior-FormsProperty surfacing path so a declared default (e.g.
     /// <c>IsEnabled = true</c>) appears in the grid without writing into state.
     /// </summary>
-    public Func<object?>? DefaultValueFallback { get; set; }
-
-    Attribute[] _attributes;
-    TypeConverter? _converter;
-    Type? _componentType;
-    bool _isReadOnlyFromDescriptor;
-    bool _isAssignedByReference;
-    bool _isVariable;
-
-    #endregion
-
-    #region Properties
-
-    public StateSaveCategory? StateSaveCategory { get; set; }
-
-    public StateSave StateSave => mStateSave;
-
-
-    public override bool IsReadOnly
+    public Func<object?>? DefaultValueFallback
     {
-        get
-        {
-            if (InstanceSave?.Locked == true && RootVariableName != "Locked")
-            {
-                return true;
-            }
-            if (_isVariable)
-            {
-                return _isReadOnlyFromDescriptor;
-            }
-            else
-            {
-                return base.IsReadOnly;
-            }
-        }
+        get => _entry.DefaultValueFallback;
+        set => _entry.DefaultValueFallback = value;
     }
 
-    public string RootVariableName
-    {
-        get
-        {
-            if (mVariableName.Contains('.'))
-            {
-                return mVariableName.Substring(mVariableName.LastIndexOf('.') + 1);
-            }
-            else
-            {
-                return mVariableName;
-            }
-        }
-    }
-
-    public override bool IsDefault
-    {
-        get
-        {
-            if (this.RootVariableName == "Name")
-            {
-                return false; // this can never be default, and if it is that causes all kinds of weirdness in variable displays.
-            }
-
-            return GetValueStrictlyOnSelectedState(InstanceSave) == null;
-        }
-        set
-        {
-            if (value && SetToDefault != null)
-            {
-                SetToDefault(DisplayName);
-            }
-        }
-    }
-
-    private object? GetValueStrictlyOnSelectedState(object component)
-    {
-        if (mStateSave != null)
-        {
-            return mStateSave.GetValue(Name);
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    public override IList<object> CustomOptions
-    {
-        get
-        {
-            if (_converter != null && (_converter is BooleanConverter == false))
-            {
-                var values = _converter.GetStandardValues(null);
-                if (values != null)
-                {
-                    List<object> toReturn = new List<object>();
-                    foreach (var item in values)
-                    {
-                        toReturn.Add(item);
-                    }
-                    return toReturn;
-                }
-            }
-
-            return base.CustomOptions;
-        }
-    }
-
-    bool IsFile
-    {
-        get
-        {
-            if (_attributes != null)
-            {
-                foreach (var attribute in _attributes)
-                {
-                    if (attribute is EditorAttribute editorAttribute)
-                    {
-                        return editorAttribute.EditorTypeName.StartsWith("System.Windows.Forms.Design.FileNameEditor");
-                    }
-                }
-            }
-
-            return false;
-        }
-    }
-
-    public override Type PreferredDisplayer
-    {
-        get
-        {
-            bool shouldBeComboBox = false;
-            // we want to still give priority to the base displayer since
-            // we may want to replace combo boxes with something like toggles:
-            if (CustomOptions != null && base.PreferredDisplayer == null)
-            {
-                shouldBeComboBox =
-                   CustomOptions.Count != 0 ||
-                   // If this is a state, still show the combo box even if there are no
-                   // available states to select from. Otherwise it's a confusing text box
-                   _converter is Converters.AvailableStatesConverter;
-            }
-            if (shouldBeComboBox)
-            {
-                return typeof(WpfDataUi.Controls.ComboBoxDisplay);
-            }
-            else if (IsFile && base.PreferredDisplayer == null)
-            {
-                return typeof(WpfDataUi.Controls.FileSelectionDisplay);
-            }
-            else
-            {
-                return base.PreferredDisplayer;
-            }
-        }
-        set
-        {
-            base.PreferredDisplayer = value;
-        }
-    }
-
-    VariableSave VariableSave
-    {
-        get
-        {
-            return mStateSave?.Variables.FirstOrDefault(item =>
-                item.Name == mVariableName || item.ExposedAsName == mVariableName);
-        }
-    }
+    public string RootVariableName => _entry.RootVariableName;
 
     public int SortValue
     {
-        get;
-        set;
+        get => _entry.SortValue;
+        set => _entry.SortValue = value;
     }
 
     // Prior to April 10 2023 this was always true. Now that we have multi-select, we don't want to
     // call it here if editing multiple objects. Instead, we want to have the multi-select call it and pass
     // the list of variables so that a single undo can be performed.
-    public bool IsCallingRefresh { get; set; } = true;
+    public bool IsCallingRefresh
+    {
+        get => _entry.IsCallingRefresh;
+        set => _entry.IsCallingRefresh = value;
+    }
+
+    public override bool IsReadOnly => _entry.IsReadOnly;
+
+    public override bool IsDefault
+    {
+        get => _entry.IsDefault;
+        set
+        {
+            if (value)
+            {
+                _entry.ResetToDefault();
+            }
+        }
+    }
+
+    public override IList<object> CustomOptions => _entry.CustomOptions ?? base.CustomOptions;
+
+    /// <summary>
+    /// Translates <see cref="VariableGridEntry.PreferredDisplayerKind"/>/<see cref="VariableGridEntry.PreferredDisplayerOverride"/>
+    /// back to the WPF control <see cref="Type"/> the live grid needs. An explicit override is
+    /// passed through unchanged (it's already the concrete WPF control type); only the "no explicit
+    /// override" case needs mapping from the neutral <see cref="VariableDisplayerKind"/>.
+    /// </summary>
+    public override Type PreferredDisplayer
+    {
+        get
+        {
+            if (_entry.PreferredDisplayerOverride != null)
+            {
+                return _entry.PreferredDisplayerOverride;
+            }
+
+            return _entry.PreferredDisplayerKind switch
+            {
+                VariableDisplayerKind.ComboBox => typeof(ComboBoxDisplay),
+                VariableDisplayerKind.FileSelection => typeof(FileSelectionDisplay),
+                VariableDisplayerKind.ListBox => typeof(ListBoxDisplay),
+                VariableDisplayerKind.MultiLineTextBox => typeof(MultiLineTextBoxDisplay),
+                _ => null,
+            };
+        }
+        set
+        {
+            _entry.PreferredDisplayerOverride = value;
+            OnPropertyChanged(nameof(PreferredDisplayer));
+        }
+    }
 
     #endregion
-
 
     #region Constructor/Initialization
 
@@ -255,44 +146,46 @@ public class StateReferencingInstanceMember : InstanceMember
         string variableName,
         InstanceSave? instanceSave,
         IStateContainer stateListCategoryContainer,
-        IUndoManager undoManager,
-        IEditVariableMenuService editVariableService,
-        IExposeVariableService exposeVariableService,
-        IHotkeyManager hotkeyManager,
-        IDeleteVariableService deleteVariableService,
         ISelectedState selectedState,
+        IUndoManager undoManager,
         IGuiCommands guiCommands,
         IFileCommands fileCommands,
         ISetVariableLogic setVariableLogic,
         IWireframeObjectManager wireframeObjectManager,
+        IPluginManager pluginManager,
+        IHotkeyManager hotkeyManager,
+        IDeleteVariableService deleteVariableService,
+        IExposeVariableService exposeVariableService,
+        IEditVariableService editVariableService,
         ITypeManager typeManager,
-        IPluginManager pluginManager) :
+        IClipboardService clipboardService) :
         base(variableName, stateSave)
     {
-        _editVariablesService = editVariableService;
-        _exposeVariableService = exposeVariableService;
-        _objectFinder = ObjectFinder.Self;
-        _hotkeyManager = hotkeyManager;
-        _deleteVariableLogic = deleteVariableService;
-        _undoManager = undoManager;
-        _selectedState = selectedState;
-        _guiCommands = guiCommands;
-        _fileCommands = fileCommands;
-        _setVariableLogic = setVariableLogic;
-        _wireframeObjectManager = wireframeObjectManager;
-        _typeManager = typeManager;
-        _pluginManager = pluginManager;
-        StateSaveCategory = stateSaveCategory;
-        InstanceSave = instanceSave;
-        mStateSave = stateSave;
-        mVariableName = variableName;
-        _attributes = attributes;
-        _converter = converter;
-        _componentType = componentType;
-        _isReadOnlyFromDescriptor = isReadOnly;
-        _isAssignedByReference = isAssignedByReference;
-        _isVariable = isVariable;
-        ElementSave = stateListCategoryContainer as ElementSave;
+        _entry = new VariableGridEntry(
+            attributes,
+            converter,
+            componentType,
+            isReadOnly,
+            isAssignedByReference,
+            isVariable,
+            stateSave,
+            stateSaveCategory,
+            variableName,
+            instanceSave,
+            stateListCategoryContainer,
+            selectedState,
+            undoManager,
+            guiCommands,
+            fileCommands,
+            setVariableLogic,
+            wireframeObjectManager,
+            pluginManager,
+            hotkeyManager,
+            deleteVariableService,
+            exposeVariableService,
+            editVariableService,
+            typeManager,
+            clipboardService);
 
         if (isReadOnly)
         {
@@ -309,432 +202,44 @@ public class StateReferencingInstanceMember : InstanceMember
 
         this.UiCreated += HandleUiCreated;
 
-        this.SortValue = int.MaxValue;
+        this.Instance = _entry.Instance;
+        this.DisplayName = _entry.DisplayName;
+        this.DetailText = _entry.DetailText;
+        this.ToolTipText = _entry.ToolTipText;
+        this.SupportsMakeDefault = _entry.SupportsMakeDefault;
 
-        if (instanceSave != null)
+        foreach (var kvp in _entry.PropertiesToSetOnDisplayer)
         {
-            this.Instance = instanceSave;
-        }
-        else
-        {
-            this.Instance = stateListCategoryContainer;
-        }
-
-        var alreadyHasSpaces = RootVariableName?.Contains(" ");
-        if (alreadyHasSpaces == false)
-        {
-            DisplayName = ToolsUtilities.StringFunctions.InsertSpacesInCamelCaseString(RootVariableName);
-        }
-        else
-        {
-            DisplayName = RootVariableName;
+            this.PropertiesToSetOnDisplayer[kvp.Key] = kvp.Value;
         }
 
-        ModifyContextMenu(instanceSave, stateListCategoryContainer);
-
-        VariableSave? standardVariable = null;
-
-        var elementSave = stateListCategoryContainer as ElementSave;
-
-        if (elementSave != null)
-        {
-            standardVariable = _objectFinder.GetRootVariable(mVariableName, elementSave);
-        }
-
-        if(RootVariableName == "BaseType" && instanceSave != null && ObjectFinder.Self.GetElementSave(instanceSave) == null)
-        {
-            // special case - if it's a base type and we have an instance,
-            // and if that instance references an invalid type, let's make
-            // this editable so the user can see their current value:
-            this.PropertiesToSetOnDisplayer["IsEditable"] = true;
-        }
-
-        // todo - this needs to go to the standard elements manager
-        if (standardVariable != null)
-        {
-            var standardElement = _objectFinder.GetContainerOf(standardVariable);
-
-            if (standardElement is StandardElementSave)
-            {
-                try
-                {
-                    var defaultState = StandardElementsManager.Self.GetDefaultStateFor(standardElement.Name);
-
-                    var definingVariable = defaultState?.Variables.FirstOrDefault(item => item.Name == standardVariable.Name);
-
-                    if (definingVariable != null)
-                    {
-                        if(definingVariable.PreferredDisplayer != null)
-                        {
-                            this.PreferredDisplayer = definingVariable.PreferredDisplayer;
-                        }
-                        this.DetailText = definingVariable.DetailText;
-                        this.ToolTipText = definingVariable.ToolTipText;
-
-                        foreach (var kvp in definingVariable.PropertiesToSetOnDisplayer)
-                        {
-                            this.PropertiesToSetOnDisplayer[kvp.Key] = kvp.Value;
-                        }
-
-                        this.SortValue = definingVariable.DesiredOrder;
-                    }
-                }
-                catch(Exception e)
-                {
-                    // this could be a missing standard element save, print output but tolerate it:
-                    _guiCommands.PrintOutput("Error getting standard element variable:\n" + e);
-                }
-            }
-        }
-        else
-        {
-            VariableListSave? standardVariableList = null;
-            if (elementSave != null)
-            {
-                standardVariableList = _objectFinder.GetRootVariableList(mVariableName, elementSave);
-            }
-            ElementSave? standardElement = null;
-
-            if (standardVariableList != null)
-            {
-                standardElement = ObjectFinder.Self.GetElementContainerOf(standardVariableList);
-            }
-
-            VariableListSave? definingVariableList = null;
-            if (standardElement != null && standardElement is StandardElementSave)
-            {
-                var defaultState = StandardElementsManager.Self.GetDefaultStateFor(standardElement.Name);
-                definingVariableList = defaultState?.VariableLists.FirstOrDefault(item => item.Name == standardVariableList.Name);
-            }
-
-            // Fallback: when the container is a Screen or Component (not a StandardElementSave),
-            // search all standard elements for a matching variable list definition (e.g. VariableReferences).
-            if (definingVariableList == null && standardVariableList != null)
-            {
-                var rootName = standardVariableList.GetRootName();
-                foreach (var se in _objectFinder.GumProjectSave?.StandardElements ?? Enumerable.Empty<StandardElementSave>())
-                {
-                    var defaultState = StandardElementsManager.Self.GetDefaultStateFor(se.Name);
-                    var match = defaultState?.VariableLists.FirstOrDefault(vl => vl.GetRootName() == rootName);
-                    if (match != null)
-                    {
-                        definingVariableList = match;
-                        break;
-                    }
-                }
-            }
-
-            if(definingVariableList != null)
-            {
-                if (definingVariableList.PreferredDisplayer != null)
-                {
-                    this.PreferredDisplayer = definingVariableList.PreferredDisplayer;
-                }
-                this.DetailText = definingVariableList.DetailText;
-
-                //foreach (var kvp in definingVariableList.PropertiesToSetOnDisplayer)
-                //{
-                //    this.PropertiesToSetOnDisplayer[kvp.Key] = kvp.Value;
-                //}
-
-                //this.SortValue = definingVariableList.DesiredOrder;
-            }
-
-        }
-
-
+        PopulateContextMenu();
     }
 
     private void HandleUiCreated(System.Windows.Controls.UserControl obj)
     {
-        if (this.RootVariableName == "VariableReferences")
+        if (RootVariableName == "VariableReferences" && obj is StringListTextBoxDisplay asTextBox)
         {
-            var asTextBox = obj as StringListTextBoxDisplay;
-
-            if (asTextBox != null)
+            asTextBox.KeyDown += (s, e) =>
             {
-                asTextBox.KeyDown += (s, e) =>
-                {
-                    if (_hotkeyManager.GoToDefinition.IsPressed(e))
-                    {
-                        HandleGotoDefinition(asTextBox);
-                    }
-                };
-            }
+                _entry.HandleReferenceTextEditKeyDown(e.ToGumKeyEventArgs(), asTextBox.GetCurrentLineText());
+            };
         }
     }
 
     #endregion
 
-    private void ModifyContextMenu(InstanceSave instanceSave, IStateContainer stateListCategoryContainer)
+    private void PopulateContextMenu()
     {
-        SupportsMakeDefault = this.mVariableName != "Name" && !_isAssignedByReference;
-
-        TryAddExposeVariableMenuOptions(instanceSave);
-
-        TryAddHideFromInstancesMenuOptions(instanceSave, stateListCategoryContainer);
-
-        TryAddCopyVariableReferenceMenuOptions();
-
-        _editVariablesService.TryAddEditVariableOptions(this, VariableSave, stateListCategoryContainer);
-    }
-
-
-    private void HandleGotoDefinition(StringListTextBoxDisplay asTextBox)
-    {
-        var text = asTextBox.GetCurrentLineText();
-
-        if (text?.Contains("=") == true)
+        foreach (var action in _entry.BuildContextMenuActions())
         {
-            var rightSideOfEquals = text.Substring(text.IndexOf("=") + 1).Trim();
-
-            if (rightSideOfEquals.Contains("."))
-            {
-                var beforeDot = rightSideOfEquals.Substring(0, rightSideOfEquals.IndexOf("."));
-
-                if (beforeDot.Contains("/"))
-                {
-                    beforeDot = beforeDot.Substring(beforeDot.LastIndexOf("/") + 1);
-                }
-
-                var element = _objectFinder.GetElementSave(beforeDot);
-
-                if (element != null)
-                {
-                    var afterDot = rightSideOfEquals.Substring(rightSideOfEquals.IndexOf(".") + 1);
-
-                    var instanceName = afterDot;
-
-                    if (afterDot.Contains("."))
-                    {
-                        instanceName = afterDot.Substring(0, afterDot.IndexOf("."));
-                    }
-
-                    InstanceSave instance = null;
-                    if (!string.IsNullOrEmpty(instanceName))
-                    {
-                        instance = element.GetInstance(instanceName);
-                    }
-                    if (instance != null)
-                    {
-                        _selectedState.SelectedInstance = instance;
-                    }
-                    else
-                    {
-                        _selectedState.SelectedElement = element;
-                    }
-                }
-            }
+            ContextMenuEvents.Add(action.Label, (sender, e) => action.Execute());
         }
     }
-
-    private void TryAddCopyVariableReferenceMenuOptions()
-    {
-        if (this.mVariableName != null && mVariableName != "Name" && mVariableName != "BaseType")
-        {
-            ContextMenuEvents.Add("Copy Qualified Variable Name", (sender, e) =>
-            {
-                if (ElementSave == null)
-                {
-                    return;
-                }
-
-                // No need to append the instance: mVariableName already contains the instance name when there
-                // is an instance.
-                var qualifiedName = _objectFinder.GetQualifiedElementName(ElementSave) + "." + mVariableName;
-
-                Clipboard.SetText(qualifiedName);
-            });
-        }
-
-
-        if (VariableSave != null && _deleteVariableLogic.CanDeleteVariable(this.VariableSave))
-        {
-            ContextMenuEvents.Add($"Delete Variable [{VariableSave.Name}]", (sender, e) =>
-            {
-                _deleteVariableLogic.DeleteVariable(this.VariableSave, this.ElementSave);
-            });
-        }
-    }
-
-    #region Expose/Unexpose
-
-    private void TryAddExposeVariableMenuOptions(InstanceSave instance)
-    {
-        bool canExpose = false;
-        bool canUnExpose = false;
-
-        if (this.VariableSave != null)
-        {
-            if (string.IsNullOrEmpty(VariableSave.ExposedAsName))
-            {
-                if (instance != null)
-                {
-                    canExpose = true;
-                }
-            }
-            else
-            {
-                canUnExpose = true;
-            }
-        }
-        else
-        {
-            var rootName = Gum.DataTypes.Variables.VariableSave.GetRootName(mVariableName);
-
-            var isVariableList = false;
-            if (instance?.ParentContainer != null)
-            {
-                var rootVariableList = _objectFinder.GetRootVariableList(mVariableName, instance.ParentContainer);
-                isVariableList = rootVariableList != null;
-            }
-
-            canExpose = !isVariableList && rootName != "Name" && rootName != "BaseType"
-                && instance != null;
-
-        }
-
-        if (canExpose)
-        {
-            // Variable doesn't exist, so they can only expose it, not unexpose it.
-            ContextMenuEvents.Add("Expose Variable", HandleExposeVariableClick);
-        }
-        if (canUnExpose)
-        {
-            ContextMenuEvents.Add($"Un-expose Variable {VariableSave.ExposedAsName} ({VariableSave.Name})", HandleUnexposeVariableClick);
-        }
-    }
-
-    private void HandleUnexposeVariableClick(object? sender, System.Windows.RoutedEventArgs e)
-    {
-        // Find this variable in the source instance and make it not exposed
-        VariableSave variableSave = this.VariableSave;
-
-        if (variableSave != null)
-        {
-            _exposeVariableService.HandleUnexposeVariableClick(VariableSave, ElementSave);
-        }
-    }
-
-    private void HandleExposeVariableClick(object? sender, System.Windows.RoutedEventArgs e)
-    {
-        _exposeVariableService.HandleExposeVariableClick(_selectedState.SelectedInstance,
-            this.RootVariableName);
-    }
-
-    #endregion
-
-    #region Hide from Instances
-
-    private void TryAddHideFromInstancesMenuOptions(InstanceSave? instanceSave, IStateContainer stateListCategoryContainer)
-    {
-        if (instanceSave != null)
-        {
-            return;
-        }
-
-        if (stateListCategoryContainer is not ComponentSave and not ScreenSave)
-        {
-            return;
-        }
-
-        if (RootVariableName == "Name" || RootVariableName == "BaseType")
-        {
-            return;
-        }
-
-        var element = stateListCategoryContainer as ElementSave;
-        var rootVariableName = RootVariableName;
-
-        if (element.VariablesHiddenFromInstances.Contains(rootVariableName))
-        {
-            ContextMenuEvents.Add("Show on Instances", (_, _) =>
-            {
-                using var undoLock = _undoManager.RequestLock();
-                element.VariablesHiddenFromInstances.Remove(rootVariableName);
-                _fileCommands.TryAutoSaveCurrentElement();
-                _guiCommands.RefreshVariables(force: true);
-            });
-        }
-        else
-        {
-            ContextMenuEvents.Add("Hide from Instances", (_, _) =>
-            {
-                using var undoLock = _undoManager.RequestLock();
-                element.VariablesHiddenFromInstances.Add(rootVariableName);
-                _fileCommands.TryAutoSaveCurrentElement();
-                _guiCommands.RefreshVariables(force: true);
-            });
-        }
-    }
-
-    #endregion
 
     #region Get Value
-    private object HandleCustomGet(object instance)
-    {
-        if (RootVariableName == "Name")
-        {
-            if ( instance is InstanceSave asInstanceSave)
-            {
-                return asInstanceSave.Name;
-            }
-            else if(instance is ElementSave elementSave)
-            {
-                // strip off prefixed folder name
-                if(elementSave.Name.Contains("/"))
-                {
-                    int slashIndex = elementSave.Name.LastIndexOf('/');
-                    return elementSave.Name.Substring(slashIndex + 1);
 
-                }
-                else
-                {
-                    return elementSave.Name;
-                }
-            }
-        }
-
-        // don't else if it, if name doesn't handle it, keep going:
-        if (RootVariableName == "BaseType" && instance is InstanceSave asInstanceForBehavior)
-        {
-            return asInstanceForBehavior.BaseType;
-        }
-        else if (_isVariable)
-        {
-            var toReturn = GetValueStrictlyOnSelectedState(instance);
-
-            if (toReturn == null)
-            {
-                var effectiveVariableName = VariableSave?.Name ?? mVariableName;
-
-                if (mStateSave != null)
-                {
-                    toReturn = mStateSave.GetValueRecursive(effectiveVariableName);
-                }
-            }
-
-            // Final tier: behavior-promoted FormsProperty defaults. When neither the
-            // selected state nor any inherited state authors a value, fall back to the
-            // declared FormsProperty.Value so the grid reflects the implicit default
-            // (e.g. IsEnabled = true) without polluting state. IsDefault remains true
-            // because nothing is explicitly authored.
-            if (toReturn == null)
-            {
-                toReturn = DefaultValueFallback?.Invoke();
-            }
-
-            return toReturn;
-        }
-        else
-        {
-            // October 8, 2023 - why wasn't this recursive?
-            //return mStateSave.GetValue(mVariableName);
-            var effectiveVariableName = VariableSave?.Name ?? mVariableName;
-
-            return mStateSave.GetValueRecursive(effectiveVariableName);
-        }
-    }
+    private object? HandleCustomGet(object instance) => _entry.GetValue(instance);
 
     #endregion
 
@@ -742,566 +247,32 @@ public class StateReferencingInstanceMember : InstanceMember
 
     private void HandleCustomSet(object gumElementOrInstanceSaveAsObject, SetPropertyArgs setPropertyArgs)
     {
-        ////////////////////Early Out/////////////////////////
-        if (!CanSetValue(gumElementOrInstanceSaveAsObject, setPropertyArgs))
+        var response = _entry.SetValue(gumElementOrInstanceSaveAsObject, setPropertyArgs.Value, MapCommitType(setPropertyArgs.CommitType));
+
+        if (!response.Succeeded)
         {
             setPropertyArgs.IsAssignmentCancelled = true;
-            return;
         }
-        /////////////////End Early Out////////////////////////
-
-        var stateSave = _selectedState.SelectedStateSave;
-        var instanceSave = gumElementOrInstanceSaveAsObject as InstanceSave;
-        var elementSave = instanceSave?.ParentContainer ?? gumElementOrInstanceSaveAsObject as ElementSave;
-
-        object newValue = setPropertyArgs.Value;
-        if (_isVariable)
-        {
-            StoreLastOldValue(setPropertyArgs, instanceSave, elementSave);
-            // <None> is a reserved 
-            // value for when we want
-            // to allow the user to reset
-            // a value through a combo box.
-            // If the value is "<None>" then 
-            // let's set it to null
-            if (newValue is "<None>")
-            {
-                newValue = null;
-            }
-
-
-            // the stateSave.SetValue method handles Name and Base Type internally just fine,
-            // but if we are on an instance in a behavior, that won't have a state save, so let's do that out here:
-            // Check for reserved names
-            // This is a variable on an instance
-            if (instanceSave != null && RootVariableName == "Name")
-            {
-                if(newValue is string newValueAsString)
-                {
-                    instanceSave.Name = newValueAsString;
-                }
-            }
-            else if(elementSave != null && RootVariableName == "Name")
-            {
-                if(newValue is string newValueAsString)
-                {
-                    if(elementSave.Name.Contains("/"))
-                    {
-                        var slash = elementSave.Name.LastIndexOf('/');
-                        var folder = elementSave.Name.Substring(0, slash + 1);
-
-                        elementSave.Name = folder + newValueAsString;
-
-                        // so that later logic can use the qualified name:
-                        newValue = elementSave.Name;
-                    }
-                    else
-                    {
-                        elementSave.Name = newValueAsString;
-                    }
-                }
-            }
-            else if (instanceSave != null && RootVariableName == "BaseType")
-            {
-                instanceSave.BaseType = newValue.ToString();
-            }
-            else if (stateSave != null && elementSave != null)
-            {
-                // If we are creating a new variable, we need to make sure it carries the same exposed
-                // name as the variable in base that defines it. We need to first get that variable...
-                VariableSave variableDefinedInThisOrBase = null;
-                var existingVariable = elementSave?.GetVariableFromThisOrBase(Name);
-                if (!string.IsNullOrEmpty(existingVariable?.ExposedAsName))
-                {
-                    variableDefinedInThisOrBase = GetVariableDefinedInThisOrBase(existingVariable);
-                }
-                string variableType = existingVariable?.Type ?? elementSave?.GetVariableFromThisOrBase(Name)?.Type;
-                if (string.IsNullOrEmpty(variableType))
-                {
-                    //variableType = this.PropertyType?.Name;
-                    var rootVariable = ObjectFinder.Self.GetRootVariable(this.Name, elementSave);
-                    variableType = rootVariable?.Type;
-                }
-                // ...set variable after getting it from base, or else we'd get the variable we just set...
-                stateSave.SetValue(Name, newValue, instanceSave, variableType);
-                if (!string.IsNullOrEmpty(existingVariable?.ExposedAsName) && variableDefinedInThisOrBase != null)
-                {
-                    //... then assign it here if we found it:
-                    var variable = stateSave.GetVariableSave(Name);
-                    variable.ExposedAsName = existingVariable.ExposedAsName;
-                }
-            }
-
-            var response = NotifyVariableLogic(gumElementOrInstanceSaveAsObject, setPropertyArgs.CommitType, trySave: setPropertyArgs.CommitType == SetPropertyCommitType.Full);
-
-            if (response.Succeeded == false)
-            {
-                setPropertyArgs.IsAssignmentCancelled = true;
-            }
-        }
-        else
-        {
-            StoreLastOldValue(setPropertyArgs, instanceSave, elementSave);
-
-            var existingVariable = elementSave?.GetVariableListFromThisOrBase(Name);
-            var type = existingVariable?.Type ?? TryGetTypeFromVariableListSave().ToString();
-            mStateSave.SetValue(mVariableName, newValue, instanceSave, type);
-
-            var response = NotifyVariableLogic(gumElementOrInstanceSaveAsObject, setPropertyArgs.CommitType, trySave: setPropertyArgs.CommitType == SetPropertyCommitType.Full);
-
-            if (response.Succeeded == false)
-            {
-                setPropertyArgs.IsAssignmentCancelled = true;
-            }
-        }
-    }
-
-    private void StoreLastOldValue(SetPropertyArgs setPropertyArgs, InstanceSave? instanceSave, ElementSave? elementSave)
-    {
-        object oldValue = base.Value;
-
-        if (elementSave != null && instanceSave == null && RootVariableName == "Name")
-        {
-            // We want to treat the old value as having folder because
-            // we display without the folder, but the actual name includes it:
-            oldValue = elementSave.Name;
-        }
-
-
-        if (setPropertyArgs.CommitType == SetPropertyCommitType.Full)
-        {
-            LastOldFullCommitValue = oldValue;
-
-            // if the value changes was a list, we want to store off a copy of it or else the modified 
-            // list will simply add to the existing list and later checks for equality will always return true:
-            if (oldValue is IList oldList)
-            {
-                var newList = Activator.CreateInstance(oldList.GetType()) as IList;
-
-                foreach (var item in oldList as IList)
-                {
-                    newList.Add(item);
-                }
-                LastOldFullCommitValue = newList;
-            }
-        }
-    }
-
-    private bool CanSetValue(object gumElementOrInstanceSaveAsObject, SetPropertyArgs setPropertyArgs)
-    {
-        if (this.RootVariableName == "Points")
-        {
-            var value = setPropertyArgs.Value as List<System.Numerics.Vector2>;
-
-            if (value?.Count < 4)
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     #endregion
 
     #region Set to default
-    public event Action<string> SetToDefault;
-    private void HandleSetToDefault(string obj)
-    {
-        string variableName = Name;
 
-        bool shouldReset = false;
-        bool affectsTreeView = false;
-
-        var selectedElement = _selectedState.SelectedElement;
-        var selectedInstance = _selectedState.SelectedInstance;
-
-        if (selectedInstance != null)
-        {
-            affectsTreeView = variableName == "Parent";
-            //variableName = _selectedState.SelectedInstance.Name + "." + variableName;
-
-            shouldReset = true;
-        }
-        else if (selectedElement != null)
-        {
-            shouldReset =
-                // Don't let the user reset standard element variables, they have to have some actual value
-                (selectedElement is StandardElementSave) == false ||
-                // ... unless it's not the default
-                _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState;
-        }
-
-        // now we reset, but we don't remove the variable:
-        //if(shouldReset)
-        //{
-        //    // If the variable is part of a category, then we don't allow setting the variable to default - they gotta do it through the cateory itself
-
-        //    if (isPartOfCategory)
-        //    {
-        //        var window = new DeletingVariablesInCategoriesMessageBox();
-        //        window.ShowDialog();
-
-        //        shouldReset = false;
-        //    }
-        //}
-
-        StateSave state = _selectedState.SelectedStateSave;
-        VariableSave variable = state?.GetVariableSave(variableName);
-        var oldValue = variable?.Value;
-        LastOldFullCommitValue = oldValue;
-
-        bool wasChangeMade = false;
-        if (shouldReset)
-        {
-            bool isPartOfCategory = StateSaveCategory != null;
-
-            if (variable != null)
-            {
-                // Don't remove the variable if it's part of an element - we still want it there
-                // so it can be set, we just don't want it to set a value
-                // Update August 13, 2013
-                // Actually, we do want to remove it if it's part of an element but not the
-                // default state
-                // Update October 17, 2017
-                // Now that components do not
-                // necessarily need to have all
-                // of their variables, we can remove
-                // the variable now. In fact, we should
-                //bool shouldRemove = _selectedState.SelectedInstance != null ||
-                //    _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState;
-                // Also, don't remove it if it's an exposed variable, this un-exposes things
-                bool shouldRemove = string.IsNullOrEmpty(variable.ExposedAsName) && !isPartOfCategory && !variable.IsCustomVariable;
-
-                // Update October 7, 2019
-                // Actually, we can remove any variable so long as the current state isn't the "base definition" for it
-                // For elements - no variables are the base variable definitions except for variables that are categorized
-                // state variables for categories defined in this element
-                if (shouldRemove)
-                {
-                    var isState = variable.IsState(selectedElement, out ElementSave categoryContainer, out StateSaveCategory categoryForVariable);
-
-                    if (isState)
-                    {
-                        var isDefinedHere = categoryForVariable != null && categoryContainer == selectedElement;
-
-                        shouldRemove = !isDefinedHere;
-                    }
-                }
-
-
-                if (shouldRemove)
-                {
-                    state.Variables.Remove(variable);
-                }
-                else if (isPartOfCategory)
-                {
-                    var variableInDefault = _selectedState.SelectedElement.DefaultState.GetVariableSave(variable.Name);
-                    if (variableInDefault != null)
-                    {
-                        _guiCommands.PrintOutput(
-                            $"The variable {variable.Name} is part of the category {StateSaveCategory.Name} so it cannot be removed. Instead, the value has been set to the value in the default state");
-
-                        variable.Value = variableInDefault.Value;
-                    }
-                    else
-                    {
-                        // If it's a state, we can un-set that back to null, that's okay:
-                        if (variable.IsState(selectedElement))
-                        {
-                            variable.Value = null;
-                            variable.SetsValue = true;
-                        }
-                        else
-                        {
-                            _guiCommands.PrintOutput("Could not set value to default because the default state doesn't set this value");
-
-                        }
-
-                    }
-
-                }
-                else
-                {
-                    variable.Value = null;
-                    variable.SetsValue = false;
-                }
-
-                wasChangeMade = true;
-                // We need to refresh the property grid and the wireframe display
-
-            }
-            else if ((obj == "BaseType") || (obj == "Base Type") && ElementSave != null)
-            {
-                ElementSave.BaseType = null;
-                wasChangeMade = true;
-            }
-            else
-            {
-                // Maybe this is a variable list?
-                VariableListSave variableList = state?.GetVariableListSave(variableName);
-                if (variableList != null)
-                {
-                    state.VariableLists.Remove(variableList);
-
-                    // We don't support this yet:
-                    // variableList.SetsValue = false; // just to be safe
-                    wasChangeMade = true;
-                }
-            }
-
-            if (selectedElement != null)
-            {
-                ElementSaveExtensions.ApplyVariableReferences(selectedElement, state);
-            }
-
-
-        }
-        else
-        {
-            IsDefault = false;
-        }
-
-        if (wasChangeMade)
-        {
-            _undoManager.RecordUndo();
-            _guiCommands.RefreshVariables(force: true);
-            _wireframeObjectManager.RefreshAll(true);
-
-            _pluginManager.VariableSet(selectedElement, selectedInstance, variableName, oldValue);
-
-            if (affectsTreeView)
-            {
-                _guiCommands.RefreshElementTreeView(_selectedState.SelectedElement);
-            }
-
-            _fileCommands.TryAutoSaveElement(_selectedState.SelectedElement);
-        }
-
-        var gumElementOrInstanceSaveAsObject = this.Instance;
-        NotifyVariableLogic(gumElementOrInstanceSaveAsObject, SetPropertyCommitType.Full, trySave: true);
-    }
+    public event Action<string>? SetToDefault;
+    private void HandleSetToDefault(string obj) => _entry.ResetToDefault();
 
     #endregion
 
-    private VariableSave GetVariableDefinedInThisOrBase(VariableSave existingVariable)
-    {
-        VariableSave variableDefinedInThisOrBase = null;
+    public GeneralResponse NotifyVariableLogic(object gumElementOrInstanceSaveAsObject, SetPropertyCommitType commitType, bool trySave = true) =>
+        _entry.NotifyVariableLogic(gumElementOrInstanceSaveAsObject, MapCommitType(commitType), trySave);
 
-        if (!string.IsNullOrEmpty(existingVariable?.ExposedAsName))
-        {
-            // need to set the exposed name on the variable, but only if it is defined in this component or in
-            // a base component:
+    private Type? HandleCustomGetType(object instance) => _entry.GetValueType(instance);
 
-            variableDefinedInThisOrBase = _selectedState.SelectedStateSave.GetVariableSave(Name);
-            if (variableDefinedInThisOrBase == null && _selectedState.SelectedStateSave != _selectedState.SelectedElement.DefaultState)
-            {
-                variableDefinedInThisOrBase = _selectedState.SelectedElement.DefaultState.GetVariableSave(Name);
-            }
+    public VariableSave? GetRootVariableSave() => _entry.GetRootVariableSave();
 
-            if (variableDefinedInThisOrBase == null)
-            {
-                var allBase = _objectFinder.GetBaseElements(_selectedState.SelectedElement);
-                foreach (var baseElement in allBase)
-                {
-                    variableDefinedInThisOrBase = baseElement.DefaultState.GetVariableSave(Name);
-                    if (variableDefinedInThisOrBase != null)
-                    {
-                        break;
-                    }
-                }
-            }
-        }
+    public Type? TryGetTypeFromVariableListSave() => _entry.TryGetTypeFromVariableListSave();
 
-        return variableDefinedInThisOrBase;
-    }
-
-    public GeneralResponse NotifyVariableLogic(object gumElementOrInstanceSaveAsObject, SetPropertyCommitType commitType, bool trySave = true)
-    {
-        GeneralResponse response = GeneralResponse.SuccessfulResponse;
-
-        string name = RootVariableName;
-
-        bool handledByExposedVariable = false;
-
-        bool effectiveRefresh = commitType == SetPropertyCommitType.Full || IsCallingRefresh;
-
-        bool effectiveRecordUndo = IsCallingRefresh && trySave;
-
-        // This might be a tunneled variable, and we want to react to the 
-        // change using the underlying variable if so:
-        if (gumElementOrInstanceSaveAsObject is ElementSave)
-        {
-            var elementSave = gumElementOrInstanceSaveAsObject as ElementSave;
-            var variable = elementSave.DefaultState.Variables
-                .FirstOrDefault(item => item.ExposedAsName == RootVariableName);
-            if (variable != null)
-            {
-                var sourceObjectName = variable.SourceObject;
-
-                name = variable.Name;
-                var instanceInElement = elementSave.Instances
-                    .FirstOrDefault(item => item.Name == sourceObjectName);
-
-                if (instanceInElement != null)
-                {
-                    handledByExposedVariable = true;
-
-                    _setVariableLogic.ReactToPropertyValueChanged(variable.GetRootName(), LastOldFullCommitValue, elementSave, instanceInElement, this.StateSave, refresh: effectiveRefresh, recordUndo: effectiveRecordUndo, isFullCommit: commitType == SetPropertyCommitType.Full);
-                }
-
-            }
-        }
-
-        if (!handledByExposedVariable)
-        {
-            var element = gumElementOrInstanceSaveAsObject as ElementSave ??
-                (gumElementOrInstanceSaveAsObject as InstanceSave)?.ParentContainer;
-
-            StateSave? stateToSet;
-
-            // If we are viewing the current element, then use the selected state so we can set
-            // values on categorized states...
-            if(_selectedState.SelectedElement == element && _selectedState.SelectedStateSave != null)
-            {
-                stateToSet = _selectedState.SelectedStateSave;
-            }
-            // ... otherwise, we may not be viewing the current element, like if we are doing a drag+drop...
-            else if(element != null)
-            {
-                stateToSet = element.DefaultState;
-            }
-            // ... otherwise, there is no valid state so don't do anythinhg:
-            else
-            {
-                stateToSet = null;
-            }
-
-            if(stateToSet != null)
-            {
-                response = _setVariableLogic.PropertyValueChanged(
-                    name,
-                    LastOldFullCommitValue,
-                    gumElementOrInstanceSaveAsObject as InstanceSave,
-                    stateToSet,
-                    refresh: effectiveRefresh,
-                    recordUndo: effectiveRecordUndo,
-                    trySave: trySave,
-                    isFullCommit: commitType == SetPropertyCommitType.Full);
-            }
-            else if (_selectedState.SelectedBehavior != null &&
-                     gumElementOrInstanceSaveAsObject is BehaviorInstanceSave behaviorInstance)
-            {
-                response = _setVariableLogic.PropertyValueChangedOnBehaviorInstance(
-                    name,
-                    LastOldFullCommitValue,
-                    _selectedState.SelectedBehavior,
-                    behaviorInstance);
-            }
-        }
-
-        return response;
-    }
-
-    private Type HandleCustomGetType(object instance)
-    {
-        if (_componentType != null)
-        {
-            if (_componentType == typeof(bool))
-            {
-                return typeof(bool);
-            }
-            else
-            {
-                return _componentType;
-            }
-        }
-        else if (_isVariable)
-        {
-            // componentType can be null for state variables or other types not recognized by TypeManager.
-            // Fall back to GetTypeFromVariableRecursively, matching the old behavior where PropertyType
-            // was string and ComponentType was null.
-            return GetTypeFromVariableRecursively();
-        }
-        else
-        {
-            return GetTypeFromVariableRecursively();
-        }
-    }
-
-#if GUM
-
-    private Type GetTypeFromVariableRecursively()
-    {
-        VariableSave variableSave = GetRootVariableSave();
-
-        if (variableSave?.Type != null)
-        {
-            return _typeManager.GetTypeFromString(variableSave.Type);
-        }
-        else
-        {
-            var variableType = TryGetTypeFromVariableListSave();
-            return variableType ??
-                typeof(string);
-        }
-    }
-
-    // Vic asks - why does this exist? Why aren't we using ObjectFinder?
-    public VariableSave GetRootVariableSave()
-    {
-        VariableSave variableSave = null;
-
-        if (InstanceSave != null)
-        {
-            if (InstanceSave.ParentContainer == null)
-            {
-                // this is an instance in a behavior
-                var elementBaseType = _objectFinder.GetElementSave(InstanceSave);
-
-                variableSave = elementBaseType?.GetVariableFromThisOrBase(RootVariableName);
-            }
-            else
-            {
-
-                variableSave = InstanceSave.GetVariableFromThisOrBase(
-                     new ElementWithState(InstanceSave.ParentContainer), RootVariableName);
-            }
-        }
-        else
-        {
-            variableSave = ElementSave.GetVariableFromThisOrBase(
-                RootVariableName);
-        }
-
-        return variableSave;
-    }
-
-    public Type TryGetTypeFromVariableListSave()
-    {
-        string typeName = null;
-
-        if (InstanceSave != null)
-        {
-            var variableList = InstanceSave?.GetVariableListFromThisOrBase(
-                InstanceSave.ParentContainer, RootVariableName);
-
-            typeName = variableList?.Type;
-        }
-        else
-        {
-            typeName = ElementSave.GetVariableListFromThisOrBase(RootVariableName)?.Type;
-        }
-
-        if (!string.IsNullOrEmpty(typeName))
-        {
-            return _typeManager.GetTypeFromString($"List<{typeName}>");
-        }
-        else
-        {
-            return null;
-        }
-    }
-#endif
-
+    private static VariablePropertyCommitType MapCommitType(SetPropertyCommitType commitType) =>
+        commitType == SetPropertyCommitType.Full ? VariablePropertyCommitType.Full : VariablePropertyCommitType.Intermediate;
 }

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -186,7 +186,6 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IAnimationUndoProviderRegistrar>(provider => provider.GetRequiredService<AnimationUndoProviderRelay>());
         services.AddSingleton<EditVariableService>();
         services.AddSingleton<IEditVariableService>(provider => provider.GetRequiredService<EditVariableService>());
-        services.AddSingleton<IEditVariableMenuService>(provider => provider.GetRequiredService<EditVariableService>());
         services.AddSingleton<IDeleteVariableService, DeleteVariableService>();
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();
         services.AddSingleton<IDragDropManager, DragDropManager>();

--- a/Gum/Services/EditVariableService.cs
+++ b/Gum/Services/EditVariableService.cs
@@ -18,25 +18,10 @@ using System.Threading.Tasks;
 using Gum.Commands;
 using Gum.Services.Dialogs;
 using Gum.Undo;
-using WpfDataUi.DataTypes;
 
 namespace Gum.Services;
 
-#region Interface
-
-/// <summary>
-/// Wires edit-variable options onto an <see cref="InstanceMember"/>'s context menu (WpfDataUi row
-/// model). Split out of <see cref="IEditVariableService"/> because <see cref="InstanceMember"/>
-/// lives in the WPF-coupled WpfDataUi assembly, so this piece must stay in the tool project while
-/// the rest of the interface moved to the headless Gum.Presentation assembly (ADR-0005, #3754).
-/// </summary>
-public interface IEditVariableMenuService
-{
-    void TryAddEditVariableOptions(InstanceMember instanceMember, VariableSave variableSave, IStateContainer stateListCategoryContainer);
-}
-#endregion
-
-public class EditVariableService : IEditVariableService, IEditVariableMenuService
+public class EditVariableService : IEditVariableService
 {
     private readonly IRenameLogic _renameLogic;
     private readonly IDialogService _dialogService;
@@ -58,17 +43,6 @@ public class EditVariableService : IEditVariableService, IEditVariableMenuServic
         _fileCommands = fileCommands;
         _undoManager = undoManager;
         _addVariableViewModelFactory = addVariableViewModelFactory;
-    }
-
-    public void TryAddEditVariableOptions(InstanceMember instanceMember, VariableSave variableSave, IStateContainer stateListCategoryContainer)
-    {
-        if (GetEditVariableMenuLabel(variableSave, stateListCategoryContainer) is { } label)
-        {
-            instanceMember.ContextMenuEvents.Add(label, (sender, e) =>
-            {
-                ShowEditVariableWindow(variableSave, stateListCategoryContainer);
-            });
-        }
     }
 
     /// <summary>

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
@@ -1,4 +1,3 @@
-﻿using FlatRedBall.Glue.StateInterpolation;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
@@ -6,6 +5,7 @@ using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
+using Gum.PropertyGridHelpers.Converters;
 using Gum.Reflection;
 using Gum.Services;
 using Gum.ToolStates;
@@ -17,6 +17,8 @@ using Shouldly;
 using System;
 using System.ComponentModel;
 using ToolsUtilities;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
 
 namespace GumToolUnitTests.VariableGrid;
 
@@ -24,50 +26,157 @@ public class StateReferencingInstanceMemberTests
 {
     private readonly AutoMocker _mocker;
 
-    StateReferencingInstanceMember _sut;
+    private StateReferencingInstanceMember CreateSut(
+        Attribute[] attributes,
+        TypeConverter? converter,
+        Type? componentType,
+        StateSave stateSave,
+        string variableName,
+        IStateContainer container)
+    {
+        return new StateReferencingInstanceMember(
+            attributes,
+            converter,
+            componentType,
+            false,
+            false,
+            true,
+            stateSave,
+            null,
+            variableName,
+            null,
+            container,
+            _mocker.Get<ISelectedState>(),
+            _mocker.Get<IUndoManager>(),
+            _mocker.Get<IGuiCommands>(),
+            _mocker.Get<IFileCommands>(),
+            _mocker.Get<ISetVariableLogic>(),
+            _mocker.Get<IWireframeObjectManager>(),
+            _mocker.Get<IPluginManager>(),
+            _mocker.Get<IHotkeyManager>(),
+            _mocker.Get<IDeleteVariableService>(),
+            _mocker.Get<IExposeVariableService>(),
+            _mocker.Get<IEditVariableService>(),
+            _mocker.Get<ITypeManager>(),
+            _mocker.Get<IClipboardService>());
+    }
 
     public StateReferencingInstanceMemberTests()
     {
         _mocker = new();
+    }
+
+    /// <summary>
+    /// The ctor's standard-variable lookup walks ObjectFinder.Self.GumProjectSave.AllElements, so a
+    /// real ComponentSave used as the row's container needs to be registered there for a
+    /// custom-variable's ObjectFinder.GetContainerOf call to resolve instead of throwing.
+    /// </summary>
+    private static ComponentSave CreateComponent(string name)
+    {
+        ComponentSave component = new ComponentSave { Name = name };
+        component.States.Add(new StateSave());
+        component.DefaultState.ParentContainer = component;
+
+        ObjectFinder.Self.GumProjectSave ??= new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave.Components.Add(component);
+
+        return component;
+    }
+
+    [Fact]
+    public void PreferredDisplayer_ShouldMapToComboBoxDisplay_WhenConverterProvidesStandardValues()
+    {
+        ComponentSave componentSave = CreateComponent("PreferredDisplayerComboBoxComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("testVariableName", "A");
+
+        var sut = CreateSut(
+            Array.Empty<Attribute>(),
+            new AvailableStatesConverter(category: "", _mocker.Get<ISelectedState>()),
+            typeof(string),
+            stateSave,
+            "testVariableName",
+            componentSave);
+
+        sut.PreferredDisplayer.ShouldBe(typeof(ComboBoxDisplay));
+    }
+
+    [Fact]
+    public void PreferredDisplayer_ShouldPassThroughExplicitOverride_WhenSet()
+    {
+        ComponentSave componentSave = CreateComponent("PreferredDisplayerOverrideComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("testVariableName", 3);
+
+        var sut = CreateSut(Array.Empty<Attribute>(), null, typeof(int), stateSave, "testVariableName", componentSave);
+
+        // SliderDisplay isn't one of VariableDisplayerKind's known mapped types, so an explicit
+        // override must pass through unchanged rather than collapse to Default:
+        sut.PreferredDisplayer = typeof(SliderDisplay);
+
+        sut.PreferredDisplayer.ShouldBe(typeof(SliderDisplay));
+    }
+
+    [Fact]
+    public void SetValue_ShouldMapFullCommitType_WhenCommitTypeIsFull()
+    {
+        ComponentSave componentSave = CreateComponent("SetValueFullCommitComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("testVariableName", 3);
+
+        Mock<ISetVariableLogic> setVariableLogic = _mocker.GetMock<ISetVariableLogic>();
+        setVariableLogic
+            .Setup(x => x.PropertyValueChanged(It.IsAny<string>(), It.IsAny<object?>(),
+                It.IsAny<InstanceSave>(), It.IsAny<StateSave>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(GeneralResponse.SuccessfulResponse);
+
+        var sut = CreateSut(Array.Empty<Attribute>(), null, typeof(int), stateSave, "testVariableName", componentSave);
+        sut.Instance = componentSave;
+
+        sut.SetValue(1, SetPropertyCommitType.Full);
+
+        setVariableLogic.Verify(x => x.PropertyValueChanged(
+            "testVariableName", It.IsAny<object?>(), null, stateSave, true, true, true, true), Times.Once);
+    }
+
+    [Fact]
+    public void SetValue_ShouldMapIntermediateCommitType_WhenCommitTypeIsIntermediate()
+    {
+        ComponentSave componentSave = CreateComponent("SetValueIntermediateCommitComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("testVariableName", 3);
+
+        Mock<ISetVariableLogic> setVariableLogic = _mocker.GetMock<ISetVariableLogic>();
+        setVariableLogic
+            .Setup(x => x.PropertyValueChanged(It.IsAny<string>(), It.IsAny<object?>(),
+                It.IsAny<InstanceSave>(), It.IsAny<StateSave>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(GeneralResponse.SuccessfulResponse);
+
+        var sut = CreateSut(Array.Empty<Attribute>(), null, typeof(int), stateSave, "testVariableName", componentSave);
+        sut.Instance = componentSave;
+
+        sut.SetValue(1, SetPropertyCommitType.Intermediate);
+
+        setVariableLogic.Verify(x => x.PropertyValueChanged(
+            "testVariableName", It.IsAny<object?>(), null, stateSave, true, false, false, false), Times.Once);
+    }
+
+    [Fact]
+    public void SetValue_ShouldStoreLastValue()
+    {
         StateSave stateSave = new StateSave();
         stateSave.SetValue("testVariableName", 3);
 
         Mock<ISetVariableLogic> setVariableLogic = _mocker.GetMock<ISetVariableLogic>();
         setVariableLogic
             .Setup(x => x.PropertyValueChanged(It.IsAny<string>(), It.IsAny<object?>(),
-                It.IsAny<InstanceSave>(), It.IsAny<StateSave>() , It.IsAny<bool>() , It.IsAny<bool>(),
+                It.IsAny<InstanceSave>(), It.IsAny<StateSave>(), It.IsAny<bool>(), It.IsAny<bool>(),
                 It.IsAny<bool>(), It.IsAny<bool>()))
             .Returns(GeneralResponse.SuccessfulResponse);
 
-        _sut = new StateReferencingInstanceMember(
-            new Attribute[0],
-            null,
-            typeof(int),
-            false,
-            false,
-            true,
-            stateSave,
-            null,
-            "testVariableName",
-            null,
-            _mocker.Get<IStateContainer>(),
-            _mocker.Get<IUndoManager>(),
-            _mocker.Get<IEditVariableMenuService>(),
-            _mocker.Get<IExposeVariableService>(),
-            _mocker.Get<IHotkeyManager>(),
-            _mocker.Get<IDeleteVariableService>(),
-            _mocker.Get<ISelectedState>(),
-            _mocker.Get<IGuiCommands>(),
-            _mocker.Get<IFileCommands>(),
-            setVariableLogic.Object,
-            _mocker.Get<IWireframeObjectManager>(),
-            _mocker.Get<ITypeManager>(),
-            _mocker.Get<IPluginManager>());
-    }
-
-    [Fact]
-    public void SetValue_ShouldStoreLastValue()
-    {
+        var sut = CreateSut(Array.Empty<Attribute>(), null, typeof(int), stateSave, "testVariableName", _mocker.Get<IStateContainer>());
 
         ComponentSave componentSave = new ComponentSave();
         componentSave.States.Add(new StateSave
@@ -75,9 +184,9 @@ public class StateReferencingInstanceMemberTests
 
         });
 
-        _sut.Instance = componentSave;
+        sut.Instance = componentSave;
 
-        _sut.SetValue(1, WpfDataUi.DataTypes.SetPropertyCommitType.Full);
-        _sut.LastOldFullCommitValue.ShouldBe(3);
+        sut.SetValue(1, WpfDataUi.DataTypes.SetPropertyCommitType.Full);
+        sut.LastOldFullCommitValue.ShouldBe(3);
     }
 }

--- a/Tools/Gum.Presentation/Services/IEditVariableService.cs
+++ b/Tools/Gum.Presentation/Services/IEditVariableService.cs
@@ -5,9 +5,9 @@ namespace Gum.Services;
 
 /// <summary>
 /// Determines how a variable can be edited and opens the corresponding editing UI. See
-/// <see cref="Gum.Services.EditVariableService"/> for the concrete implementation (tool project)
-/// and <c>IEditVariableMenuService</c> for the WpfDataUi-coupled counterpart that wires this into a
-/// variable row's context menu.
+/// <see cref="Gum.Services.EditVariableService"/> for the concrete implementation (tool project).
+/// <see cref="Gum.Plugins.InternalPlugins.VariableGrid.VariableGridEntry"/> wires this into a
+/// variable row's context menu via <c>GetEditVariableMenuLabel</c>/<c>ShowEditVariableWindow</c>.
 /// </summary>
 public interface IEditVariableService
 {


### PR DESCRIPTION
## Summary

PR 2/3 of the variable-grid decoupling (#3860). `StateReferencingInstanceMember` is now a thin WPF adapter over `VariableGridEntry` (the headless heir added additive-only in #3872) instead of duplicating its decision logic.

- Still derives from `WpfDataUi.DataTypes.InstanceMember` (required for the live grid), but every decision (`GetValue`/`SetValue`/`ResetToDefault`/`NotifyVariableLogic`/context-menu building) now forwards to a held `VariableGridEntry`, translating only at the WPF boundary:
  - `VariableDisplayerKind` <-> `Type` (`PreferredDisplayer`, including pass-through for an explicit override that isn't one of the mapped WpfDataUi control types - e.g. `SliderDisplay` - since the enum mapping is otherwise lossy for those)
  - `VariablePropertyCommitType` <-> `WpfDataUi.DataTypes.SetPropertyCommitType`
  - `VariableContextMenuAction` -> `InstanceMember.ContextMenuEvents`
- Kept directly on the adapter (no headless equivalent): the go-to-definition `KeyDown` wiring and `HandleUiCreated(UserControl)`.
- `ElementSaveDisplayer`'s 3 `StateReferencingInstanceMember` construction call sites now pass `IEditVariableService`/`IClipboardService` instead of `IEditVariableMenuService` (already-injected on `PropertyGridManager`, no new bridges). Since `VariableGridEntry.BuildContextMenuActions` already replaces `IEditVariableMenuService.TryAddEditVariableOptions`, removed that now-dead interface/method and its `Builder.cs` registration.

## Tests

- Rewrote `StateReferencingInstanceMemberTests.cs`: updated ctor call, plus 4 new pinning tests for the WPF-boundary translations (`PreferredDisplayer` Kind<->Type mapping including explicit-override pass-through, commit-type mapping to `isFullCommit`).
- Mutation-tested `MapCommitType` (forced `Full` regardless of input, confirmed the Intermediate-commit test went red, reverted).
- `GumToolUnitTests`: 1120 passed, 0 failed (includes `AllPluginsCompositionTests`/`ServiceProviderCompositionSpikeTests`, confirming DI/MEF composition still resolves after the `IEditVariableMenuService` removal).
- `Gum.Presentation.Tests`: 455 passed.

## Manual test

Needed - this rewires the live Variables tab's editing path. See PR comment / issue #3860 for steps (editing values, undo/redo, reset-to-default, expose/hide-from-instances, delete-variable menu).

## Known limitation (not a regression risk in practice)

The adapter's inherited `InstanceMember.DisplayName` and `VariableGridEntry`'s own `DisplayName` field start identical but aren't kept in sync afterward (base `DisplayName` isn't virtual, so the adapter can't forward it). `VariableGridEntry.ResetToDefault()`'s `DisplayName == "BaseType"`/`"Base Type"` check reads its own copy. In practice no call site overrides `DisplayName` for a `BaseType` row (only `IsSlot`/`Default Slot` get custom display names today), so this doesn't affect current behavior - flagging for visibility, not fixing preemptively.

Closes: part of #3860 (not closing the issue - PR 3 relocating `ElementSaveDisplayer` + `CompositeMemberLogic`/`StateSaveCategoryDisplayer`/`BehaviorShowingLogic`/`CategorySortAndColorLogic` is still needed).
