### PR TITLE
Relocate DeleteObjectPlugin's delete-decision logic into headless Gum.Presentation

### DIFF
--- a/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
@@ -4,10 +4,8 @@ using System.Linq;
 using Gum.Plugins.BaseClasses;
 using System.ComponentModel.Composition;
 using Gum.DataTypes;
-using Gum.DataTypes.Behaviors;
 using System.Windows.Controls;
 using Gum.Commands;
-using ToolsUtilities;
 using Gum.Managers;
 
 namespace Gum.Gui.Plugins;
@@ -80,7 +78,7 @@ public class DeleteObjectPlugin : PriorityPlugin
 
             if (deleteXmlCheckBox.IsChecked == true)
             {
-                var fileName = GetFileNameForObject(deletedObject);
+                var fileName = _instanceDeletionHelper.GetFileNameForObject(deletedObject);
 
                 if (fileName?.Exists() == true)
                 {
@@ -99,7 +97,11 @@ public class DeleteObjectPlugin : PriorityPlugin
         // Perform batch instance deletion
         if (instancesToDelete.Count > 0)
         {
-            PerformMultipleInstancesDeleteLogic(instancesToDelete);
+            var shouldDetachChildren = deleteJustParent.IsChecked == true;
+            var shouldDeleteChildren = deleteAllContainedObjects.IsChecked == true;
+
+            _instanceDeletionHelper.PerformMultipleInstancesDelete(
+                instancesToDelete, shouldDetachChildren, shouldDeleteChildren);
         }
 
         if (deleteOptionsWindow.MainStackPanel.Children.Contains(deleteXmlCheckBox))
@@ -111,49 +113,6 @@ public class DeleteObjectPlugin : PriorityPlugin
         {
             deleteOptionsWindow.MainStackPanel.Children.Remove(deleteGroupBox);
         }
-    }
-
-    private void PerformInstanceDeleteLogic(InstanceSave instance)
-    {
-        PerformMultipleInstancesDeleteLogic(new[] { instance });
-    }
-
-    private void PerformMultipleInstancesDeleteLogic(IEnumerable<InstanceSave> instances)
-    {
-        var instancesList = instances.ToList();
-        if (instancesList.Count == 0)
-            return;
-
-        var shouldDetachChildren = deleteJustParent.IsChecked == true;
-        var shouldDeleteChildren = deleteAllContainedObjects.IsChecked == true;
-
-        if (shouldDetachChildren)
-        {
-            _instanceDeletionHelper.DetachChildrenFromInstances(instancesList);
-        }
-        if (shouldDeleteChildren)
-        {
-            // Group by parent container since instances may belong to different elements
-            var instancesByParent = instancesList
-                .GroupBy(i => i.ParentContainer)
-                .Where(g => g.Key != null);
-
-            foreach (var group in instancesByParent)
-            {
-                _instanceDeletionHelper.RecursivelyDeleteChildrenOfInstances(group.ToList(), group.Key);
-            }
-        }
-    }
-
-    public FilePath GetFileNameForObject(object deletedObject)
-    {
-        return deletedObject switch
-        {
-            ElementSave elementSave => elementSave.GetFullPathXmlFile(),
-            BehaviorSave behaviorSave => _fileCommands.GetFullPathXmlFile(behaviorSave),
-            InstanceSave => null,
-            _ => throw new NotImplementedException($"Unsupported object type: {deletedObject?.GetType().Name}")
-        };
     }
 
     void HandleDeleteOptionsShow(Windows.DeleteOptionsWindow deleteWindow, Array objectsToDelete)
@@ -182,22 +141,13 @@ public class DeleteObjectPlugin : PriorityPlugin
 
         foreach (var objectToDelete in objectsToDelete)
         {
-
-            var shouldAddDeleteXml = objectToDelete is not InstanceSave && !alreadyAddedDeleteXmlCheckBox;
-
-            // offer to delete this only if there are no duplicates
-            if(shouldAddDeleteXml)
-            {
-                if(objectToDelete is ElementSave elementSave)
-                {
-                    var numberOfMatches = ObjectFinder.Self.GumProjectSave?.AllElements.Count(item => item.Name == elementSave.Name) ?? 0;
-                    // If there are more than 1 match, we don't want to delete XML files because we don't want to remove the base file if
-                    // duplicates were somehow added to the .gumx.
-                    // it's possible the user has multiple components selected, and wants to delete both, but that's an edge case that adds complexity
-                    // so I'm not going to worry about that.
-                    shouldAddDeleteXml = numberOfMatches < 2;
-                }
-            }
+            // Offer to delete the XML file only if there are no duplicates - if there are more than 1
+            // match, we don't want to delete XML files because we don't want to remove the base file if
+            // duplicates were somehow added to the .gumx. It's possible the user has multiple components
+            // selected, and wants to delete both, but that's an edge case that adds complexity so I'm not
+            // going to worry about that.
+            var shouldAddDeleteXml = !alreadyAddedDeleteXmlCheckBox
+                && _instanceDeletionHelper.ShouldOfferDeleteXmlOption(objectToDelete);
 
             if (shouldAddDeleteXml)
             {

--- a/Tool/Tests/GumToolUnitTests/Plugins/InstanceDeletionHelperTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InstanceDeletionHelperTests.cs
@@ -1,5 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Gui.Plugins;
 using Gum.Managers;
@@ -7,6 +8,7 @@ using Gum.ToolCommands;
 using Moq;
 using Moq.AutoMock;
 using Shouldly;
+using ToolsUtilities;
 
 namespace GumToolUnitTests.Plugins;
 
@@ -203,6 +205,40 @@ public class InstanceDeletionHelperTests : BaseTestClass
     }
 
     [Fact]
+    public void GetFileNameForObject_BehaviorSave_ReturnsFileCommandsPath()
+    {
+        BehaviorSave behaviorSave = new BehaviorSave { Name = "MyBehavior" };
+        FilePath expectedPath = new FilePath("C:/project/MyBehavior.behx");
+        _fileCommands.Setup(x => x.GetFullPathXmlFile(behaviorSave)).Returns(expectedPath);
+
+        FilePath? result = _helper.GetFileNameForObject(behaviorSave);
+
+        result.ShouldBe(expectedPath);
+    }
+
+    [Fact]
+    public void GetFileNameForObject_ElementSave_ReturnsFileCommandsPath()
+    {
+        ScreenSave screenSave = new ScreenSave { Name = "MyScreen" };
+        FilePath expectedPath = new FilePath("C:/project/Screens/MyScreen.gusx");
+        _fileCommands.Setup(x => x.GetFullPathXmlFile(screenSave, screenSave.Name)).Returns(expectedPath);
+
+        FilePath? result = _helper.GetFileNameForObject(screenSave);
+
+        result.ShouldBe(expectedPath);
+    }
+
+    [Fact]
+    public void GetFileNameForObject_InstanceSave_ReturnsNull()
+    {
+        InstanceSave instanceSave = new InstanceSave { Name = "MyInstance" };
+
+        FilePath? result = _helper.GetFileNameForObject(instanceSave);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
     public void InstanceHasChildren_NoChildren_ReturnsFalse()
     {
         var screen = CreateScreenWithInstances("Parent");
@@ -241,6 +277,45 @@ public class InstanceDeletionHelperTests : BaseTestClass
         var result = _helper.InstanceHasChildren(screen.Instances[0]);
 
         result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PerformMultipleInstancesDelete_EmptyList_DoesNothing()
+    {
+        _helper.PerformMultipleInstancesDelete(Array.Empty<InstanceSave>(), shouldDetachChildren: true, shouldDeleteChildren: true);
+
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(It.IsAny<InstanceSave>(), It.IsAny<ElementSave>()), Times.Never);
+        _deleteLogic.Verify(x => x.RemoveInstance(It.IsAny<InstanceSave>(), It.IsAny<ElementSave>()), Times.Never);
+    }
+
+    [Fact]
+    public void PerformMultipleInstancesDelete_ShouldDeleteChildren_DeletesChildrenGroupedByParent()
+    {
+        ScreenSave screen = CreateScreenWithInstances("Parent1", "Parent2");
+        InstanceSave parent1 = screen.Instances[0];
+        InstanceSave parent2 = screen.Instances[1];
+        InstanceSave child1 = AddChild(screen, "Child1", "Parent1");
+        InstanceSave child2 = AddChild(screen, "Child2", "Parent2");
+
+        _helper.PerformMultipleInstancesDelete(new[] { parent1, parent2 }, shouldDetachChildren: false, shouldDeleteChildren: true);
+
+        _deleteLogic.Verify(x => x.RemoveInstance(child1, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveInstance(child2, screen), Times.Once);
+    }
+
+    [Fact]
+    public void PerformMultipleInstancesDelete_ShouldDetachChildren_DetachesFromEachInstance()
+    {
+        ScreenSave screen = CreateScreenWithInstances("Parent1", "Parent2");
+        InstanceSave parent1 = screen.Instances[0];
+        InstanceSave parent2 = screen.Instances[1];
+        AddChild(screen, "Child1", "Parent1");
+        AddChild(screen, "Child2", "Parent2");
+
+        _helper.PerformMultipleInstancesDelete(new[] { parent1, parent2 }, shouldDetachChildren: true, shouldDeleteChildren: false);
+
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent1, screen), Times.Once);
+        _deleteLogic.Verify(x => x.RemoveReferencesToInstance(parent2, screen), Times.Once);
     }
 
     [Fact]
@@ -390,6 +465,54 @@ public class InstanceDeletionHelperTests : BaseTestClass
         deletionOrder[0].ShouldBe(grandchild1, "Deepest child should be deleted first");
         deletionOrder.ShouldContain(child1);
         deletionOrder.ShouldContain(child2);
+    }
+
+    [Fact]
+    public void ShouldOfferDeleteXmlOption_BehaviorSave_ReturnsTrue()
+    {
+        BehaviorSave behaviorSave = new BehaviorSave { Name = "MyBehavior" };
+
+        bool result = _helper.ShouldOfferDeleteXmlOption(behaviorSave);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldOfferDeleteXmlOption_ElementSaveWithDuplicateName_ReturnsFalse()
+    {
+        ScreenSave screenSave = new ScreenSave { Name = "MyScreen" };
+        ScreenSave duplicateScreenSave = new ScreenSave { Name = "MyScreen" };
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Screens.Add(screenSave);
+        gumProjectSave.Screens.Add(duplicateScreenSave);
+        ObjectFinder.Self.GumProjectSave = gumProjectSave;
+
+        bool result = _helper.ShouldOfferDeleteXmlOption(screenSave);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldOfferDeleteXmlOption_ElementSaveWithUniqueName_ReturnsTrue()
+    {
+        ScreenSave screenSave = new ScreenSave { Name = "MyScreen" };
+        GumProjectSave gumProjectSave = new GumProjectSave();
+        gumProjectSave.Screens.Add(screenSave);
+        ObjectFinder.Self.GumProjectSave = gumProjectSave;
+
+        bool result = _helper.ShouldOfferDeleteXmlOption(screenSave);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldOfferDeleteXmlOption_InstanceSave_ReturnsFalse()
+    {
+        InstanceSave instanceSave = new InstanceSave { Name = "MyInstance" };
+
+        bool result = _helper.ShouldOfferDeleteXmlOption(instanceSave);
+
+        result.ShouldBeFalse();
     }
 
     private ScreenSave CreateScreenWithInstances(params string[] instanceNames)

--- a/Tools/Gum.Presentation/Managers/InstanceDeletionHelper.cs
+++ b/Tools/Gum.Presentation/Managers/InstanceDeletionHelper.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.Managers;
-using Gum.ToolCommands;
+using ToolsUtilities;
 
 namespace Gum.Gui.Plugins;
 
@@ -168,5 +169,79 @@ public class InstanceDeletionHelper
         _guiCommands.RefreshElementTreeView(parentElement);
         _wireframeCommands.Refresh();
         _fileCommands.TryAutoSaveElement(parentElement);
+    }
+
+    /// <summary>
+    /// Detaches and/or recursively deletes the children of the given instances, according to
+    /// the caller's chosen delete-children option. Instances are grouped by parent container
+    /// when deleting children, since a multi-select delete may span multiple elements.
+    /// </summary>
+    public void PerformMultipleInstancesDelete(
+        IEnumerable<InstanceSave> instances,
+        bool shouldDetachChildren,
+        bool shouldDeleteChildren)
+    {
+        var instancesList = instances.ToList();
+        if (instancesList.Count == 0)
+        {
+            return;
+        }
+
+        if (shouldDetachChildren)
+        {
+            DetachChildrenFromInstances(instancesList);
+        }
+        if (shouldDeleteChildren)
+        {
+            // Group by parent container since instances may belong to different elements
+            var instancesByParent = instancesList
+                .GroupBy(i => i.ParentContainer)
+                .Where(g => g.Key != null);
+
+            foreach (var group in instancesByParent)
+            {
+                RecursivelyDeleteChildrenOfInstances(group.ToList(), group.Key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the full path to the XML file backing the given object (an <see cref="ElementSave"/>
+    /// or <see cref="BehaviorSave"/>), or null for an <see cref="InstanceSave"/> (which has no XML
+    /// file of its own).
+    /// </summary>
+    public FilePath? GetFileNameForObject(object deletedObject)
+    {
+        return deletedObject switch
+        {
+            ElementSave elementSave => _fileCommands.GetFullPathXmlFile(elementSave, elementSave.Name),
+            BehaviorSave behaviorSave => _fileCommands.GetFullPathXmlFile(behaviorSave),
+            InstanceSave => null,
+            _ => throw new NotImplementedException($"Unsupported object type: {deletedObject?.GetType().Name}")
+        };
+    }
+
+    /// <summary>
+    /// Decides whether the "Delete XML file?" option should be offered for the given object being
+    /// deleted. Instances have no XML file of their own. An element only offers this option when
+    /// its name is not shared by another element in the project (e.g. duplicates added directly to
+    /// the .gumx) — deleting the shared XML file in that case would remove the base file out from
+    /// under any surviving duplicate.
+    /// </summary>
+    public bool ShouldOfferDeleteXmlOption(object objectToDelete)
+    {
+        if (objectToDelete is InstanceSave)
+        {
+            return false;
+        }
+
+        if (objectToDelete is ElementSave elementSave)
+        {
+            var numberOfMatches = ObjectFinder.Self.GumProjectSave?.AllElements
+                .Count(item => item.Name == elementSave.Name) ?? 0;
+            return numberOfMatches < 2;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
## Categorization

`DeleteObjectPlugin.cs` is fundamentally a WPF dialog-population plugin (contributes `CheckBox`/`GroupBox`/`RadioButton` widgets to `DeleteOptionsWindow`) - the widget creation/manipulation stays plugin-side and is genuinely stuck. But three decisions inside it were the "field-coupled but WPF-free" pattern: pure logic gated behind a direct WPF-field read.

- **(a) Genuinely relocatable now:** `InstanceDeletionHelper` itself - already zero WPF references, just not physically in `Gum.Presentation` yet. All its dependencies (`IDeleteLogic`, `IGuiCommands`, `IWireframeCommands`, `IFileCommands`) already live there.
- **(b) Convertible with reasonable effort (done):**
  - `PerformMultipleInstancesDeleteLogic` — read `deleteJustParent.IsChecked`/`deleteAllContainedObjects.IsChecked` directly, then delegated entirely to `InstanceDeletionHelper`. Fixed by having the plugin read the two bools and pass them into a new `InstanceDeletionHelper.PerformMultipleInstancesDelete(instances, shouldDetachChildren, shouldDeleteChildren)`.
  - `GetFileNameForObject` — called `elementSave.GetFullPathXmlFile()`, a `Locator<IProjectManager>`-based extension method defined in `Gum.csproj` (unreachable from `Gum.Presentation`). Swapped for the already-injected `IFileCommands.GetFullPathXmlFile(element, name)` equivalent (`FileCommands.cs` doc comment confirms "Behavior is identical") and moved the method onto the helper.
  - `ShouldOfferDeleteXmlOption` — the "don't offer XML delete if the element name has a duplicate in the project" check, buried in a WPF-widget-population loop. Extracted as its own pure predicate on the helper.
- **(c) Genuinely stuck (left as-is):** `StartUp`, `CreateDeleteChildrenGroupBox`, `CreateDeleteXmlFileComboBox`, and the WPF-widget-manipulation portions of `HandleDeleteConfirmed`/`HandleDeleteOptionsShow` (`MainStackPanel.Children.Add/Remove`, `IsChecked` sets). These are real platform glue — the plugin contributes live WPF controls to a WPF `Window`, and `PluginBase`'s event signatures (`Action<DeleteOptionsWindow, Array>`) are themselves WPF-typed, so the plugin class can never move.

## What changed

- Moved `InstanceDeletionHelper.cs` → `Tools/Gum.Presentation/Managers/InstanceDeletionHelper.cs` (namespace unchanged, no consumer `using` changes needed).
- Added `PerformMultipleInstancesDelete`, `GetFileNameForObject`, `ShouldOfferDeleteXmlOption` to the helper.
- `DeleteObjectPlugin.cs` now only reads WPF widget state and delegates to the helper — no behavior change.
- Added 10 new pinning tests to the existing `InstanceDeletionHelperTests.cs` (39 total, all green). Mutation-tested `ShouldOfferDeleteXmlOption`'s duplicate-count branch (flipped `< 2` → `< 1`, confirmed a test goes red, reverted).

## New gotcha (for `ui-decoupling-plan.md`, not self-edited)

A method can look pure/WPF-free yet still be blocked by an **extension method that hides a `Locator` call**, in the exact shape already documented — but concretely, `ElementSave.GetFullPathXmlFile()` (defined in `Gum.csproj`, resolves `IProjectManager` via `Locator`) already has a drop-in headless replacement sitting right next to it: `IFileCommands.GetFullPathXmlFile(element, elementName)` on `FileCommands.cs`, whose doc comment states behavior is identical. Worth grepping for this specific extension before assuming a "blocked by Locator-hiding extension method" case needs new design work — the replacement may already exist.

Closes #3930
