### PR TITLE
Clear ProjectManager's remaining WPF/WinForms blockers, part of #3863

### DIFF
--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -12,41 +12,6 @@ using Gum.Services.Fonts;
 
 namespace Gum.CommandLine
 {
-    /// <summary>
-    /// Parses the process command-line arguments and exposes the resulting startup intent
-    /// (which project/element to load, whether to code-gen or rebuild fonts, and whether the
-    /// tool should exit immediately rather than show its window).
-    /// </summary>
-    public interface ICommandLineManager
-    {
-        /// <summary>
-        /// The .gumx project the command line requested be loaded, or null if none was specified.
-        /// </summary>
-        string GlueProjectToLoad { get; }
-
-        /// <summary>
-        /// True when the command line requested an immediate exit after processing (for example a
-        /// headless code-gen or font rebuild), so the tool should not run its main window loop.
-        /// </summary>
-        bool ShouldExitImmediately { get; }
-
-        /// <summary>
-        /// True when the command line requested code generation for the whole project.
-        /// </summary>
-        bool ShouldCodeGenAll { get; }
-
-        /// <summary>
-        /// The element the command line requested be selected after load, or null if none was specified.
-        /// </summary>
-        string ElementName { get; }
-
-        /// <summary>
-        /// Parses the process command-line arguments (<see cref="Environment.GetCommandLineArgs"/>)
-        /// and populates this manager's properties accordingly.
-        /// </summary>
-        Task ReadCommandLine();
-    }
-
     /// <inheritdoc cref="ICommandLineManager"/>
     public class CommandLineManager : ICommandLineManager
     {

--- a/Gum/Managers/ProjectManager.cs
+++ b/Gum/Managers/ProjectManager.cs
@@ -52,6 +52,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     // IProjectManager — deferring it breaks the construction cycle, same as _commandLineManager above.
     private readonly Lazy<IHotkeyManager> _hotkeyManager;
     private readonly IGumProjectRepairLogic _gumProjectRepairLogic;
+    private readonly IFilePickingFolderProvider _filePickingFolderProvider;
 
     #endregion
 
@@ -60,9 +61,10 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     public GumProjectSave? GumProjectSave => _gumProjectSave;
 
     /// <summary>
-    /// The full settings object, including the WinForms-typed members (<c>MainWindowBounds</c>,
-    /// <c>MainWindowState</c>) that keep it out of <see cref="IProjectManager"/>'s headless surface.
-    /// Concrete-only; interface consumers use the narrowed members below instead.
+    /// The full settings object. Concrete-only -- <see cref="IProjectManager"/> intentionally exposes
+    /// only the narrowed members below instead of this whole object. <see cref="Gum.Settings.GeneralSettingsFile"/>
+    /// is no longer WinForms-typed itself (see <see cref="Gum.Settings.LegacyMainWindowState"/>), but the
+    /// narrowed surface is kept as the smaller, encapsulated contract for headless consumers.
     /// </summary>
     public GeneralSettingsFile GeneralSettingsFile
     {
@@ -127,7 +129,8 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         Lazy<ICommandLineManager> commandLineManager,
         IPluginManager pluginManager,
         Lazy<IHotkeyManager> hotkeyManager,
-        IGumProjectRepairLogic gumProjectRepairLogic)
+        IGumProjectRepairLogic gumProjectRepairLogic,
+        IFilePickingFolderProvider filePickingFolderProvider)
     {
         _selectedState = selectedState;
         _elementCommands = elementCommands;
@@ -142,6 +145,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         _pluginManager = pluginManager;
         _hotkeyManager = hotkeyManager;
         _gumProjectRepairLogic = gumProjectRepairLogic;
+        _filePickingFolderProvider = filePickingFolderProvider;
         // Default settings until LoadSettings() replaces this with the loaded (or newly-created)
         // file. Avoids a null-before-load window that every narrowed IProjectManager member above
         // would otherwise need to guard against (some plugins read these before LoadSettings runs -
@@ -285,7 +289,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
         ObjectFinder.Self.GumProjectSave = _gumProjectSave;
 
-        WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo = fileName.GetDirectoryContainingThis().FullPath;
+        _filePickingFolderProvider.FolderRelativeTo = fileName.GetDirectoryContainingThis().FullPath;
 
         if (_gumProjectSave != null)
         {
@@ -314,7 +318,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
                     }
                 }
                 _standardElementsManagerGumTool.FixCustomTypeConverters(_gumProjectSave);
-                RecreateMissingStandardElements();
+                RecreateMissingStandardElements(_gumProjectSave);
 
                 if (RecreateMissingDefinedByBaseObjects())
                 {
@@ -356,7 +360,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
             GraphicalUiElement.ShowLineRectangles = _gumProjectSave.ShowOutlines;
 
-            CopyLinkedComponents();
+            CopyLinkedComponents(_gumProjectSave);
 
             if (_gumProjectRepairLogic.FixRecursiveAssignments(_gumProjectSave))
             {
@@ -429,9 +433,9 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         }
     }
 
-    private void CopyLinkedComponents()
+    internal void CopyLinkedComponents(GumProjectSave gumProjectSave)
     {
-        var gumDirectory = new FilePath(_gumProjectSave.FullFileName).GetDirectoryContainingThis();
+        var gumDirectory = new FilePath(gumProjectSave.FullFileName).GetDirectoryContainingThis();
 
         void CopyReference(ElementReference reference)
         {
@@ -452,26 +456,26 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
             }
         }
 
-        foreach (var reference in _gumProjectSave.ScreenReferences)
+        foreach (var reference in gumProjectSave.ScreenReferences)
         {
             CopyReference(reference);
         }
 
-        foreach (var reference in _gumProjectSave.ComponentReferences)
+        foreach (var reference in gumProjectSave.ComponentReferences)
         {
             CopyReference(reference);
         }
 
-        foreach (var reference in _gumProjectSave.StandardElementReferences)
+        foreach (var reference in gumProjectSave.StandardElementReferences)
         {
             CopyReference(reference);
         }
     }
 
