### PR TITLE
Stop HotkeyManager's key-matching logic bouncing through WPF/WinForms KeyEventArgs

### DIFF
--- a/Gum/Managers/HotkeyManager.cs
+++ b/Gum/Managers/HotkeyManager.cs
@@ -13,12 +13,9 @@ using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using System;
-using System.Windows;
 using System.Windows.Forms;
-using System.Windows.Input;
 using Gum.SelectionHistory;
 using Gum.Undo;
-using KeyEventArgs = System.Windows.Forms.KeyEventArgs;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 
 namespace Gum.Managers;
@@ -137,17 +134,12 @@ public class HotkeyManager : IHotkeyManager
 
     public bool PreviewKeyDownAppWide(GumKeyEventArgs e, bool enableEntireAppZoom = true)
     {
-        // Rebuild the WPF key event the matching logic consumes, run it, and copy Handled back onto the
-        // framework-neutral args. ToWpf() reads live modifier state via the keyboard device, as before.
-        System.Windows.Input.KeyEventArgs wpfE = e.ToWinFormsKeyEventArgs().ToWpf();
-        bool result = PreviewKeyDownAppWideInternal(wpfE, enableEntireAppZoom);
-        e.Handled = wpfE.Handled;
-        return result;
+        return PreviewKeyDownAppWideInternal(e, enableEntireAppZoom);
     }
 
-    private bool PreviewKeyDownAppWideInternal(System.Windows.Input.KeyEventArgs e, bool enableEntireAppZoom = true)
+    private bool PreviewKeyDownAppWideInternal(GumKeyEventArgs e, bool enableEntireAppZoom = true)
     {
-        Action? match = (e.Key, Keyboard.Modifiers) switch
+        Action? match = true switch
         {
             _ when Search.IsPressed(e)  => _guiCommands.FocusSearch,
             _ when RedoAlt.IsPressed(e) || Redo.IsPressed(e) => _undoManager.PerformRedo,
@@ -180,32 +172,21 @@ public class HotkeyManager : IHotkeyManager
 
     public void HandleKeyDownElementTreeView(GumKeyEventArgs e)
     {
-        // Rebuild the WinForms key event the matching logic consumes, run the existing logic unchanged,
-        // then copy Handled/SuppressKeyPress back onto the framework-neutral args for the boundary caller.
-        KeyEventArgs winE = e.ToWinFormsKeyEventArgs();
-        try
+        if (PreviewKeyDownAppWideInternal(e))
         {
-            if (PreviewKeyDownAppWideInternal(winE.ToWpf()))
-            {
-                winE.Handled = true;
-                return;
-            }
+            e.Handled = true;
+            return;
+        }
 
-            HandleCopyCutPaste(winE);
-            HandleDelete(winE);
-            HandleReorder(winE);
-            TryHandleCtrlF(winE);
-            HandleGoToDefinition(winE);
-            HandleRename(winE);
-        }
-        finally
-        {
-            e.Handled = winE.Handled;
-            e.SuppressKeyPress = winE.SuppressKeyPress;
-        }
+        HandleCopyCutPaste(e);
+        HandleDelete(e);
+        HandleReorder(e);
+        TryHandleCtrlF(e);
+        HandleGoToDefinition(e);
+        HandleRename(e);
     }
 
-    private void HandleRename(KeyEventArgs e)
+    private void HandleRename(GumKeyEventArgs e)
     {
         if(Rename.IsPressed(e))
         {
@@ -255,7 +236,7 @@ public class HotkeyManager : IHotkeyManager
         }
     }
 
-    private void TryHandleCtrlF(KeyEventArgs e)
+    private void TryHandleCtrlF(GumKeyEventArgs e)
     {
 
         if(Search.IsPressed(e))
@@ -265,7 +246,7 @@ public class HotkeyManager : IHotkeyManager
         }
     }
 
-    private void HandleReorder(KeyEventArgs e)
+    private void HandleReorder(GumKeyEventArgs e)
     {
         if(ReorderUp.IsPressed(e))
         {
@@ -279,7 +260,7 @@ public class HotkeyManager : IHotkeyManager
         }
     }
 
-    void HandleDelete(KeyEventArgs e)
+    void HandleDelete(GumKeyEventArgs e)
     {
         if (Delete.IsPressed(e))
         {
@@ -290,7 +271,7 @@ public class HotkeyManager : IHotkeyManager
         }
     }
 
