### PR TITLE
Port gamepad IGamePad navigation and stick-scroll to FRB

### DIFF
--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -31,6 +31,9 @@ using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using BindableGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
 using GamepadButton = FlatRedBall.Input.Xbox360GamePad.Button;
+// Duck-typed alias (same trick as GamepadButton/Buttons above) so gamepad-handling method
+// bodies can be written once instead of duplicated per platform under #if FRB.
+using GamePadForNavigation = FlatRedBall.Input.Xbox360GamePad;
 namespace FlatRedBall.Forms.Controls;
 #else
 // Non-FRB branch. These Forms control files compile exactly once — into GumCommon
@@ -41,6 +44,7 @@ namespace FlatRedBall.Forms.Controls;
 // The Forms abstraction lives in Gum.Input / Gum.Forms.Input.
 using Gum.Input;
 using Keys = Gum.Forms.Input.Keys;
+using GamePadForNavigation = Gum.Input.IGamePad;
 #endif
 
 
@@ -1124,11 +1128,7 @@ public class FrameworkElement : INotifyPropertyChanged
     /// </summary>
     public bool IsUsingLeftAndRightGamepadDirectionsForNavigation { get; set; } = true;
 
-#if FRB
-    protected void HandleGamepadNavigation(Xbox360GamePad gamepad)
-#else
-    protected void HandleGamepadNavigation(IGamePad gamepad)
-#endif
+    protected void HandleGamepadNavigation(GamePadForNavigation gamepad)
     {
         if (gamepad.ButtonRepeatRate(GamepadButton.DPadDown) ||
             (IsUsingLeftAndRightGamepadDirectionsForNavigation && gamepad.ButtonRepeatRate(GamepadButton.DPadRight)) ||

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -2035,11 +2035,9 @@ public class ListBox : ItemsControl, IInputReceiver
 
             HandleGamepadNavigation(gamepad);
 
-#if !FRB
             // Shared with ScrollViewer.DoTopLevelFocusUpdate so the right-stick scroll code
             // isn't duplicated between the two copies (issue #3839).
             ApplyGamepadStickScroll(gamepad);
-#endif
 
             if (gamepad.ButtonPushed(GamepadButton.A))
             {

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -16,11 +16,17 @@ using FlatRedBall.Gui;
 using FlatRedBall.Input;
 using InteractiveGue = global::Gum.Wireframe.GraphicalUiElement;
 using Buttons = FlatRedBall.Input.Xbox360GamePad.Button;
+// Duck-typed alias (same trick as GamepadButton/Buttons above) so gamepad-handling method
+// bodies can be written once instead of duplicated per platform under #if FRB.
+using GamePadForNavigation = FlatRedBall.Input.Xbox360GamePad;
+using AnalogStickForScroll = FlatRedBall.Input.AnalogStick;
 namespace FlatRedBall.Forms.Controls;
 #else
 using Gum.Input;
 using GamepadButton = Gum.Input.GamepadButton;
 using Keys = Gum.Forms.Input.Keys;
+using GamePadForNavigation = Gum.Input.IGamePad;
+using AnalogStickForScroll = Gum.Input.IAnalogStick;
 #endif
 
 #if !FRB
@@ -198,14 +204,12 @@ public class ScrollViewer :
     /// </remarks>
     public double MouseWheelScrollSpeed { get; set; } = 30;
 
-#if !FRB
     /// <summary>
     /// Units per second that <see cref="VerticalScrollBarValue"/> changes when the gamepad's
     /// right stick is fully deflected vertically (scaled linearly for partial deflection).
     /// Defaults to 600.
     /// </summary>
     public double GamepadStickScrollSpeed { get; set; } = 600;
-#endif
 
     /// <summary>
     /// The vertical scroll bar value. Assigning this automatically scrolls
@@ -1088,9 +1092,7 @@ public class ScrollViewer :
 
             HandleGamepadNavigation(gamepad);
 
-#if !FRB
             ApplyGamepadStickScroll(gamepad);
-#endif
 
             if (gamepad.ButtonPushed(GamepadButton.A))
             {
@@ -1138,7 +1140,6 @@ public class ScrollViewer :
 #endif
     }
 
-#if !FRB
     // Elapsed-time source for ApplyGamepadStickScroll, so scroll speed is frame-rate independent.
     // Null until the first call so the initial frame only records a baseline instead of jumping
     // by a spurious large delta.
@@ -1150,10 +1151,27 @@ public class ScrollViewer :
     /// separate <c>DoTopLevelFocusUpdate</c> copies don't each need their own stick-scroll code.
     /// Horizontal (X) scrolling is not wired up yet.
     /// </summary>
-    protected void ApplyGamepadStickScroll(IGamePad gamepad)
+    public void ApplyGamepadStickScroll(GamePadForNavigation gamepad) =>
+        ApplyGamepadStickScroll(gamepad.RightStick);
+
+    /// <summary>
+    /// Applies continuous vertical scrolling from <paramref name="stick"/>, scaled by elapsed
+    /// time. Call this directly — instead of relying on the automatic per-frame loop over
+    /// <see cref="FrameworkElement.GamePadsForUiControl"/> — when a specific gamepad's stick
+    /// should drive this specific control every frame regardless of focus, e.g. one gamepad
+    /// permanently paired with one <see cref="ListBox"/> in a split-input UI (Gum's Forms
+    /// system has a single global focus, not one focus per gamepad).
+    /// </summary>
+    public void ApplyGamepadStickScroll(AnalogStickForScroll stick)
     {
         var currentTime = InteractiveGue.CurrentGameTime;
-        var y = gamepad.RightStick.Y;
+        // FlatRedBall.Input.AnalogStick implements I2DInput.X/Y explicitly (not as public
+        // members), unlike Gum.Input.IAnalogStick where Y is a plain public property.
+#if FRB
+        var y = ((FlatRedBall.Input.I2DInput)stick).Y;
+#else
+        var y = stick.Y;
+#endif
 
         if (y != 0 && _lastGamepadStickScrollTime.HasValue)
         {
@@ -1166,7 +1184,6 @@ public class ScrollViewer :
 
         _lastGamepadStickScrollTime = currentTime;
     }
-#endif
 
     private void DoItemFocusUpdate()
     {


### PR DESCRIPTION
## Summary
- Collapse `FrameworkElement.HandleGamepadNavigation`'s duplicate `Xbox360GamePad`/`IGamePad` overloads into one, via a duck-typed `GamePadForNavigation` alias (same pattern as the existing `GamepadButton`/`Buttons` aliases).
- Port `ScrollViewer.ApplyGamepadStickScroll` (right-stick scroll) to FRB — was `#if !FRB`-only.
- Split it into a gamepad-level and a stick-level overload, both now public, so a control can be driven directly by a specific gamepad's stick (needed for split-input UIs where each gamepad owns its own control, since Gum's Forms focus is global/single).
- `ListBox` picks both up via `ItemsControl : ScrollViewer`.

## Test plan
- [x] Built `GumCommon/GumCommon.csproj` (non-FRB) — 0 errors
- [x] Built FlatRedBall's `FlatRedBall.Forms.DesktopGlNet6.csproj` canary (FRB, both net6.0/net8.0 TFMs) — 0 errors