### PR TITLE
Relocate NameVerifier into headless Gum.Presentation

### DIFF
--- a/Tests/Gum.Presentation.Tests/NameVerifierTests.cs
+++ b/Tests/Gum.Presentation.Tests/NameVerifierTests.cs
@@ -3,25 +3,37 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
 using Gum.Managers;
+using Gum.Plugins;
+using Gum.ToolStates;
 using Moq;
 using Shouldly;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace GumToolUnitTests.Managers;
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="NameVerifier"/>'s name-validation logic after its relocation to
+/// Gum.Presentation (ADR-0005, #3889) — the class had no WPF/WinForms-typed members; every
+/// dependency (<see cref="IVariableSaveLogic"/>, <see cref="IPluginManager"/>,
+/// <see cref="StandardElementsManager"/>, <see cref="ObjectFinder"/>) was already headless. The one
+/// wrinkle: <see cref="NameVerifier.IsVariableNameValid"/> used to resolve <see cref="ISelectedState"/>
+/// via an ambient tool-only extension method (<c>ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase</c>,
+/// which called <c>Locator</c> internally) instead of taking it as a dependency; it is now a real
+/// constructor parameter, which is also what makes the "existing active variable" branch below
+/// testable for the first time (it previously required a live <c>Locator</c> container).
+/// </summary>
 public class NameVerifierTests : BaseTestClass
 {
     private readonly NameVerifier _nameVerifier;
-    private readonly Mock<Gum.Plugins.IPluginManager> _pluginManager;
+    private readonly Mock<IPluginManager> _pluginManager;
+    private readonly Mock<IVariableSaveLogic> _variableSaveLogic;
+    private readonly Mock<ISelectedState> _selectedState;
 
     public NameVerifierTests()
     {
-        _pluginManager = new Mock<Gum.Plugins.IPluginManager>();
-        _nameVerifier = new NameVerifier(new Mock<IVariableSaveLogic>().Object, _pluginManager.Object);
+        _pluginManager = new Mock<IPluginManager>();
+        _variableSaveLogic = new Mock<IVariableSaveLogic>();
+        _selectedState = new Mock<ISelectedState>();
+        _nameVerifier = new NameVerifier(_variableSaveLogic.Object, _pluginManager.Object, _selectedState.Object);
     }
 
     #region ElementSave
@@ -77,6 +89,61 @@ public class NameVerifierTests : BaseTestClass
         isValid.ShouldBeFalse("Because spaces are not allowed. This makes variable references difficult to parse");
 
         whyNotValid.ShouldBe("Variable names cannot contain spaces");
+    }
+
+    [Fact]
+    public void IsVariableNameValid_ShouldReturnFalse_ForExistingActiveVariable_InDefaultState_WhenElementIsNotSelected()
+    {
+        ComponentSave element = new ComponentSave { Name = "MyComponent" };
+        element.States.Add(new StateSave { Name = "Default", ParentContainer = element });
+        VariableSave existingVariable = new VariableSave { Name = "ExistingVar" };
+        element.DefaultState.Variables.Add(existingVariable);
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns((ElementSave?)null);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns((StateSave?)null);
+        _variableSaveLogic.Setup(x => x.GetIfVariableIsActive(existingVariable, element, null)).Returns(true);
+
+        bool isValid = _nameVerifier.IsVariableNameValid("ExistingVar", element, new VariableSave(), out string whyNotValid);
+
+        isValid.ShouldBeFalse("Because the element is not the selected element, so the default state (not any selected state) should be searched.");
+        whyNotValid.ShouldBe("The variable name ExistingVar is already used");
+    }
+
+    [Fact]
+    public void IsVariableNameValid_ShouldReturnFalse_ForExistingActiveVariable_InSelectedState_WhenElementIsSelected()
+    {
+        ComponentSave element = new ComponentSave { Name = "MyComponent" };
+        StateSave selectedStateSave = new StateSave();
+        VariableSave existingVariable = new VariableSave { Name = "ExistingVar" };
+        selectedStateSave.Variables.Add(existingVariable);
+        // Deliberately NOT added to element.DefaultState, to prove the selected state (not the
+        // default state) is what gets searched when the element is currently selected.
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns(element);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns(selectedStateSave);
+        _variableSaveLogic.Setup(x => x.GetIfVariableIsActive(existingVariable, element, null)).Returns(true);
+
+        bool isValid = _nameVerifier.IsVariableNameValid("ExistingVar", element, new VariableSave(), out string whyNotValid);
+
+        isValid.ShouldBeFalse("Because the element is the selected element with a selected state, so that state should be searched.");
+        whyNotValid.ShouldBe("The variable name ExistingVar is already used");
+    }
+
+    [Fact]
+    public void IsVariableNameValid_ShouldReturnTrue_WhenExistingVariableIsNotActive()
+    {
+        ComponentSave element = new ComponentSave { Name = "MyComponent" };
+        element.States.Add(new StateSave { Name = "Default", ParentContainer = element });
+        VariableSave existingVariable = new VariableSave { Name = "ExistingVar" };
+        element.DefaultState.Variables.Add(existingVariable);
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns((ElementSave?)null);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns((StateSave?)null);
+        _variableSaveLogic.Setup(x => x.GetIfVariableIsActive(existingVariable, element, null)).Returns(false);
+
+        bool isValid = _nameVerifier.IsVariableNameValid("ExistingVar", element, new VariableSave(), out string whyNotValid);
+
+        isValid.ShouldBeTrue("Because an inactive variable (e.g. a leftover from a type change) should not block reuse of its name.");
     }
 
     #endregion