-    void HandleGoToDefinition(KeyEventArgs e)
+    void HandleGoToDefinition(GumKeyEventArgs e)
     {
         if (GoToDefinition.IsPressed(e))
         {
@@ -311,7 +292,7 @@ public class HotkeyManager : IHotkeyManager
         }
     }
 
-    void HandleCopyCutPaste(KeyEventArgs e)
+    void HandleCopyCutPaste(GumKeyEventArgs e)
     {
         if(Copy.IsPressed(e))
         {
@@ -339,33 +320,22 @@ public class HotkeyManager : IHotkeyManager
 
     public void HandleEditorKeyDown(GumKeyEventArgs e)
     {
-        // Rebuild the WinForms key event the matching logic consumes, run the existing logic unchanged,
-        // then copy Handled/SuppressKeyPress back onto the framework-neutral args for the boundary caller.
-        KeyEventArgs winE = e.ToWinFormsKeyEventArgs();
-        try
+        if (PreviewKeyDownAppWideInternal(e, enableEntireAppZoom: false))
         {
-            if (PreviewKeyDownAppWideInternal(winE.ToWpf(), enableEntireAppZoom: false))
-            {
-                winE.Handled = true;
-                return;
-            }
-
-            HandleCopyCutPaste(winE);
-
-            HandleDelete(winE);
-            // Up moves the control "up" in the tree view, but when you are in the wireframe
-            // up should move it the opposite direction. We'll see how it goes...
-            // Update - inverting is not a good idea because it will work differently when
-            // dealing with stack layouts, and that's more complexity than I want to handle
-            HandleReorder(winE);
-
-            HandleGoToDefinition(winE);
+            e.Handled = true;
+            return;
         }
-        finally
-        {
-            e.Handled = winE.Handled;
-            e.SuppressKeyPress = winE.SuppressKeyPress;
-        }
+
+        HandleCopyCutPaste(e);
+
+        HandleDelete(e);
+        // Up moves the control "up" in the tree view, but when you are in the wireframe
+        // up should move it the opposite direction. We'll see how it goes...
+        // Update - inverting is not a good idea because it will work differently when
+        // dealing with stack layouts, and that's more complexity than I want to handle
+        HandleReorder(e);
+
+        HandleGoToDefinition(e);
     }
 
     public void HandleKeyUpWireframe()
@@ -454,43 +424,4 @@ public class HotkeyManager : IHotkeyManager
 
 
     #endregion
-
-    #region State Tree View
-
-    internal void HandleKeyDownStateView(KeyEventArgs e)
-    {
-        HandleCopyCutPasteState(e);
-    }
-
-    private void HandleCopyCutPasteState(KeyEventArgs e)
-    {
-        if (Copy.IsPressed(e))
-        {
-            _copyPasteLogic.OnCopy(CopyType.State);
-            e.Handled = true;
-            e.SuppressKeyPress = true;
-        }
-        else if (Paste.IsPressed(e))
-        {
-            _copyPasteLogic.OnPaste(CopyType.State);
-            e.Handled = true;
-            e.SuppressKeyPress = true;
-        }
-    }
-
-    #endregion
-}
-file static class Helpers
-{
-    public static System.Windows.Input.KeyEventArgs ToWpf(this System.Windows.Forms.KeyEventArgs e)
-    {
-        return new System.Windows.Input.KeyEventArgs(
-            Keyboard.PrimaryDevice,
-            PresentationSource.FromVisual(System.Windows.Application.Current.MainWindow),
-            0, // timestamp
-            KeyInterop.KeyFromVirtualKey((int)e.KeyCode))
-        {
-            RoutedEvent = Keyboard.KeyDownEvent
-        };
-    }
 }

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -171,9 +171,6 @@ public class HotkeyManagerTests : BaseTestClass
     public void IsPressed_KeyData_NavigateBack_MatchesAltPlusLeft()
     {
         // NavigateBack is Alt+Left: matches only when both the Alt flag and the Left key code are present.
-        // (PreviewKeyDownAppWide's actual dispatch isn't unit-testable here - it constructs a real WPF
-        // KeyEventArgs via Keyboard.PrimaryDevice, which requires an STA thread this test host doesn't
-        // guarantee. Same pre-existing gap applies to Undo/Redo/Search; verified manually instead.)
         _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Left).ShouldBeTrue();
         _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Left).ShouldBeFalse();
     }
