### PR TITLE
Relocate MainBehaviorsPlugin business logic into headless Gum.Presentation, part of #3928

### DIFF
--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -1,17 +1,11 @@
 using Gum.Plugins.BaseClasses;
-using System;
 using System.ComponentModel.Composition;
-using System.Linq;
-using Gum.DataTypes;
 using Gum.ToolStates;
 using Gum.DataTypes.Behaviors;
-using WpfDataUi;
 using System.Windows.Forms;
 using Gum.Undo;
-using Gum.DataTypes.Variables;
-using Gum.Managers;
-using System.Collections.Generic;
 using Gum.ToolCommands;
+using Gum.Managers;
 
 namespace Gum.Plugins.Behaviors;
 
@@ -26,8 +20,8 @@ public class MainBehaviorsPlugin : PriorityPlugin
     private readonly IPluginManager _pluginManager;
 
     BehaviorsViewModel viewModel;
-    DataUiGrid stateDataUiGrid;
     PluginTab behaviorsTab;
+    BehaviorsLogic behaviorsLogic;
 
     [ImportingConstructor]
     public MainBehaviorsPlugin(
@@ -46,92 +40,42 @@ public class MainBehaviorsPlugin : PriorityPlugin
 
     public override void StartUp()
     {
-
         viewModel = new BehaviorsViewModel(_selectedState, _projectManager);
-        viewModel.ApplyChangedValues += HandleApplyBehaviorChanges;
-
 
         control = new BehaviorsControl();
         control.DataContext = viewModel;
         behaviorsTab = _tabManager.AddControl(control, "Behaviors", TabLocation.CenterBottom);
         behaviorsTab.Hide();
-        
-        stateDataUiGrid = new DataUiGrid();
+
+        // The bulk of this plugin's logic lives in BehaviorsLogic (Gum.Presentation, headless and
+        // unit tested) - this plugin is just the WPF glue that builds the view/tab above and
+        // forwards its own plugin events into that logic (ADR-0005 Phase 3, #3928).
+        behaviorsLogic = new BehaviorsLogic(
+            _selectedState, _elementCommands, _undoManager, _pluginManager,
+            _guiCommands, _fileCommands, viewModel, behaviorsTab);
+
+        viewModel.ApplyChangedValues += behaviorsLogic.HandleApplyBehaviorChanges;
+
         AssignEvents();
     }
 
     private void AssignEvents()
     {
-        this.ElementSelected += HandleElementSelected;
-        this.InstanceSelected += HandleInstanceSelected;
+        this.ElementSelected += behaviorsLogic.HandleElementSelected;
+        this.InstanceSelected += behaviorsLogic.HandleInstanceSelected;
         this.BehaviorSelected += HandleBehaviorSelected;
         this.StateWindowTreeNodeSelected += HandleStateSelected;
-        this.BehaviorReferencesChanged += HandleBehaviorReferencesChanged;
+        this.BehaviorReferencesChanged += behaviorsLogic.HandleBehaviorReferencesChanged;
 
-        this.RefreshBehaviorView += HandleRefreshBehaviorView;
+        this.RefreshBehaviorView += behaviorsLogic.HandleRefreshBehaviorView;
 
-        this.StateAdd += HandleStateAdd;
-        this.StateMovedToCategory += HandleStateMovedToCategory;
+        this.StateAdd += behaviorsLogic.HandleStateAdd;
+        this.StateMovedToCategory += behaviorsLogic.HandleStateMovedToCategory;
     }
 
-    private void HandleRefreshBehaviorView()
-    {
-        HandleElementSelected(_selectedState.SelectedElement);
-    }
-
-    private void HandleStateMovedToCategory(StateSave stateSave, StateSaveCategory newCategory, StateSaveCategory oldCategory)
-    {
-        var behavior = ObjectFinder.Self.GumProjectSave.Behaviors
-            .FirstOrDefault(item => item.AllStates.Contains(stateSave));
-
-        if (behavior != null)
-        {
-            AddStateToElementsImplementingBehavior(stateSave, behavior);
-        }
-    }
-
-    private void HandleStateAdd(StateSave stateSave)
-    {
-        var behavior = ObjectFinder.Self.GumProjectSave.Behaviors
-            .FirstOrDefault(item => item.AllStates.Contains(stateSave));
-
-        if (behavior != null)
-        {
-            AddStateToElementsImplementingBehavior(stateSave, behavior);
-        }
-    }
-
-    private void AddStateToElementsImplementingBehavior(StateSave stateSave, BehaviorSave behavior)
-    {
-        var category = behavior.Categories.FirstOrDefault(item => item.States.Contains(stateSave));
-
-        var elementsUsingBehavior = ObjectFinder.Self.GumProjectSave.AllElements
-            .Where(item => item.Behaviors.Any(b => b.BehaviorName == behavior.Name))
-            .ToList();
-
-        var categoryName = category?.Name;
-
-        List<ElementSave> elementsToSave = new List<ElementSave>();
-
-        foreach (var element in elementsUsingBehavior)
-        {
-            var categoryInElement = element.Categories.FirstOrDefault(item => item.Name == categoryName);
-
-            if (categoryInElement != null)
-            {
-                var existingState = categoryInElement.States.FirstOrDefault(item => item.Name == stateSave.Name);
-
-                if (existingState == null)
-                {
-                    // add a new state to this category
-                    _elementCommands.AddState(element, categoryInElement, stateSave.Name);
-
-                    elementsToSave.Add(element);
-                }
-            }
-        }
-    }
-
+    // System.Windows.Forms.TreeNode is a real WinForms-glue signature baked into
+    // PluginBase.StateWindowTreeNodeSelected itself, so this handler can't move into
+    // BehaviorsLogic; it's a no-op today regardless.
     private void HandleStateSelected(TreeNode obj)
     {
 
@@ -141,110 +85,4 @@ public class MainBehaviorsPlugin : PriorityPlugin
     {
 
     }
-
-    bool isApplyingChanges = false;
-    private void HandleApplyBehaviorChanges(object? sender, EventArgs e)
-    {
-
-        var component = _selectedState.SelectedComponent;
-        if (component == null) return;
-
-        isApplyingChanges = true;
-
-        try
-        {
-            using var undoLock = _undoManager.RequestLock();
-
-            var selectedBehaviorNames = viewModel.AllBehaviors
-                .Where(item => item.IsChecked)
-                .Select(item => item.Name)
-                .ToList();
-
-            var addedBehaviors = selectedBehaviorNames
-                .Except(component.Behaviors.Select(item => item.BehaviorName))
-                .ToList();
-
-            var removedBehaviors = component.Behaviors.Select(item => item.BehaviorName)
-                .Except(selectedBehaviorNames)
-                .ToList();
-
-            if (removedBehaviors.Any())
-            {
-                // ask the user what to do
-            }
-
-            if (removedBehaviors.Any() || addedBehaviors.Any())
-            {
-                component.Behaviors.Clear();
-                foreach (var behavior in viewModel.AllBehaviors.Where(item => item.IsChecked))
-                {
-                    _elementCommands.AddBehaviorTo(behavior.Name, component, performSave: false);
-                }
-
-                _guiCommands.RefreshStateTreeView();
-                _fileCommands.TryAutoSaveElement(component);
-                // _elementCommands.AddBehaviorTo only raises BehaviorReferencesChanged
-                // when a real (project-existing) behavior is added. Pure removals — e.g.
-                // unchecking only a stale orphan — would otherwise leave error state stale.
-                _pluginManager.BehaviorReferencesChanged(component);
-            }
-            viewModel.UpdateTo(component);
-
-        }
-        finally
-        {
-            isApplyingChanges = false;
-        }
-    }
-
-
-    private void HandleBehaviorReferencesChanged(ElementSave element)
-    {
-        if (isApplyingChanges)
-        {
-            return;
-        }
-        HandleElementSelected(element);
-
-        if(element == _selectedState.SelectedElement)
-        {
-            this.behaviorsTab.Show();
-        }
-    }
-
-    private void HandleElementSelected(ElementSave element)
-    {
-        // In case the user left without clicking "OK" on the previous edit:
-        viewModel.IsEditing = false;
-        UpdateTabPresence();
-    }
-
-    private void UpdateTabPresence()
-    {
-        var asComponent = _selectedState.SelectedComponent;
-
-
-        bool shouldShow = asComponent != null &&
-            // Don't show behaviors if an instance is selected since that can be confusing
-            // Only show it on the element to be clear that behaviors are element-wide.
-            _selectedState.SelectedInstance == null;
-
-        if (shouldShow)
-        {
-            viewModel.UpdateTo(asComponent);
-
-            this.behaviorsTab.Show();
-        }
-        else
-        {
-            this.behaviorsTab.Hide();
-        }
-    }
-
-    private void HandleInstanceSelected(ElementSave save1, InstanceSave save2)
-    {
-        UpdateTabPresence();
-    }
-
-
 }

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -7,7 +7,7 @@ using Gum.Plugins;
 
 namespace Gum.Plugins
 {
-    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate, ITabDockingCandidate
+    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate, ITabDockingCandidate, ITabVisibility
     {
         private readonly IMessenger _messenger;
         public event Action? TabShown;

--- a/Tests/Gum.Presentation.Tests/BehaviorsLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/BehaviorsLogicTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Linq;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.Behaviors;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainBehaviorsPlugin into the headless Gum.Presentation
+/// assembly (ADR-0005 Phase 3, #3928) so this business logic is unit testable. The tab dependency
+/// is narrowed to <see cref="ITabVisibility"/> since the concrete PluginTab is WPF-typed.
+/// </summary>
+public class BehaviorsLogicTests
+{
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly Mock<IElementCommands> _elementCommands = new();
+    private readonly Mock<IUndoManager> _undoManager = new();
+    private readonly Mock<IPluginManager> _pluginManager = new();
+    private readonly Mock<IGuiCommands> _guiCommands = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<ITabVisibility> _tab = new();
+    private readonly BehaviorsViewModel _viewModel;
+    private readonly BehaviorsLogic _logic;
+
+    public BehaviorsLogicTests()
+    {
+        _undoManager.Setup(x => x.RequestLock()).Returns(new UndoLock(() => { }));
+        _projectManager.SetupGet(x => x.GumProjectSave).Returns(new GumProjectSave());
+        _viewModel = new BehaviorsViewModel(_selectedState.Object, _projectManager.Object);
+
+        _logic = new BehaviorsLogic(
+            _selectedState.Object, _elementCommands.Object, _undoManager.Object, _pluginManager.Object,
+            _guiCommands.Object, _fileCommands.Object, _viewModel, _tab.Object);
+    }
+
+    [Fact]
+    public void HandleApplyBehaviorChanges_NoSelectedComponent_DoesNothing()
+    {
+        _selectedState.Setup(x => x.SelectedComponent).Returns((ComponentSave?)null);
+
+        _logic.HandleApplyBehaviorChanges(null, EventArgs.Empty);
+
+        _elementCommands.Verify(x => x.AddBehaviorTo(It.IsAny<string>(), It.IsAny<ComponentSave>(), It.IsAny<bool>()), Times.Never);
+        _guiCommands.Verify(x => x.RefreshStateTreeView(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleApplyBehaviorChanges_NoCheckedOrExistingBehaviors_DoesNotRefreshOrSave()
+    {
+        ComponentSave component = new() { Name = "Component1" };
+        _selectedState.Setup(x => x.SelectedComponent).Returns(component);
+        _viewModel.UpdateTo(component);
+
+        _logic.HandleApplyBehaviorChanges(null, EventArgs.Empty);
+
+        _guiCommands.Verify(x => x.RefreshStateTreeView(), Times.Never);
+        _fileCommands.Verify(x => x.TryAutoSaveElement(It.IsAny<ElementSave>()), Times.Never);
+        _pluginManager.Verify(x => x.BehaviorReferencesChanged(It.IsAny<ElementSave>()), Times.Never);
+    }
+
+    [Fact]
+    public void HandleApplyBehaviorChanges_AddedBehavior_AddsToComponentAndRefreshesAndSaves()
+    {
+        GumProjectSave project = new();
+        project.Behaviors.Add(new BehaviorSave { Name = "Flyable" });
+        _projectManager.SetupGet(x => x.GumProjectSave).Returns(project);
+
+        ComponentSave component = new() { Name = "Component1" };
+        _selectedState.Setup(x => x.SelectedComponent).Returns(component);
+        _viewModel.UpdateTo(component);
+        _viewModel.AllBehaviors.Single(x => x.Name == "Flyable").IsChecked = true;
+
+        _logic.HandleApplyBehaviorChanges(null, EventArgs.Empty);
+
+        _elementCommands.Verify(x => x.AddBehaviorTo("Flyable", component, false), Times.Once);
+        _guiCommands.Verify(x => x.RefreshStateTreeView(), Times.Once);
+        _fileCommands.Verify(x => x.TryAutoSaveElement(component), Times.Once);
+        _pluginManager.Verify(x => x.BehaviorReferencesChanged(component), Times.Once);
+    }
+
+    [Fact]
+    public void HandleApplyBehaviorChanges_WhilePluginManagerReentersSynchronously_SuppressesReentrantTabUpdate()
+    {
+        // PluginManager.BehaviorReferencesChanged, in the real tool, fans out synchronously to every
+        // subscribed plugin - including this plugin's own HandleBehaviorReferencesChanged. This pins
+        // the _isApplyingChanges guard that keeps that reentrant call from touching the tab while the
+        // apply is still in flight.
+        GumProjectSave project = new();
+        project.Behaviors.Add(new BehaviorSave { Name = "Flyable" });
+        _projectManager.SetupGet(x => x.GumProjectSave).Returns(project);
+
+        ComponentSave component = new() { Name = "Component1" };
+        _selectedState.Setup(x => x.SelectedComponent).Returns(component);
+        _selectedState.Setup(x => x.SelectedElement).Returns(component);
+        _selectedState.Setup(x => x.SelectedInstance).Returns((InstanceSave?)null);
+        _viewModel.UpdateTo(component);
+        _viewModel.AllBehaviors.Single(x => x.Name == "Flyable").IsChecked = true;
+
+        _pluginManager.Setup(x => x.BehaviorReferencesChanged(component))
+            .Callback(() => _logic.HandleBehaviorReferencesChanged(component));
+
+        _logic.HandleApplyBehaviorChanges(null, EventArgs.Empty);
+
+        _tab.Verify(x => x.Show(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleElementSelected_ComponentSelectedWithNoInstance_ShowsTab()
+    {
+        ComponentSave component = new() { Name = "Component1" };
+        _selectedState.Setup(x => x.SelectedComponent).Returns(component);
+        _selectedState.Setup(x => x.SelectedInstance).Returns((InstanceSave?)null);
+
+        _logic.HandleElementSelected(component);
+
+        _tab.Verify(x => x.Show(), Times.Once);
+        _tab.Verify(x => x.Hide(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleInstanceSelected_InstanceSelected_HidesTab()
+    {
+        ComponentSave component = new() { Name = "Component1" };
+        InstanceSave instance = new() { Name = "Instance1" };
+        _selectedState.Setup(x => x.SelectedComponent).Returns(component);
+        _selectedState.Setup(x => x.SelectedInstance).Returns(instance);
+
+        _logic.HandleInstanceSelected(component, instance);
+
+        _tab.Verify(x => x.Hide(), Times.Once);
+        _tab.Verify(x => x.Show(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleStateAdd_ElementImplementingBehaviorMissingState_AddsStateToThatElement()
+    {
+        GumProjectSave project = new();
+        BehaviorSave behavior = new() { Name = "Flyable" };
+        StateSaveCategory behaviorCategory = new() { Name = "FlyState" };
+        StateSave newState = new() { Name = "Flying" };
+        behaviorCategory.States.Add(newState);
+        behavior.Categories.Add(behaviorCategory);
+        project.Behaviors.Add(behavior);
+
+        ComponentSave elementMissingState = new() { Name = "Bird" };
+        elementMissingState.Behaviors.Add(new ElementBehaviorReference { BehaviorName = "Flyable" });
+        StateSaveCategory elementCategory = new() { Name = "FlyState" };
+        elementMissingState.Categories.Add(elementCategory);
+        project.Screens.Clear();
+        project.Components.Add(elementMissingState);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            _logic.HandleStateAdd(newState);
+
+            _elementCommands.Verify(
+                x => x.AddState(elementMissingState, elementCategory, "Flying"), Times.Once);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/ITabVisibility.cs
+++ b/Tools/Gum.Presentation/Plugins/ITabVisibility.cs
@@ -1,0 +1,14 @@
+namespace Gum.Plugins;
+
+/// <summary>
+/// Narrow, headless-safe seam over a plugin's own tab (<c>PluginTab</c>) for logic that only needs
+/// to show/hide it. <c>PluginTab</c> itself is WPF-typed (its <c>Content</c> is a
+/// <c>System.Windows.FrameworkElement</c>), which would block referencing it from
+/// <c>Gum.Presentation</c> even though this seam's members don't touch WPF at all - same shape as
+/// <c>ITabDockingCandidate</c>/<c>ITabAutoSelectCandidate</c>.
+/// </summary>
+public interface ITabVisibility
+{
+    void Show();
+    void Hide();
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/Behaviors/BehaviorsLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/Behaviors/BehaviorsLogic.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Commands;
+using Gum.Plugins;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Managers;
+
+namespace Gum.Plugins.Behaviors;
+
+/// <summary>
+/// Business logic behind the Behaviors panel, relocated out of the WPF-hosted
+/// <c>MainBehaviorsPlugin</c> (ADR-0005 Phase 3, #3928) so it can be unit tested headlessly.
+/// The plugin stays a thin wrapper: it builds the WPF view/tab in <c>StartUp</c>, constructs this
+/// class, and forwards its own plugin events into the matching methods here.
+/// </summary>
+public class BehaviorsLogic
+{
+    private readonly ISelectedState _selectedState;
+    private readonly IElementCommands _elementCommands;
+    private readonly IUndoManager _undoManager;
+    private readonly IPluginManager _pluginManager;
+    private readonly IGuiCommands _guiCommands;
+    private readonly IFileCommands _fileCommands;
+    private readonly BehaviorsViewModel _viewModel;
+    private readonly ITabVisibility _tab;
+
+    private bool _isApplyingChanges;
+
+    public BehaviorsLogic(
+        ISelectedState selectedState,
+        IElementCommands elementCommands,
+        IUndoManager undoManager,
+        IPluginManager pluginManager,
+        IGuiCommands guiCommands,
+        IFileCommands fileCommands,
+        BehaviorsViewModel viewModel,
+        ITabVisibility tab)
+    {
+        _selectedState = selectedState;
+        _elementCommands = elementCommands;
+        _undoManager = undoManager;
+        _pluginManager = pluginManager;
+        _guiCommands = guiCommands;
+        _fileCommands = fileCommands;
+        _viewModel = viewModel;
+        _tab = tab;
+    }
+
+    public void HandleRefreshBehaviorView()
+    {
+        HandleElementSelected(_selectedState.SelectedElement);
+    }
+
+    public void HandleStateMovedToCategory(StateSave stateSave, StateSaveCategory newCategory, StateSaveCategory oldCategory)
+    {
+        BehaviorSave? behavior = ObjectFinder.Self.GumProjectSave.Behaviors
+            .FirstOrDefault(item => item.AllStates.Contains(stateSave));
+
+        if (behavior != null)
+        {
+            AddStateToElementsImplementingBehavior(stateSave, behavior);
+        }
+    }
+
+    public void HandleStateAdd(StateSave stateSave)
+    {
+        BehaviorSave? behavior = ObjectFinder.Self.GumProjectSave.Behaviors
+            .FirstOrDefault(item => item.AllStates.Contains(stateSave));
+
+        if (behavior != null)
+        {
+            AddStateToElementsImplementingBehavior(stateSave, behavior);
+        }
+    }
+
+    private void AddStateToElementsImplementingBehavior(StateSave stateSave, BehaviorSave behavior)
+    {
+        StateSaveCategory? category = behavior.Categories.FirstOrDefault(item => item.States.Contains(stateSave));
+
+        List<ElementSave> elementsUsingBehavior = ObjectFinder.Self.GumProjectSave.AllElements
+            .Where(item => item.Behaviors.Any(b => b.BehaviorName == behavior.Name))
+            .ToList();
+
+        string? categoryName = category?.Name;
+
+        foreach (ElementSave element in elementsUsingBehavior)
+        {
+            StateSaveCategory? categoryInElement = element.Categories.FirstOrDefault(item => item.Name == categoryName);
+
+            if (categoryInElement != null)
+            {
+                StateSave? existingState = categoryInElement.States.FirstOrDefault(item => item.Name == stateSave.Name);
+
+                if (existingState == null)
+                {
+                    // add a new state to this category
+                    _elementCommands.AddState(element, categoryInElement, stateSave.Name);
+                }
+            }
+        }
+    }
+
+    public void HandleApplyBehaviorChanges(object? sender, EventArgs e)
+    {
+        ComponentSave? component = _selectedState.SelectedComponent;
+        if (component == null)
+        {
+            return;
+        }
+
+        _isApplyingChanges = true;
+
+        try
+        {
+            using UndoLock undoLock = _undoManager.RequestLock();
+
+            List<string> selectedBehaviorNames = _viewModel.AllBehaviors
+                .Where(item => item.IsChecked)
+                .Select(item => item.Name)
+                .ToList();
+
+            List<string> addedBehaviors = selectedBehaviorNames
+                .Except(component.Behaviors.Select(item => item.BehaviorName))
+                .ToList();
+
+            List<string> removedBehaviors = component.Behaviors.Select(item => item.BehaviorName)
+                .Except(selectedBehaviorNames)
+                .ToList();
+
+            if (removedBehaviors.Any() || addedBehaviors.Any())
+            {
+                component.Behaviors.Clear();
+                foreach (CheckListBehaviorItem behavior in _viewModel.AllBehaviors.Where(item => item.IsChecked))
+                {
+                    _elementCommands.AddBehaviorTo(behavior.Name, component, performSave: false);
+                }
+
+                _guiCommands.RefreshStateTreeView();
+                _fileCommands.TryAutoSaveElement(component);
+                // _elementCommands.AddBehaviorTo only raises BehaviorReferencesChanged
+                // when a real (project-existing) behavior is added. Pure removals — e.g.
+                // unchecking only a stale orphan — would otherwise leave error state stale.
+                _pluginManager.BehaviorReferencesChanged(component);
+            }
+            _viewModel.UpdateTo(component);
+        }
+        finally
+        {
+            _isApplyingChanges = false;
+        }
+    }
+
+    public void HandleBehaviorReferencesChanged(ElementSave element)
+    {
+        if (_isApplyingChanges)
+        {
+            return;
+        }
+        HandleElementSelected(element);
+
+        if (element == _selectedState.SelectedElement)
+        {
+            _tab.Show();
+        }
+    }
+
+    public void HandleElementSelected(ElementSave? element)
+    {
+        // In case the user left without clicking "OK" on the previous edit:
+        _viewModel.IsEditing = false;
+        UpdateTabPresence();
+    }
+
+    private void UpdateTabPresence()
+    {
+        ComponentSave? asComponent = _selectedState.SelectedComponent;
+
+        bool shouldShow = asComponent != null &&
+            // Don't show behaviors if an instance is selected since that can be confusing
+            // Only show it on the element to be clear that behaviors are element-wide.
+            _selectedState.SelectedInstance == null;
+
+        if (shouldShow)
+        {
+            _viewModel.UpdateTo(asComponent!);
+
+            _tab.Show();
+        }
+        else
+        {
+            _tab.Hide();
+        }
+    }
+
+    public void HandleInstanceSelected(ElementSave save1, InstanceSave save2)
+    {
+        UpdateTabPresence();
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts `MainBehaviorsPlugin`'s business logic into a new `BehaviorsLogic` class in the headless `Gum.Presentation` assembly (ADR-0005 Phase 3).
- The plugin now only builds the WPF view/tab in `StartUp` and forwards its own plugin events into `BehaviorsLogic` methods - a thin wrapper, same shape as `AnimationTabController`/`ExclusionsLogic`.
- `PluginTab` (WPF-typed via its `Content: FrameworkElement`) gains a narrow `ITabVisibility` (`Show`/`Hide`) seam so `BehaviorsLogic` can command tab visibility without referencing the WPF-typed class - same pattern as `ITabDockingCandidate`/`ITabAutoSelectCandidate`.
- Drop-in boy-scout: removed a dead `DataUiGrid` field that was assigned and never read.

## Categorization (per the north-star test)
- **(a) Genuinely relocatable now:** all of it except the two items below - the whole event-handling/business-logic surface (apply-behavior-changes, tab show/hide presence logic, state-add/category-move propagation) had zero real WPF dependency once the tab was narrowed.
- **(b) Convertible with reasonable effort:** the `PluginTab` dependency - WPF-typed by its `Content` property, but the two members actually used (`Show`/`Hide`) don't touch WPF at all. Fixed via the new `ITabVisibility` interface (same shape as the `ContextMenu`/`IEditVariableService` gotchas in the plan doc).
- **(c) Genuinely stuck:** `HandleStateSelected(TreeNode obj)` - `PluginBase.StateWindowTreeNodeSelected` is declared as `Action<System.Windows.Forms.TreeNode>` on the base class itself, so the handler's *signature* is WinForms-coupled regardless of body content. It's a no-op today; left in the plugin. `HandleBehaviorSelected(BehaviorSave obj)` is a no-op too and stayed for symmetry (its type is clean, but there was nothing to move).

## New gotcha for `Direction/ui-decoupling-plan.md`
`PluginTab`'s two settable-boolean wrapper methods (`Show()`/`Hide()`) are usable from a headless caller even though the class itself is WPF-typed by an unrelated member (`Content: FrameworkElement`) - narrow with a single-purpose interface (`ITabVisibility`) rather than treating the whole class as blocked, same shape as the existing `ITabDockingCandidate`/`ITabAutoSelectCandidate`/`IEditVariableService` split-interface gotchas already in the doc.

## Test plan
- `BehaviorsLogicTests` (7 tests, all headless/mocked): apply-behavior-changes happy path, no-op guards, the `_isApplyingChanges` reentrancy guard (mutation-tested: inverting the guard flips a `Times.Never` assertion to a failing `Times(2)`), tab show/hide on element/instance selection, and state-add propagation via `ObjectFinder.Self`.
- `AllPluginsCompositionTests` and `ServiceProviderCompositionSpikeTests` pass (no ctor/DI changes; `BehaviorsLogic` is constructed with `new` inside `StartUp`, not DI-resolved).
- `dotnet build GumFull.sln` clean, `Gum.Presentation.Tests` full suite green (637/637).

Closes #3928
