### PR TITLE
Relocate VariableSaveLogic (concrete class) into headless Gum.Presentation

### DIFF
--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -483,6 +483,7 @@
 		<Compile Remove="Reflection\ITypeManager.cs" />
 		<Compile Remove="Reflection\TypeManager.cs" />
 		<Compile Remove="Logic\IVariableSaveLogic.cs" />
+		<Compile Remove="Logic\IVariableTypeConverterProvider.cs" />
 		<Compile Remove="Mvvm\ObservableCollectionExtensions.cs" />
 		<Compile Remove="Mvvm\ViewModel.cs" />
 		<Compile Remove="RenderingLibrary\Blend.cs" />

--- a/Gum/Logic/IVariableSaveLogic.cs
+++ b/Gum/Logic/IVariableSaveLogic.cs
@@ -27,9 +27,11 @@ public interface IVariableSaveLogic
     /// <summary>
     /// Returns the <see cref="TypeConverter"/> that should be used to edit/display the given variable
     /// in the Variables tab (classified by file/font/guide/state/animation-chain/exposed-variable, or
-    /// ultimately its runtime type). Narrow seam over <c>VariableSaveExtensionMethodsGumTool.GetTypeConverter</c>
-    /// (Locator-resolving, tool-only) so headless callers (e.g. the relocated <c>ElementSaveDisplayer</c>)
-    /// don't need to reference it directly.
+    /// ultimately its runtime type). Implemented by delegating to the injected
+    /// <c>IVariableTypeConverterProvider</c> — the actual narrow seam over
+    /// <c>VariableSaveExtensionMethodsGumTool.GetTypeConverter</c> (Locator-resolving, tool-only) —
+    /// so headless callers (e.g. the relocated <c>ElementSaveDisplayer</c>) don't need to reference
+    /// that tool-only extension method directly.
     /// </summary>
     TypeConverter GetTypeConverter(VariableSave defaultVariable, ElementSave? container);
 }

--- a/Gum/Logic/IVariableTypeConverterProvider.cs
+++ b/Gum/Logic/IVariableTypeConverterProvider.cs
@@ -1,0 +1,19 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using System.ComponentModel;
+
+namespace Gum.Logic;
+
+/// <summary>
+/// Narrow seam over <c>Gum.DataTypes.VariableSaveExtensionMethodsGumTool.GetTypeConverter</c>
+/// (Locator-resolving, tool-only) so <see cref="VariableSaveLogic"/> (headless, Gum.Presentation)
+/// can obtain a variable's <see cref="TypeConverter"/> without referencing that tool-only
+/// extension method directly.
+/// </summary>
+public interface IVariableTypeConverterProvider
+{
+    /// <summary>
+    /// Returns the <see cref="TypeConverter"/> that should be used to edit/display the given variable.
+    /// </summary>
+    TypeConverter GetTypeConverter(VariableSave defaultVariable, ElementSave? container);
+}

--- a/Gum/Logic/VariableTypeConverterProvider.cs
+++ b/Gum/Logic/VariableTypeConverterProvider.cs
@@ -1,0 +1,13 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using System.ComponentModel;
+
+namespace Gum.Logic;
+
+/// <inheritdoc/>
+public class VariableTypeConverterProvider : IVariableTypeConverterProvider
+{
+    /// <inheritdoc/>
+    public TypeConverter GetTypeConverter(VariableSave defaultVariable, ElementSave? container) =>
+        defaultVariable.GetTypeConverter(container);
+}

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -231,6 +231,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<ProjectServices.IErrorDocsRegistry, ProjectServices.ErrorDocsRegistry>();
         services.AddSingleton<ErrorChecker>();
         services.AddSingleton<IErrorChecker>(provider => provider.GetRequiredService<ErrorChecker>());
+        services.AddSingleton<IVariableTypeConverterProvider, VariableTypeConverterProvider>();
         services.AddSingleton<IVariableSaveLogic, VariableSaveLogic>();
         services.AddSingleton<IVariableReferenceLogic, VariableReferenceLogic>();
         services.AddSingleton<IReferenceFinder, ReferenceFinder>();

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -86,14 +86,20 @@
 			resolve System.Type by name via reflection over GumCommon-compiled assemblies), but
 			physically live in Gum/ alongside the WPF-coupled tool code. Linked here so
 			Gum.Presentation (which references GumCommon transitively but not Gum.csproj) can take
