### PR TITLE
Relocate CodeOutputPlugin's WPF-free Manager classes into Gum.Presentation

### DIFF
--- a/.claude/skills/gum-tool-codegen/SKILL.md
+++ b/.claude/skills/gum-tool-codegen/SKILL.md
@@ -14,15 +14,14 @@ The code generation system produces C# partial classes from Gum Screens and Comp
 ## Architecture
 
 ```
-Tool UI                              Shared Engine
-  CodeOutputPlugin/                    Gum.ProjectServices/CodeGeneration/
-    MainCodeOutputPlugin               CodeGenerator (~5700 lines)
-    CodeGenerationService              CustomCodeGenerator
-    CodeWindow (Code tab)              CodeGenerationFileLocationsService
-    ParentSetLogic                     CodeGenerationNameVerifier
-    RenameService                      VariableExclusionLogic
-                                       CodeOutputProjectSettingsManager
-                                       CodeOutputElementSettingsManager
+Tool UI (Gum.csproj)                 Headless (Gum.Presentation / Gum.ProjectServices)
+  CodeOutputPlugin/                    CodeOutputPlugin/Manager/ (Gum.Presentation)
+    MainCodeOutputPlugin                 CodeGenerationService, ParentSetLogic, RenameService
+    CodeWindow (Code tab)               CodeGeneration/ (Gum.ProjectServices)
+                                          CodeGenerator (~5700 lines), CustomCodeGenerator
+                                          CodeGenerationFileLocationsService, CodeGenerationNameVerifier
+                                          VariableExclusionLogic, CodeOutputProjectSettingsManager
+                                          CodeOutputElementSettingsManager
 ```
 
 `CodeGenerationService` (tool-side) orchestrates generation by calling into `CodeGenerator` (shared engine). The same `CodeGenerator` is used by the CLI via `HeadlessCodeGenerationService` -- see the gum-cli skill for that path.
@@ -95,7 +94,7 @@ Tool UI                              Shared Engine
 | `Tools/Gum.ProjectServices/CodeGeneration/CodeGenerationFileLocationsService.cs` | Output path resolution |
 | `Tools/Gum.ProjectServices/CodeGeneration/CodeGenerationNameVerifier.cs` | C# name compliance |
 | `Tools/Gum.ProjectServices/CodeGeneration/VariableExclusionLogic.cs` | Platform-specific variable exclusion |
-| `Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs` | Tool UI plugin entry point |
-| `Gum/CodeOutputPlugin/Manager/CodeGenerationService.cs` | Tool-side generation orchestration |
-| `Gum/CodeOutputPlugin/Manager/ParentSetLogic.cs` | Forms parent relationship handling |
-| `Gum/CodeOutputPlugin/Manager/RenameService.cs` | Element rename to code rename |
+| `Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs` | Tool UI plugin entry point (WPF, `Gum.csproj`) |
+| `Tools/Gum.Presentation/CodeOutputPlugin/Manager/CodeGenerationService.cs` | Generation orchestration (headless) |
+| `Tools/Gum.Presentation/CodeOutputPlugin/Manager/ParentSetLogic.cs` | Forms parent relationship handling (headless) |
+| `Tools/Gum.Presentation/CodeOutputPlugin/Manager/RenameService.cs` | Element rename to code rename (headless) |

