### PR TITLE
Finish HotkeyManager decoupling: rewrite HandleNudge, seam modifier read, relocate to Gum.Presentation

### DIFF
--- a/Gum/Managers/KeyCombinationExtensions.cs
+++ b/Gum/Managers/KeyCombinationExtensions.cs
@@ -46,39 +46,4 @@ public static class KeyCombinationExtensions
         }
     }
 
-    public static bool IsPressed(this KeyCombination kc, Keys keyData)
-    {
-        Keys extracted = keyData;
-
-        if (kc.IsAltDown)
-        {
-            if (kc.Key == null)
-            {
-                return keyData == Keys.Alt;
-            }
-            else
-            {
-                return keyData == (Keys.Alt | ToWinFormsKey(kc.Key.Value));
-            }
-        }
-        else
-        {
-            if (keyData >= Keys.KeyCode)
-            {
-                int value = (int)(keyData) + (int)Keys.Modifiers;
-
-                extracted = (Keys)value;
-            }
-
-            bool shiftDown = (keyData & Keys.Shift) == Keys.Shift;
-            bool ctrlDown = (keyData & Keys.Control) == Keys.Control;
-            bool altDown = (keyData & Keys.Alt) == Keys.Alt;
-
-            if (kc.IsCtrlDown && !ctrlDown) return false;
-            if (kc.IsShiftDown && !shiftDown) return false;
-            if (kc.IsAltDown && !altDown) return false;
-
-            return kc.Key == null || extracted == ToWinFormsKey(kc.Key.Value);
-        }
-    }
 }

--- a/Gum/Managers/WinFormsModifierKeyState.cs
+++ b/Gum/Managers/WinFormsModifierKeyState.cs
@@ -1,0 +1,20 @@
+using System.Windows.Forms;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Reads the live OS modifier-key state via WinForms' <see cref="Control.ModifierKeys"/>. Kept in the
+/// tool layer so <see cref="IModifierKeyState"/> (headless <c>Gum.Presentation</c>, ADR-0005) stays
+/// framework-neutral; see <see cref="HotkeyManager.IsPressedInControl"/>, its only consumer.
+/// </summary>
+public class WinFormsModifierKeyState : IModifierKeyState
+{
+    /// <inheritdoc/>
+    public bool IsCtrlDown => (Control.ModifierKeys & Keys.Control) == Keys.Control;
+
+    /// <inheritdoc/>
+    public bool IsShiftDown => (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
+
+    /// <inheritdoc/>
+    public bool IsAltDown => (Control.ModifierKeys & Keys.Alt) == Keys.Alt;
+}

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -181,6 +181,7 @@ file static class ServiceCollectionExtensions
                 provider.GetRequiredService<IFontFileGenerator>(),
                 provider.GetRequiredService<IFontGenerationCallbacks>()));
         services.AddSingleton<IFontManager, FontManager>();
+        services.AddSingleton<IModifierKeyState, WinFormsModifierKeyState>();
         services.AddSingleton<IHotkeyManager, HotkeyManager>();
         services.AddSingleton<IRetryService, RetryService>();
         services.AddSingleton<LocalizationService>();

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -32,6 +32,7 @@ public class HotkeyManagerTests : BaseTestClass
     private readonly Mock<IReorderLogic> _reorderLogic;
     private readonly Mock<IPluginManager> _pluginManager;
     private readonly Mock<ISelectionHistory> _selectionHistory;
+    private readonly Mock<IModifierKeyState> _modifierKeyState;
     private readonly HotkeyManager _hotkeyManager;
 
     public HotkeyManagerTests()
@@ -49,6 +50,7 @@ public class HotkeyManagerTests : BaseTestClass
         _reorderLogic = new Mock<IReorderLogic>();
         _pluginManager = new Mock<IPluginManager>();
         _selectionHistory = new Mock<ISelectionHistory>();
