### PR TITLE
Extract plugin-enablement persistence out of PluginManager (Avalonia north-star scoping)

### DIFF
--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -60,7 +60,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 {
     #region Fields
 
-    static PluginSettingsSave mPluginSettingsSave = new PluginSettingsSave();
+    private readonly IPluginEnablementStore _pluginEnablementStore;
 
     private List<Assembly> mExternalAssemblies = new List<Assembly>();
     private List<string> mReferenceListInternal = new List<string>();
@@ -100,14 +100,6 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
     #endregion
 
     #region Properties
-
-    static string PluginSettingsSaveFileName
-    {
-        get
-        {
-            return FileManager.UserApplicationDataForThisApplication + "GumPluginSettings.xml";
-        }
-    }
 
     [Export("LocalizationService")]
     public LocalizationService LocalizationService => Locator.GetRequiredService<LocalizationService>();
@@ -733,9 +725,17 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 
     #region Additional Methods
 
-    public PluginManager()
+    // [ImportingConstructor] is required, not just decorative: PluginManager's own assembly is added
+    // to LoadPlugins' AggregateCatalog (see CreateCatalog), and the class exports a member
+    // ("LocalizationService" below), which makes MEF treat PluginManager itself as an implicit part it
+    // must activate - a *second*, throwaway instance distinct from the DI-built singleton bridged as
+    // IPluginManager. That activation only reads the parameterless-safe LocalizationService property,
+    // never _pluginEnablementStore, but MEF still needs a satisfiable constructor to build it, hence
+    // both the attribute and the IPluginEnablementStore bridge in LoadPlugins below.
+    [ImportingConstructor]
+    public PluginManager(IPluginEnablementStore pluginEnablementStore)
     {
-
+        _pluginEnablementStore = pluginEnablementStore;
     }
 
 
@@ -746,28 +746,15 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
         _dialogService = Locator.GetRequiredService<IDialogService>();
 
         _messenger.Register<AfterUndoMessage>(this, (_, _) => AfterUndo());
-        LoadPluginSettings();
+        _pluginEnablementStore.Load();
         LoadPlugins(this);
         mInstances.Add(this);
         mGlobalInstance = this;
     }
 
-    private void LoadPluginSettings()
-    {
-
-        if (System.IO.File.Exists(PluginSettingsSaveFileName))
-        {
-            mPluginSettingsSave = PluginSettingsSave.Load(PluginSettingsSaveFileName);
-        }
-        else
-        {
-            mPluginSettingsSave = new PluginSettingsSave();
-        }
-    }
-
     public void SavePluginSettings()
     {
-        FileManager.XmlSerialize(mPluginSettingsSave, PluginSettingsSaveFileName);
+        _pluginEnablementStore.Save();
     }
 
     private void LoadReferenceLists()
@@ -845,6 +832,10 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             AggregateCatalog catalog = instance.CreateCatalog();
 
             var batch = new CompositionBatch();
+            // PluginManager's own [ImportingConstructor] dep (#3880): MEF activates PluginManager itself
+            // as an implicit part (see the ctor's comment), so its ctor param must be bridged like any
+            // plugin dependency even though PluginManager is not a PluginBase.
+            batch.AddExportedValue<IPluginEnablementStore>(Locator.GetRequiredService<IPluginEnablementStore>());
             batch.AddExportedValue<ISelectedState>(Locator.GetRequiredService<ISelectedState>());
             batch.AddExportedValue<IElementCommands>(Locator.GetRequiredService<IElementCommands>());
             batch.AddExportedValue<IUndoManager>(Locator.GetRequiredService<IUndoManager>());
@@ -1089,7 +1080,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
                 plugin.UniqueId = plugin.GetType().FullName;
 
 