--- a/Tests/Gum.Presentation.Tests/CodeGenerationAdapterTests.cs
+++ b/Tests/Gum.Presentation.Tests/CodeGenerationAdapterTests.cs
@@ -1,0 +1,67 @@
+using CodeOutputPlugin.Manager;
+using Gum.Managers;
+using Gum.Reflection;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) tests for the small tool-to-engine adapters relocated out of
+/// Gum/CodeOutputPlugin/Manager (Gum.csproj) into the headless Gum.Presentation assembly (#3905) -
+/// each just forwards to an already-headless dependency and had no WPF dependency of its own.
+/// Bumped from internal to public so the plugin (still in Gum.csproj) can construct them across the
+/// new assembly boundary.
+/// </summary>
+public class CodeGenerationAdapterTests
+{
+    [Fact]
+    public void ToolCodeGenLogger_PrintOutput_ForwardsToOutputManager()
+    {
+        Mock<IOutputManager> outputManager = new();
+        var logger = new ToolCodeGenLogger(outputManager.Object);
+
+        logger.PrintOutput("hello");
+
+        outputManager.Verify(x => x.AddOutput("hello"), Times.Once);
+    }
+
+    [Fact]
+    public void ToolCodeGenLogger_PrintError_ForwardsToOutputManager()
+    {
+        Mock<IOutputManager> outputManager = new();
+        var logger = new ToolCodeGenLogger(outputManager.Object);
+
+        logger.PrintError("uh oh");
+
+        outputManager.Verify(x => x.AddError("uh oh"), Times.Once);
+    }
+
+    [Fact]
+    public void ToolTypeStringResolver_GetTypeFromString_ForwardsToTypeManager()
+    {
+        Mock<ITypeManager> typeManager = new();
+        typeManager.Setup(x => x.GetTypeFromString("System.String")).Returns(typeof(string));
+        var resolver = new ToolTypeStringResolver(typeManager.Object);
+
+        var result = resolver.GetTypeFromString("System.String");
+
+        result.ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void ProjectStateDirectoryProvider_ProjectDirectory_ReflectsCurrentProjectState()
+    {
+        Mock<IProjectState> projectState = new();
+        projectState.SetupSequence(x => x.ProjectDirectory)
+            .Returns("C:\\First\\")
+            .Returns("C:\\Second\\");
+        var provider = new ProjectStateDirectoryProvider(projectState.Object);
+
+        // Reads live (not captured at construction), so it tracks project switches (issue driving
+        // ProjectStateDirectoryProvider's own existence - see its doc comment).
+        provider.ProjectDirectory.ShouldBe("C:\\First\\");
+        provider.ProjectDirectory.ShouldBe("C:\\Second\\");
+    }
+}

--- a/Tests/Gum.Presentation.Tests/CodeGenerationServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/CodeGenerationServiceTests.cs
@@ -1,0 +1,98 @@
+using CodeOutputPlugin.Manager;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) tests for CodeGenerationService, relocated out of
+/// Gum/CodeOutputPlugin/Manager (Gum.csproj) into the headless Gum.Presentation assembly (#3905) -
+/// it had no WPF dependency of its own, only interfaces (IGuiCommands/IDialogService/IRetryService)
+/// that already lived in Gum.Presentation. Bumped from internal to public so the plugin (still in
+/// Gum.csproj) can construct it across the new assembly boundary.
+/// </summary>
+public class CodeGenerationServiceTests : BaseTestClass
+{
+    private readonly Mock<IGuiCommands> _guiCommands = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IRetryService> _retryService = new();
+    private readonly CodeGenerationService _codeGenerationService;
+
+    public CodeGenerationServiceTests()
+    {
+        Mock<INameVerifier> nameVerifier = new();
+        string whyNotValid;
+        CommonValidationError error;
+        nameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+
+        CodeGenerationNameVerifier codeGenNameVerifier = new(nameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new(directoryProvider);
+        LocalizationService localizationService = new();
+
+        CodeGenerator codeGenerator = new(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+
+        CustomCodeGenerator customCodeGenerator = new(codeGenerator, codeGenNameVerifier);
+
+        _codeGenerationService = new CodeGenerationService(
+            _guiCommands.Object,
+            codeGenerator,
+            _dialogService.Object,
+            customCodeGenerator,
+            codeGenNameVerifier,
+            directoryProvider,
+            _retryService.Object);
+    }
+
+    private static ComponentSave CreateComponent()
+    {
+        var component = new ComponentSave { Name = "MyComponent" };
+        var defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    [Fact]
+    public void GenerateCodeForElement_WithEmptyCodeProjectRoot_AndShowPopups_ShowsErrorMessage()
+    {
+        var element = CreateComponent();
+        var elementSettings = new CodeOutputElementSettings();
+        var projectSettings = new CodeOutputProjectSettings(); // CodeProjectRoot defaults to empty
+
+        _codeGenerationService.GenerateCodeForElement(element, elementSettings, projectSettings, showPopups: true);
+
+        _dialogService.Verify(
+            x => x.ShowMessage("You must first specify a Code Project Root before generating code", null, null),
+            Times.Once);
+        _guiCommands.Verify(x => x.PrintOutput(It.IsAny<string>()), Times.Never);
+        _retryService.Verify(x => x.TryMultipleTimes(It.IsAny<Action>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public void GenerateCodeForElement_WithEmptyCodeProjectRoot_AndNoPopups_DoesNotShowDialog()
+    {
+        var element = CreateComponent();
+        var elementSettings = new CodeOutputElementSettings();
+        var projectSettings = new CodeOutputProjectSettings(); // CodeProjectRoot defaults to empty
+
+        _codeGenerationService.GenerateCodeForElement(element, elementSettings, projectSettings, showPopups: false);
+
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
+        _guiCommands.Verify(x => x.PrintOutput(It.IsAny<string>()), Times.Never);
+        _retryService.Verify(x => x.TryMultipleTimes(It.IsAny<Action>(), It.IsAny<int>()), Times.Never);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/RenameServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/RenameServiceTests.cs
@@ -1,0 +1,69 @@
+using CodeOutputPlugin.Manager;
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Gum.Services.Dialogs;
+using Moq;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) test for RenameService, relocated out of Gum/CodeOutputPlugin/Manager
+/// (Gum.csproj) into the headless Gum.Presentation assembly (#3905) - no WPF dependency of its own,
+/// only interfaces (IDialogService) and engine types already headless. Bumped from internal to public
+/// (class and the two Handle* methods) so the plugin, still in Gum.csproj, can call it across the new
+/// assembly boundary.
+/// </summary>
+public class RenameServiceTests : BaseTestClass
+{
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly RenameService _renameService;
+
+    public RenameServiceTests()
+    {
+        Mock<INameVerifier> nameVerifier = new();
+        string whyNotValid;
+        CommonValidationError error;
+        nameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+
+        CodeGenerationNameVerifier codeGenNameVerifier = new(nameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new(directoryProvider);
+        LocalizationService localizationService = new();
+
+        CodeGenerator codeGenerator = new(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+
+        CustomCodeGenerator customCodeGenerator = new(codeGenerator, codeGenNameVerifier);
+
+        // codeGenerationService is unused by the early-out this test exercises, so null! is safe here
+        // (mirrors ParentSetLogicTests's same null!-for-unreached-dependency pattern).
+        _renameService = new RenameService(
+            codeGenerationService: null!,
+            codeGenerator,
+            customCodeGenerator,
+            codeGenNameVerifier,
+            _dialogService.Object,
+            directoryProvider);
+    }
+
+    [Fact]
+    public void HandleRename_WithEmptyCodeProjectRoot_DoesNothing()
+    {
+        var element = new ComponentSave { Name = "MyComponent" };
+
+        _renameService.HandleRename(
+            element,
+            oldName: "OldName",
+            codeOutputProjectSettings: new CodeOutputProjectSettings(), // CodeProjectRoot defaults to empty
+            visualApi: VisualApi.Gum);
+
+        _dialogService.VerifyNoOtherCalls();
+    }
+}

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/CodeGenerationService.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/CodeGenerationService.cs
@@ -12,7 +12,7 @@ using Gum.ToolStates;
 
 namespace CodeOutputPlugin.Manager;
 
-internal class CodeGenerationService
+public class CodeGenerationService
 {
     private readonly CodeGenerator _codeGenerator;
     private readonly CustomCodeGenerator _customCodeGenerator;

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ParentSetLogic.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ParentSetLogic.cs
@@ -78,7 +78,7 @@ public class ParentSetLogic
         }
     }
 
-    internal void HandleNewCreatedInstance(ElementSave element, InstanceSave instance,  CodeOutputProjectSettings codeOutputProjectSettings)
+    public void HandleNewCreatedInstance(ElementSave element, InstanceSave instance,  CodeOutputProjectSettings codeOutputProjectSettings)
     {
        
         var rfv = new RecursiveVariableFinder(element.DefaultState);

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ProjectStateDirectoryProvider.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ProjectStateDirectoryProvider.cs
@@ -9,7 +9,7 @@ namespace CodeOutputPlugin.Manager;
 /// is computed on each call, services consuming this provider automatically see
 /// the current project directory after the user switches projects.
 /// </summary>
-internal class ProjectStateDirectoryProvider : IProjectDirectoryProvider
+public class ProjectStateDirectoryProvider : IProjectDirectoryProvider
 {
     private readonly IProjectState _projectState;
 

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/RenameService.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/RenameService.cs
@@ -8,7 +8,7 @@ using Gum.ToolStates;
 
 namespace CodeOutputPlugin.Manager;
 
-internal class RenameService
+public class RenameService
 {
     private readonly CodeGenerationFileLocationsService _codeGenerationFileLocationsService;
     private readonly CodeGenerationService _codeGenerationService;
@@ -32,7 +32,7 @@ internal class RenameService
         _dialogService = dialogService;
     }
 
-    internal void HandleRename(ElementSave element, string oldName, CodeOutputProjectSettings codeOutputProjectSettings, VisualApi visualApi)
+    public void HandleRename(ElementSave element, string oldName, CodeOutputProjectSettings codeOutputProjectSettings, VisualApi visualApi)
     {
         if (codeOutputProjectSettings.CodeProjectRoot == string.Empty)
         {
@@ -112,7 +112,7 @@ internal class RenameService
         _codeGenerationService.GenerateCodeForElement(element, thisElementOutputSettings, codeOutputProjectSettings, showPopups: false);
     }
 
-    internal void HandleVariableSet(ElementSave element, InstanceSave? instance, string variableName, object? oldValue, CodeOutputProjectSettings codeOutputProjectSettings)
+    public void HandleVariableSet(ElementSave element, InstanceSave? instance, string variableName, object? oldValue, CodeOutputProjectSettings codeOutputProjectSettings)
     {
         /////////////////////////Early Out////////////////////
         if (variableName != "BaseType" || instance != null)

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ToolCodeGenLogger.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ToolCodeGenLogger.cs
@@ -6,7 +6,7 @@ namespace CodeOutputPlugin.Manager;
 /// <summary>
 /// Adapts the Gum tool's IOutputManager to the headless ICodeGenLogger interface.
 /// </summary>
-internal class ToolCodeGenLogger : ICodeGenLogger
+public class ToolCodeGenLogger : ICodeGenLogger
 {
     private readonly IOutputManager _outputManager;
 

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ToolTypeStringResolver.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/ToolTypeStringResolver.cs
@@ -7,7 +7,7 @@ namespace CodeOutputPlugin.Manager;
 /// <summary>
 /// Adapts the Gum tool's TypeManager to the headless ITypeStringResolver interface.
 /// </summary>
-internal class ToolTypeStringResolver : ITypeStringResolver
+public class ToolTypeStringResolver : ITypeStringResolver
 {
     private readonly ITypeManager _typeManager;
 


### PR DESCRIPTION
## Summary
Scoped #3905 by classifying MainCodeOutputPlugin's logic into: (a) genuinely relocatable now, (b) convertible with reasonable effort, (c) genuinely stuck. Implemented (a): moved the plugin's WPF-free `Manager` classes into `Gum.Presentation`.

**Relocated** (`Gum/CodeOutputPlugin/Manager/` → `Tools/Gum.Presentation/CodeOutputPlugin/Manager/`, namespace unchanged):
- `CodeGenerationService`, `RenameService`, `ParentSetLogic` (business logic — only depended on already-headless interfaces: `IGuiCommands`/`IDialogService`/`IRetryService`/`ISelectedState`/`IFileCommands` plus `Gum.ProjectServices.CodeGeneration` engine types)
- `ToolCodeGenLogger`, `ToolTypeStringResolver`, `ProjectStateDirectoryProvider` (thin tool-to-engine adapters)

Bumped `internal` → `public` on the classes/methods `MainCodeOutputPlugin` (staying in `Gum.csproj`) calls across the new assembly boundary. No `using`/namespace changes needed at any call site.

**Not relocatable yet** — `MainCodeOutputPlugin` itself, and everything routed through its `Views.CodeWindow`/`PluginTab` fields (`RefreshCodeDisplay`, `LoadCodeSettingsFile`, `HandleRefreshAndExport(ForElement)`, `HandleCodeOutputPropertyChanged`, `CreateControl`). Nearly every event handler in the file eventually reads or writes the WPF `control` field directly (e.g. `settings ?? control?.CodeOutputElementSettings` as a live fallback), unlike the `AnimationTabController` precedent where the WPF window only received a push at the end via one event. Narrowing this needs a real `ICodeOutputTabView`-style seam design (what the View exposes: current settings, visibility, show/hide) — that's a separate, larger PR, not a mechanical extraction.

**New gotcha for `Direction/ui-decoupling-plan.md`** (not edited here, per convention — for the next consolidation pass): a "control-coupled" plugin isn't always a clean `AnimationTabController`-shape extraction. The Animation plugin's WPF window only received a *push* (`ViewModelRefreshed`/`DataSaved` events) at the end of each business-logic method, so extracting the logic and leaving the push in the plugin was clean. Here, the View is read *mid-logic* as a live settings fallback (`control?.CodeOutputElementSettings`) and its visibility gates whether work even happens (`pluginTab.IsSelected`) — the View isn't just a sink, it's an ambient input. That shape needs a narrow view-state interface designed first, not a drop-in controller extraction.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] New pinning tests (`Tests/Gum.Presentation.Tests/{CodeGenerationServiceTests,RenameServiceTests,CodeGenerationAdapterTests}.cs`) — all green
- [x] Full `Gum.Presentation.Tests` suite green (559 passed)
- [x] Full `GumToolUnitTests` suite green (1084 passed, 2 pre-existing skips) — `ParentSetLogicTests` needed zero changes
- [x] `Gum.ProjectServices.Tests` green (367 passed)
- [x] Mutation-tested `CodeGenerationServiceTests` (inverted the `showPopups` branch) — both tests went red, then reverted to green
- Manual test: not needed — pure relocation/accessibility-bump, no constructor dependency changed, no behavior change; compiler + full test suites are the proof.

Closes #3905