+        _modifierKeyState = new Mock<IModifierKeyState>();
 
         _hotkeyManager = new HotkeyManager(
             _guiCommands.Object,
@@ -63,42 +65,9 @@ public class HotkeyManagerTests : BaseTestClass
             _editCommands.Object,
             _reorderLogic.Object,
             _pluginManager.Object,
-            _selectionHistory.Object
+            _selectionHistory.Object,
+            _modifierKeyState.Object
         );
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_NudgeUp5_RequiresShift()
-    {
-        // NudgeUp5 is Shift+Up: the Shift modifier bit is required.
-        _hotkeyManager.NudgeUp5.IsPressed(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up).ShouldBeTrue();
-        _hotkeyManager.NudgeUp5.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_NudgeUp_MatchesUp_AndIgnoresShiftBit()
-    {
-        // NudgeUp is a plain Up with no modifier requirement. The keyData flags overload must
-        // strip modifier bits to extract the key code, so Shift+Up still matches the key part.
-        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeTrue();
-        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Down).ShouldBeFalse();
-        _hotkeyManager.NudgeUp.IsPressed(System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.Up).ShouldBeTrue();
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_ReorderUp_MatchesAltPlusKey()
-    {
-        // ReorderUp is Alt+Up: matches only when both the Alt flag and the Up key code are present.
-        _hotkeyManager.ReorderUp.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Up).ShouldBeTrue();
-        _hotkeyManager.ReorderUp.IsPressed(System.Windows.Forms.Keys.Up).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_ResizeFromCenter_MatchesAltOnly()
-    {
-        // ResizeFromCenter is Alt with no key: matches the bare Alt modifier, not Alt+other.
-        _hotkeyManager.ResizeFromCenter.IsPressed(System.Windows.Forms.Keys.Alt).ShouldBeTrue();
-        _hotkeyManager.ResizeFromCenter.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.C).ShouldBeFalse();
     }
 
     [Fact]