--- a/Tools/Gum.Presentation/Managers/NameVerifier.cs
+++ b/Tools/Gum.Presentation/Managers/NameVerifier.cs
@@ -2,7 +2,7 @@
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
-using System.CodeDom.Compiler;
+using Gum.ToolStates;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -139,16 +139,18 @@ public class NameVerifier : INameVerifier
     private readonly StandardElementsManager _standardElementsManager;
     private readonly IVariableSaveLogic _variableSaveLogic;
     private readonly Plugins.IPluginManager _pluginManager;
-    
+    private readonly ISelectedState _selectedState;
+
     #endregion
-    
+
     #region Folder
-    
-    public NameVerifier(IVariableSaveLogic variableSaveLogic, Plugins.IPluginManager pluginManager)
+
+    public NameVerifier(IVariableSaveLogic variableSaveLogic, Plugins.IPluginManager pluginManager, ISelectedState selectedState)
     {
         _standardElementsManager = StandardElementsManager.Self;
         _variableSaveLogic = variableSaveLogic;
         _pluginManager = pluginManager;
+        _selectedState = selectedState;
     }
     public bool IsFolderNameValid(string? folderName, out string whyNotValid)
     {
@@ -165,10 +167,6 @@ public class NameVerifier : INameVerifier
         {
             IsFileNameWindowsReserved(componentNameWithoutFolder, out whyNotValid);
         }
-        //if (string.IsNullOrEmpty(whyNotValid))
-        //{
-        //    IsNameValidVariable(componentName, out whyNotValid);
-        //}
         if (string.IsNullOrEmpty(whyNotValid) && componentNameWithoutFolder != null)
         {
             IsNameAnExistingElement(componentNameWithoutFolder, folderName, elementSave, out whyNotValid);
@@ -242,10 +240,6 @@ public class NameVerifier : INameVerifier
     public bool IsInstanceNameValid(string instanceName, InstanceSave instanceSave, IInstanceContainer instanceContainer, out string whyNotValid)
     {
         IsNameValidCommon(instanceName, out whyNotValid, out _);
-        //if (string.IsNullOrEmpty(whyNotValid))
-        //{
-        //    IsNameValidVariable(instanceName, out whyNotValid);
-        //}
         // See if this is a variable used by any state in the StandardElementsManager:
         if(string.IsNullOrEmpty(whyNotValid))
         {
@@ -339,7 +333,7 @@ public class NameVerifier : INameVerifier
 
         if (string.IsNullOrEmpty(whyNotValid))
         {
-            var existingVariable = elementSave?.GetVariableFromThisOrBase(variableName);
+            var existingVariable = elementSave != null ? GetVariableFromThisOrBase(elementSave, variableName) : null;
             // there's a variable but we shouldn't consider it
             // unless it's "Active" - inactive variables may be
             // leftovers from a type change
@@ -405,15 +399,6 @@ public class NameVerifier : INameVerifier
         commonValidationError = CommonValidationError.None;
         return true;
     }
-    private void IsNameValidVariable(string name, out string whyNotValid)
-    {
-        whyNotValid = null;
-        CodeDomProvider provider = CodeDomProvider.CreateProvider("C#");
-        if (provider.IsValidIdentifier(name) == false)
-        {
-            whyNotValid = "The name uses an invalid character";
-        }
-    }
     private void IsFileNameWindowsReserved(string? name, out string? whyNotValid)
     {
         whyNotValid = null;
@@ -421,6 +406,20 @@ public class NameVerifier : INameVerifier
         {
             whyNotValid = $"The name {name} is a reserved file name in Windows";
         }
+    }
+    /// <summary>
+    /// Returns the variable from the element's currently-selected state if <paramref name="element"/>
+    /// is the currently selected element and a state is selected, otherwise from its default state.
+    /// Headless replacement for the tool-only <c>ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase</c>,
+    /// which resolves <see cref="ISelectedState"/> via <c>Locator</c> instead of taking it as a dependency.
+    /// </summary>
+    private VariableSave? GetVariableFromThisOrBase(ElementSave element, string variable)
+    {
+        var stateToPullFrom = (element == _selectedState.SelectedElement && _selectedState.SelectedStateSave != null)
+            ? _selectedState.SelectedStateSave
+            : element.DefaultState;
+
+        return stateToPullFrom.GetVariableRecursive(variable);
     }
     public bool IsValidCSharpName(string name, out string whyNotValid, out CommonValidationError commonValidationError)
     {


### PR DESCRIPTION
## Summary
Relocates `NameVerifier` (name-validation logic) from `Gum.csproj` into headless `Gum.Presentation`, per the Avalonia north-star test.

Categorization: the whole file was **(a) genuinely relocatable now** — every dependency (`IVariableSaveLogic`, `IPluginManager`, `StandardElementsManager`, `ObjectFinder`) was already headless. The one real blocker: `IsVariableNameValid` called a tool-only, `Locator`-resolving extension method (`ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase`) to pick the currently-selected state vs. the default state. Fixed by injecting `ISelectedState` (already living in `Gum.Presentation`) into `NameVerifier`'s constructor and replicating the exact same conditional inline — behavior-preserving.

Also removed `IsNameValidVariable`, a private unreachable method (both call sites were already commented out) that would have needed a new `System.CodeDom` NuGet reference for zero live behavior.

## Tests
- Moved `NameVerifierTests` (22 tests) into `Gum.Presentation.Tests`, alongside the class (matches the `SelectionManager`/`CameraController` precedent).
- Added 3 new tests covering the injected `ISelectedState` branch, which was previously untestable (needed a live `Locator` container) — this is the actual new seam this relocation unlocked.
- Mutation-tested the injected-condition seam (flipped `==` to `!=`): the new "selected state" test went red, the other 24 stayed green; reverted.
- `Gum.Presentation.Tests`: 537 passed. `GumToolUnitTests` (full suite): 1084 passed, 2 pre-existing skips. `ServiceProviderCompositionSpikeTests`/`AllPluginsCompositionTests`: both green. `GumFull.sln`: 0 errors.

## Manual test
Not needed — pure data-in/data-out validation logic, behavior-preserving move, fully covered by unit tests + compilation.

Closes #3889
