### PR TITLE
Relocate ImportLogic into headless Gum.Presentation

### DIFF
--- a/Tools/Gum.Presentation/Plugins/ImportPlugin/Manager/ImportLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/ImportPlugin/Manager/ImportLogic.cs
@@ -21,9 +21,9 @@ public class ImportLogic : IImportLogic
     private readonly IDialogService _dialogService;
     private readonly IProjectManager _projectManager;
     private readonly IPluginManager _pluginManager;
-    private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly IStandardElementsManagerGumTool _standardElementsManagerGumTool;
 
-    public ImportLogic(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands, IDialogService dialogService, IProjectManager projectManager, IPluginManager pluginManager, StandardElementsManagerGumTool standardElementsManagerGumTool)
+    public ImportLogic(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands, IDialogService dialogService, IProjectManager projectManager, IPluginManager pluginManager, IStandardElementsManagerGumTool standardElementsManagerGumTool)
     {
         _selectedState = selectedState;
         _guiCommands = guiCommands;
@@ -216,5 +216,4 @@ public class ImportLogic : IImportLogic
         return toReturn;
     }
 }
-
 


### PR DESCRIPTION
## Summary
- `ImportLogic` was already dependency-clean per the Avalonia north-star test — every injected interface (`ISelectedState`, `IGuiCommands`, `IFileCommands`, `IDialogService`, `IProjectManager`, `IPluginManager`) already lives in `Gum.Presentation`.
- The only blocker was one field typed against the concrete `StandardElementsManagerGumTool` (WPF-coupled). Only `.FixCustomTypeConverters()` is called, which `IStandardElementsManagerGumTool` (already in `Gum.Presentation`, already DI-registered) exposes — swapped the ctor param/field to the interface.
- Physically moved `ImportLogic.cs` from `Gum/Plugins/ImportPlugin/Manager/` to `Tools/Gum.Presentation/Plugins/ImportPlugin/Manager/` (next to `IImportLogic.cs`). No other file changes needed — `IImportLogic` bridging in `PluginManager.LoadPlugins` and `Builder.cs` DI registrations are unaffected.

## Test plan
- [x] `GumFull.sln` builds clean (0 errors)
- [x] `GumToolUnitTests` full suite green (1084 passed, 2 skipped, 0 failed)
- [x] Pre-existing `ImportLogicTests` pinning suite green (4/4)
- [x] `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests` green (no new/changed ctor deps beyond the concrete→interface swap, which was already DI-registered)
- [x] Mutation-tested: flipped the compact/v1 format branch in `ImportBehavior`, confirmed `ImportBehavior_ShouldDeserializeV2Behavior` goes red, reverted

Closes #3911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