@@ -145,6 +114,18 @@ public class HotkeyManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void ProcessCmdKeyWireframe_AltArrow_DoesNotNudge()
+    {
+        // Alt+arrow reorders the selected instance elsewhere, so it must not also nudge here.
+        SetUpSelectedInstance(x: 10f, y: 20f);
+
+        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(GumKey.Up, isShiftDown: false, isCtrlDown: false, isAltDown: true);
+
+        handled.ShouldBeFalse();
+        _elementCommands.Verify(e => e.MoveSelectedObjectsBy(It.IsAny<float>(), It.IsAny<float>()), Times.Never);
+    }
+
+    [Fact]
     public void ProcessCmdKeyWireframe_LockedInstance_DoesNothing()
     {
         SetUpSelectedInstance(x: 10f, y: 20f, locked: true);
@@ -165,22 +146,6 @@ public class HotkeyManagerTests : BaseTestClass
 
         handled.ShouldBeTrue();
         _elementCommands.Verify(e => e.MoveSelectedObjectsBy(0f, -5f), Times.Once);
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_NavigateBack_MatchesAltPlusLeft()
-    {
-        // NavigateBack is Alt+Left: matches only when both the Alt flag and the Left key code are present.
-        _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Left).ShouldBeTrue();
-        _hotkeyManager.NavigateBack.IsPressed(System.Windows.Forms.Keys.Left).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void IsPressed_KeyData_NavigateForward_MatchesAltPlusRight()
-    {
-        // NavigateForward is Alt+Right: matches only when both the Alt flag and the Right key code are present.
-        _hotkeyManager.NavigateForward.IsPressed(System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.Right).ShouldBeTrue();
-        _hotkeyManager.NavigateForward.IsPressed(System.Windows.Forms.Keys.Right).ShouldBeFalse();
     }
 
     [Fact]
@@ -379,6 +344,32 @@ public class HotkeyManagerTests : BaseTestClass
         _hotkeyManager.HandleEditorKeyDown(e);
 
         _uiSettingsService.Object.BaseFontSize.ShouldBe(12d);
+    }
+
+    [Fact]
+    public void IsPressedInControl_RequiredModifierHeld_KeyNull_ReturnsTrue()
+    {
+        // MultiSelect is Shift with no key: the modifier-only check is the only requirement.
+        _modifierKeyState.Setup(m => m.IsShiftDown).Returns(true);
+
+        _hotkeyManager.IsPressedInControl(_hotkeyManager.MultiSelect).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPressedInControl_RequiredModifierNotHeld_ReturnsFalse()
+    {
+        _modifierKeyState.Setup(m => m.IsShiftDown).Returns(false);
+
+        _hotkeyManager.IsPressedInControl(_hotkeyManager.MultiSelect).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressedInControl_ComboHasKeySet_AlwaysReturnsFalse()
+    {
+        // Pre-existing residual quirk, preserved as-is: the live modifier-key read reports only
+        // Ctrl/Shift/Alt, never a key code, so a combo with Key set (e.g. NudgeUp) never matches
+        // here even when no modifier is required and none are held.
+        _hotkeyManager.IsPressedInControl(_hotkeyManager.NudgeUp).ShouldBeFalse();
     }
 
     private (ComponentSave element, InstanceSave instance) SetUpSelectedInstance(float x, float y, bool locked = false)

--- a/Tools/Gum.Presentation/Managers/HotkeyManager.cs
+++ b/Tools/Gum.Presentation/Managers/HotkeyManager.cs
@@ -1,5 +1,4 @@
 using Gum.Commands;
-using Gum.Controls;
 using Gum.DataTypes;
 using Gum.Dialogs;
 using Gum.Input;
@@ -8,12 +7,10 @@ using Gum.Plugins;
 using Gum.PropertyGridHelpers;
 using Gum.Services;
 using Gum.Services.Dialogs;
-using Gum.Themes;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using System;
-using System.Windows.Forms;
 using Gum.SelectionHistory;
 using Gum.Undo;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -87,6 +84,7 @@ public class HotkeyManager : IHotkeyManager
     private readonly IReorderLogic _reorderLogic;
     private readonly IPluginManager _pluginManager;
     private readonly ISelectionHistory _selectionHistory;
+    private readonly IModifierKeyState _modifierKeyState;
 
 
     public HotkeyManager(IGuiCommands guiCommands,
@@ -101,7 +99,8 @@ public class HotkeyManager : IHotkeyManager
         IEditCommands editCommands,
         IReorderLogic reorderLogic,
         IPluginManager pluginManager,
-        ISelectionHistory selectionHistory)
+        ISelectionHistory selectionHistory,
+        IModifierKeyState modifierKeyState)
     {
         _copyPasteLogic = copyPasteLogic;
         _guiCommands = guiCommands;
@@ -116,17 +115,21 @@ public class HotkeyManager : IHotkeyManager
         _reorderLogic = reorderLogic;
         _pluginManager = pluginManager;
         _selectionHistory = selectionHistory;
+        _modifierKeyState = modifierKeyState;
     }
 
     public bool IsPressedInControl(KeyCombination combo)
     {
-        // Reads the live WinForms modifier state (Control.ModifierKeys). This stays in the tool layer
-        // (off the now-headless KeyCombination) and on the interface so it remains mockable in tests.
-        if (combo.IsCtrlDown && (Control.ModifierKeys & Keys.Control) != Keys.Control) return false;
-        if (combo.IsShiftDown && (Control.ModifierKeys & Keys.Shift) != Keys.Shift) return false;
-        if (combo.IsAltDown && (Control.ModifierKeys & Keys.Alt) != Keys.Alt) return false;
+        if (combo.IsCtrlDown && !_modifierKeyState.IsCtrlDown) return false;
+        if (combo.IsShiftDown && !_modifierKeyState.IsShiftDown) return false;
+        if (combo.IsAltDown && !_modifierKeyState.IsAltDown) return false;
 
-        return combo.Key == null || (Control.ModifierKeys & Keys.KeyCode) == (Keys)(int)combo.Key.Value;
+        // Pre-existing behavior, preserved as-is: the live modifier-key read only ever reports the
+        // held modifiers, never a key code, so a combo with Key set never actually matched here -
+        // only combos with Key == null (checked purely by the modifier guards above) can return
+        // true. Left as a known residual quirk rather than fixed here (Ruler.cs calls this with
+        // NudgeUp/Down/Left/Right, which have Key set, so those calls always report "not pressed").
+        return combo.Key == null;
     }
 
     #region App Wide Keys
@@ -352,34 +355,38 @@ public class HotkeyManager : IHotkeyManager
 
     public bool ProcessCmdKeyWireframe(GumKey? key, bool isShiftDown, bool isCtrlDown, bool isAltDown)
     {
-        // The interface is framework-neutral (GumKey, not WinForms Keys). Rebuild the Keys value the
-        // nudge logic matches against: GumKey values equal Win32 virtual-key codes (pinned by GumKeyTests),
-        // so the key is a pure cast, and the modifier bits are re-applied from the booleans. Reconstructing
-        // here keeps HandleNudge / KeyCombination.IsPressed unchanged and behavior identical — including the
-        // existing suppression of nudging while Ctrl/Alt are held (Ctrl+arrow pans the camera instead).
-        Keys keyData = key.HasValue ? (Keys)(int)key.Value : Keys.None;
-        if (isShiftDown) { keyData |= Keys.Shift; }
-        if (isCtrlDown) { keyData |= Keys.Control; }
-        if (isAltDown) { keyData |= Keys.Alt; }
+        GumKeyEventArgs e = new()
+        {
+            Key = key,
+            IsShiftDown = isShiftDown,
+            IsCtrlDown = isCtrlDown,
+            IsAltDown = isAltDown
+        };
 
-        return HandleNudge(keyData);
+        return HandleNudge(e);
     }
 
-    private bool HandleNudge(Keys keyData)
+    private bool HandleNudge(GumKeyEventArgs e)
     {
+        // Ctrl+arrow pans the camera and Alt+arrow reorders the selected instance elsewhere - neither
+        // should also nudge the selection here, regardless of which key combo would otherwise match.
+        if (e.IsCtrlDown || e.IsAltDown)
+        {
+            return false;
+        }
 
         int nudgeX = 0;
         int nudgeY = 0;
-        
-        if (NudgeUp5.IsPressed(keyData)) nudgeY = -5;
-        else if (NudgeDown5.IsPressed(keyData)) nudgeY = 5;
-        else if (NudgeUp.IsPressed(keyData)) nudgeY = -1;
-        else if (NudgeDown.IsPressed(keyData)) nudgeY = 1;
 
-        if (NudgeRight5.IsPressed(keyData)) nudgeX = 5;
-        else if (NudgeLeft5.IsPressed(keyData)) nudgeX = -5;
-        else if (NudgeRight.IsPressed(keyData)) nudgeX = 1;
-        else if (NudgeLeft.IsPressed(keyData)) nudgeX = -1;
+        if (NudgeUp5.IsPressed(e)) nudgeY = -5;
+        else if (NudgeDown5.IsPressed(e)) nudgeY = 5;
+        else if (NudgeUp.IsPressed(e)) nudgeY = -1;
+        else if (NudgeDown.IsPressed(e)) nudgeY = 1;
+
+        if (NudgeRight5.IsPressed(e)) nudgeX = 5;
+        else if (NudgeLeft5.IsPressed(e)) nudgeX = -5;
+        else if (NudgeRight.IsPressed(e)) nudgeX = 1;
+        else if (NudgeLeft.IsPressed(e)) nudgeX = -1;
 
         bool handled = false;
 

--- a/Tools/Gum.Presentation/Managers/IModifierKeyState.cs
+++ b/Tools/Gum.Presentation/Managers/IModifierKeyState.cs
@@ -1,0 +1,19 @@
+namespace Gum.Managers;
+
+/// <summary>
+/// Live OS keyboard-modifier state (Ctrl/Shift/Alt currently held), independent of any specific key
+/// event. Framework-neutral (ADR-0005) so <see cref="HotkeyManager.IsPressedInControl"/> can stay in
+/// headless <c>Gum.Presentation</c>; the WinForms read (<c>Control.ModifierKeys</c>) lives in the
+/// tool-side implementation, injected in from there.
+/// </summary>
+public interface IModifierKeyState
+{
+    /// <summary>Whether a Ctrl key is currently held.</summary>
+    bool IsCtrlDown { get; }
+
+    /// <summary>Whether a Shift key is currently held.</summary>
+    bool IsShiftDown { get; }
+
+    /// <summary>Whether an Alt key is currently held.</summary>
+    bool IsAltDown { get; }
+}


### PR DESCRIPTION
Closes #3906.

## What

Finishes the 3-item follow-up plan from #3919:

1. **`HandleNudge`/`ProcessCmdKeyWireframe`** now build a `GumKeyEventArgs` and match via the already-existing `KeyCombinationGumEventArgsExtensions.IsPressed(GumKeyEventArgs)` (same mechanism `PreviewKeyDownAppWide`/etc. already use), instead of rebuilding a WinForms `Keys` bitflag. Added an explicit early-return guard (`if (e.IsCtrlDown || e.IsAltDown) return false;`) to preserve the existing "Ctrl/Alt+arrow never nudges" behavior - Ctrl+arrow pans the camera, Alt+arrow reorders, elsewhere.
2. **`IsPressedInControl`** now reads modifier state through a new `IModifierKeyState` interface (`Gum.Presentation`) instead of `System.Windows.Forms.Control.ModifierKeys` directly - same shape as the existing `IGumCursorState`/`Cursor.Self` seam. `WinFormsModifierKeyState` (tool-side) is the concrete implementation, registered in `Builder.cs`.
   - **Found and flagged, not fixed:** `Control.ModifierKeys` only ever reports held modifiers, never a key code, so a combo with `Key` set (e.g. `NudgeUp`/`NudgeDown`/`NudgeLeft`/`NudgeRight`) never actually matched here even before this PR - only `Key == null` combos (checked purely by the modifier guards) could return true. `Ruler.cs` calls `IsPressedInControl` with all four Nudge combos, so those calls have always silently reported "not pressed." Preserved as-is (documented in a code comment) rather than fixed, since fixing it is a real behavior change outside this PR's scope - flagging here for a maintainer decision.
3. **Physically relocated `HotkeyManager`** into `Tools/Gum.Presentation` (`Gum/Managers/HotkeyManager.cs` -> `Tools/Gum.Presentation/Managers/HotkeyManager.cs`). `IHotkeyManager` was already there and already MEF-bridged in `PluginManager.LoadPlugins`, so no new bridge was needed. Dropped two now-unused `using`s (`Gum.Controls`, `Gum.Themes`) that only existed because the file used to live in `Gum.csproj`.

Boyscout: deleted the now-dead `KeyCombinationExtensions.IsPressed(this KeyCombination kc, Keys keyData)` overload - its only caller was `HandleNudge`, now gone.

## Testing

- Rewrote `HotkeyManagerTests`: removed the 6 `IsPressed_KeyData_*` tests that pinned the deleted `Keys` overload directly; added `ProcessCmdKeyWireframe_AltArrow_DoesNotNudge` (new branch) and 3 new `IsPressedInControl_*` tests (previously untested - the seam makes it mockable for the first time).
- Mutation-test proof: reverted the Ctrl-only guard to confirm `ProcessCmdKeyWireframe_AltArrow_DoesNotNudge` goes red; reverted `IsPressedInControl`'s `return combo.Key == null;` to `return true;` and confirmed `IsPressedInControl_ComboHasKeySet_AlwaysReturnsFalse` goes red. Both reverted back to green.
- `GumToolUnitTests`: 1055 passed, 2 pre-existing skips, 0 failed (one unrelated pre-existing flaky test, `MultiSelectTreeViewNavigationTests.ShouldSelectOnMouseUp_LeftButton_ReturnsTrue`, failed once under full-suite parallelism and passed both in isolation and on a second full-suite run - not touched by this PR).
- `Gum.Presentation.Tests`: 630 passed, 0 failed.
- `ServiceProviderCompositionSpikeTests` + `AllPluginsCompositionTests`: pass.
- `GumFull.sln`: builds clean, 0 errors.

Manual test: not needed - behavior-preserving (same matching semantics reused from the already-merged #3919 pattern, same interface, same call sites), proven by the compiler plus the unit tests including mutation-test proof on the two new branches.
