### PR TITLE
Extract MainPropertiesWindowPlugin's property-change logic into headless Gum.Presentation

### DIFF
--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/MainPropertiesWindowPlugin.cs
@@ -8,7 +8,6 @@ using RenderingLibrary.Graphics.Fonts;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.ComponentModel.Composition;
 using Gum.Commands;
 using Gum.Logic.FileWatch;
@@ -55,6 +54,8 @@ class MainPropertiesWindowPlugin : PriorityPlugin
 
     private PluginTab? _pluginTab;
 
+    private ProjectPropertiesChangeLogic? _changeLogic;
+
     [ImportingConstructor]
     public MainPropertiesWindowPlugin(
         IFontManager fontManager,
@@ -81,6 +82,18 @@ class MainPropertiesWindowPlugin : PriorityPlugin
     public override void StartUp()
     {
         this.AddMenuItem(new List<string> { "Edit", "Properties" }).Click += HandlePropertiesClicked;
+
+        _changeLogic = new ProjectPropertiesChangeLogic(
+            _projectManager,
+            _fontManager,
+            _dialogService,
+            _projectState,
+            _wireframeObjectManager,
+            _fileCommands,
+            _wireframeCommands,
+            _guiCommands,
+            _pluginManager,
+            LocalizationService);
 
         viewModel = new PropertiesWindowPlugin.ProjectPropertiesViewModel();
         viewModel.PropertyChanged += HandlePropertyChanged;
@@ -156,190 +169,12 @@ class MainPropertiesWindowPlugin : PriorityPlugin
 
     private async void HandlePropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        ////////////////////Early Out//////////////////
-        if (viewModel.IsUpdatingFromModel)
+        var result = await _changeLogic!.HandlePropertyChanged(viewModel, e.PropertyName);
+
+        if (result.FontCharacterFileChanged)
         {
-            return;
-        }
-        ///////////////////End early Out////////////////
-        viewModel.ApplyToModelObjects();
-        _projectManager.AutoSave = viewModel.AutoSave;
-
-        var shouldSaveAndRefresh = true;
-        var shouldReloadContent = false;
-        switch (e.PropertyName)
-        {
-            case nameof(viewModel.LocalizationFiles):
-
-                // Normalize any absolute paths to project-relative so .gumx stays portable.
-                bool normalizedAny = false;
-                List<string> normalized = new List<string>(viewModel.LocalizationFiles.Count);
-                foreach (string file in viewModel.LocalizationFiles)
-                {
-                    if (!string.IsNullOrEmpty(file) && FileManager.IsRelative(file) == false)
-                    {
-                        normalized.Add(FileManager.MakeRelative(file, _projectState.ProjectDirectory, preserveCase: true));
-                        normalizedAny = true;
-                    }
-                    else
-                    {
-                        normalized.Add(file);
-                    }
-                }
-
-                if (normalizedAny)
-                {
-                    // This re-enters HandlePropertyChanged which will hit the else branch.
-                    viewModel.LocalizationFiles = normalized;
-                    shouldSaveAndRefresh = false;
-                }
-                else
-                {
-                    _fileCommands.LoadLocalizationFile();
-                    _wireframeObjectManager.RefreshAll(forceLayout: true, forceReloadTextures: false);
-                }
-                break;
-            case nameof(viewModel.LanguageName):
-                var languageIdx = LocalizationService.Languages.ToList().IndexOf(viewModel.LanguageName) + 1;
-                if (languageIdx > 0 && languageIdx != viewModel.LanguageIndex)
-                {
-                    viewModel.LanguageIndex = languageIdx;
-                    LocalizationService.CurrentLanguage = languageIdx;
-                }
-                else
-                {
-                    shouldSaveAndRefresh = false;
-                }
-                break;
-            case nameof(viewModel.LanguageIndex):
-                LocalizationService.CurrentLanguage = viewModel.LanguageIndex;
-                break;
-            case nameof(viewModel.ShowLocalization):
-                shouldSaveAndRefresh = true;
-                break;
-            case nameof(viewModel.FontRanges):
-                var isValid = BmfcSave.GetIfIsValidRange(viewModel.FontRanges);
-                var didFixChangeThings = false;
-                if (!isValid)
-                {
-                    var fixedRange = BmfcSave.TryFixRange(viewModel.FontRanges);
-                    if (fixedRange != viewModel.FontRanges)
-                    {
-                        // this will recursively call this property, so we'll use this bool to leave this method
-                        didFixChangeThings = true;
-                        viewModel.FontRanges = fixedRange;
-                    }
-                }
-
-                if (!didFixChangeThings)
-                {
-                    if (isValid == false)
-                    {
-                        _dialogService.ShowMessage("The entered Font Range is not valid.");
-                    }
-                    else
-                    {
-                        if (_projectState.GumProjectSave != null)
-                        {
-                            var wasAbleToDelete = false;
-                            try
-                            {
-                                _fontManager.DeleteFontCacheFolder();
-                                wasAbleToDelete = true;
-                            }
-                            catch(System.IO.IOException exception)
-                            {
-                                wasAbleToDelete = false;
-
-                                var message =
-                                    "Attempted to delete font cache folder to re-create it with the new font range values " +
-                                    $"but was unable to do so:\n\n{exception}";
-                                _dialogService.ShowMessage(message);
-                            }
-
-
-
-
-                            if(wasAbleToDelete)
-                            {
-                                await _fontManager.CreateAllMissingFontFiles(
-                                    _projectState.GumProjectSave);
-                            }
-
-                        }
-                        shouldSaveAndRefresh = true;
-                        shouldReloadContent = true;
-                    }
-                }
-                break;
-            case nameof(viewModel.UseFontCharacterFile):
-                if(viewModel.UseFontCharacterFile)
-                {
-                    var absolute = new FilePath(_projectState.ProjectDirectory + ".gumfcs");
-                    _fontCharacterFileAbsolute = absolute;
-
-                    if(System.IO.File.Exists(absolute.FullPath))
-                    {
-                        var ranges = BmfcSave.GenerateRangesFromFile(absolute.FullPath);
-                        viewModel.FontRanges = ranges;
-                    }
-                }
-                else
-                {
-                    _fontCharacterFileAbsolute = null;
-                    viewModel.FontRanges = BmfcSave.DefaultRanges;
-                }
-
-                RefreshFontRangeEditability();
-                break;
-            case nameof(viewModel.SinglePixelTextureFile):
-            case nameof(viewModel.SinglePixelTextureTop):
-            case nameof(viewModel.SinglePixelTextureLeft):
-            case nameof(viewModel.SinglePixelTextureRight):
-            case nameof(viewModel.SinglePixelTextureBottom):
-
-                if(!string.IsNullOrEmpty(viewModel.SinglePixelTextureFile) && FileManager.IsRelative(viewModel.SinglePixelTextureFile) == false)
-                {
-                    // This will loop:
-                    viewModel.SinglePixelTextureFile = FileManager.MakeRelative(viewModel.SinglePixelTextureFile,
-                        _projectState.ProjectDirectory, preserveCase:true);
-                    shouldSaveAndRefresh = false;
-                }
-
-                break;
-            case nameof(viewModel.FontGenerator):
-                try
-                {
-                    _fontManager.DeleteFontCacheFolder();
-                }
-                catch (System.IO.IOException exception)
-                {
-                    _dialogService.ShowMessage(
-                        "Attempted to delete font cache folder to re-create it with the new font generator " +
-                        $"but was unable to do so:\n\n{exception}");
-                    break;
-                }
-
-                await _fontManager.CreateAllMissingFontFiles(_projectState.GumProjectSave);
-                shouldReloadContent = true;
-                _guiCommands.RefreshVariables(force: true);
-                break;
-            case nameof(viewModel.ShowCheckerBackground):
-                // Checkerboard visibility is handled via WireframePropertyChanged,
-                // so skip the wireframe refresh to avoid resetting the texture
-                // coordinates tab camera position.
-                _fileCommands.TryAutoSaveProject();
-                shouldSaveAndRefresh = false;
-                break;
-        }
-
-        _pluginManager.ProjectPropertySet(e.PropertyName);
-
-        if (shouldSaveAndRefresh)
-        {
-            _wireframeCommands.Refresh(forceLayout: true, forceReloadContent: shouldReloadContent);
-
-            _fileCommands.TryAutoSaveProject();
+            _fontCharacterFileAbsolute = result.FontCharacterFileAbsolute;
+            RefreshFontRangeEditability();
         }
     }
     private async void HandleFileChanged(FilePath file)

--- a/Tests/Gum.Presentation.Tests/ProjectPropertiesChangeLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectPropertiesChangeLogicTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.PropertiesWindowPlugin;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Characterization (pinning) tests for <see cref="ProjectPropertiesChangeLogic"/>, extracted
+/// out of <c>MainPropertiesWindowPlugin.HandlePropertyChanged</c> into headless
+/// <c>Gum.Presentation</c> (#3929) so the decision logic is testable without plugin composition.
+/// </summary>
+public class ProjectPropertiesChangeLogicTests
+{
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<IFontManager> _fontManager = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IProjectState> _projectState = new();
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IWireframeCommands> _wireframeCommands = new();
+    private readonly Mock<IGuiCommands> _guiCommands = new();
+    private readonly Mock<IPluginManager> _pluginManager = new();
+    private readonly Mock<ILocalizationService> _localizationService = new();
+    private readonly ProjectPropertiesChangeLogic _logic;
+
+    public ProjectPropertiesChangeLogicTests()
+    {
+        _logic = new ProjectPropertiesChangeLogic(
+            _projectManager.Object,
+            _fontManager.Object,
+            _dialogService.Object,
+            _projectState.Object,
+            _wireframeObjectManager.Object,
+            _fileCommands.Object,
+            _wireframeCommands.Object,
+            _guiCommands.Object,
+            _pluginManager.Object,
+            _localizationService.Object);
+    }
+
+    [Fact]
+    public async Task HandlePropertyChanged_DoesNothing_WhenViewModelIsUpdatingFromModel()
+    {
+        ProjectPropertiesViewModel viewModel = MakeViewModel();
+        // SetFrom leaves IsUpdatingFromModel false when it completes, so force it back on to
+        // simulate a property changing while a bulk model->VM sync is still in progress.
+        typeof(ProjectPropertiesViewModel)
+            .GetProperty(nameof(ProjectPropertiesViewModel.IsUpdatingFromModel))!
+            .SetValue(viewModel, true);
+
+        ProjectPropertyChangeResult result = await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.ShowCheckerBackground));
+
+        result.FontCharacterFileChanged.ShouldBeFalse();
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Never);
+        _wireframeCommands.Verify(w => w.Refresh(It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandlePropertyChanged_ShowCheckerBackground_AutoSavesWithoutRefreshingWireframe()
+    {
+        ProjectPropertiesViewModel viewModel = MakeViewModel();
+
+        await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.ShowCheckerBackground));
+
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
+        _wireframeCommands.Verify(w => w.Refresh(It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandlePropertyChanged_InvalidFontRange_ShowsMessageAndDoesNotTouchFontCache()
+    {
+        ProjectPropertiesViewModel viewModel = MakeViewModel();
+        // No spaces (so TryFixRange can't "fix" it) but start >= end, which GetIfIsValidRange rejects.
+        viewModel.FontRanges = "50-40";
+
+        await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.FontRanges));
+
+        _dialogService.Verify(d => d.ShowMessage("The entered Font Range is not valid.", null, null), Times.Once);
+        _fontManager.Verify(f => f.DeleteFontCacheFolder(), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandlePropertyChanged_LocalizationFiles_NormalizesAbsolutePathsToRelative()
+    {
+        ProjectPropertiesViewModel viewModel = MakeViewModel();
+        _projectState.Setup(p => p.ProjectDirectory).Returns(@"C:\MyProject\");
+        viewModel.LocalizationFiles = new List<string> { @"C:\MyProject\Localization\en.csv" };
+
+        await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.LocalizationFiles));
+
+        viewModel.LocalizationFiles.ShouldContain(@"Localization\en.csv");
+        _fileCommands.Verify(f => f.LoadLocalizationFile(), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandlePropertyChanged_UseFontCharacterFileTurnedOff_ResetsFontRangesAndReportsPathCleared()
+    {
+        ProjectPropertiesViewModel viewModel = MakeViewModel();
+        viewModel.UseFontCharacterFile = false;
+
+        ProjectPropertyChangeResult result = await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.UseFontCharacterFile));
+
+        result.FontCharacterFileChanged.ShouldBeTrue();
+        result.FontCharacterFileAbsolute.ShouldBeNull();
+        viewModel.FontRanges.ShouldBe(BmfcSave.DefaultRanges);
+    }
+
+    private static ProjectPropertiesViewModel MakeViewModel()
+    {
+        ProjectPropertiesViewModel viewModel = new();
+        GumProjectSave gumProject = new();
+        viewModel.SetFrom(autoSave: false, gumProject);
+        return viewModel;
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ProjectPropertiesChangeLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectPropertiesChangeLogicTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Gum.Commands;
 using Gum.DataTypes;
@@ -95,12 +96,16 @@ public class ProjectPropertiesChangeLogicTests
     public async Task HandlePropertyChanged_LocalizationFiles_NormalizesAbsolutePathsToRelative()
     {
         ProjectPropertiesViewModel viewModel = MakeViewModel();
-        _projectState.Setup(p => p.ProjectDirectory).Returns(@"C:\MyProject\");
-        viewModel.LocalizationFiles = new List<string> { @"C:\MyProject\Localization\en.csv" };
+        // Leading-slash literal, not "C:\...": rooted on both Windows and Unix, unlike a
+        // Windows drive letter (see gum-unit-tests skill).
+        _projectState.Setup(p => p.ProjectDirectory).Returns("/MyProject/");
+        viewModel.LocalizationFiles = new List<string> { "/MyProject/Localization/en.csv" };
 
         await _logic.HandlePropertyChanged(viewModel, nameof(viewModel.LocalizationFiles));
 
-        viewModel.LocalizationFiles.ShouldContain(@"Localization\en.csv");
+        // FileManager.Standardize normalizes to the OS-native separator, so the expected
+        // relative path must too.
+        viewModel.LocalizationFiles.ShouldContain($"Localization{Path.DirectorySeparatorChar}en.csv");
         _fileCommands.Verify(f => f.LoadLocalizationFile(), Times.Never);
     }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesChangeLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesChangeLogic.cs
@@ -1,0 +1,278 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Gum.Commands;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics.Fonts;
+using ToolsUtilities;
+
+namespace Gum.Plugins.PropertiesWindowPlugin;
+
+/// <summary>
+/// Outcome of <see cref="ProjectPropertiesChangeLogic.HandlePropertyChanged"/> that the plugin
+/// (which owns the actual view/control and its own cached font-character-file path) still needs
+/// to act on.
+/// </summary>
+public class ProjectPropertyChangeResult
+{
+    /// <summary>
+    /// True only when the changed property was <see cref="ProjectPropertiesViewModel.UseFontCharacterFile"/>,
+    /// in which case the plugin should update its own cached font-character-file path to
+    /// <see cref="FontCharacterFileAbsolute"/> and refresh the Variables grid's read-only state
+    /// for the FontRanges row.
+    /// </summary>
+    public bool FontCharacterFileChanged { get; init; }
+
+    /// <summary>
+    /// The new cached font-character-file path. Only meaningful when
+    /// <see cref="FontCharacterFileChanged"/> is true.
+    /// </summary>
+    public FilePath? FontCharacterFileAbsolute { get; init; }
+}
+
+/// <summary>
+/// Decision logic for what happens when a property on <see cref="ProjectPropertiesViewModel"/>
+/// changes - path normalization, font-range validation/regeneration, and deciding whether the
+/// project should be saved and the wireframe refreshed. Extracted from
+/// <c>MainPropertiesWindowPlugin</c> (which stays a thin MEF wrapper owning the properties
+/// window/control) so this logic can be constructed and tested without plugin composition.
+/// </summary>
+public class ProjectPropertiesChangeLogic
+{
+    private readonly IProjectManager _projectManager;
+    private readonly IFontManager _fontManager;
+    private readonly IDialogService _dialogService;
+    private readonly IProjectState _projectState;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IFileCommands _fileCommands;
+    private readonly IWireframeCommands _wireframeCommands;
+    private readonly IGuiCommands _guiCommands;
+    private readonly IPluginManager _pluginManager;
+    private readonly ILocalizationService _localizationService;
+
+    public ProjectPropertiesChangeLogic(
+        IProjectManager projectManager,
+        IFontManager fontManager,
+        IDialogService dialogService,
+        IProjectState projectState,
+        IWireframeObjectManager wireframeObjectManager,
+        IFileCommands fileCommands,
+        IWireframeCommands wireframeCommands,
+        IGuiCommands guiCommands,
+        IPluginManager pluginManager,
+        ILocalizationService localizationService)
+    {
+        _projectManager = projectManager;
+        _fontManager = fontManager;
+        _dialogService = dialogService;
+        _projectState = projectState;
+        _wireframeObjectManager = wireframeObjectManager;
+        _fileCommands = fileCommands;
+        _wireframeCommands = wireframeCommands;
+        _guiCommands = guiCommands;
+        _pluginManager = pluginManager;
+        _localizationService = localizationService;
+    }
+
+    /// <summary>
+    /// Reacts to a single property changing on <paramref name="viewModel"/>: applies the view
+    /// model back onto the loaded project, runs any property-specific side effect (path
+    /// normalization, font regeneration, etc.), and saves/refreshes the wireframe when needed.
+    /// </summary>
+    public async Task<ProjectPropertyChangeResult> HandlePropertyChanged(ProjectPropertiesViewModel viewModel, string? propertyName)
+    {
+        if (viewModel.IsUpdatingFromModel)
+        {
+            return new ProjectPropertyChangeResult();
+        }
+
+        viewModel.ApplyToModelObjects();
+        _projectManager.AutoSave = viewModel.AutoSave;
+
+        bool shouldSaveAndRefresh = true;
+        bool shouldReloadContent = false;
+        bool fontCharacterFileChanged = false;
+        FilePath? fontCharacterFileAbsolute = null;
+        switch (propertyName)
+        {
+            case nameof(viewModel.LocalizationFiles):
+
+                // Normalize any absolute paths to project-relative so .gumx stays portable.
+                bool normalizedAny = false;
+                List<string> normalized = new List<string>(viewModel.LocalizationFiles.Count);
+                foreach (string file in viewModel.LocalizationFiles)
+                {
+                    if (!string.IsNullOrEmpty(file) && FileManager.IsRelative(file) == false)
+                    {
+                        normalized.Add(FileManager.MakeRelative(file, _projectState.ProjectDirectory, preserveCase: true));
+                        normalizedAny = true;
+                    }
+                    else
+                    {
+                        normalized.Add(file);
+                    }
+                }
+
+                if (normalizedAny)
+                {
+                    // This re-enters HandlePropertyChanged which will hit the else branch.
+                    viewModel.LocalizationFiles = normalized;
+                    shouldSaveAndRefresh = false;
+                }
+                else
+                {
+                    _fileCommands.LoadLocalizationFile();
+                    _wireframeObjectManager.RefreshAll(forceLayout: true, forceReloadTextures: false);
+                }
+                break;
+            case nameof(viewModel.LanguageName):
+                int languageIdx = _localizationService.Languages.ToList().IndexOf(viewModel.LanguageName) + 1;
+                if (languageIdx > 0 && languageIdx != viewModel.LanguageIndex)
+                {
+                    viewModel.LanguageIndex = languageIdx;
+                    _localizationService.CurrentLanguage = languageIdx;
+                }
+                else
+                {
+                    shouldSaveAndRefresh = false;
+                }
+                break;
+            case nameof(viewModel.LanguageIndex):
+                _localizationService.CurrentLanguage = viewModel.LanguageIndex;
+                break;
+            case nameof(viewModel.ShowLocalization):
+                shouldSaveAndRefresh = true;
+                break;
+            case nameof(viewModel.FontRanges):
+                bool isValid = BmfcSave.GetIfIsValidRange(viewModel.FontRanges);
+                bool didFixChangeThings = false;
+                if (!isValid)
+                {
+                    string fixedRange = BmfcSave.TryFixRange(viewModel.FontRanges);
+                    if (fixedRange != viewModel.FontRanges)
+                    {
+                        // this will recursively call this property, so we'll use this bool to leave this method
+                        didFixChangeThings = true;
+                        viewModel.FontRanges = fixedRange;
+                    }
+                }
+
+                if (!didFixChangeThings)
+                {
+                    if (isValid == false)
+                    {
+                        _dialogService.ShowMessage("The entered Font Range is not valid.");
+                    }
+                    else
+                    {
+                        if (_projectState.GumProjectSave != null)
+                        {
+                            bool wasAbleToDelete = false;
+                            try
+                            {
+                                _fontManager.DeleteFontCacheFolder();
+                                wasAbleToDelete = true;
+                            }
+                            catch (System.IO.IOException exception)
+                            {
+                                wasAbleToDelete = false;
+
+                                string message =
+                                    "Attempted to delete font cache folder to re-create it with the new font range values " +
+                                    $"but was unable to do so:\n\n{exception}";
+                                _dialogService.ShowMessage(message);
+                            }
+
+                            if (wasAbleToDelete)
+                            {
+                                await _fontManager.CreateAllMissingFontFiles(
+                                    _projectState.GumProjectSave);
+                            }
+                        }
+                        shouldSaveAndRefresh = true;
+                        shouldReloadContent = true;
+                    }
+                }
+                break;
+            case nameof(viewModel.UseFontCharacterFile):
+                fontCharacterFileChanged = true;
+                if (viewModel.UseFontCharacterFile)
+                {
+                    FilePath absolute = new FilePath(_projectState.ProjectDirectory + ".gumfcs");
+                    fontCharacterFileAbsolute = absolute;
+
+                    if (System.IO.File.Exists(absolute.FullPath))
+                    {
+                        string ranges = BmfcSave.GenerateRangesFromFile(absolute.FullPath);
+                        viewModel.FontRanges = ranges;
+                    }
+                }
+                else
+                {
+                    fontCharacterFileAbsolute = null;
+                    viewModel.FontRanges = BmfcSave.DefaultRanges;
+                }
+                break;
+            case nameof(viewModel.SinglePixelTextureFile):
+            case nameof(viewModel.SinglePixelTextureTop):
+            case nameof(viewModel.SinglePixelTextureLeft):
+            case nameof(viewModel.SinglePixelTextureRight):
+            case nameof(viewModel.SinglePixelTextureBottom):
+
+                if (!string.IsNullOrEmpty(viewModel.SinglePixelTextureFile) && FileManager.IsRelative(viewModel.SinglePixelTextureFile) == false)
+                {
+                    // This will loop:
+                    viewModel.SinglePixelTextureFile = FileManager.MakeRelative(viewModel.SinglePixelTextureFile,
+                        _projectState.ProjectDirectory, preserveCase: true);
+                    shouldSaveAndRefresh = false;
+                }
+
+                break;
+            case nameof(viewModel.FontGenerator):
+                try
+                {
+                    _fontManager.DeleteFontCacheFolder();
+                }
+                catch (System.IO.IOException exception)
+                {
+                    _dialogService.ShowMessage(
+                        "Attempted to delete font cache folder to re-create it with the new font generator " +
+                        $"but was unable to do so:\n\n{exception}");
+                    break;
+                }
+
+                await _fontManager.CreateAllMissingFontFiles(_projectState.GumProjectSave);
+                shouldReloadContent = true;
+                _guiCommands.RefreshVariables(force: true);
+                break;
+            case nameof(viewModel.ShowCheckerBackground):
+                // Checkerboard visibility is handled via WireframePropertyChanged,
+                // so skip the wireframe refresh to avoid resetting the texture
+                // coordinates tab camera position.
+                _fileCommands.TryAutoSaveProject();
+                shouldSaveAndRefresh = false;
+                break;
+        }
+
+        _pluginManager.ProjectPropertySet(propertyName);
+
+        if (shouldSaveAndRefresh)
+        {
+            _wireframeCommands.Refresh(forceLayout: true, forceReloadContent: shouldReloadContent);
+
+            _fileCommands.TryAutoSaveProject();
+        }
+
+        return new ProjectPropertyChangeResult
+        {
+            FontCharacterFileChanged = fontCharacterFileChanged,
+            FontCharacterFileAbsolute = fontCharacterFileAbsolute
+        };
+    }
+}


### PR DESCRIPTION
Part of #3929.

## What moved

`MainPropertiesWindowPlugin.HandlePropertyChanged` (the whole switch deciding path
normalization, font-range validation/regeneration, localization language switching, and
save/refresh) had zero WPF-typed dependencies - every service it touches (`IProjectManager`,
`IFontManager`, `IDialogService`, `IProjectState`, `IWireframeObjectManager`, `IFileCommands`,
`IWireframeCommands`, `IGuiCommands`, `IPluginManager`, `ILocalizationService`) already lives in
`Gum.Presentation`. Extracted it verbatim into `ProjectPropertiesChangeLogic` (no interface -
matches the `ExclusionsLogic`/`AnimationTabController` precedent of a plugin-owned, single-consumer
logic class). The plugin constructs it in `StartUp()` (after MEF property injection sets
`LocalizationService`) and its `HandlePropertyChanged` handler is now a 6-line wrapper.

One plugin-owned side effect had to be carried across the seam explicitly rather than dropped:
the `UseFontCharacterFile` case updates the plugin's own cached `_fontCharacterFileAbsolute` field
and refreshes the Variables grid's read-only state (`RefreshFontRangeEditability`, which reads the
WPF `DataGrid`). `ProjectPropertiesChangeLogic.HandlePropertyChanged` returns a small
`ProjectPropertyChangeResult` (`FontCharacterFileChanged` + `FontCharacterFileAbsolute`) so the
plugin keeps ownership of that field and the view push, instead of silently losing them.

## What's still tool-side (and why)

The rest of the file is genuine plugin/window glue, not business logic:
- `HandleProjectLoad`, `HandlePropertiesClicked`, `HandleLocalizationLoaded`,
  `RefreshFontRangeEditability`, `HandleCloseClicked` all push into or read from the concrete
  `ProjectPropertiesControl` (WPF `UserControl`) or `PluginTab` (holds a WPF `FrameworkElement`),
  which are the actual live-window ownership this plugin exists for.
- `HandlePropertiesClicked`'s `System.Windows.RoutedEventArgs` parameter is the file's one literal
  `System.Windows` hit - a thin WPF event-handler signature, not logic.
- `HandleProjectLoad`/`HandleFileChanged` also touch the font-character-file path, but do so
  interleaved with `control.ViewModel`/`control.DataGrid` pushes in a way that isn't cleanly
  separable without a bigger reshape (would mean moving `_fontCharacterFileAbsolute` ownership
  into the headless class too, which changes more surface than this bounded slice).

So #3929 is not fully closed - the remaining methods above are correctly-scoped-out platform glue
per the north star's "push target, not ambient input" carve-out, not unmigrated logic.

## Testing

New `ProjectPropertiesChangeLogicTests` (5 cases: early-out on `IsUpdatingFromModel`, checkerboard
save-without-refresh, invalid font range, localization-file path normalization, font-character-file
toggle-off) pins the extracted logic. Mutation-checked the normalization test (flipped
`FileManager.IsRelative(...) == false` to `== true`, confirmed red, reverted).

- `dotnet build Tools/Gum.Presentation/Gum.Presentation.csproj` - clean
- `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` - 635/635 pass
- `dotnet build GumFull.sln` - clean (0 errors)
- `AllPluginsCompositionTests` + `ServiceProviderCompositionSpikeTests` - pass (no new ctor
  dependency was added to the plugin itself, so no new MEF bridge was needed)

Manual test: not needed - behavior-preserving extraction backed by pinning tests + compiler
verification; no observable runtime/visual change.
