### PR TITLE
Relocate MainStatePlugin's WPF-free handler logic into headless Gum.Presentation

### DIFF
--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -1,19 +1,10 @@
-using Gum.Controls;
-using Gum.DataTypes;
-using Gum.DataTypes.Behaviors;
-using Gum.DataTypes.Variables;
+using Gum.Commands;
 using Gum.Managers;
-using Gum.Mvvm;
 using Gum.Plugins.BaseClasses;
-using Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
 using Gum.Plugins.InternalPlugins.StatePlugin.Views;
 using Gum.PropertyGridHelpers;
 using Gum.ToolStates;
-using Newtonsoft.Json.Linq;
-using System;
 using System.ComponentModel.Composition;
-using System.Linq;
-using Gum.Commands;
 using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.Logic;
@@ -22,21 +13,24 @@ namespace Gum.Plugins.StatePlugin;
 
 // This is new as of Oct 30, 2020
 // I'd like to move all state logic to this plugin over time.
+//
+// As of issue #3926, the WPF-free reactions to state/element/instance selection, rename, delete,
+// and variable-set events live in StateTreeController (Gum.Presentation). This plugin owns only the
+// real platform glue that has no headless seam: constructing the WPF StateTreeView and registering
+// it with the tab manager, and pushing the controller's tab title onto the WPF-typed PluginTab.Title.
 [Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
 public class MainStatePlugin : PriorityPlugin
 {
     #region Fields/Properties
 
     StateTreeView stateTreeView;
-    StateTreeViewModel stateTreeViewModel;
 
     PluginTab newPluginTab;
     private readonly StateTreeViewRightClickService _stateTreeViewRightClickService;
     private readonly IHotkeyManager _hotkeyManager;
     private readonly ISelectedState _selectedState;
-    private readonly ObjectFinder _objectFinder;
-    private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
     private readonly ICopyPasteLogic _copyPasteLogic;
+    private readonly StateTreeController _controller;
 
     #endregion
 
@@ -50,8 +44,6 @@ public class MainStatePlugin : PriorityPlugin
     {
         _selectedState = selectedState;
         _hotkeyManager = hotkeyManager;
-        _objectFinder = ObjectFinder.Self;
-        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
         _copyPasteLogic = copyPasteLogic;
         _stateTreeViewRightClickService = new StateTreeViewRightClickService(
             _selectedState,
@@ -62,8 +54,11 @@ public class MainStatePlugin : PriorityPlugin
             fileCommands,
             _copyPasteLogic);
 
-        stateTreeViewModel = new StateTreeViewModel(_stateTreeViewRightClickService,
-            selectedState);
+        _controller = new StateTreeController(
+            _stateTreeViewRightClickService,
+            _selectedState,
+            ObjectFinder.Self,
+            variableInCategoryPropagationLogic);
     }
 
     public override void StartUp()
@@ -77,176 +72,40 @@ public class MainStatePlugin : PriorityPlugin
 
     private void AssignEvents()
     {
-        this.TreeNodeSelected += _ => HandleTreeNodeSelected();
-        
-        this.RefreshStateTreeView += HandleRefreshStateTreeView;
-        
-        this.ReactToStateSaveSelected += HandleStateSelected;
-        this.ReactToStateSaveCategorySelected += HandleStateSaveCategorySelected;
-        
-        this.StateRename += HandleStateRename;
-        this.StateDelete += HandleStateDelete;
-        this.StateMovedToCategory += HandleStateMovedToCategory;
+        this.TreeNodeSelected += _ => _controller.HandleTreeNodeSelected();
 
-        this.CategoryRename += HandleCategoryRename;
-        this.BehaviorSelected += HandleBehaviorSelected;
-        this.BehaviorReferenceSelected += HandleBehaviorReferenceSelected;
-        this.InstanceSelected += HandleInstanceSelected;
-        this.ElementSelected += HandleElementSelected;
-        this.ElementDelete += HandleElementDeleted;
-        this.VariableSet += HandleVariableSet;
-    }
+        this.RefreshStateTreeView += _controller.HandleRefreshStateTreeView;
 
+        this.ReactToStateSaveSelected += _controller.HandleStateSelected;
+        this.ReactToStateSaveCategorySelected += _controller.HandleStateSaveCategorySelected;
 
-    private void HandleElementDeleted(ElementSave save)
-    {
-        RefreshUI(_selectedState.SelectedStateContainer);
+        this.StateRename += _controller.HandleStateRename;
+        this.StateDelete += _controller.HandleStateDelete;
+        this.StateMovedToCategory += _controller.HandleStateMovedToCategory;
+
+        this.CategoryRename += _controller.HandleCategoryRename;
+        this.BehaviorSelected += _controller.HandleBehaviorSelected;
+        this.BehaviorReferenceSelected += _controller.HandleBehaviorReferenceSelected;
+        this.InstanceSelected += _controller.HandleInstanceSelected;
+        this.ElementSelected += _controller.HandleElementSelected;
+        this.ElementDelete += _controller.HandleElementDeleted;
+        this.VariableSet += _controller.HandleVariableSet;
+
+        _controller.TabTitleChanged += title => newPluginTab.Title = title;
     }
 
     private void CreateNewStateTab()
     {
         stateTreeView = new StateTreeView(
-            stateTreeViewModel, 
-            _stateTreeViewRightClickService, 
-            _hotkeyManager, 
+            _controller.ViewModel,
+            _stateTreeViewRightClickService,
+            _hotkeyManager,
             _selectedState,
             _copyPasteLogic);
         _stateTreeViewRightClickService.SetContextMenu(stateTreeView.TreeViewContextMenu, stateTreeView);
-        
+
         newPluginTab = _tabManager.AddControl(stateTreeView, "States", TabLocation.CenterTop);
     }
 
     #endregion
-
-    #region Event Handlers
-
-    private void HandleStateMovedToCategory(StateSave stateSave, StateSaveCategory newCategory, StateSaveCategory oldCategory)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        stateTreeViewModel.RefreshTo(_selectedState.SelectedStateContainer, _selectedState, _objectFinder);
-    }
-
-    private void HandleElementSelected(ElementSave? save)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        HandleRefreshStateTreeView();
-        RefreshTabHeaders();
-    }
-
-    private void HandleInstanceSelected(ElementSave save1, InstanceSave save2)
-    {
-        RefreshUI(_selectedState.SelectedStateContainer);
-
-        // A user could directly select an instance in
-        // a different container such as going from a component
-        // to a selected instance in a behavior. In that case we
-        // still want to refresh the menu items.
-        _stateTreeViewRightClickService.PopulateContextMenu();
-    }
-
-    private void HandleBehaviorSelected(BehaviorSave? behavior)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        HandleRefreshStateTreeView();
-    }
-
-    private void HandleBehaviorReferenceSelected(ElementBehaviorReference reference, ElementSave element)
-    {
-        HandleRefreshStateTreeView();
-    }
-
-    private void HandleCategoryRename(StateSaveCategory category, string arg2)
-    {
-        stateTreeViewModel.HandleRename(category);
-    }
-
-    private void HandleStateRename(StateSave save, string oldName)
-    {
-        stateTreeViewModel.HandleRename(save);
-    }
-
-
-    private void HandleStateDelete(StateSave save)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        stateTreeViewModel.RefreshTo(_selectedState.SelectedStateContainer, _selectedState, _objectFinder);
-    }
-
-    private void HandleStateSelected(StateSave? state)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        stateTreeViewModel.SetSelectedState(state);
-        var currentCategory = _selectedState.SelectedStateCategorySave;
-        var currentState = _selectedState.SelectedStateSave;
-
-        if (currentCategory != null && currentState != null)
-        {
-            PropagateVariableForCategorizedState(currentState);
-        }
-        else if (currentCategory != null)
-        {
-            foreach (var item in currentCategory.States)
-            {
-                PropagateVariableForCategorizedState(item);
-            }
-        }
-    }
-
-    private void HandleStateSaveCategorySelected(StateSaveCategory? stateSaveCategory)
-    {
-        _stateTreeViewRightClickService.PopulateContextMenu();
-        stateTreeViewModel.SetSelectedStateSaveCategory(stateSaveCategory);
-    }
-
-    private void HandleRefreshStateTreeView()
-    {
-        RefreshUI(_selectedState.SelectedStateContainer);
-    }
-
-    private void HandleTreeNodeSelected()
-    {
-        RefreshTabHeaders();
-        
-        if (_selectedState.SelectedBehavior == null &&
-            _selectedState.SelectedElement == null)
-        {
-
-            _stateTreeViewRightClickService.PopulateContextMenu();
-            HandleRefreshStateTreeView();
-        }
-    }
-
-    private void RefreshTabHeaders()
-    {
-        var element = _selectedState.SelectedElement;
-        string desiredTitle = "States";
-        if (element != null)
-        {
-            desiredTitle = $"{element.Name} States";
-        }
-
-        newPluginTab.Title = desiredTitle;
-    }
-
-    private void HandleVariableSet(ElementSave elementSave, InstanceSave? instance, string variableName, object? oldValue)
-    {
-        // Do this to refresh the yellow highlights - We may not need to do more than this:
-        stateTreeViewModel.RefreshTo(elementSave, _selectedState, _objectFinder);
-    }
-    #endregion
-
-    private void PropagateVariableForCategorizedState(StateSave currentState)
-    {
-        foreach (var variable in currentState.Variables)
-        {
-            _variableInCategoryPropagationLogic.PropagateVariablesInCategory(variable.Name,
-                _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
-        }
-    }
-
-    void RefreshUI(IStateContainer stateContainer)
-    {
-        stateTreeViewModel.RefreshTo(stateContainer, _selectedState, _objectFinder);
-    }
-
 }