-			ITypeManager as a constructor dependency. IVariableSaveLogic (interface only - the
-			concrete VariableSaveLogic stays in Gum/Logic since it depends on IPluginManager/
-			ISelectedState, which live in Gum.Presentation and would create a circular reference)
-			is linked for the same reason, prepping ElementSaveDisplayer's future relocation.
+			ITypeManager as a constructor dependency. IVariableSaveLogic and
+			IVariableTypeConverterProvider are linked for the same reason: the concrete
+			VariableSaveLogic itself moved to Tools/Gum.Presentation/Logic (#3907) since
+			IPluginManager/ISelectedState already live there too - no circular reference, since
+			Gum.Presentation depends on GumCommon, not the other way around. Only its
+			GetTypeConverter member stayed tool-only, behind the IVariableTypeConverterProvider
+			seam (VariableTypeConverterProvider, the concrete implementation, stays in Gum/Logic -
+			it delegates to VariableSaveExtensionMethodsGumTool.GetTypeConverter, which is
+			Locator-resolving and tool-only).
 		-->
 		<Compile Include="..\Gum\Reflection\ITypeManager.cs" Link="Reflection\ITypeManager.cs" />
 		<Compile Include="..\Gum\Reflection\TypeManager.cs" Link="Reflection\TypeManager.cs" />
 		<Compile Include="..\Gum\Logic\IVariableSaveLogic.cs" Link="Logic\IVariableSaveLogic.cs" />
+		<Compile Include="..\Gum\Logic\IVariableTypeConverterProvider.cs" Link="Logic\IVariableTypeConverterProvider.cs" />
 		<Compile Include="..\Gum\Mvvm\ObservableCollectionExtensions.cs" Link="Mvvm\ObservableCollectionExtensions.cs" />
 		<Compile Include="..\Gum\Mvvm\ViewModel.cs" Link="Mvvm\ViewModel.cs" />
 		<Compile Include="..\RenderingLibrary\Content\IContentLoader.cs" Link="Content\IContentLoader.cs" />

--- a/Tests/Gum.Presentation.Tests/VariableSaveLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableSaveLogicTests.cs
@@ -7,12 +7,13 @@ using Gum.ToolStates;
 using Moq;
 using Shouldly;
 
-namespace GumToolUnitTests.Logic;
+namespace Gum.Presentation.Tests;
 
 public class VariableSaveLogicTests : BaseTestClass
 {
     private readonly Mock<ISelectedState> _mockSelectedState;
     private readonly Mock<IPluginManager> _mockPluginManager;
+    private readonly Mock<IVariableTypeConverterProvider> _mockVariableTypeConverterProvider;
     private readonly VariableSaveLogic _logic;
 
     public VariableSaveLogicTests()
@@ -21,7 +22,9 @@ public class VariableSaveLogicTests : BaseTestClass
         _mockPluginManager = new Mock<IPluginManager>();
         _mockPluginManager.Setup(p => p.ShouldExclude(It.IsAny<VariableSave>(), It.IsAny<RecursiveVariableFinder>()))
             .Returns(false);
-        _logic = new VariableSaveLogic(_mockSelectedState.Object, _mockPluginManager.Object);
+        _mockVariableTypeConverterProvider = new Mock<IVariableTypeConverterProvider>();
+        _logic = new VariableSaveLogic(_mockSelectedState.Object, _mockPluginManager.Object,
+            _mockVariableTypeConverterProvider.Object);
 
         ObjectFinder.Self.GumProjectSave = new GumProjectSave();
     }
@@ -105,6 +108,25 @@ public class VariableSaveLogicTests : BaseTestClass
         bool result = _logic.GetShouldIncludeBasedOnBaseType(variableList, container, rootElementSave: null);
 
         result.ShouldBeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // GetTypeConverter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetTypeConverter_DelegatesToInjectedVariableTypeConverterProvider()
+    {
+        VariableSave variable = new VariableSave { Name = "MyVar" };
+        ComponentSave container = new ComponentSave();
+        System.ComponentModel.TypeConverter expectedConverter = new System.ComponentModel.TypeConverter();
+        _mockVariableTypeConverterProvider
+            .Setup(p => p.GetTypeConverter(variable, container))
+            .Returns(expectedConverter);
+
+        System.ComponentModel.TypeConverter result = _logic.GetTypeConverter(variable, container);
+
+        result.ShouldBeSameAs(expectedConverter);
     }
 
     // -----------------------------------------------------------------------

--- a/Tools/Gum.Presentation/Logic/VariableSaveLogic.cs
+++ b/Tools/Gum.Presentation/Logic/VariableSaveLogic.cs
@@ -1,4 +1,4 @@
-﻿using Gum.DataTypes;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins;
@@ -14,12 +14,25 @@ public class VariableSaveLogic : IVariableSaveLogic
 {
     private readonly ISelectedState _selectedState;
     private readonly IPluginManager _pluginManager;
+    private readonly IVariableTypeConverterProvider _variableTypeConverterProvider;
 
-    public VariableSaveLogic(ISelectedState selectedState, IPluginManager pluginManager)
+    public VariableSaveLogic(ISelectedState selectedState, IPluginManager pluginManager,
+        IVariableTypeConverterProvider variableTypeConverterProvider)
     {
         _selectedState = selectedState;
         _pluginManager = pluginManager;
+        _variableTypeConverterProvider = variableTypeConverterProvider;
     }
+
+    /// <summary>
+    /// Returns the VariableSave from the argument element's default state, walking the base-element
+    /// chain. Headless replacement for the tool-only <c>ElementSaveExtensionMethodsGumTool
+    /// .GetVariableFromThisOrBase</c>'s <c>forceDefault: true</c> overload (the only overload this
+    /// class uses) - that overload never touches <see cref="ISelectedState"/>/<c>Locator</c> either,
+    /// it only does so on the <c>forceDefault: false</c> path this class doesn't call.
+    /// </summary>
+    private static VariableSave? GetVariableFromThisOrBaseDefaultState(ElementSave element, string variable) =>
+        element.DefaultState.GetVariableRecursive(variable);
 
     /// <inheritdoc/>
     public bool GetIfVariableIsActive(VariableSave defaultVariable, ElementSave container, InstanceSave? currentInstance)
@@ -114,18 +127,19 @@ public class VariableSaveLogic : IVariableSaveLogic
         if (currentInstance != null)
         {
             var root = ObjectFinder.Self.GetRootStandardElementSave(currentInstance);
-            if (root != null && root.GetVariableFromThisOrBase(defaultVariable.Name, true) != null)
+            var foundVariable = root != null ? GetVariableFromThisOrBaseDefaultState(root, defaultVariable.Name) : null;
+            if (foundVariable != null)
             {
-                var foundVariable = root.GetVariableFromThisOrBase(defaultVariable.Name, true);
                 canOnlyBeSetInDefaultState = foundVariable.CanOnlyBeSetInDefaultState;
             }
         }
         else if (container != null)
         {
             var root = ObjectFinder.Self.GetRootStandardElementSave(container);
-            if (root != null && root.GetVariableFromThisOrBase(defaultVariable.Name, true) != null)
+            var foundVariable = root != null ? GetVariableFromThisOrBaseDefaultState(root, defaultVariable.Name) : null;
+            if (foundVariable != null)
             {
-                canOnlyBeSetInDefaultState = root.GetVariableFromThisOrBase(defaultVariable.Name, true).CanOnlyBeSetInDefaultState;
+                canOnlyBeSetInDefaultState = foundVariable.CanOnlyBeSetInDefaultState;
             }
         }
         bool shouldInclude = true;
@@ -299,5 +313,5 @@ public class VariableSaveLogic : IVariableSaveLogic
 
     /// <inheritdoc/>
     public System.ComponentModel.TypeConverter GetTypeConverter(VariableSave defaultVariable, ElementSave? container) =>
-        defaultVariable.GetTypeConverter(container);
+        _variableTypeConverterProvider.GetTypeConverter(defaultVariable, container);
 }


### PR DESCRIPTION
## Summary
- Relocates the concrete `VariableSaveLogic` class from `Gum.csproj` into headless `Tools/Gum.Presentation/Logic/` (its interface `IVariableSaveLogic` was already GumCommon-linked, per #3907). `ISelectedState`/`IPluginManager` already live in `Gum.Presentation`, so no circular reference existed - the `GumCommon.csproj` comment claiming one was stale.
- One member, `GetTypeConverter`, delegates to a Locator-resolving, tool-only extension method and genuinely can't move. Carved it behind a new `IVariableTypeConverterProvider` seam (headless interface, tool-side implementation) so the rest of the class relocates cleanly - same shape as the existing `IEditVariableService`/`WpfDataUi` split precedent.
- Replaced an ambient tool-only `ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase(ElementSave, bool forceDefault)` call with an equivalent private helper - the class always passed `forceDefault: true`, and that path never touched `Locator`/`ISelectedState` anyway, so this is a pure algebraic simplification, not a behavior change.
- Migrated `VariableSaveLogicTests` to `Gum.Presentation.Tests`, added a test for the new seam's delegation, mutation-tested it (inverted the delegation, confirmed the test goes red).

Closes #3907

## Test plan
- [x] `dotnet build GumFull.sln` - green
- [x] `Gum.Presentation.Tests` (560 tests) - green
- [x] `GumToolUnitTests` full suite (1077 passed, 2 pre-existing unrelated skips) - green
- [x] `ServiceProviderCompositionSpikeTests`/`AllPluginsCompositionTests` (real containers, new ctor dependency added) - green
- [x] Mutation-tested the new `IVariableTypeConverterProvider` delegation test