-                if (!mPluginSettingsSave.DisabledPlugins.Contains(plugin.UniqueId))
+                if (!instance._pluginEnablementStore.IsDisabled(plugin.UniqueId))
                 {
 
                     plugin.StartUp();
@@ -1285,11 +1276,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 
         if (shutDownReason == PluginShutDownReason.UserDisabled)
         {
-            if (!mPluginSettingsSave.DisabledPlugins.Contains(pluginToShutDown.UniqueId))
-            {
-                mPluginSettingsSave.DisabledPlugins.Add(pluginToShutDown.UniqueId);
-                mPluginSettingsSave.Save(PluginSettingsSaveFileName);
-            }
+            mGlobalInstance._pluginEnablementStore.Disable(pluginToShutDown.UniqueId);
         }
 
         return doesPluginWantToShutDown;
@@ -1297,8 +1284,7 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 
     internal static void ReenablePlugin(IPlugin pluginToReenable)
     {
-        if (mPluginSettingsSave.DisabledPlugins.Remove(pluginToReenable.UniqueId))
-            mPluginSettingsSave.Save(PluginSettingsSaveFileName);
+        mGlobalInstance._pluginEnablementStore.Enable(pluginToReenable.UniqueId);
     }
 
     /// <inheritdoc/>

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -94,8 +94,14 @@ file static class ServiceCollectionExtensions
 
         // static singletons
         services.AddSingleton<IObjectFinder>(ObjectFinder.Self);
-        // PluginManager: drained from a static Self singleton (#3291). DI-constructed (empty ctor); Initialize()
-        // (Program.cs) does the heavy two-stage setup and registers the global instance for the static plugin machinery.
+        // PluginEnablementStore: the user-disabled-plugins persistence PluginManager used to own via a
+        // static field (#3880) - genuinely relocatable (plain string plugin ids, no MEF/WinForms types),
+        // so it lives in the headless Gum.Presentation assembly even though PluginManager itself stays
+        // tool-side.
+        services.AddSingleton<IPluginEnablementStore, PluginEnablementStore>();
+        // PluginManager: drained from a static Self singleton (#3291). DI-constructed (lightweight ctor
+        // taking only IPluginEnablementStore); Initialize() (Program.cs) does the heavy two-stage setup
+        // and registers the global instance for the static plugin machinery.
         services.AddSingleton<PluginManager>();
         services.AddSingleton<IPluginManager>(provider => provider.GetRequiredService<PluginManager>());
         // IUndoPluginNotifier: narrow headless port (ADR-0005 Phase 3) so UndoManager no longer depends on the

--- a/Tests/Gum.Presentation.Tests/PluginEnablementStoreTests.cs
+++ b/Tests/Gum.Presentation.Tests/PluginEnablementStoreTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using Gum.Plugins;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) test for PluginEnablementStore, extracted out of PluginManager's
+/// static mPluginSettingsSave field/LoadPluginSettings/SavePluginSettings/ShutDownPlugin/
+/// ReenablePlugin logic (#3880) so plugin-enablement persistence is testable independent of the
+/// MEF composition machinery PluginManager itself owns.
+/// </summary>
+public class PluginEnablementStoreTests : IDisposable
+{
+    private readonly string _fileName = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xml");
+
+    public void Dispose()
+    {
+        if (File.Exists(_fileName))
+        {
+            File.Delete(_fileName);
+        }
+    }
+
+    [Fact]
+    public void IsDisabled_ReturnsFalse_WhenNoFileExistsYet()
+    {
+        PluginEnablementStore store = new(_fileName);
+
+        store.Load();
+
+        store.IsDisabled("SomePlugin").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Disable_PersistsAcrossReload()
+    {
+        PluginEnablementStore store = new(_fileName);
+        store.Load();
+
+        store.Disable("SomePlugin");
+
+        PluginEnablementStore reloaded = new(_fileName);
+        reloaded.Load();
+        reloaded.IsDisabled("SomePlugin").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Disable_CalledTwice_DoesNotDuplicateEntry()
+    {
+        PluginEnablementStore store = new(_fileName);
+        store.Load();
+
+        store.Disable("SomePlugin");
+        store.Disable("SomePlugin");
+        // A single Enable() call only removes one occurrence - if Disable() had duplicated the entry
+        // (no Contains guard), a duplicate would survive and IsDisabled would still report true here.
+        store.Enable("SomePlugin");
+
+        store.IsDisabled("SomePlugin").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Enable_RemovesPreviouslyDisabledPlugin_AndPersists()
+    {
+        PluginEnablementStore store = new(_fileName);
+        store.Load();
+        store.Disable("SomePlugin");
+
+        store.Enable("SomePlugin");
+
+        PluginEnablementStore reloaded = new(_fileName);
+        reloaded.Load();
+        reloaded.IsDisabled("SomePlugin").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Enable_WhenNotDisabled_DoesNotCreateFile()
+    {
+        PluginEnablementStore store = new(_fileName);
+        store.Load();
+
+        store.Enable("SomePlugin");
+
+        File.Exists(_fileName).ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -43,6 +43,9 @@ internal static class PluginBridgedServiceTypes
 {
     internal static readonly Type[] All =
     {
+        // PluginManager's own [ImportingConstructor] dep (#3880) - bridged because PluginManager itself
+        // is an implicit MEF part (see its ctor's comment), not because it's a plugin.
+        typeof(IPluginEnablementStore),
         typeof(ISelectedState),
         typeof(IElementCommands),
         typeof(IUndoManager),

--- a/Tools/Gum.Presentation/Plugins/IPluginEnablementStore.cs
+++ b/Tools/Gum.Presentation/Plugins/IPluginEnablementStore.cs
@@ -1,0 +1,30 @@
+namespace Gum.Plugins;
+
+/// <summary>
+/// Tracks which plugins the user has disabled, persisting the choice to disk across sessions.
+/// Plugin identity crosses this seam as a plain <see cref="string"/> unique id, so this interface
+/// (and its implementation) has no MEF/WinForms dependency and can live in the headless
+/// Gum.Presentation assembly - unlike <see cref="PluginManager"/> itself, which legitimately stays
+/// tool-side because it owns the live MEF composition machinery.
+/// </summary>
+public interface IPluginEnablementStore
+{
+    /// <summary>
+    /// Loads the persisted disabled-plugin list from disk, or starts empty if no file exists yet.
+    /// Must be called once (mirrors the tool's two-stage init pattern) before the other members are
+    /// meaningful.
+    /// </summary>
+    void Load();
+
+    /// <summary>Whether the given plugin was previously disabled by the user.</summary>
+    bool IsDisabled(string pluginUniqueId);
+
+    /// <summary>Marks the given plugin disabled and persists the change. Idempotent.</summary>
+    void Disable(string pluginUniqueId);
+
+    /// <summary>Marks the given plugin enabled and persists the change. Idempotent.</summary>
+    void Enable(string pluginUniqueId);
+
+    /// <summary>Re-persists the current state unconditionally.</summary>
+    void Save();
+}

--- a/Tools/Gum.Presentation/Plugins/PluginEnablementStore.cs
+++ b/Tools/Gum.Presentation/Plugins/PluginEnablementStore.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using Gum.DataTypes;
+using ToolsUtilities;
+
+namespace Gum.Plugins;
+
+/// <inheritdoc cref="IPluginEnablementStore"/>
+public class PluginEnablementStore : IPluginEnablementStore
+{
+    private readonly string _fileName;
+    private PluginSettingsSave _settings = new();
+
+    /// <summary>Persists to the default per-user Gum plugin settings file.</summary>
+    public PluginEnablementStore() : this(DefaultFileName)
+    {
+    }
+
+    /// <summary>Persists to the given file - mainly for tests that need an isolated file.</summary>
+    public PluginEnablementStore(string fileName)
+    {
+        _fileName = fileName;
+    }
+
+    private static string DefaultFileName =>
+        FileManager.UserApplicationDataForThisApplication + "GumPluginSettings.xml";
+
+    public void Load()
+    {
+        _settings = File.Exists(_fileName)
+            ? PluginSettingsSave.Load(_fileName)
+            : new PluginSettingsSave();
+    }
+
+    public bool IsDisabled(string pluginUniqueId) =>
+        _settings.DisabledPlugins.Contains(pluginUniqueId);
+
+    public void Disable(string pluginUniqueId)
+    {
+        if (!_settings.DisabledPlugins.Contains(pluginUniqueId))
+        {
+            _settings.DisabledPlugins.Add(pluginUniqueId);
+            Save();
+        }
+    }
+
+    public void Enable(string pluginUniqueId)
+    {
+        if (_settings.DisabledPlugins.Remove(pluginUniqueId))
+        {
+            Save();
+        }
+    }
+
+    public void Save() => _settings.Save(_fileName);
+}


### PR DESCRIPTION
## Summary

Scoped `Gum/Plugins/PluginManager.cs` (~1343 lines) against the Avalonia north-star test. Classification:

- **(a) Genuinely relocatable — done.** Disabled-plugins persistence (the static `PluginSettingsSave` field, its load/save, and the enable/disable/is-disabled checks in `Initialize`/`StartupPlugin`/`ShutDownPlugin`/`ReenablePlugin`) was a plain string-keyed concern with zero MEF/WinForms typing. Extracted into `IPluginEnablementStore`/`PluginEnablementStore` in the headless `Gum.Presentation` assembly, injected into `PluginManager`'s constructor.
- **(b) Convertible but not worth it.** `PluginFolder` reads `System.Windows.Forms.Application.ExecutablePath`; could swap to `Environment.ProcessPath` (already the pattern used elsewhere in this file), but its only consumer is `CreateCatalog`, itself MEF-only — no independent value to relocating it alone.
- **(c) Genuinely stuck (the expected bulk).** Everything else is real MEF-composition/plugin-hosting machinery per the north-star's own scope boundary: the `CallMethodOnPlugin` dispatch family and all `Call*` notification methods (operate over `PluginBase`/`IPlugin`/`PluginContainer`), `LoadPlugins`/`CreateCatalog`/`CreateResilientCatalog`/`currentDomain_AssemblyResolve` (MEF catalog/composition), `StartupPlugin`/`ShutDownPlugin`/`ReenablePlugin`'s lifecycle bodies, `ShouldExclude` (iterates live `PluginBase` instances), and the already-deliberately-shaped `GetWorldCursorPosition`/`FillWithErrors`/`GetAllPluginSummaries`/`DisableUserPlugin`/`TryEnablePlugin` (interface already headless via opaque handles/neutral params; only the concrete plugin-hosting implementation stays here, by design).
- Also found genuinely **dead code** (`ExportFile`, `LoadReferenceLists`/`LoadExternalReferenceList`/`mReferenceListInternal`/`mReferenceListExternal`/`mReferenceListLoaded`, `IsCompatible`+commented-out `CompilePlugin`) — left untouched since removal wasn't this PR's ask; flagging for a future cleanup pass.

## New gotcha (not written into the doc — for the maintainer to fold in)

`PluginManager`'s own assembly is added to `LoadPlugins`' MEF `AggregateCatalog` (`CreateCatalog`), and the class exports a member (`[Export("LocalizationService")]`). That makes MEF treat `PluginManager` itself as an implicit part it must activate — a second, throwaway instance distinct from the DI-built singleton bridged as `IPluginManager`. Giving such a class's constructor a new required dependency isn't just a normal DI change: it needs `[ImportingConstructor]` plus a `batch.AddExportedValue<T>` bridge in `LoadPlugins`, exactly like a plugin ctor drain, even though `PluginManager` is not itself a `PluginBase`. Caught only by `AllPluginsCompositionTests` (which scans the real MEF catalog) — the host-container `ServiceProviderCompositionSpikeTests` passed even before the fix, since it resolves through ordinary Microsoft.Extensions DI and never touches MEF's catalog scan.

## Testing

- New `PluginEnablementStoreTests` (5 tests, `Tests/Gum.Presentation.Tests`) — pinning tests for load/save round-trip, disable idempotency, enable. Mutation-tested one (removed the `Contains` guard in `Disable`, confirmed `Disable_CalledTwice_DoesNotDuplicateEntry` goes red, reverted).
- `AllPluginsCompositionTests` and `ServiceProviderCompositionSpikeTests` updated (`PluginBridgedServiceTypes.All` gained `IPluginEnablementStore`) and pass.
- Full `GumToolUnitTests` (1119 passed, 2 pre-existing skips) and full `Gum.Presentation.Tests` (496 passed) green.
- `GumFull.sln` builds with 0 errors.

Manual test: not needed — behavior-preserving extraction, covered by the pinning tests + the MEF composition tests exercising the exact real-world activation path that would break on a startup regression.

Closes #3880
