### PR TITLE
Relocate FileWatchManager into headless Gum.Presentation, part of #3904

### DIFF
--- a/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
@@ -1,0 +1,138 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Logic.FileWatch;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Exercises FileWatchManager end-to-end against a real temp directory and real
+/// FileSystemWatcher, since its whole job is wiring OS file-change events to the queue/flush
+/// pipeline - mocking FileSystemWatcher itself would test nothing. Polls with a generous
+/// timeout rather than a fixed sleep to absorb OS event-delivery jitter.
+/// </summary>
+public class FileWatchManagerTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public FileWatchManagerTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "FileWatchManagerTests_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDirectory, recursive: true); } catch { /* best-effort */ }
+    }
+
+    private static FileWatchManager BuildSut(
+        out Mock<IGuiCommands> guiCommandsMock,
+        out Mock<IPluginManager> pluginManagerMock,
+        out Mock<IFileWatchIgnoreList> ignoreListMock,
+        FilePath projectDirectory)
+    {
+        guiCommandsMock = new Mock<IGuiCommands>();
+        pluginManagerMock = new Mock<IPluginManager>();
+
+        ignoreListMock = new Mock<IFileWatchIgnoreList>();
+        ignoreListMock.Setup(i => i.TryGetIgnoreFileChange(It.IsAny<FilePath>())).Returns(false);
+
+        var projectManagerMock = new Mock<IProjectManager>();
+        var gumProject = new GumProjectSave { FullFileName = projectDirectory + "Project.gumx" };
+        projectManagerMock.Setup(p => p.GumProjectSave).Returns(gumProject);
+
+        var fileChangeReactionLogic = new FileChangeReactionLogic(
+            new Mock<ISelectedState>().Object,
+            new Mock<IWireframeCommands>().Object,
+            guiCommandsMock.Object,
+            new Mock<IFileCommands>().Object,
+            new Mock<IOutputManager>().Object,
+            new Mock<IWireframeObjectManager>().Object,
+            new Mock<IProjectState>().Object,
+            new Mock<IStandardElementsManagerGumTool>().Object,
+            pluginManagerMock.Object);
+
+        return new FileWatchManager(
+            guiCommandsMock.Object,
+            projectManagerMock.Object,
+            fileChangeReactionLogic,
+            ignoreListMock.Object);
+    }
+
+    private static bool PollUntil(Func<bool> condition, int timeoutMilliseconds = 4000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMilliseconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            Thread.Sleep(50);
+        }
+        return condition();
+    }
+
+    [Fact]
+    public void EnableWithDirectories_ThenFlush_ShouldReactToFileCreatedInWatchedDirectory()
+    {
+        FilePath watchedDirectory = new FilePath(_tempDirectory + "/");
+        FileWatchManager sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out Mock<IPluginManager> pluginManagerMock,
+            out _,
+            watchedDirectory);
+
+        sut.EnableWithDirectories(new HashSet<FilePath> { watchedDirectory });
+        sut.Enabled.ShouldBeTrue();
+
+        FilePath createdFile = new FilePath(Path.Combine(_tempDirectory, "NewFile.txt"));
+        File.WriteAllText(createdFile.FullPath, "contents");
+
+        PollUntil(() => sut.ChangedFilesWaitingForFlush.Contains(createdFile)).ShouldBeTrue(
+            "the watcher should queue the created file for flush");
+
+        // Flush debounces for 500ms after the last change; wait it out so Flush() doesn't early-out.
+        PollUntil(() => sut.TimeToNextFlush.TotalSeconds <= 0).ShouldBeTrue();
+
+        sut.Flush();
+
+        sut.ChangedFilesWaitingForFlush.ShouldNotContain(createdFile);
+        pluginManagerMock.Verify(p => p.ReactToFileChanged(createdFile), Times.Once);
+    }
+
+    [Fact]
+    public void IgnoreNextChangeUntil_ShouldSuppressQueuedChange_ForIgnoredFile()
+    {
+        FilePath watchedDirectory = new FilePath(_tempDirectory + "/");
+        FileWatchManager sut = BuildSut(
+            out _,
+            out Mock<IPluginManager> pluginManagerMock,
+            out Mock<IFileWatchIgnoreList> ignoreListMock,
+            watchedDirectory);
+
+        FilePath ignoredFile = new FilePath(Path.Combine(_tempDirectory, "Ignored.txt"));
+        ignoreListMock.Setup(i => i.TryGetIgnoreFileChange(ignoredFile)).Returns(true);
+
+        sut.EnableWithDirectories(new HashSet<FilePath> { watchedDirectory });
+
+        File.WriteAllText(ignoredFile.FullPath, "contents");
+
+        // Negative assertion: poll for the un-ignored behavior (queued) and expect it NOT to
+        // happen within the window, rather than a fixed sleep guessing at "long enough".
+        PollUntil(() => sut.ChangedFilesWaitingForFlush.Contains(ignoredFile), timeoutMilliseconds: 1000)
+            .ShouldBeFalse("an ignored file change should never be queued for flush");
+
+        pluginManagerMock.Verify(p => p.ReactToFileChanged(ignoredFile), Times.Never);
+    }
+}

--- a/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
+++ b/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
@@ -1,7 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
-using Gum.Services;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -72,7 +71,6 @@ public class FileWatchManager : IFileWatchManager
         {
             return;
         }
-        FilePath gumProjectFilePath = gumProject.FullFileName;
 
         foreach(var item in this.fileSystemWatchers)
         {


### PR DESCRIPTION
## Summary
- Relocates `FileWatchManager` (queue/flush/ignore-list wiring around `FileSystemWatcher`) from `Gum.csproj` into headless `Gum.Presentation`.
- Categorization per the north-star test: **(a) genuinely relocatable now** — 0 `System.Windows` hits, not linked into `GumCommon.csproj`, and all four ctor dependencies (`IGuiCommands`, `IProjectManager`, `FileChangeReactionLogic`, `IFileWatchIgnoreList`) already live in `Gum.Presentation` from an earlier PR. `IFileWatchManager`/`IFileWatchIgnoreList` were also already extracted there.
- No new ctor dependency and no plugin/MEF change — `Builder.cs`'s `FileWatchManager` registration is unaffected (same namespace, now resolved via the project reference `Gum.csproj` already has to `Gum.Presentation`).
- Drive-by boyscout cleanup: dropped an unused `using Gum.Services;` and a dead local variable (`gumProjectFilePath`, assigned and never read) in `EnableWithDirectories`.
- Added `Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs` — no test existed for this class before. Covers the real `FileSystemWatcher` → queue → `Flush()` → `FileChangeReactionLogic` pipeline, and the ignore-list suppression path. Mutation-tested (broke the ignore check, confirmed the ignore test goes red, reverted).

Closes #3904

## Test plan
- `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` — 554/554 passed.
- `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 1084/1086 passed, 2 pre-existing skips.
- `dotnet build GumFull.sln` — 0 errors.
- `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests` — passed.
