### PR TITLE
Add opt-in per-property default for UpdateSourceTrigger

### DIFF
--- a/.claude/skills/gum-runtime-binding/SKILL.md
+++ b/.claude/skills/gum-runtime-binding/SKILL.md
@@ -130,3 +130,5 @@ All binding features work with indexed paths: modes, converters, StringFormat, F
 **Lambda extracts path at call time, not at update time.** `vm => vm.Child.Text` becomes the static path `"Child.Text"`. If `Child` is replaced, `PropertyPathObserver` re-hooks the listener chain automatically.
 
 **ListBox `Items` is bindable.** `listBox.SetBinding(nameof(ListBox.Items), nameof(vm.Items))` works and keeps the list in sync with an `ObservableCollection` on the VM.
+
+**`UpdateSourceTrigger.Default` is project-configurable.** `Binding.DefaultUpdateTriggers` lets a project register a default trigger per control type + property, resolved in `NpcBindingExpression.HookUpdateSource` before falling back to `PropertyChanged`. See [Default Update Triggers](../../../docs/code/binding-viewmodels/advanced-binding-options.md#default-update-triggers).

--- a/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
@@ -382,9 +382,88 @@ public class FrameworkElementBindingTests : BaseTestClass
         element.Text = "Initial";
         element.IsFocused = false;
 
-        vm.TimesCalled.ShouldBe(1, 
+        vm.TimesCalled.ShouldBe(1,
             "only once from the initializer, because the TextBox's value never changed, " +
             "so setting IsFocused to false should not update the source value");
+    }
+
+    [Fact]
+    public void DefaultUpdateTrigger_Registered_AppliesAsLostFocus()
+    {
+        // Arrange
+        Binding.DefaultUpdateTriggers[(typeof(TextBox), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
+        try
+        {
+            TestViewModel vm = new() { Text = "Initial" };
+            TextBox element = new() { BindingContext = vm };
+
+            // No explicit UpdateSourceTrigger - uses Default, which should resolve via the registry
+            element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.Text));
+            element.IsFocused = true;
+            element.Text = "FromUI";
+
+            // Act / Assert
+            vm.Text.ShouldBe("Initial");
+            element.IsFocused = false;
+            vm.Text.ShouldBe("FromUI");
+        }
+        finally
+        {
+            Binding.DefaultUpdateTriggers.Remove((typeof(TextBox), nameof(TextBox.Text)));
+        }
+    }
+
+    [Fact]
+    public void DefaultUpdateTrigger_ExplicitBindingValue_OverridesRegisteredDefault()
+    {
+        // Arrange
+        Binding.DefaultUpdateTriggers[(typeof(TextBox), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
+        try
+        {
+            TestViewModel vm = new() { Text = "Initial" };
+            TextBox element = new() { BindingContext = vm };
+
+            Binding binding = new(nameof(TestViewModel.Text))
+            {
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            };
+            element.SetBinding(nameof(TextBox.Text), binding);
+
+            // Act
+            element.Text = "FromUI";
+
+            // Assert - explicit PropertyChanged wins over the registered LostFocus default
+            vm.Text.ShouldBe("FromUI");
+        }
+        finally
+        {
+            Binding.DefaultUpdateTriggers.Remove((typeof(TextBox), nameof(TextBox.Text)));
+        }
+    }
+
+    [Fact]
+    public void DefaultUpdateTrigger_RegisteredOnBaseType_AppliesToSubclass()
+    {
+        // Arrange
+        Binding.DefaultUpdateTriggers[(typeof(TextBoxBase), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
+        try
+        {
+            TestViewModel vm = new() { Text = "Initial" };
+            TextBox element = new() { BindingContext = vm };
+
+            element.SetBinding(nameof(TextBox.Text), nameof(TestViewModel.Text));
+            element.IsFocused = true;
+            element.Text = "FromUI";
+
+            // Act / Assert
+            vm.Text.ShouldBe("Initial");
+            element.IsFocused = false;
+            vm.Text.ShouldBe("FromUI");
+        }
+        finally
+        {
+            Binding.DefaultUpdateTriggers.Remove((typeof(TextBoxBase), nameof(TextBox.Text)));
+        }
     }
 
     [Theory]

--- a/MonoGameGum/Forms/Data/Binding.cs
+++ b/MonoGameGum/Forms/Data/Binding.cs
@@ -126,6 +126,45 @@ public class Binding(string path)
     public static object DoNothing { get; } = new();
 
     /// <summary>
+    /// Project-configurable defaults for <see cref="UpdateSourceTrigger.Default"/>, keyed by the
+    /// target control type and the bound property name. Lets a project opt every binding of a given
+    /// control/property pair into a trigger (e.g. <c>LostFocus</c> for every <c>TextBox.Text</c>)
+    /// without setting <see cref="UpdateSourceTrigger"/> on each individual <see cref="Binding"/>.
+    /// </summary>
+    /// <remarks>
+    /// Empty by default, so registering nothing reproduces today's behavior exactly (falls back to
+    /// <see cref="Data.UpdateSourceTrigger.PropertyChanged"/>). A binding's own explicit
+    /// <see cref="UpdateSourceTrigger"/> always takes precedence over anything registered here.
+    /// Lookup walks up from the control's runtime type through its base types, so registering
+    /// against a base control type (e.g. <c>TextBoxBase</c>) applies to all its subclasses unless a
+    /// more derived type has its own registration.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// Binding.DefaultUpdateTriggers[(typeof(TextBox), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
+    /// </code>
+    /// </example>
+    public static Dictionary<(Type ControlType, string PropertyName), UpdateSourceTrigger> DefaultUpdateTriggers { get; } = new();
+
+    /// <summary>
+    /// Resolves <see cref="Data.UpdateSourceTrigger.Default"/> to a concrete trigger for the given
+    /// control type and property, consulting <see cref="DefaultUpdateTriggers"/> before falling back
+    /// to <see cref="Data.UpdateSourceTrigger.PropertyChanged"/>.
+    /// </summary>
+    internal static UpdateSourceTrigger ResolveDefaultUpdateTrigger(Type controlType, string propertyName)
+    {
+        for (Type? type = controlType; type is not null; type = type.BaseType)
+        {
+            if (DefaultUpdateTriggers.TryGetValue((type, propertyName), out UpdateSourceTrigger trigger))
+            {
+                return trigger;
+            }
+        }
+
+        return UpdateSourceTrigger.PropertyChanged;
+    }
+
+    /// <summary>
     /// Creates a binding using a lambda expression to specify the property path.
     /// This provides compile-time safety and refactoring support compared to using a string path.
     /// </summary>

--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -63,11 +63,13 @@ internal class NpcBindingExpression : UntypedBindingExpression
 
     private void HookUpdateSource(UpdateSourceTrigger trigger)
     {
+        if (trigger == UpdateSourceTrigger.Default)
+        {
+            trigger = Binding.ResolveDefaultUpdateTrigger(TargetElement.GetType(), TargetProperty.Name);
+        }
+
         switch (trigger)
         {
-            case UpdateSourceTrigger.Default:
-                // A more robust property system could have a default trigger defined on the property metadata
-                // for now we just default to PropertyChanged
             case UpdateSourceTrigger.PropertyChanged:
                 if (TargetElement is INotifyPropertyChanged npc)
                 {

--- a/docs/code/binding-viewmodels/advanced-binding-options.md
+++ b/docs/code/binding-viewmodels/advanced-binding-options.md
@@ -141,6 +141,19 @@ The following properties are available on the Binding class. Note that the term 
 * `ConverterParameter` - an optional parameter to pass to the Converter
 * `StringFormat` - a format string to apply to the value
 
+### Default Update Triggers
+
+By default, `UpdateSourceTrigger.Default` resolves to `UpdateSourceTrigger.PropertyChanged` for every control and property. A project can change this per control type and property using `Binding.DefaultUpdateTriggers`:
+
+```csharp
+// Initialize
+Binding.DefaultUpdateTriggers[(typeof(TextBox), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
+```
+
+Once registered, any binding to that property that doesn't set `UpdateSourceTrigger` explicitly uses the registered trigger instead of `PropertyChanged`. An explicit `UpdateSourceTrigger` on an individual `Binding` always overrides the registered default.
+
+Registering against a base type applies to all its subclasses, unless a more derived type has its own registration. Remove a registration with `Remove`, or clear all of them with `Clear`.
+
 ### Converter Example
 
 The `Converter` property accepts an `IValueConverter` implementation that transforms values as they flow between the source and target. The following example converts a boolean to a display string:

--- a/docs/code/controls/textbox.md
+++ b/docs/code/controls/textbox.md
@@ -322,6 +322,8 @@ mainPanel.AddChild(textBox);
 
 <figure><img src="../../.gitbook/assets/24_07 50 58.gif" alt=""><figcaption><p>Pressing enter applies binding</p></figcaption></figure>
 
+If every `TextBox` in a project should use `LostFocus` by default, it can be registered once instead of set on every individual binding. See [Default Update Triggers](../binding-viewmodels/advanced-binding-options.md#default-update-triggers).
+
 ## Binding to Numeric Properties
 
 `TextBox.Text` can be bound to any standard numeric ViewModel property — `byte`, `int`, `float`, `double`, or `decimal`. The binding automatically converts between strings and numbers, so no `Converter` is required for these types.


### PR DESCRIPTION
## Summary

Adds an opt-in, per-property registry so a project can set a project-wide default for `UpdateSourceTrigger` instead of setting it on every `Binding`/`SetBinding` call:

```csharp
Binding.DefaultUpdateTriggers[(typeof(TextBox), nameof(TextBox.Text))] = UpdateSourceTrigger.LostFocus;
```

Resolution order when a binding's trigger is `Default`: explicit `Binding.UpdateSourceTrigger` > most-derived-type match in `DefaultUpdateTriggers` (walks up the type hierarchy) > `PropertyChanged` fallback (today's behavior). The registry ships empty, so nothing changes unless a project opts in — no shipped control default changed as part of this.

Closes #3896.

## Test plan

- [x] 3 new unit tests: registered default applies as `LostFocus`, explicit `Binding.UpdateSourceTrigger` overrides the registered default, registration on a base type (`TextBoxBase`) applies to a subclass (`TextBox`)
- [x] Full binding/TextBox/PasswordBox test suites green (159 tests, no regressions)
- [x] Docs added: `docs/code/binding-viewmodels/advanced-binding-options.md` (system-level) + a short cross-link note on `docs/code/controls/textbox.md`

Manual test: not needed — this is headless binding logic with no tool UI or rendering surface; the new unit tests exercise the same focus/text-change primitives a running app would hit.

FRB canary: not needed — `MonoGameGum/Forms/Data/` is not included in FRB1's `FlatRedBall.Forms.Shared.projitems` (confirmed via grep), so this doesn't touch FRB1-shared source.
