### PR TITLE
Relocate ExposeVariableService into headless Gum.Presentation, part of #3846

### DIFF
--- a/Tests/Gum.Presentation.Tests/ExposeVariableServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/ExposeVariableServiceTests.cs
@@ -1,0 +1,130 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Logic;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pinning tests for <see cref="ExposeVariableService"/> — added when the class moved from
+/// <c>Gum.csproj</c> into the headless <c>Gum.Presentation</c> assembly (ADR-0005 Phase 3, #3909).
+/// The move was behavior-preserving, so these characterize existing behavior rather than TDD-driving
+/// new behavior.
+/// </summary>
+public class ExposeVariableServiceTests : BaseTestClass
+{
+    private readonly Mock<IUndoManager> _undoManager;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IRenameLogic> _renameLogic;
+    private readonly Mock<ISelectedState> _selectedState;
+    private readonly Mock<INameVerifier> _nameVerifier;
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IVariableSaveLogic> _variableSaveLogic;
+    private readonly Mock<IPluginManager> _pluginManager;
+    private readonly ExposeVariableService _service;
+
+    public ExposeVariableServiceTests()
+    {
+        _undoManager = new Mock<IUndoManager>();
+        _undoManager.Setup(x => x.RequestLock()).Returns(new UndoLock(() => { }));
+        _guiCommands = new Mock<IGuiCommands>();
+        _fileCommands = new Mock<IFileCommands>();
+        _renameLogic = new Mock<IRenameLogic>();
+        _selectedState = new Mock<ISelectedState>();
+        _nameVerifier = new Mock<INameVerifier>();
+        _dialogService = new Mock<IDialogService>();
+        _variableSaveLogic = new Mock<IVariableSaveLogic>();
+        _pluginManager = new Mock<IPluginManager>();
+
+        _service = new ExposeVariableService(
+            _undoManager.Object,
+            _guiCommands.Object,
+            _fileCommands.Object,
+            _renameLogic.Object,
+            _selectedState.Object,
+            _nameVerifier.Object,
+            _dialogService.Object,
+            _variableSaveLogic.Object,
+            _pluginManager.Object);
+    }
+
+    [Fact]
+    public void ExposeVariable_ShouldSetExposedAsNameAndNotifyPlugins_WhenVariableAlreadyExists()
+    {
+        var component = new ComponentSave { Name = "MyComponent" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        var instance = new InstanceSave { Name = "MyInstance", ParentContainer = component };
+        component.Instances.Add(instance);
+
+        var variable = new VariableSave { Name = "MyInstance.Visible", Value = true };
+        component.DefaultState.Variables.Add(variable);
+
+        _selectedState.Setup(x => x.SelectedElement).Returns(component);
+        _selectedState.Setup(x => x.SelectedStateSave).Returns((StateSave?)null);
+
+        _variableSaveLogic
+            .Setup(x => x.GetIfVariableIsActive(It.IsAny<VariableSave>(), It.IsAny<ElementSave>(), It.IsAny<InstanceSave?>()))
+            .Returns(true);
+
+        var response = _service.ExposeVariable(instance, "Visible", "MyExposedVisible");
+
+        response.Succeeded.ShouldBeTrue();
+        response.Data!.ExposedAsName.ShouldBe("MyExposedVisible");
+        _pluginManager.Verify(x => x.VariableAdd(component, "MyExposedVisible"), Times.Once);
+        _fileCommands.Verify(x => x.TryAutoSaveCurrentElement(), Times.Once);
+        _guiCommands.Verify(x => x.RefreshVariables(true), Times.Once);
+    }
+
+    [Fact]
+    public void HandleUnexposeVariableClick_ShouldClearExposedAsNameAndNotifyPlugins_WhenNoReferencesExist()
+    {
+        var component = new ComponentSave { Name = "MyComponent" };
+        var variable = new VariableSave { Name = "MyInstance.Visible", ExposedAsName = "MyExposedVisible" };
+
+        _renameLogic
+            .Setup(x => x.GetChangesForRenamedVariable(component, variable.Name, "MyExposedVisible"))
+            .Returns(new VariableChangeResponse());
+
+        _service.HandleUnexposeVariableClick(variable, component);
+
+        variable.ExposedAsName.ShouldBeNull();
+        _pluginManager.Verify(x => x.VariableDelete(component, "MyExposedVisible"), Times.Once);
+        _fileCommands.Verify(x => x.TryAutoSaveCurrentElement(), Times.Once);
+        _guiCommands.Verify(x => x.RefreshVariables(true), Times.Once);
+    }
+
+    [Fact]
+    public void HandleUnexposeVariableClick_ShouldShowMessageAndNotClear_WhenVariableIsReferenced()
+    {
+        var component = new ComponentSave { Name = "MyComponent" };
+        var variable = new VariableSave { Name = "MyInstance.Visible", ExposedAsName = "MyExposedVisible" };
+
+        var changes = new VariableChangeResponse();
+        changes.VariableReferenceChanges.Add(new VariableReferenceChange
+        {
+            Container = component,
+            LineIndex = 0,
+            VariableReferenceList = new VariableListSave<string> { Name = "SomeVariableReferences", Value = new List<string> { "SomeInstance.Visible = true" } }
+        });
+
+        _renameLogic
+            .Setup(x => x.GetChangesForRenamedVariable(component, variable.Name, "MyExposedVisible"))
+            .Returns(changes);
+
+        _service.HandleUnexposeVariableClick(variable, component);
+
+        variable.ExposedAsName.ShouldBe("MyExposedVisible");
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Once);
+        _pluginManager.Verify(x => x.VariableDelete(It.IsAny<ElementSave>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Architecture/UiDecouplingRatchetTests.cs
@@ -107,11 +107,14 @@ public class UiDecouplingRatchetTests
         //
         // Heuristic: a file that declares an interface and imports a System.Windows* namespace, with no
         // class declared in the same file. The class exclusion avoids false positives from files that
-        // combine an interface with its WPF-heavy implementation (e.g. ExposeVariableService.cs,
-        // ThemingDialogViewModel.cs), where the using is consumed by the class, not the interface
-        // (audited 2026-07 -- both interfaces there only reference Gum/System.Drawing types). Known
-        // blind spot: a leak added to an interface living in a combined interface+class file won't be
-        // caught by this heuristic.
+        // combine an interface with its WPF-heavy implementation (e.g. ThemingDialogViewModel.cs),
+        // where the using is consumed by the class, not the interface (audited 2026-07 -- the interface
+        // there only references Gum/System.Drawing types). Known blind spot: a leak added to an
+        // interface living in a combined interface+class file won't be caught by this heuristic.
+        // (ExposeVariableService.cs was cited here previously, but IExposeVariableService/
+        // ExposeVariableService were already split into separate files before this comment's last
+        // edit and ExposeVariableService itself has since moved to Gum.Presentation entirely (#3909)
+        // -- neither file is scanned here or matches this heuristic anymore.)
         //
         // ITabManager.AddControl and IBitmapLoader.LoadImage (the 2 sites baseline=2 was tracking)
         // were sealed to object/byte[] respectively -- see issue #3225.

--- a/Tools/Gum.Presentation/Services/ExposeVariableService.cs
+++ b/Tools/Gum.Presentation/Services/ExposeVariableService.cs
@@ -12,7 +12,7 @@ using ToolsUtilities;
 
 namespace Gum.Services;
 
-internal class ExposeVariableService : IExposeVariableService
+public class ExposeVariableService : IExposeVariableService
 {
     private readonly IUndoManager _undoManager;
     private readonly IGuiCommands _guiCommands;
@@ -115,7 +115,7 @@ internal class ExposeVariableService : IExposeVariableService
         var elementSave = _selectedState.SelectedElement;
 
         // if there is an inactive variable, we should get rid of it:
-        var existingVariable = elementSave.GetVariableFromThisOrBase(exposedName);
+        var existingVariable = GetVariableFromThisOrBase(elementSave, exposedName);
 
         // there's a variable but we shouldn't consider it
         // unless it's "Active" - inactive variables may be
@@ -170,6 +170,21 @@ internal class ExposeVariableService : IExposeVariableService
             Succeeded = true,
             Data = variableSave,
         };
+    }
+
+    /// <summary>
+    /// Returns the variable from the element's currently-selected state if <paramref name="element"/>
+    /// is the currently selected element and a state is selected, otherwise from its default state.
+    /// Headless replacement for the tool-only <c>ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase</c>,
+    /// which resolves <see cref="ISelectedState"/> via <c>Locator</c> instead of taking it as a dependency.
+    /// </summary>
+    private VariableSave? GetVariableFromThisOrBase(ElementSave element, string variable)
+    {
+        var stateToPullFrom = (element == _selectedState.SelectedElement && _selectedState.SelectedStateSave != null)
+            ? _selectedState.SelectedStateSave
+            : element.DefaultState;
+
+        return stateToPullFrom.GetVariableRecursive(variable);
     }
 
     private GeneralResponse GetIfCanExpose(InstanceSave instanceSave, VariableSave variableSave, string rootVariableName)


### PR DESCRIPTION
## Summary
`IExposeVariableService` already lived in `Gum.Presentation`; the concrete `ExposeVariableService` was left behind in `Gum.csproj` (same pattern `ProjectManager`/`NameVerifier` were in before their own moves). Full audit found all 9 ctor dependencies already headless (interfaces in `Gum.Presentation` or GumCommon-linked `INameVerifier`/`IVariableSaveLogic`), so this is a full relocation, category (a) in the north-star test.

Only real snag: `ElementSaveExtensionMethodsGumTool.GetVariableFromThisOrBase` (tool-only, `Locator`-resolving) was shadowed by a differently-signatured GumDataTypes overload once moved. Fixed with a private headless replacement, mirroring the identical fix already in `NameVerifier`/`ElementSaveDisplayer`/`VariableGridEntry`.

## Changes
- Moved `Gum/Services/ExposeVariableService.cs` -> `Tools/Gum.Presentation/Services/ExposeVariableService.cs`, `internal` -> `public` (cross-assembly DI registration in `Builder.cs`).
- Added `GetVariableFromThisOrBase` private headless replacement + pinning tests (`ExposeVariableServiceTests`, none existed before).
- Fixed a stale comment in `UiDecouplingRatchetTests` that cited `ExposeVariableService.cs` as a still-combined interface+class file (it split apart before this PR; now fully gone from `Gum/`).

Closes #3909

## Test plan
- [x] `Gum.Presentation.csproj` builds clean standalone
- [x] `GumFull.sln` builds clean (0 errors)
- [x] `Gum.Presentation.Tests`: 555/555 pass (3 new + all existing)
- [x] `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests`: pass
- [x] Mutated one branch (`> 0` -> `>= 0`) in `HandleUnexposeVariableClick`'s reference check, confirmed the pinning test goes red, reverted

Manual test: not needed -- pure behavior-preserving relocation, covered by unit tests + compiler-enforced boundary.
