### PR TITLE
Relocate EditVariableService into headless Gum.Presentation

### DIFF
--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -268,6 +268,11 @@ file static class ServiceCollectionExtensions
         // other
         services.AddDialogs();
         services.AddViewModelFuncFactories(typeof(ServiceCollectionExtensions).Assembly);
+        // ADR-0005: mirrors the ViewModel-registration double-scan above (line ~88) — a service that
+        // moved into the headless Gum.Presentation assembly (e.g. EditVariableService, which takes a
+        // Func<AddVariableViewModel>) needs its ctor scanned from that assembly too, or the factory the
+        // container needs to activate it never gets registered.
+        services.AddViewModelFuncFactories(typeof(DialogViewModel).Assembly);
         services.AddSingleton<IDispatcher>(_ => new AppDispatcher(() => Application.Current.Dispatcher));
         services.AddSingleton<IAppScaleProvider, AppScaleProvider>();
         services.AddSingleton<IUiSettingsService, UiSettingsService>();

--- a/Tests/Gum.Presentation.Tests/EditVariableServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/EditVariableServiceTests.cs
@@ -6,14 +6,12 @@ using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
 using Gum.Services;
 using Gum.Services.Dialogs;
-using Gum.ToolCommands;
-using Gum.ToolStates;
 using Gum.Undo;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
 
-namespace GumToolUnitTests.Services;
+namespace Gum.Presentation.Tests;
 
 public class EditVariableServiceTests : BaseTestClass
 {

--- a/Tools/Gum.Presentation/Services/EditVariableService.cs
+++ b/Tools/Gum.Presentation/Services/EditVariableService.cs
@@ -1,23 +1,13 @@
-using CommonFormsAndControls;
-using ExCSS;
-using Gum.Controls;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Logic;
-using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid.ViewModels;
-using Gum.Plugins.VariableGrid;
-using Gum.ToolCommands;
-using Gum.ToolStates;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Gum.Commands;
 using Gum.Services.Dialogs;
 using Gum.Undo;
+using System;
+using System.Collections.Generic;
 
 namespace Gum.Services;
 


### PR DESCRIPTION
## Summary
- Relocates `EditVariableService` (concrete class behind `IEditVariableService`) into headless `Gum.Presentation` — a pure physical move, no `#if`/split needed. The class had zero real WPF coupling; 6 unused usings (`CommonFormsAndControls`, `ExCSS`, `Gum.Controls`, `Gum.Managers`, `Gum.ToolCommands`, `Gum.ToolStates`) made it look more entangled than it was on first read. All 5 injected interfaces and `AddVariableViewModel` already lived in `Gum.Presentation`. It only ever implements `IEditVariableService` — no `IEditVariableMenuService` sibling exists on this class.
- Moved its tests alongside into `Tests/Gum.Presentation.Tests/EditVariableServiceTests.cs` (same 4 tests, unchanged assertions).
- Fixed a real DI break the move surfaced: `Builder.cs`'s `Func<ViewModel>` factory auto-registration only scanned `Gum.csproj`'s own assembly for consumer constructors requesting a `Func<TViewModel>`. `EditVariableService`'s `Func<AddVariableViewModel>` ctor param went unregistered once relocated — caught by `ServiceProviderCompositionSpikeTests`. Fixed with a second scan anchored in `Gum.Presentation`'s assembly, mirroring the already-existing VM-registration double-scan.

## Test plan
- [x] `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` — 556 passed
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter "ServiceProviderCompositionSpikeTests|AllPluginsCompositionTests"` — both passed
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] Mutation test: inverted the `isExposed` ternary in `GetAvailableEditModeFor`, confirmed 3/4 tests went red, reverted

Closes #3914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