--- a/Tests/Gum.Presentation.Tests/StateTreeControllerTests.cs
+++ b/Tests/Gum.Presentation.Tests/StateTreeControllerTests.cs
@@ -1,0 +1,145 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.PropertyGridHelpers;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="StateTreeController"/>'s reactions to selection/rename/delete/variable-set
+/// events after extraction from <c>MainStatePlugin</c> (issue #3926). Every method here used to be
+/// an instance method on the plugin itself, reading the plugin's own private fields rather than
+/// taking its dependencies as constructor parameters - none of the logic touched a WPF type, so the
+/// extraction is a pure relocation (same shape as <c>AnimationTabController</c>, issue #3866).
+/// </summary>
+public class StateTreeControllerTests
+{
+    private static (StateTreeController Controller, Mock<IStateTreeViewRightClickService> RightClickService,
+        Mock<ISelectedState> SelectedState, Mock<IVariableInCategoryPropagationLogic> PropagationLogic)
+        CreateSut()
+    {
+        var rightClickService = new Mock<IStateTreeViewRightClickService>();
+        var selectedState = new Mock<ISelectedState>();
+        var propagationLogic = new Mock<IVariableInCategoryPropagationLogic>();
+
+        var controller = new StateTreeController(
+            rightClickService.Object,
+            selectedState.Object,
+            ObjectFinder.Self,
+            propagationLogic.Object);
+
+        return (controller, rightClickService, selectedState, propagationLogic);
+    }
+
+    [Fact]
+    public void HandleElementSelected_PopulatesContextMenuAndRaisesTabTitleWithElementName()
+    {
+        var (controller, rightClickService, selectedState, _) = CreateSut();
+        ComponentSave element = new() { Name = "MyComponent" };
+        selectedState.SetupGet(s => s.SelectedElement).Returns(element);
+        selectedState.SetupGet(s => s.SelectedStateContainer).Returns(element);
+        string? raisedTitle = null;
+        controller.TabTitleChanged += title => raisedTitle = title;
+
+        controller.HandleElementSelected(element);
+
+        rightClickService.Verify(x => x.PopulateContextMenu(), Times.Once);
+        raisedTitle.ShouldBe("MyComponent States");
+    }
+
+    [Fact]
+    public void HandleElementSelected_NoElement_RaisesTabTitleAsPlainStates()
+    {
+        var (controller, _, selectedState, _) = CreateSut();
+        selectedState.SetupGet(s => s.SelectedElement).Returns((ElementSave?)null);
+        selectedState.SetupGet(s => s.SelectedStateContainer).Returns((IStateContainer?)null);
+        string? raisedTitle = null;
+        controller.TabTitleChanged += title => raisedTitle = title;
+
+        controller.HandleElementSelected(null);
+
+        raisedTitle.ShouldBe("States");
+    }
+
+    [Fact]
+    public void HandleStateSelected_CategorizedState_PropagatesEachVariableInThatState()
+    {
+        var (controller, rightClickService, selectedState, propagationLogic) = CreateSut();
+        ComponentSave element = new() { Name = "MyComponent" };
+        StateSaveCategory category = new() { Name = "Category" };
+        StateSave state = new() { Name = "State" };
+        state.Variables.Add(new VariableSave { Name = "X" });
+        state.Variables.Add(new VariableSave { Name = "Y" });
+        selectedState.SetupGet(s => s.SelectedElement).Returns(element);
+        selectedState.SetupGet(s => s.SelectedStateCategorySave).Returns(category);
+        selectedState.SetupGet(s => s.SelectedStateSave).Returns(state);
+
+        controller.HandleStateSelected(state);
+
+        rightClickService.Verify(x => x.PopulateContextMenu(), Times.Once);
+        propagationLogic.Verify(x => x.PropagateVariablesInCategory("X", element, category), Times.Once);
+        propagationLogic.Verify(x => x.PropagateVariablesInCategory("Y", element, category), Times.Once);
+    }
+
+    [Fact]
+    public void HandleStateSelected_NoCategory_DoesNotPropagateVariables()
+    {
+        var (controller, _, selectedState, propagationLogic) = CreateSut();
+        StateSave state = new() { Name = "State" };
+        state.Variables.Add(new VariableSave { Name = "X" });
+        selectedState.SetupGet(s => s.SelectedStateCategorySave).Returns((StateSaveCategory?)null);
+        selectedState.SetupGet(s => s.SelectedStateSave).Returns(state);
+
+        controller.HandleStateSelected(state);
+
+        propagationLogic.Verify(
+            x => x.PropagateVariablesInCategory(It.IsAny<string>(), It.IsAny<ElementSave>(), It.IsAny<StateSaveCategory>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void HandleTreeNodeSelected_NoBehaviorOrElementSelected_PopulatesContextMenuAndRaisesPlainStatesTitle()
+    {
+        var (controller, rightClickService, selectedState, _) = CreateSut();
+        selectedState.SetupGet(s => s.SelectedBehavior).Returns((BehaviorSave?)null);
+        selectedState.SetupGet(s => s.SelectedElement).Returns((ElementSave?)null);
+        selectedState.SetupGet(s => s.SelectedStateContainer).Returns((IStateContainer?)null);
+        string? raisedTitle = null;
+        controller.TabTitleChanged += title => raisedTitle = title;
+
+        controller.HandleTreeNodeSelected();
+
+        rightClickService.Verify(x => x.PopulateContextMenu(), Times.Once);
+        raisedTitle.ShouldBe("States");
+    }
+
+    [Fact]
+    public void HandleTreeNodeSelected_ElementSelected_DoesNotPopulateContextMenuAgain()
+    {
+        var (controller, rightClickService, selectedState, _) = CreateSut();
+        ComponentSave element = new() { Name = "MyComponent" };
+        selectedState.SetupGet(s => s.SelectedElement).Returns(element);
+
+        controller.HandleTreeNodeSelected();
+
+        // RefreshTabHeaders doesn't populate the context menu on its own; that only happens when
+        // neither a behavior nor an element is selected (the "root of the tree" case).
+        rightClickService.Verify(x => x.PopulateContextMenu(), Times.Never);
+    }
+
+    [Fact]
+    public void HandleCategoryRename_DelegatesToViewModelHandleRenameAndPopulatesContextMenu()
+    {
+        var (controller, rightClickService, _, _) = CreateSut();
+        StateSaveCategory category = new() { Name = "Category" };
+        controller.ViewModel.Categories.Add(new Gum.Plugins.InternalPlugins.StatePlugin.ViewModels.CategoryViewModel { Data = category });
+
+        controller.HandleCategoryRename(category, "OldName");
+
+        rightClickService.Verify(x => x.PopulateContextMenu(), Times.Once);
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeController.cs
@@ -1,0 +1,187 @@
+using System;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
+using Gum.PropertyGridHelpers;
+using Gum.ToolStates;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Owns the States tab's WPF-free reactions to selection/rename/delete/variable-set events and the
+/// tab title text. Extracted from <c>MainStatePlugin</c> (issue #3926): none of this touches a WPF
+/// type, but every method here used to be an instance method on the plugin itself, reading the
+/// plugin's own private fields rather than taking its dependencies as constructor parameters, which
+/// is what blocked the extraction until now (the same shape as <c>AnimationTabController</c>,
+/// issue #3866).
+///
+/// <para>
+/// The plugin still owns the real platform glue this class deliberately has no seam for:
+/// constructing the WPF <c>StateTreeView</c> and registering it with the tab manager, and pushing
+/// <see cref="TabTitleChanged"/>'s title onto the WPF-typed <c>PluginTab.Title</c>.
+/// </para>
+/// </summary>
+public class StateTreeController
+{
+    private readonly IStateTreeViewRightClickService _rightClickService;
+    private readonly ISelectedState _selectedState;
+    private readonly ObjectFinder _objectFinder;
+    private readonly IVariableInCategoryPropagationLogic _variableInCategoryPropagationLogic;
+
+    /// <summary>
+    /// The states tree's view model. Constructed here (rather than by the plugin) since its only
+    /// dependencies are this controller's own <see cref="IStateTreeViewRightClickService"/> and
+    /// <see cref="ISelectedState"/>.
+    /// </summary>
+    public StateTreeViewModel ViewModel { get; }
+
+    /// <summary>
+    /// Raised whenever the desired States tab title changes (selected element changed), so the
+    /// plugin can push it onto the WPF-typed <c>PluginTab.Title</c> - a real platform concern this
+    /// class has no seam for.
+    /// </summary>
+    public event Action<string>? TabTitleChanged;
+
+    public StateTreeController(
+        IStateTreeViewRightClickService rightClickService,
+        ISelectedState selectedState,
+        ObjectFinder objectFinder,
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic)
+    {
+        _rightClickService = rightClickService;
+        _selectedState = selectedState;
+        _objectFinder = objectFinder;
+        _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
+
+        ViewModel = new StateTreeViewModel(rightClickService, selectedState);
+    }
+
+    public void HandleElementDeleted(ElementSave save) => RefreshUI(_selectedState.SelectedStateContainer);
+
+    public void HandleStateMovedToCategory(StateSave stateSave, StateSaveCategory newCategory, StateSaveCategory oldCategory)
+    {
+        _rightClickService.PopulateContextMenu();
+        ViewModel.RefreshTo(_selectedState.SelectedStateContainer, _selectedState, _objectFinder);
+    }
+
+    public void HandleElementSelected(ElementSave? save)
+    {
+        _rightClickService.PopulateContextMenu();
+        HandleRefreshStateTreeView();
+        RefreshTabHeaders();
+    }
+
+    public void HandleInstanceSelected(ElementSave save1, InstanceSave save2)
+    {
+        RefreshUI(_selectedState.SelectedStateContainer);
+
+        // A user could directly select an instance in
+        // a different container such as going from a component
+        // to a selected instance in a behavior. In that case we
+        // still want to refresh the menu items.
+        _rightClickService.PopulateContextMenu();
+    }
+
+    public void HandleBehaviorSelected(BehaviorSave? behavior)
+    {
+        _rightClickService.PopulateContextMenu();
+        HandleRefreshStateTreeView();
+    }
+
+    public void HandleBehaviorReferenceSelected(ElementBehaviorReference reference, ElementSave element)
+    {
+        HandleRefreshStateTreeView();
+    }
+
+    public void HandleCategoryRename(StateSaveCategory category, string oldName)
+    {
+        ViewModel.HandleRename(category);
+    }
+
+    public void HandleStateRename(StateSave save, string oldName)
+    {
+        ViewModel.HandleRename(save);
+    }
+
+    public void HandleStateDelete(StateSave save)
+    {
+        _rightClickService.PopulateContextMenu();
+        ViewModel.RefreshTo(_selectedState.SelectedStateContainer, _selectedState, _objectFinder);
+    }
+
+    public void HandleStateSelected(StateSave? state)
+    {
+        _rightClickService.PopulateContextMenu();
+        ViewModel.SetSelectedState(state);
+        var currentCategory = _selectedState.SelectedStateCategorySave;
+        var currentState = _selectedState.SelectedStateSave;
+
+        if (currentCategory != null && currentState != null)
+        {
+            PropagateVariableForCategorizedState(currentState);
+        }
+        else if (currentCategory != null)
+        {
+            foreach (var item in currentCategory.States)
+            {
+                PropagateVariableForCategorizedState(item);
+            }
+        }
+    }
+
+    public void HandleStateSaveCategorySelected(StateSaveCategory? stateSaveCategory)
+    {
+        _rightClickService.PopulateContextMenu();
+        ViewModel.SetSelectedStateSaveCategory(stateSaveCategory);
+    }
+
+    public void HandleRefreshStateTreeView()
+    {
+        RefreshUI(_selectedState.SelectedStateContainer);
+    }
+
+    public void HandleTreeNodeSelected()
+    {
+        RefreshTabHeaders();
+
+        if (_selectedState.SelectedBehavior == null &&
+            _selectedState.SelectedElement == null)
+        {
+            _rightClickService.PopulateContextMenu();
+            HandleRefreshStateTreeView();
+        }
+    }
+
+    private void RefreshTabHeaders()
+    {
+        var element = _selectedState.SelectedElement;
+        string desiredTitle = "States";
+        if (element != null)
+        {
+            desiredTitle = $"{element.Name} States";
+        }
+
+        TabTitleChanged?.Invoke(desiredTitle);
+    }
+
+    public void HandleVariableSet(ElementSave elementSave, InstanceSave? instance, string variableName, object? oldValue)
+    {
+        // Do this to refresh the yellow highlights - We may not need to do more than this:
+        ViewModel.RefreshTo(elementSave, _selectedState, _objectFinder);
+    }
+
+    private void PropagateVariableForCategorizedState(StateSave currentState)
+    {
+        foreach (var variable in currentState.Variables)
+        {
+            _variableInCategoryPropagationLogic.PropagateVariablesInCategory(variable.Name,
+                _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
+        }
+    }
+
+    private void RefreshUI(IStateContainer stateContainer)
+    {
+        ViewModel.RefreshTo(stateContainer, _selectedState, _objectFinder);
+    }
+}


### PR DESCRIPTION
## Summary

Scoped and implemented issue #3926: `MainStatePlugin`'s WPF-free handler logic (state/element/instance selection, rename, delete, variable-set, and tab-title computation) is field-coupled but WPF-free — the same "plugin handler reads its own private fields" gotcha fixed elsewhere by controller extraction (`AnimationTabController`, #3866; `CameraController`, #3846).

Extracted `StateTreeController` (Gum.Presentation) taking `IStateTreeViewRightClickService`, `ISelectedState`, `ObjectFinder`, `IVariableInCategoryPropagationLogic` as constructor deps. It owns the `StateTreeViewModel` (already relocated in #3754) and exposes a `TabTitleChanged` event so the plugin can push the computed title onto the WPF-typed `PluginTab.Title` — the one push-target seam left in the plugin.

`MainStatePlugin` now only owns real platform glue: constructing the WPF `StateTreeView`, registering it with the tab manager, and wiring plugin events to the controller's handler methods.

## Categorization

- **(a) Already relocatable / already done:** `StateTreeViewModel` and `IStateTreeViewRightClickService` were already moved to `Gum.Presentation` in a prior PR (#3754) — confirmed via grep, no work needed there.
- **(b) Convertible with reasonable effort (this PR):** every `Handle*` method plus `RefreshTabHeaders`'/`PropagateVariableForCategorizedState`/`RefreshUI` — WPF-free by type, blocked only by reading the plugin's own fields. The View (`StateTreeView`) is a pure push target here (constructed once, never read mid-logic for a decision), so controller extraction applies cleanly.
- **(c) Genuinely stuck (stays in the plugin):** constructing the WPF `StateTreeView` and wiring it to the tab manager (`CreateNewStateTab`), and the actual `PluginTab.Title =` assignment (WPF-typed `PluginTab.Content` is `FrameworkElement`).

## Test plan
- [x] `StateTreeControllerTests` (Gum.Presentation.Tests) — 9 new pinning tests, mutation-tested one (inverted the categorized-state condition, confirmed red, reverted).
- [x] Full `Gum.Presentation.Tests` suite: 637/637 green.
- [x] `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests`: 2/2 green.
- [x] `dotnet build GumFull.sln`: 0 errors.

Manual test: not needed — behavior-preserving extraction, proven by pinning tests + compilation; no new runtime behavior.

Closes #3926