@@ -216,6 +213,172 @@ public class HotkeyManagerTests : BaseTestClass
         // Verify alternative zoom out hotkey configuration
         _hotkeyManager.ZoomCameraOutAlternative.Key.ShouldBe(GumKey.OemMinus);
         _hotkeyManager.ZoomCameraOutAlternative.IsCtrlDown.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlF_InvokesFocusSearchAndSetsHandled()
+    {
+        // Previously untestable: the dispatch used to round-trip through a real WPF KeyEventArgs
+        // (Keyboard.PrimaryDevice), which requires an STA thread this test host doesn't guarantee.
+        // Now matched directly against the framework-neutral GumKeyEventArgs.
+        GumKeyEventArgs e = new() { Key = GumKey.F, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        e.Handled.ShouldBeTrue();
+        _guiCommands.Verify(g => g.FocusSearch(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlZ_InvokesPerformUndo()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Z, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _undoManager.Verify(u => u.PerformUndo(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlY_InvokesPerformRedo()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Y, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _undoManager.Verify(u => u.PerformRedo(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlShiftZ_InvokesPerformRedo()
+    {
+        // RedoAlt is Ctrl+Shift+Z.
+        GumKeyEventArgs e = new() { Key = GumKey.Z, IsCtrlDown = true, IsShiftDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _undoManager.Verify(u => u.PerformRedo(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_AltLeft_InvokesNavigateBack()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Left, IsAltDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _selectionHistory.Verify(s => s.NavigateBack(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_AltRight_InvokesNavigateForward()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Right, IsAltDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _selectionHistory.Verify(s => s.NavigateForward(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlAdd_IncreasesBaseFontSize()
+    {
+        _uiSettingsService.SetupProperty(u => u.BaseFontSize, 12d);
+        GumKeyEventArgs e = new() { Key = GumKey.Add, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        _uiSettingsService.Object.BaseFontSize.ShouldBe(13d);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_CtrlAdd_WhenAppWideZoomDisabled_DoesNotHandle()
+    {
+        _uiSettingsService.SetupProperty(u => u.BaseFontSize, 12d);
+        GumKeyEventArgs e = new() { Key = GumKey.Add, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e, enableEntireAppZoom: false);
+
+        handled.ShouldBeFalse();
+        _uiSettingsService.Object.BaseFontSize.ShouldBe(12d);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_UnmatchedKey_ReturnsFalseAndLeavesHandledFalse()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.C };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeFalse();
+        e.Handled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleKeyDownElementTreeView_Delete_InvokesDeleteSelectionAndSuppressesKeyPress()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Delete };
+
+        _hotkeyManager.HandleKeyDownElementTreeView(e);
+
+        _editCommands.Verify(c => c.DeleteSelection(), Times.Once);
+        e.Handled.ShouldBeTrue();
+        e.SuppressKeyPress.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleKeyDownElementTreeView_CtrlZ_DispatchesToAppWideUndo_NotDelete()
+    {
+        // App-wide keys (Undo/Redo/Search/...) take precedence over the element-tree-specific keys.
+        GumKeyEventArgs e = new() { Key = GumKey.Z, IsCtrlDown = true };
+
+        _hotkeyManager.HandleKeyDownElementTreeView(e);
+
+        _undoManager.Verify(u => u.PerformUndo(), Times.Once);
+        _editCommands.Verify(c => c.DeleteSelection(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleKeyDownElementTreeView_CtrlC_InvokesOnCopyAndSuppressesKeyPress()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.C, IsCtrlDown = true };
+
+        _hotkeyManager.HandleKeyDownElementTreeView(e);
+
+        _copyPasteLogic.Verify(c => c.OnCopy(CopyType.InstanceOrElement), Times.Once);
+        e.Handled.ShouldBeTrue();
+        e.SuppressKeyPress.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleEditorKeyDown_Delete_InvokesDeleteSelection()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.Delete };
+
+        _hotkeyManager.HandleEditorKeyDown(e);
+
+        _editCommands.Verify(c => c.DeleteSelection(), Times.Once);
+        e.Handled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleEditorKeyDown_CtrlAdd_DoesNotDispatchAppWideZoom()
+    {
+        // HandleEditorKeyDown calls the app-wide dispatch with enableEntireAppZoom: false -
+        // zoom in the wireframe editor is handled elsewhere (e.g. CameraController).
+        _uiSettingsService.SetupProperty(u => u.BaseFontSize, 12d);
+        GumKeyEventArgs e = new() { Key = GumKey.Add, IsCtrlDown = true };
+
+        _hotkeyManager.HandleEditorKeyDown(e);
+
+        _uiSettingsService.Object.BaseFontSize.ShouldBe(12d);
     }
 
     private (ComponentSave element, InstanceSave instance) SetUpSelectedInstance(float x, float y, bool locked = false)


### PR DESCRIPTION
Part of #3906.

## What

`IHotkeyManager` and its types (`KeyCombination`, `GumKey`, `GumKeyEventArgs`) were already fully framework-neutral and live in headless `Gum.Presentation` (#3267/#3343/#3344/#3345). But the concrete `HotkeyManager`'s own decision methods still rebuilt a real WinForms `KeyEventArgs`, then a real WPF `KeyEventArgs`, on every call just to match against them - including constructing `Keyboard.PrimaryDevice` / `PresentationSource.FromVisual(Application.Current.MainWindow)`, which needs a live WPF `Application` and an STA thread.

Fixed by matching directly against the already-passed `GumKeyEventArgs`, using the neutral `KeyCombinationGumEventArgsExtensions.IsPressed(GumKeyEventArgs)` overload that already existed (used by `CameraController`) but this class wasn't using. Zero interface change, zero call-site change anywhere else in the tool - every consumer already passed/received `GumKeyEventArgs`.

Boyscout: deleted `HandleKeyDownStateView`/`HandleCopyCutPasteState` (confirmed dead, zero call sites anywhere in the repo - vestigial state-tree glue) and the now-unused `Helpers.ToWpf`.

## Testing

Side effect worth noting: `PreviewKeyDownAppWide`/`HandleKeyDownElementTreeView`/`HandleEditorKeyDown` were previously **untestable** in this repo's xunit host - the WPF round-trip threw outside an STA thread (see the removed comment in the test file). They're now fully covered: 16 new tests exercising the app-wide dispatch (Search/Undo/Redo/RedoAlt/NavigateBack/Forward/Zoom) and the element-tree/editor key handlers (Delete/Copy/app-wide-precedence).

- `GumToolUnitTests`: 1098 passed, 2 pre-existing skips, 0 failed.
- `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests`: pass (no ctor/interface signature changed, so not strictly required, but run since the campaign touches `IHotkeyManager`'s wide injection footprint).
- Mutation-test proof: disabled `HandleKeyDownElementTreeView`'s app-wide-precedence early return, confirmed `HandleKeyDownElementTreeView_CtrlZ_DispatchesToAppWideUndo_NotDelete` goes red, reverted, confirmed green again.

Manual test: not needed - behavior-preserving (same matching logic, same interface, same call sites), proven by the compiler plus the now-working unit tests.

## What's left (issue stays open)

The concrete `HotkeyManager` class itself still lives in `Gum.csproj` (WPF/WinForms) rather than `Gum.Presentation`. Its dependency closure is already fully headless-clean (all 13 injected interfaces - `ICopyPasteLogic`, `IGuiCommands`, `ISelectedState`, `IElementCommands`, `IDialogService`, `IFileCommands`, `ISetVariableLogic`, `IUiSettingsService`, `IUndoManager`, `IEditCommands`, `IReorderLogic`, `IPluginManager`, `ISelectionHistory` - already live in `Gum.Presentation`), and after this PR only two methods still reference WinForms types:
- `IsPressedInControl` - reads the live OS modifier state via `System.Windows.Forms.Control.ModifierKeys`; genuinely can't relocate (same shape as the `IGumCursorState`/`Cursor.Self` gotcha already in `ui-decoupling-plan.md`).
- `ProcessCmdKeyWireframe`/`HandleNudge` - builds a WinForms `Keys` bitflag purely as an internal calculation convenience; could be rewritten to match directly against `GumKey?` + 3 bools with no WinForms reference at all.

Phased plan for a follow-up PR: (1) rewrite `HandleNudge`'s bitflag calculation off `Keys` (small, same shape as this PR), (2) narrow `IsPressedInControl`'s live-modifier read behind a small seam living tool-side (or accept it stays the one tool-side residual), (3) physically move the `HotkeyManager` concrete class into `Tools/Gum.Presentation`, mirroring the ~15 other "Relocate X into headless Gum.Presentation" PRs in this campaign (Builder.cs registration + `PluginManager.LoadPlugins` bridge already lists `IHotkeyManager` as bridged, so the MEF side needs no new work).

