### PR TITLE
Relocate InheritanceLogic into headless Gum.Presentation

### DIFF
--- a/Tests/Gum.Presentation.Tests/InheritanceLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/InheritanceLogicTests.cs
@@ -3,14 +3,20 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.Logic;
 using Gum.Managers;
-using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
-using Gum.ToolStates;
 using Moq;
 using Shouldly;
 
-namespace GumToolUnitTests.Logic;
+namespace Gum.Presentation.Tests;
 
+/// <summary>
+/// Pins <see cref="InheritanceLogic"/>'s behavior after its relocation to Gum.Presentation
+/// (ADR-0005, #3908). The only blocker was its constructor depending on the concrete,
+/// still-WPF/WinForms-side <c>StandardElementsManagerGumTool</c> instead of the already-headless
+/// <see cref="IStandardElementsManagerGumTool"/> interface — everything else it touches
+/// (<c>ObjectFinder.Self</c>, <c>StandardElementsManager.Self</c>, <see cref="IFileCommands"/>,
+/// <see cref="IGuiCommands"/>) was already reachable from this assembly.
+/// </summary>
 public class InheritanceLogicTests : BaseTestClass
 {
     private readonly Mock<IFileCommands> _fileCommands;
@@ -25,7 +31,21 @@ public class InheritanceLogicTests : BaseTestClass
         _sut = new InheritanceLogic(
             _fileCommands.Object,
             _guiCommands.Object,
-            new StandardElementsManagerGumTool(new Mock<IPluginManager>().Object, new Mock<ISelectedState>().Object));
+            new Mock<IStandardElementsManagerGumTool>().Object);
+    }
+
+    [Fact]
+    public void HandleInstanceRenamed_WithNullContainer_DoesNotSaveOrRefresh()
+    {
+        var project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        var behaviorInstance = new BehaviorInstanceSave { Name = "NewName" };
+
+        _sut.HandleInstanceRenamed(container: null, instance: behaviorInstance, oldName: "OldName");
+
+        _fileCommands.Verify(f => f.TryAutoSaveElement(It.IsAny<ElementSave>()), Times.Never);
+        _guiCommands.Verify(g => g.RefreshElementTreeView(It.IsAny<IInstanceContainer>()), Times.Never);
     }
 
     [Fact]
@@ -43,20 +63,6 @@ public class InheritanceLogicTests : BaseTestClass
             container: null,
             instance: behaviorInstance,
             oldName: "OldName"));
-    }
-
-    [Fact]
-    public void HandleInstanceRenamed_WithNullContainer_DoesNotSaveOrRefresh()
-    {
-        var project = new GumProjectSave();
-        ObjectFinder.Self.GumProjectSave = project;
-
-        var behaviorInstance = new BehaviorInstanceSave { Name = "NewName" };
-
-        _sut.HandleInstanceRenamed(container: null, instance: behaviorInstance, oldName: "OldName");
-
-        _fileCommands.Verify(f => f.TryAutoSaveElement(It.IsAny<ElementSave>()), Times.Never);
-        _guiCommands.Verify(g => g.RefreshElementTreeView(It.IsAny<IInstanceContainer>()), Times.Never);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Logic/InheritanceLogic.cs
+++ b/Tools/Gum.Presentation/Logic/InheritanceLogic.cs
@@ -3,7 +3,6 @@ using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
-using Gum.Services;
 using System.Linq;
 
 namespace Gum.Logic;
@@ -12,10 +11,10 @@ public class InheritanceLogic
 {
     private readonly IFileCommands _fileCommands;
     private readonly IGuiCommands _guiCommands;
-    private readonly StandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly IStandardElementsManagerGumTool _standardElementsManagerGumTool;
 
     public InheritanceLogic(IFileCommands fileCommands, IGuiCommands guiCommands,
-        StandardElementsManagerGumTool standardElementsManagerGumTool)
+        IStandardElementsManagerGumTool standardElementsManagerGumTool)
     {
         _fileCommands = fileCommands;
         _guiCommands = guiCommands;


### PR DESCRIPTION
Closes #3908

Relocates `InheritanceLogic` from `Gum.csproj` into headless `Gum.Presentation`.

## Categorization
- **(a) genuinely relocatable now:** all of `InheritanceLogic`'s own logic — `ObjectFinder.Self`/`StandardElementsManager.Self` (sanctioned, already headless via GumCommon), `IFileCommands`/`IGuiCommands` (already in `Gum.Presentation`), `ElementSave`/`InstanceSave`/`StateSave`/`GumProjectSave` (GumDataTypes, already headless).
- **(b) convertible with reasonable effort:** the one blocker — the constructor took the concrete, still-WPF-coupled `StandardElementsManagerGumTool` (lives in `Gum.csproj`, pulls in `WpfDataUi.Controls`/`Gum.Controls`) instead of its own already-headless `IStandardElementsManagerGumTool` interface (already in `Gum.Presentation`, DI-registered as a passthrough in `Builder.cs`). Swapped the ctor param to the interface — a thin, pre-existing seam, not new design.
- **(c) genuinely stuck:** none.

## What changed
- Moved `Gum/Logic/InheritanceLogic.cs` → `Tools/Gum.Presentation/Logic/InheritanceLogic.cs` (namespace unchanged, so no consumer edits needed in `Builder.cs`/`PluginManager.cs`/`MainInheritancePlugin.cs`).
- Ctor param `StandardElementsManagerGumTool` → `IStandardElementsManagerGumTool`.
- Dropped a dead `using Gum.Services;`.
- Moved `InheritanceLogicTests` to `Tests/Gum.Presentation.Tests/`, mocking the interface instead of constructing the concrete type.

## Verification
- `Tests/Gum.Presentation.Tests` (555 tests): pass.
- `Tool/Tests/GumToolUnitTests` full suite (1081 tests, 2 pre-existing skips): pass.
- `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests`: pass (no new bridge needed — `InheritanceLogic` was already MEF-bridged; ctor dependency type changed but not its DI registration shape).
- `dotnet build GumFull.sln`: 0 errors.
- Mutation-test proof: temporarily neutered the rename in `HandleInstanceRenamed`, confirmed `HandleInstanceRenamed_WithValidContainer_RenamesInstanceInDerivedElements` goes red for the right reason, reverted.

No new gotcha beyond what's already in `Direction/ui-decoupling-plan.md`'s "interface-typed field doesn't save you" family — this is the mirror case: a *concrete-typed* ctor param blocked the move even though a clean interface for it already existed and was already used elsewhere in DI. Worth a one-line addition to that gotcha list (not made here, per the no-self-edit rule for that doc).
