### PR TITLE
Relocate RenameManager into headless Gum.Presentation, part of #3927

### DIFF
--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/RenameManager.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/RenameManager.cs
@@ -1,5 +1,4 @@
-﻿using Gum;
-using Gum.DataTypes;
+﻿using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.ToolStates;
@@ -8,8 +7,6 @@ using StateAnimationPlugin.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using ToolsUtilities;
 
 namespace StateAnimationPlugin.Managers


### PR DESCRIPTION
Closes #3927

## Categorization

`RenameManager` (issue #3927) audited against the north-star test: **(a) genuinely relocatable now** - no WPF types, no blockers. All 5 ctor deps (`ISelectedState`, `IOutputManager`, `IAnimationFilePathService`, `IAnimationCollectionViewModelManager`, `IProjectManager`) already live in `Gum.Presentation`, as does the interface it implements (`IRenameManager`) and every type it touches (save-class model, the animation ViewModels, `ObjectFinder.Self`, `FileManager`/`FilePath`). It was the last concrete class still blocking `StateAnimationPlugin`'s `MainStateAnimationPlugin.cs` from being 100% interface-typed against the plugin's headless logic.

## What changed

Pure file move: `Gum/StateAnimationPlugin/Managers/RenameManager.cs` -> `Tools/Gum.Presentation/StateAnimationPlugin/Managers/RenameManager.cs`. No csproj edits - `StateAnimationPlugin.csproj` already transitively references `Gum.Presentation` via `Gum.csproj`. Dropped 3 unused usings (`Gum`, `System.Text`, `System.Threading.Tasks`) as a boyscout cleanup while touching the file.

## Testing

- `GumFull.sln` builds clean (0 errors).
- Existing `RenameManagerTests` (5 tests, `GumToolUnitTests`) already fully pin all 5 `HandleRename` overloads - all pass unchanged post-move.
- Mutation-tested the state-rename branch (neutered the equality check) - the pinning test failed for the right reason, then reverted.
- `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests` green (no ctor/csproj compile-item changes, but ran per the campaign's standing rule).

Manual test: not needed - behavior-preserving move, covered by the existing pinning tests + compiler.