-    internal void RecreateMissingStandardElements()
+    internal void RecreateMissingStandardElements(GumProjectSave gumProjectSave)
     {
         List<StandardElementSave> missingElements = new List<StandardElementSave>();
-        foreach (var element in _gumProjectSave.StandardElements)
+        foreach (var element in gumProjectSave.StandardElements)
         {
             if (element.IsSourceFileMissing)
             {
@@ -500,14 +504,14 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
             if (result)
             {
-                _gumProjectSave.StandardElements.RemoveAll(item => item.Name == element.Name);
-                _gumProjectSave.StandardElementReferences.RemoveAll(item => item.Name == element.Name);
+                gumProjectSave.StandardElements.RemoveAll(item => item.Name == element.Name);
+                gumProjectSave.StandardElementReferences.RemoveAll(item => item.Name == element.Name);
 
-                StandardElementsManager.Self.AddStandardElementSaveInstance(_gumProjectSave, element.Name);
+                StandardElementsManager.Self.AddStandardElementSaveInstance(gumProjectSave, element.Name);
 
-                string gumProjectDirectory = FileManager.GetDirectory(_gumProjectSave.FullFileName);
+                string gumProjectDirectory = FileManager.GetDirectory(gumProjectSave.FullFileName);
 
-                _gumProjectSave.SaveStandardElements(gumProjectDirectory);
+                gumProjectSave.SaveStandardElements(gumProjectDirectory);
             }
         }
 
@@ -726,7 +730,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
                 GumProjectSave.FullFileName = chosenFileName!;
                 var filePath = new FilePath(chosenFileName!);
                 _pluginManager.ProjectLocationSet(filePath);
-                WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo = filePath.GetDirectoryContainingThis().FullPath;
+                _filePickingFolderProvider.FolderRelativeTo = filePath.GetDirectoryContainingThis().FullPath;
 
                 shouldSave = true;
                 isProjectNew = true;

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -133,6 +133,7 @@ file static class ServiceCollectionExtensions
         // RenameAllReferencesTo. Resolves to the same ProjectManager singleton.
         services.AddSingleton<IRenameProjectProvider>(provider => provider.GetRequiredService<ProjectManager>());
         services.AddSingleton<ICommandLineManager, CommandLineManager>();
+        services.AddSingleton<IFilePickingFolderProvider, FilePickingFolderProvider>();
         services.AddSingleton<IProjectState, ProjectState>();
         // ElementTreeViewManager: drained from a static Self singleton (#3286). Concrete is needed for the
         // Initialize() call in Program.cs (two-stage initialization); no interface is extracted because it is a

--- a/Gum/Services/FilePickingFolderProvider.cs
+++ b/Gum/Services/FilePickingFolderProvider.cs
@@ -1,0 +1,12 @@
+using WpfDataUi.Controls;
+
+namespace Gum.Services;
+
+/// <inheritdoc cref="IFilePickingFolderProvider"/>
+public class FilePickingFolderProvider : IFilePickingFolderProvider
+{
+    public string FolderRelativeTo
+    {
+        set => FilePickingLogic.FolderRelativeTo = value;
+    }
+}

--- a/Gum/Services/RetryService.cs
+++ b/Gum/Services/RetryService.cs
@@ -3,21 +3,6 @@ using System.Threading;
 
 namespace Gum.Services;
 
-/// <summary>
-/// Retries an action that may transiently fail (for example, writing to disk), swallowing
-/// intermediate exceptions and rethrowing only if every attempt fails.
-/// </summary>
-public interface IRetryService
-{
-    /// <summary>
-    /// Performs the argument action multiple times, swallowing exceptions every time except the last.
-    /// This can be used to perform operations which may fail from time to time, like writing to disk.
-    /// </summary>
-    /// <param name="action">The action to perform.</param>
-    /// <param name="numberOfTimesToTry">The number of times to try.</param>
-    void TryMultipleTimes(Action action, int numberOfTimesToTry = 5);
-}
-
 /// <inheritdoc cref="IRetryService"/>
 public class RetryService : IRetryService
 {

--- a/Tests/Gum.Presentation.Tests/GeneralSettingsFileLegacyWindowStateTests.cs
+++ b/Tests/Gum.Presentation.Tests/GeneralSettingsFileLegacyWindowStateTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Xml.Serialization;
+using Gum.Settings;
+using Shouldly;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins that an older <c>GeneralSettings.xml</c> written while <see cref="GeneralSettingsFile"/>
+/// .MainWindowState was still <c>System.Windows.Forms.FormWindowState</c> continues to deserialize
+/// correctly now that the property is typed as the neutral <see cref="LegacyMainWindowState"/>
+/// instead -- <see cref="XmlSerializer"/> round-trips an enum by its member name, so this only holds
+/// because the two enums' member names match exactly.
+/// </summary>
+public class GeneralSettingsFileLegacyWindowStateTests
+{
+    [Theory]
+    [InlineData("Normal", LegacyMainWindowState.Normal)]
+    [InlineData("Minimized", LegacyMainWindowState.Minimized)]
+    [InlineData("Maximized", LegacyMainWindowState.Maximized)]
+    public void MainWindowState_DeserializesFromLegacyXmlValue(string xmlValue, LegacyMainWindowState expected)
+    {
+        string xml = $"<GeneralSettingsFile><MainWindowState>{xmlValue}</MainWindowState></GeneralSettingsFile>";
+        XmlSerializer serializer = new XmlSerializer(typeof(GeneralSettingsFile));
+        using StringReader reader = new StringReader(xml);
+
+        GeneralSettingsFile settings = (GeneralSettingsFile)serializer.Deserialize(reader)!;
+
+        settings.MainWindowState.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void MainWindowState_DefaultsToNormal_WhenAbsentFromXml()
+    {
+        string xml = "<GeneralSettingsFile></GeneralSettingsFile>";
+        XmlSerializer serializer = new XmlSerializer(typeof(GeneralSettingsFile));
+        using StringReader reader = new StringReader(xml);
+
+        GeneralSettingsFile settings = (GeneralSettingsFile)serializer.Deserialize(reader)!;
+
+        settings.MainWindowState.ShouldBe(LegacyMainWindowState.Normal);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/LayoutSettingsTests.cs
+++ b/Tests/Gum.Presentation.Tests/LayoutSettingsTests.cs
@@ -1,0 +1,60 @@
+using System.Drawing;
+using Gum.Settings;
+using Shouldly;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="LayoutSettings.MigrateLegacyLayout"/>, pinning the
+/// one-time migration of the legacy <see cref="GeneralSettingsFile"/> window bounds/state into the
+/// newer <see cref="WindowSettings"/> shape.
+/// </summary>
+public class LayoutSettingsTests
+{
+    [Fact]
+    public void MigrateLegacyLayout_DoesNotChangeSettings_WhenLegacyBoundsAreDefault()
+    {
+        GeneralSettingsFile legacySettings = new GeneralSettingsFile();
+        LayoutSettings settings = new LayoutSettings();
+        WindowSettings originalWindow = settings.MainWindow;
+
+        LayoutSettings.MigrateLegacyLayout(legacySettings, settings);
+
+        settings.MainWindow.ShouldBe(originalWindow);
+    }
+
+    [Fact]
+    public void MigrateLegacyLayout_SetsIsMaximizedTrue_WhenLegacyStateIsMaximized()
+    {
+        GeneralSettingsFile legacySettings = new GeneralSettingsFile
+        {
+            MainWindowBounds = new Rectangle(10, 20, 1280, 720),
+            MainWindowState = LegacyMainWindowState.Maximized
+        };
+        LayoutSettings settings = new LayoutSettings();
+
+        LayoutSettings.MigrateLegacyLayout(legacySettings, settings);
+
+        settings.MainWindow.IsMaximized.ShouldBeTrue();
+        settings.MainWindow.Width.ShouldBe(1280);
+        settings.MainWindow.Height.ShouldBe(720);
+        settings.MainWindow.Left.ShouldBe(10);
+        settings.MainWindow.Top.ShouldBe(20);
+    }
+
+    [Fact]
+    public void MigrateLegacyLayout_SetsIsMaximizedFalse_WhenLegacyStateIsNormal()
+    {
+        GeneralSettingsFile legacySettings = new GeneralSettingsFile
+        {
+            MainWindowBounds = new Rectangle(0, 0, 1024, 768),
+            MainWindowState = LegacyMainWindowState.Normal
+        };
+        LayoutSettings settings = new LayoutSettings();
+
+        LayoutSettings.MigrateLegacyLayout(legacySettings, settings);
+
+        settings.MainWindow.IsMaximized.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ProjectManagerTests.cs
@@ -38,6 +38,7 @@ public class ProjectManagerTests : BaseTestClass
     private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<IHotkeyManager> _hotkeyManager;
     private readonly Mock<IGumProjectRepairLogic> _gumProjectRepairLogic;
+    private readonly Mock<IFilePickingFolderProvider> _filePickingFolderProvider;
     private readonly ProjectManager _projectManager;
 
     public ProjectManagerTests()
@@ -55,6 +56,7 @@ public class ProjectManagerTests : BaseTestClass
         _pluginManager = new Mock<IPluginManager>();
         _hotkeyManager = new Mock<IHotkeyManager>();
         _gumProjectRepairLogic = new Mock<IGumProjectRepairLogic>();
+        _filePickingFolderProvider = new Mock<IFilePickingFolderProvider>();
 
         _projectManager = new ProjectManager(
             _selectedState.Object,
@@ -69,7 +71,8 @@ public class ProjectManagerTests : BaseTestClass
             new Lazy<ICommandLineManager>(() => _commandLineManager.Object),
             _pluginManager.Object,
             new Lazy<IHotkeyManager>(() => _hotkeyManager.Object),
-            _gumProjectRepairLogic.Object);
+            _gumProjectRepairLogic.Object,
+            _filePickingFolderProvider.Object);
     }
 
     [Fact]
@@ -171,6 +174,108 @@ public class ProjectManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void AskUserForProjectNameIfNecessary_SetsFilePickingFolderRelativeTo_WhenUserChoosesEmptyFolder()
+    {
+        SetCurrentProject(new GumProjectSave());
+
+        string tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "GumProjectManagerTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            string chosenFile = Path.Combine(tempDirectory, "NewProject.gumx");
+            _dialogService
+                .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+                .Returns(chosenFile);
+
+            bool shouldSave = _projectManager.AskUserForProjectNameIfNecessary(out bool isProjectNew);
+
+            shouldSave.ShouldBeTrue();
+            isProjectNew.ShouldBeTrue();
+            string normalizedTempDirectory = tempDirectory.Replace('\\', '/');
+            _filePickingFolderProvider.VerifySet(
+                p => p.FolderRelativeTo = It.Is<string>(s => s.Replace('\\', '/').Contains(normalizedTempDirectory)),
+                Times.Once);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyLinkedComponents_CopiesFile_WhenLinkTypeIsCopyLocally()
+    {
+        string tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "GumProjectManagerTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        Directory.CreateDirectory(Path.Combine(tempDirectory, "Components"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDirectory, "Source.gucx"), "source contents");
+
+            GumProjectSave project = new GumProjectSave
+            {
+                FullFileName = Path.Combine(tempDirectory, "Project.gumx")
+            };
+            project.ComponentReferences.Add(new ElementReference
+            {
+                ElementType = ElementType.Component,
+                LinkType = LinkType.CopyLocally,
+                Name = "Copied",
+                Link = "Source.gucx"
+            });
+
+            _projectManager.CopyLinkedComponents(project);
+
+            string destination = Path.Combine(tempDirectory, "Components", "Copied.gucx");
+            File.Exists(destination).ShouldBeTrue();
+            File.ReadAllText(destination).ShouldBe("source contents");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyLinkedComponents_PrintsError_WhenSourceFileIsMissing()
+    {
+        string tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "GumProjectManagerTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        Directory.CreateDirectory(Path.Combine(tempDirectory, "Components"));
+
+        try
+        {
+            GumProjectSave project = new GumProjectSave
+            {
+                FullFileName = Path.Combine(tempDirectory, "Project.gumx")
+            };
+            project.ComponentReferences.Add(new ElementReference
+            {
+                ElementType = ElementType.Component,
+                LinkType = LinkType.CopyLocally,
+                Name = "Missing",
+                Link = "DoesNotExist.gucx"
+            });
+
+            Should.NotThrow(() => _projectManager.CopyLinkedComponents(project));
+
+            _guiCommands.Verify(g => g.PrintOutput(It.Is<string>(m => m.StartsWith("Error"))), Times.Once);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void LoadProject_LoadsAndReturnsTrue_WhenFileChosen()
     {
         string chosenFile = "c:/projects/MyGame.gumx";
@@ -206,14 +311,13 @@ public class ProjectManagerTests : BaseTestClass
         // single informational message instead.
         GumProjectSave project = new GumProjectSave();
         project.StandardElements.Add(new StandardElementSave { Name = "Arc", IsSourceFileMissing = true });
-        SetCurrentProject(project);
 
         // Simulate the user clicking "Yes" on any recreate prompt -- the pre-fix crash path.
         _dialogService
             .Setup(d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s != null)))
             .Returns(MessageDialogResult.Affirmative);
 
-        Should.NotThrow(() => _projectManager.RecreateMissingStandardElements());
+        Should.NotThrow(() => _projectManager.RecreateMissingStandardElements(project));
 
         // No Yes/No prompt (the only call with a non-null style) is offered for a plugin standard.
         _dialogService.Verify(
@@ -238,13 +342,12 @@ public class ProjectManagerTests : BaseTestClass
         // shows no plugin-standard informational message.
         GumProjectSave project = new GumProjectSave();
         project.StandardElements.Add(new StandardElementSave { Name = "Sprite", IsSourceFileMissing = true });
-        SetCurrentProject(project);
 
         _dialogService
             .Setup(d => d.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.Is<MessageDialogStyle?>(s => s != null)))
             .Returns(MessageDialogResult.Negative);
 
-        _projectManager.RecreateMissingStandardElements();
+        _projectManager.RecreateMissingStandardElements(project);
 
         // The Yes/No recreate prompt (non-null style) is offered for a built-in standard...
         _dialogService.Verify(

--- a/Tools/Gum.Presentation/CommandLine/ICommandLineManager.cs
+++ b/Tools/Gum.Presentation/CommandLine/ICommandLineManager.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+
+namespace Gum.CommandLine;
+
+/// <summary>
+/// Parses the process command-line arguments and exposes the resulting startup intent
+/// (which project/element to load, whether to code-gen or rebuild fonts, and whether the
+/// tool should exit immediately rather than show its window). See
+/// <see cref="Gum.CommandLine.CommandLineManager"/> for the concrete implementation (tool project).
+/// </summary>
+public interface ICommandLineManager
+{
+    /// <summary>
+    /// The .gumx project the command line requested be loaded, or null if none was specified.
+    /// </summary>
+    string GlueProjectToLoad { get; }
+
+    /// <summary>
+    /// True when the command line requested an immediate exit after processing (for example a
+    /// headless code-gen or font rebuild), so the tool should not run its main window loop.
+    /// </summary>
+    bool ShouldExitImmediately { get; }
+
+    /// <summary>
+    /// True when the command line requested code generation for the whole project.
+    /// </summary>
+    bool ShouldCodeGenAll { get; }
+
+    /// <summary>
+    /// The element the command line requested be selected after load, or null if none was specified.
+    /// </summary>
+    string ElementName { get; }
+
+    /// <summary>
+    /// Parses the process command-line arguments (<see cref="System.Environment.GetCommandLineArgs"/>)
+    /// and populates this manager's properties accordingly.
+    /// </summary>
+    Task ReadCommandLine();
+}

--- a/Tools/Gum.Presentation/Services/IFilePickingFolderProvider.cs
+++ b/Tools/Gum.Presentation/Services/IFilePickingFolderProvider.cs
@@ -1,0 +1,14 @@
+namespace Gum.Services;
+
+/// <summary>
+/// Sets the base folder used to resolve relative paths in file-picking controls (e.g. "reveal in
+/// Explorer" on a file-selection property). Abstracts the WPF-typed
+/// <c>WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo</c> static so consumers can set it
+/// without referencing <c>WpfDataUi</c> (ADR-0005). See
+/// <see cref="Gum.Services.FilePickingFolderProvider"/> for the concrete implementation (tool project).
+/// </summary>
+public interface IFilePickingFolderProvider
+{
+    /// <summary>The base directory relative-path resolution should use.</summary>
+    string FolderRelativeTo { set; }
+}

--- a/Tools/Gum.Presentation/Services/IRetryService.cs
+++ b/Tools/Gum.Presentation/Services/IRetryService.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Gum.Services;
+
+/// <summary>
+/// Retries an action that may transiently fail (for example, writing to disk), swallowing
+/// intermediate exceptions and rethrowing only if every attempt fails. See
+/// <see cref="Gum.Services.RetryService"/> for the concrete implementation (tool project).
+/// </summary>
+public interface IRetryService
+{
+    /// <summary>
+    /// Performs the argument action multiple times, swallowing exceptions every time except the last.
+    /// This can be used to perform operations which may fail from time to time, like writing to disk.
+    /// </summary>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="numberOfTimesToTry">The number of times to try.</param>
+    void TryMultipleTimes(Action action, int numberOfTimesToTry = 5);
+}

--- a/Tools/Gum.Presentation/Settings/GeneralSettingsFile.cs
+++ b/Tools/Gum.Presentation/Settings/GeneralSettingsFile.cs
@@ -1,16 +1,10 @@
-﻿using Gum;
-using Gum.Dialogs;
-using Gum.Settings;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
-using System.Windows.Forms;
 using System.Xml.Serialization;
-using CommunityToolkit.Mvvm.Messaging;
 using ToolsUtilities;
 
 namespace Gum.Settings
@@ -89,7 +83,13 @@ namespace Gum.Settings
             set;
         }
 
-        public FormWindowState MainWindowState
+        /// <summary>
+        /// Legacy main-window maximize/minimize state, read from an older <c>GeneralSettings.xml</c>
+        /// on load and migrated once into <see cref="Settings.WindowSettings.IsMaximized"/> (see
+        /// <c>LayoutSettings.MigrateLegacyLayout</c>). See <see cref="LegacyMainWindowState"/> for
+        /// why this isn't <c>System.Windows.Forms.FormWindowState</c> anymore.
+        /// </summary>
+        public LegacyMainWindowState MainWindowState
         {
             get;
             set;

--- a/Tools/Gum.Presentation/Settings/LayoutSettings.cs
+++ b/Tools/Gum.Presentation/Settings/LayoutSettings.cs
@@ -15,7 +15,7 @@ public class LayoutSettings
                 Height = legacySettings.MainWindowBounds.Height,
                 Left = legacySettings.MainWindowBounds.Left,
                 Top = legacySettings.MainWindowBounds.Top,
-                IsMaximized = legacySettings.MainWindowState == System.Windows.Forms.FormWindowState.Maximized
+                IsMaximized = legacySettings.MainWindowState == LegacyMainWindowState.Maximized
             };
         }
     }

--- a/Tools/Gum.Presentation/Settings/LegacyMainWindowState.cs
+++ b/Tools/Gum.Presentation/Settings/LegacyMainWindowState.cs
@@ -1,0 +1,18 @@
+namespace Gum.Settings;
+
+/// <summary>
+/// Mirrors <c>System.Windows.Forms.FormWindowState</c>'s member names exactly (<c>Normal</c>,
+/// <c>Minimized</c>, <c>Maximized</c>) so a <c>GeneralSettings.xml</c> file written by an older
+/// version of the tool (which serialized the real WinForms enum) keeps deserializing correctly --
+/// <see cref="System.Xml.Serialization.XmlSerializer"/> round-trips an enum by its member name, not
+/// its underlying integer value, so matching names is sufficient. This neutral copy exists purely so
+/// <see cref="GeneralSettingsFile"/> can live in the headless Gum.Presentation assembly (ADR-0005);
+/// it is read only once, by <c>LayoutSettings.MigrateLegacyLayout</c>, to migrate the legacy value
+/// into <c>WindowSettings.IsMaximized</c>. Never written by current code.
+/// </summary>
+public enum LegacyMainWindowState
+{
+    Normal,
+    Minimized,
+    Maximized
+}

--- a/Tools/Gum.Presentation/Settings/ThemeSettingsMigration.cs
+++ b/Tools/Gum.Presentation/Settings/ThemeSettingsMigration.cs
@@ -5,13 +5,11 @@ namespace Gum.Settings;
 
 /// <summary>
 /// One-time migration of legacy per-channel theme colors (<see cref="GeneralSettingsFile"/>) into
-/// the newer <see cref="ThemeSettings"/> shape. Kept in the Gum tool project rather than moved
-/// alongside <see cref="ThemeSettings"/> into the headless Gum.Presentation assembly (ADR-0005),
-/// since <see cref="GeneralSettingsFile"/> is WinForms-entangled and can't move with it.
+/// the newer <see cref="ThemeSettings"/> shape (ADR-0005).
 /// </summary>
-internal static class ThemeSettingsMigration
+public static class ThemeSettingsMigration
 {
-    internal static void MigrateExplicitLegacyColors(GeneralSettingsFile settings, ThemeSettings themeSettings)
+    public static void MigrateExplicitLegacyColors(GeneralSettingsFile settings, ThemeSettings themeSettings)
     {
         ThemeDefaultsProvider defaults = new();
         Color checker1Old = Color.FromArgb(settings.CheckerColor1R, settings.CheckerColor1G, settings.CheckerColor1B);

--- a/Tools/Gum.Presentation/Settings/WindowSettings.cs
+++ b/Tools/Gum.Presentation/Settings/WindowSettings.cs
@@ -2,10 +2,10 @@ namespace Gum.Settings;
 
 /// <summary>
 /// Relocated from <c>Gum/Settings/LayoutSettings.cs</c> (part of #3856) — pure data records, no WPF
-/// dependency. <see cref="LayoutSettings"/> itself stays in <c>Gum.csproj</c> because
-/// <c>LayoutSettings.MigrateLegacyLayout</c> reads WinForms-typed legacy settings
-/// (<c>GeneralSettingsFile.MainWindowBounds</c>/<c>MainWindowState</c>). Pure file-location move:
-/// namespace and members are unchanged, so no consumer needed an import change.
+/// dependency. Pure file-location move: namespace and members are unchanged, so no consumer needed
+/// an import change. <see cref="LayoutSettings"/> itself has since relocated alongside these records
+/// once <c>GeneralSettingsFile.MainWindowState</c> stopped being WinForms-typed (see
+/// <see cref="LegacyMainWindowState"/>).
 /// </summary>
 public record WindowSettings(
     double Width = 1280,


### PR DESCRIPTION
Part of #3863.

Clears every remaining blocker found in the prior scoping/repair pass (#3873) on `Gum/Managers/ProjectManager.cs`:

- **`WpfDataUi.Controls.FilePickingLogic.FolderRelativeTo`** (2 call sites) — replaced with a new `IFilePickingFolderProvider` seam (WPF-side impl stays in `Gum.csproj`).
- **`ICommandLineManager`/`IRetryService`** — interfaces relocated into `Gum.Presentation`, concrete implementations stay tool-side.
- **`GeneralSettingsFile`** — was blocking the concrete `ProjectManager` class from moving because its `MainWindowState` property was typed `System.Windows.Forms.FormWindowState`. Converted to a neutral `LegacyMainWindowState` enum (member names match exactly, so `XmlSerializer` — which round-trips enums by name, not integer value — still deserializes an older `GeneralSettings.xml` correctly). `MainWindowBounds` keeps `System.Drawing.Rectangle`, which isn't `UseWPF`/`UseWindowsForms`-gated, so it didn't need converting. `GeneralSettingsFile`, `LayoutSettings`, and `ThemeSettingsMigration` all relocated into `Gum.Presentation` alongside this fix.
- **`CopyLinkedComponents`/`RecreateMissingStandardElements`** — now take `GumProjectSave` as a parameter instead of reading `_gumProjectSave` off the field (mechanical, unblocks testing/reuse independent of instance state).

**Remaining scope for #3863:** `ProjectManager.cs` itself is still physically in `Gum/Managers/` — every known blocker is now clear, so the next slice is the physical move + `Gum.csproj` exclusion + `Gum.Presentation` inclusion. Leaving the issue open for that.

Tests: `Gum.Presentation.Tests` 462/462, `GumToolUnitTests` 1119/1121 (2 pre-existing skips), `GumFull.sln` builds clean.

Manual test: not needed — behavior-preserving relocation/parameterization, proven by build + full test suite (including `ServiceProviderCompositionSpikeTests`, which resolves the real DI container).
