### PR TITLE
Extract WpfPluginBase from PluginBase - bounded first slice

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -346,6 +346,16 @@ changelog — update this list when a *new kind* of gotcha is discovered, not fo
   reason). Check where the parameter *flows*, not just its declared type, before writing a member
   off as blocked — a class-wide "N regions are WPF-coupled" count can overstate true blast radius
   this way.
+- **Splitting a common base class into a headless one plus a narrower WPF-coupled subclass can
+  break a caller that iterates "for every plugin" via the common base type**, not just the
+  declaration site. A `Call*` forwarder moved from the base onto the narrower subclass needs the
+  generic-iteration caller updated to `(plugin as NarrowerBase)?.Call...()` — behavior-preserving,
+  since only subclass-derived plugins could ever have subscribed to that event in the first place,
+  but easy to miss because the compile error surfaces at the call site, not the moved member.
+  Relatedly, retyping a delegate's parameter (e.g. a concrete runtime type to its neutral interface)
+  can silently break a subscriber whose handler still declares the old concrete parameter type —
+  delegate contravariance only allows a *wider* handler parameter, never narrower, so check every
+  subscriber's signature after a publisher-side retype, not just the publisher.
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
 - *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated

--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -19,7 +19,6 @@ using System.Linq;
 using System.Runtime;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using Gum.Services.Dialogs;
 using ToolsUtilities;
 using CommunityToolkit.Mvvm.Messaging;
@@ -228,7 +227,7 @@ public class MainCodeOutputPlugin : PluginBase
         HandleElementSelected(null);
     }
 
-    private void HandleStateSelected(TreeNode obj)
+    private void HandleStateSelected(ITreeNode obj)
     {
         if (control != null && _selectedState.SelectedElement != null)
         {

--- a/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
+++ b/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
@@ -22,7 +22,7 @@ using Gum.Logic.FileWatch;
 namespace GumFormsPlugin;
 
 [Export(typeof(PluginBase))]
-internal class MainGumFormsPlugin : PluginBase
+internal class MainGumFormsPlugin : WpfPluginBase
 {
     #region Fields/Properties
 

--- a/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
+++ b/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
@@ -16,7 +16,7 @@ using System.Windows;
 namespace ImportFromGumxPlugin;
 
 [Export(typeof(PluginBase))]
-internal class MainImportFromGumxPlugin : PluginBase
+internal class MainImportFromGumxPlugin : WpfPluginBase
 {
     public override string FriendlyName => "Import from .gumx Plugin";
     public override bool ShutDown(PluginShutDownReason shutDownReason) => true;

--- a/Gum/Plugins/BaseClasses/PluginBase.cs
+++ b/Gum/Plugins/BaseClasses/PluginBase.cs
@@ -3,13 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Gum.DataTypes;
-using Gum.Gui.Windows;
 using Gum.DataTypes.Variables;
-using System.Windows;
-using System.Windows.Forms;
-using System.Windows;
-using MenuItem = System.Windows.Controls.MenuItem;
-using Separator = System.Windows.Controls.Separator;
 using Gum.DataTypes.Behaviors;
 using RenderingLibrary.Graphics;
 using Gum.Responses;
@@ -23,6 +17,7 @@ using Gum.Commands;
 using Gum.Managers;
 using Gum.Services;
 using Gum.Services.Dialogs;
+using Gum.Input;
 
 namespace Gum.Plugins.BaseClasses;
 
@@ -37,13 +32,11 @@ public abstract class PluginBase : IPlugin
     protected IFileCommands _fileCommands;
     protected ITabManager _tabManager;
     protected IDialogService _dialogService;
-    private MenuStripManager _menuStripManager;
 
     [Import] public IGuiCommands GuiCommands { get => _guiCommands; set => _guiCommands = value; }
     [Import] public IFileCommands FileCommands { get => _fileCommands; set => _fileCommands = value; }
     [Import] public ITabManager TabManager { get => _tabManager; set => _tabManager = value; }
     [Import] public IDialogService DialogService { get => _dialogService; set => _dialogService = value; }
-    [Import] public MenuStripManager MenuStripManager { get => _menuStripManager; set => _menuStripManager = value; }
 
     #region Events
 
@@ -56,8 +49,6 @@ public abstract class PluginBase : IPlugin
     public event Action<ElementSave>? BeforeElementSave;
     public event Action<ElementSave>? AfterElementSave;
     public event Action<ElementSave>? Export;
-    public event Action<DeleteOptionsWindow, Array>? DeleteOptionsWindowShow;
-    public event Action<DeleteOptionsWindow, Array>? DeleteConfirmed;
 
     public event Action<ElementSave>? ElementAdd;
     public event Action<ElementSave>? ElementDelete;
@@ -158,8 +149,8 @@ public abstract class PluginBase : IPlugin
     public event Action<ElementSave, string>? VariableDelete;
 
     public event Action<ElementSave?>? ElementSelected;
-    public event Action<TreeNode?>? TreeNodeSelected;
-    public event Action<TreeNode>? StateWindowTreeNodeSelected;
+    public event Action<ITreeNode?>? TreeNodeSelected;
+    public event Action<ITreeNode>? StateWindowTreeNodeSelected;
     public event Func<ITreeNode?>? GetTreeNodeOver;
     public event Func<IEnumerable<ITreeNode>>? GetSelectedNodes;
     public event Action? FocusSearch;
@@ -247,7 +238,7 @@ public abstract class PluginBase : IPlugin
 
     public event Func<bool>? TryHandleDelete;
 
-    public event Func<InputLibrary.Cursor, Vector2?>? GetWorldCursorPosition;
+    public event Func<IGumCursorState, Vector2?>? GetWorldCursorPosition;
 
     public event Func<IEnumerable<ErrorViewModel>>? GetAllErrors;
 
@@ -268,85 +259,9 @@ public abstract class PluginBase : IPlugin
     public abstract void StartUp();
     public abstract bool ShutDown(PluginShutDownReason shutDownReason);
 
-    #region Menu Items
-
-    /// <summary>
-    /// Adds a menu item using the path specified by the menuAndSubmenus. 
-    /// </summary>
-    /// <param name="menuAndSubmenus">The menu path. The first item may specify an existing menu to add to.
-    /// For example, to add a Properties item to the existing Edit item, the following
-    /// parameter could be used:
-    /// new List<string> { "Edit", "Properties" }
-    /// </param>
-    /// <returns>The newly-created menu item.</returns>
-    public MenuItem AddMenuItem(IEnumerable<string> menuAndSubmenus) =>
-        _menuStripManager.AddMenuItem(menuAndSubmenus);
-
-    public MenuItem AddMenuItem(params string[] menuAndSubmenus)
-    {
-        return AddMenuItem((IEnumerable<string>)menuAndSubmenus);
-    }
-
-    MenuItem GetItem(string name) => _menuStripManager.GetItem(name);
-
-    public MenuItem GetChildMenuItem(string parentText, string childText)
-    {
-        MenuItem parentItem = GetItem(parentText);
-        if (parentItem != null)
-        {
-            MenuItem childMenuItem = parentItem.Items
-                .OfType<MenuItem>()
-                .FirstOrDefault(item => item.Header as string == childText);
-
-            return childMenuItem;
-        }
-
-        return null;
-    }
-
-
-    protected MenuItem AddMenuItemTo(string whatToAdd, RoutedEventHandler eventHandler, string container, int? preferredIndex = null)
-    {
-        var menuItem = new MenuItem { Header = whatToAdd };
-        if (eventHandler != null)
-            menuItem.Click += eventHandler;
-
-        MenuItem itemToAddTo = GetItem(container);
-
-#if DEBUG
-        if (itemToAddTo == null)
-        {
-            throw new InvalidOperationException(
-                $"Could not find menu item '{container}'. Make sure the menu is populated before calling AddMenuItemTo.");
-        }
-#endif
-
-        if (preferredIndex == -1)
-        {
-            itemToAddTo.Items.Add(menuItem);
-        }
-        else
-        {
-            int indexToInsertAt = itemToAddTo.Items.Count;
-            if(preferredIndex != null)
-            {
-                indexToInsertAt = System.Math.Min(preferredIndex.Value, itemToAddTo.Items.Count);
-            }
-
-            itemToAddTo.Items.Insert(indexToInsertAt, menuItem);
-        }
-
-        _menuStripManager.ApplyLayout(container);
-
-        return menuItem;
-    }
-
-    #endregion
-
     #region Plugin Tabs
 
-
-    public PluginTab CreateTab(System.Windows.FrameworkElement control, string tabName, TabLocation defaultLocation = TabLocation.RightBottom)
+    public PluginTab CreateTab(object control, string tabName, TabLocation defaultLocation = TabLocation.RightBottom)
     {
         PluginTab newTab = _tabManager.AddControl(control, tabName, defaultLocation);
         newTab.Location = defaultLocation;
@@ -354,7 +269,7 @@ public abstract class PluginBase : IPlugin
         return newTab;
     }
 
-    public PluginTab AddControl(System.Windows.FrameworkElement control, string tabName, TabLocation tabLocation)
+    public PluginTab AddControl(object control, string tabName, TabLocation tabLocation)
     {
         return _tabManager.AddControl(control, tabName, tabLocation);
     }
@@ -390,12 +305,6 @@ public abstract class PluginBase : IPlugin
         return false;
     }
 
-    public void CallDeleteOptionsWindowShow(DeleteOptionsWindow optionsWindow, Array objectsToDelete) =>
-            DeleteOptionsWindowShow?.Invoke(optionsWindow, objectsToDelete);
-
-    public void CallDeleteConfirmed(DeleteOptionsWindow optionsWindow, Array deletedObjects) =>
-        DeleteConfirmed?.Invoke(optionsWindow, deletedObjects);
-    
     public void CallElementAdd(ElementSave element) =>
         ElementAdd?.Invoke(element);
     public void CallElementDelete(ElementSave element) =>
@@ -458,9 +367,9 @@ public abstract class PluginBase : IPlugin
 
     public void CallElementSelected(ElementSave? element) => ElementSelected?.Invoke(element);
 
-    public void CallTreeNodeSelected(TreeNode? treeNode) => TreeNodeSelected?.Invoke(treeNode);
+    public void CallTreeNodeSelected(ITreeNode? treeNode) => TreeNodeSelected?.Invoke(treeNode);
 
-    public void CallStateWindowTreeNodeSelected(TreeNode treeNode) => StateWindowTreeNodeSelected?.Invoke(treeNode);
+    public void CallStateWindowTreeNodeSelected(ITreeNode treeNode) => StateWindowTreeNodeSelected?.Invoke(treeNode);
 
     public void CallBehaviorSelected(BehaviorSave? behavior) => BehaviorSelected?.Invoke(behavior);
 
@@ -546,7 +455,7 @@ public abstract class PluginBase : IPlugin
     public GraphicalUiElement? CallCreateGraphicalUiElement(ElementSave elementSave) =>
         CreateGraphicalUiElement?.Invoke(elementSave);
 
-    public Vector2? CallGetWorldCursorPosition(InputLibrary.Cursor cursor) =>
+    public Vector2? CallGetWorldCursorPosition(IGumCursorState cursor) =>
         GetWorldCursorPosition?.Invoke(cursor);
 
     public IEnumerable<ErrorViewModel>? CallGetAllErrors() =>

--- a/Gum/Plugins/BaseClasses/PriorityPlugin.cs
+++ b/Gum/Plugins/BaseClasses/PriorityPlugin.cs
@@ -5,7 +5,7 @@ namespace Gum.Plugins.BaseClasses
     // This can't be done on the base class - it must be done on the
     // class that inherits from PriorityPlugin...oh well
     //[Export(typeof(Gum.Plugins.BaseClasses.PluginBase))]
-    public abstract class PriorityPlugin : PluginBase
+    public abstract class PriorityPlugin : WpfPluginBase
     {
         public override string FriendlyName
         {

--- a/Gum/Plugins/BaseClasses/WpfPluginBase.cs
+++ b/Gum/Plugins/BaseClasses/WpfPluginBase.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Windows;
+using Gum.Gui.Windows;
+using Gum.Managers;
+using MenuItem = System.Windows.Controls.MenuItem;
+
+namespace Gum.Plugins.BaseClasses;
+
+/// <summary>
+/// <see cref="PluginBase"/> plus the members that are genuinely WPF-coupled: menu items
+/// (<c>System.Windows.Controls.MenuItem</c>) and the delete-confirmation dialog events
+/// (<c>Gum.Gui.Windows.DeleteOptionsWindow</c> is a real WPF <see cref="System.Windows.Window"/>).
+/// Plugins that don't touch menus or the delete dialog can inherit <see cref="PluginBase"/>
+/// directly and stay WPF-free.
+/// </summary>
+public abstract class WpfPluginBase : PluginBase
+{
+    private MenuStripManager _menuStripManager;
+
+    [Import] public MenuStripManager MenuStripManager { get => _menuStripManager; set => _menuStripManager = value; }
+
+    public event Action<DeleteOptionsWindow, Array>? DeleteOptionsWindowShow;
+    public event Action<DeleteOptionsWindow, Array>? DeleteConfirmed;
+
+    #region Menu Items
+
+    /// <summary>
+    /// Adds a menu item using the path specified by the menuAndSubmenus.
+    /// </summary>
+    /// <param name="menuAndSubmenus">The menu path. The first item may specify an existing menu to add to.
+    /// For example, to add a Properties item to the existing Edit item, the following
+    /// parameter could be used:
+    /// new List<string> { "Edit", "Properties" }
+    /// </param>
+    /// <returns>The newly-created menu item.</returns>
+    public MenuItem AddMenuItem(IEnumerable<string> menuAndSubmenus) =>
+        _menuStripManager.AddMenuItem(menuAndSubmenus);
+
+    public MenuItem AddMenuItem(params string[] menuAndSubmenus)
+    {
+        return AddMenuItem((IEnumerable<string>)menuAndSubmenus);
+    }
+
+    MenuItem GetItem(string name) => _menuStripManager.GetItem(name);
+
+    public MenuItem GetChildMenuItem(string parentText, string childText)
+    {
+        MenuItem parentItem = GetItem(parentText);
+        if (parentItem != null)
+        {
+            MenuItem childMenuItem = parentItem.Items
+                .OfType<MenuItem>()
+                .FirstOrDefault(item => item.Header as string == childText);
+
+            return childMenuItem;
+        }
+
+        return null;
+    }
+
+
+    protected MenuItem AddMenuItemTo(string whatToAdd, RoutedEventHandler eventHandler, string container, int? preferredIndex = null)
+    {
+        var menuItem = new MenuItem { Header = whatToAdd };
+        if (eventHandler != null)
+            menuItem.Click += eventHandler;
+
+        MenuItem itemToAddTo = GetItem(container);
+
+#if DEBUG
+        if (itemToAddTo == null)
+        {
+            throw new InvalidOperationException(
+                $"Could not find menu item '{container}'. Make sure the menu is populated before calling AddMenuItemTo.");
+        }
+#endif
+
+        if (preferredIndex == -1)
+        {
+            itemToAddTo.Items.Add(menuItem);
+        }
+        else
+        {
+            int indexToInsertAt = itemToAddTo.Items.Count;
+            if(preferredIndex != null)
+            {
+                indexToInsertAt = System.Math.Min(preferredIndex.Value, itemToAddTo.Items.Count);
+            }
+
+            itemToAddTo.Items.Insert(indexToInsertAt, menuItem);
+        }
+
+        _menuStripManager.ApplyLayout(container);
+
+        return menuItem;
+    }
+
+    #endregion
+
+    #region Event calling
+
+    public void CallDeleteOptionsWindowShow(DeleteOptionsWindow optionsWindow, Array objectsToDelete) =>
+        DeleteOptionsWindowShow?.Invoke(optionsWindow, objectsToDelete);
+
+    public void CallDeleteConfirmed(DeleteOptionsWindow optionsWindow, Array deletedObjects) =>
+        DeleteConfirmed?.Invoke(optionsWindow, deletedObjects);
+
+    #endregion
+}

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -1,7 +1,7 @@
-﻿using Gum.Plugins.BaseClasses;
+﻿using Gum.Managers;
+using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
-using System.Windows.Forms;
 
 namespace Gum.Plugins.AlignmentButtons
 {
@@ -31,12 +31,12 @@ namespace Gum.Plugins.AlignmentButtons
             this.StateWindowTreeNodeSelected += HandleStateWindowTreeNodeSelected;
         }
 
-        private void HandleStateWindowTreeNodeSelected(TreeNode obj)
+        private void HandleStateWindowTreeNodeSelected(ITreeNode obj)
         {
             RefreshTabVisibility();
         }
 
-        private void HandleTreeNodeSelected(TreeNode? treeNode)
+        private void HandleTreeNodeSelected(ITreeNode? treeNode)
         {
             RefreshTabVisibility();
         }

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -2,7 +2,6 @@ using Gum.Plugins.BaseClasses;
 using System.ComponentModel.Composition;
 using Gum.ToolStates;
 using Gum.DataTypes.Behaviors;
-using System.Windows.Forms;
 using Gum.Undo;
 using Gum.ToolCommands;
 using Gum.Managers;
@@ -73,10 +72,9 @@ public class MainBehaviorsPlugin : PriorityPlugin
         this.StateMovedToCategory += behaviorsLogic.HandleStateMovedToCategory;
     }
 
-    // System.Windows.Forms.TreeNode is a real WinForms-glue signature baked into
-    // PluginBase.StateWindowTreeNodeSelected itself, so this handler can't move into
-    // BehaviorsLogic; it's a no-op today regardless.
-    private void HandleStateSelected(TreeNode obj)
+    // A no-op today regardless of type - StateWindowTreeNodeSelected has no live invoker
+    // (PluginManager.StateWindowTreeNodeSelected is never called), so this handler never fires.
+    private void HandleStateSelected(ITreeNode obj)
     {
 
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -10,7 +10,6 @@ using Gum.ToolStates;
 using GumRuntime;
 using System;
 using System.ComponentModel.Composition;
-using System.Windows.Forms;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -140,7 +139,7 @@ public class MainVariableGridPlugin : PriorityPlugin
         //_propertyGridManager.RefreshVariablesDataGridValues();
     }
 
-    private void HandleTreeNodeSelected(TreeNode? node)
+    private void HandleTreeNodeSelected(ITreeNode? node)
     {
         _selectionCoordinator.Reset();
         var selectedState = _selectedState;

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -274,10 +274,10 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
     /// <param name="window">The window to modify.</param>
     /// <param name="objectsToDelete">An array of objects that may be deleted, which could be any Gum type.</param>
     public void ShowDeleteDialog(DeleteOptionsWindow window, Array objectsToDelete) =>
-        CallMethodOnPlugin(plugin => plugin.CallDeleteOptionsWindowShow(window, objectsToDelete));
+        CallMethodOnPlugin(plugin => (plugin as WpfPluginBase)?.CallDeleteOptionsWindowShow(window, objectsToDelete));
 
     public void DeleteConfirmed(DeleteOptionsWindow window, Array objectsToDelete) =>
-        CallMethodOnPlugin(plugin => plugin.CallDeleteConfirmed(window, objectsToDelete));
+        CallMethodOnPlugin(plugin => (plugin as WpfPluginBase)?.CallDeleteConfirmed(window, objectsToDelete));
 
     public void ElementRename(ElementSave elementSave, string oldName) =>
         CallMethodOnPlugin(plugin => plugin.CallElementRename(elementSave, oldName));
@@ -370,10 +370,10 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
         CallMethodOnPlugin(plugin => plugin.CallElementSelected(elementSave));
 
     public void TreeNodeSelected(object? treeNode) =>
-        CallMethodOnPlugin(plugin => plugin.CallTreeNodeSelected(treeNode as TreeNode));
+        CallMethodOnPlugin(plugin => plugin.CallTreeNodeSelected(treeNode as ITreeNode));
 
     internal void StateWindowTreeNodeSelected(TreeNode treeNode) =>
-        CallMethodOnPlugin(plugin => plugin.CallStateWindowTreeNodeSelected(treeNode));
+        CallMethodOnPlugin(plugin => plugin.CallStateWindowTreeNodeSelected((ITreeNode)treeNode));
 
     public ITreeNode? GetTreeNodeOver()
     {

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -35,7 +35,7 @@ namespace StateAnimationPlugin;
 /// model onto the window's DataContext.
 /// </summary>
 [Export(typeof(PluginBase))]
-public class MainStateAnimationPlugin : PluginBase, IAnimationUndoProvider
+public class MainStateAnimationPlugin : WpfPluginBase, IAnimationUndoProvider
 {
     private readonly ISelectedState _selectedState;
     private readonly INameVerifier _nameVerifier;

--- a/Gum/SvgPlugin/MainSkiaPlugin.cs
+++ b/Gum/SvgPlugin/MainSkiaPlugin.cs
@@ -24,7 +24,7 @@ using ToolsUtilities;
 namespace SkiaPlugin
 {
     [Export(typeof(PluginBase))]
-    public class MainSkiaPlugin : PluginBase
+    public class MainSkiaPlugin : WpfPluginBase
     {
         #region Fields/Properties
 

--- a/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
@@ -12,7 +12,6 @@ using Gum.Undo;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Windows.Forms;
 using CommunityToolkit.Mvvm.Messaging;
 using TextureCoordinateSelectionPlugin.Logic;
 using TextureCoordinateSelectionPlugin.Models;
@@ -182,7 +181,7 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
         }
     }
 
-    private void HandleTreeNodeSelected(TreeNode? treeNode)
+    private void HandleTreeNodeSelected(ITreeNode? treeNode)
     {
         _displayController.Refresh();
         _displayController.CenterCameraOnSelection();

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -8,6 +8,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Dialogs;
 using Gum.Extensions;
+using Gum.Input;
 using Gum.Localization;
 using Gum.Logic;
 using Gum.Managers;
@@ -367,7 +368,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _wireframeObjectManager.RefreshAll(false);
     }
 
-    private Vector2? HandleGetWorldCursorPosition(InputLibrary.Cursor cursor)
+    private Vector2? HandleGetWorldCursorPosition(IGumCursorState cursor)
     {
         Renderer.Self.Camera.ScreenToWorld(cursor.X, cursor.Y,
                                    out float worldX, out float worldY);

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBaseCompositionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBaseCompositionTests.cs
@@ -25,7 +25,9 @@ public class PluginBaseCompositionTests : BaseTestClass
         plugin.GuiCommands.ShouldBeSameAs(services.GuiCommands);
         plugin.FileCommands.ShouldBeSameAs(services.FileCommands);
         plugin.TabManager.ShouldBeSameAs(services.TabManager);
-        plugin.MenuStripManager.ShouldBeSameAs(services.MenuStripManager);
+        // MenuStripManager lives on WpfPluginBase (not PluginBase itself) - PropertyInjectedTestPlugin
+        // reaches it transitively via PriorityPlugin : WpfPluginBase.
+        ((WpfPluginBase)plugin).MenuStripManager.ShouldBeSameAs(services.MenuStripManager);
         plugin.DialogService.ShouldBeSameAs(services.DialogService);
     }
 

--- a/Tool/Tests/GumToolUnitTests/Plugins/WpfPluginBaseTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/WpfPluginBaseTests.cs
@@ -1,0 +1,147 @@
+using Gum;
+using Gum.Gui.Windows;
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Plugins.BaseClasses;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins;
+
+// Characterization tests pinning behavior across the WpfPluginBase extraction (#3942): the
+// TreeNode -> ITreeNode, InputLibrary.Cursor -> IGumCursorState, and FrameworkElement -> object
+// retypes on PluginBase still flow the same instances through, and the Delete-dialog events newly
+// declared on WpfPluginBase (rather than PluginBase itself) still forward correctly.
+public class WpfPluginBaseTests
+{
+    [Fact]
+    public void CallTreeNodeSelected_InvokesEventWithSameTreeNodeInstance()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        ITreeNode? received = null;
+        plugin.TreeNodeSelected += node => received = node;
+        FakeTreeNode treeNode = new FakeTreeNode();
+
+        plugin.CallTreeNodeSelected(treeNode);
+
+        received.ShouldBeSameAs(treeNode);
+    }
+
+    [Fact]
+    public void CallStateWindowTreeNodeSelected_InvokesEventWithSameTreeNodeInstance()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        ITreeNode? received = null;
+        plugin.StateWindowTreeNodeSelected += node => received = node;
+        FakeTreeNode treeNode = new FakeTreeNode();
+
+        plugin.CallStateWindowTreeNodeSelected(treeNode);
+
+        received.ShouldBeSameAs(treeNode);
+    }
+
+    [Fact]
+    public void CallGetWorldCursorPosition_InvokesEventWithSameCursorAndReturnsResult()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        IGumCursorState? received = null;
+        plugin.GetWorldCursorPosition += cursor =>
+        {
+            received = cursor;
+            return new Vector2(cursor.X, cursor.Y);
+        };
+        FakeCursorState cursorState = new FakeCursorState { X = 12, Y = 34 };
+
+        Vector2? result = plugin.CallGetWorldCursorPosition(cursorState);
+
+        received.ShouldBeSameAs(cursorState);
+        result.ShouldBe(new Vector2(12, 34));
+    }
+
+    [Fact]
+    public void AddControl_ForwardsArbitraryObjectControlToTabManager()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        Mock<ITabManager> tabManagerMock = new Mock<ITabManager>();
+        plugin.TabManager = tabManagerMock.Object;
+        // Not a FrameworkElement - proves the retyped `object control` parameter no longer
+        // requires a WPF type to flow through to ITabManager.AddControl (which already took object).
+        object arbitraryControl = new object();
+
+        plugin.AddControl(arbitraryControl, "My Tab", TabLocation.CenterBottom);
+
+        tabManagerMock.Verify(m => m.AddControl(arbitraryControl, "My Tab", TabLocation.CenterBottom), Times.Once);
+    }
+
+    [Fact]
+    public void CallDeleteOptionsWindowShow_InvokesEventWithSameArguments()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        DeleteOptionsWindow? receivedWindow = null;
+        Array? receivedObjects = null;
+        plugin.DeleteOptionsWindowShow += (window, objects) =>
+        {
+            receivedWindow = window;
+            receivedObjects = objects;
+        };
+        Array objectsToDelete = new object[] { "a" };
+
+        plugin.CallDeleteOptionsWindowShow(null!, objectsToDelete);
+
+        receivedWindow.ShouldBeNull();
+        receivedObjects.ShouldBeSameAs(objectsToDelete);
+    }
+
+    [Fact]
+    public void CallDeleteConfirmed_InvokesEventWithSameArguments()
+    {
+        TestWpfPlugin plugin = new TestWpfPlugin();
+        Array? receivedObjects = null;
+        plugin.DeleteConfirmed += (window, objects) => receivedObjects = objects;
+        Array deletedObjects = new object[] { "b" };
+
+        plugin.CallDeleteConfirmed(null!, deletedObjects);
+
+        receivedObjects.ShouldBeSameAs(deletedObjects);
+    }
+
+    private sealed class TestWpfPlugin : WpfPluginBase
+    {
+        public override string FriendlyName => "Test Wpf Plugin";
+        public override void StartUp() { }
+        public override bool ShutDown(PluginShutDownReason shutDownReason) => true;
+    }
+
+    private sealed class FakeTreeNode : ITreeNode
+    {
+        public object? Tag => null;
+        public string Text { get; set; } = "";
+        public string FullPath => "";
+        public ITreeNode? Parent => null;
+        public IEnumerable<ITreeNode> Children => Array.Empty<ITreeNode>();
+        public FilePath GetFullFilePath() => new FilePath(FullPath);
+        public void Expand() { }
+    }
+
+    private sealed class FakeCursorState : IGumCursorState
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float XChange => 0;
+        public float YChange => 0;
+        public bool PrimaryDown => false;
+        public bool PrimaryPush => false;
+        public bool PrimaryClick => false;
+        public bool IsInWindow => true;
+        public bool PrimaryDoubleClick => false;
+        public bool SecondaryPush => false;
+        public bool PrimaryDownIgnoringIsInWindow => false;
+        public void SetCursor(GumCursorKind kind) { }
+    }
+}


### PR DESCRIPTION
Closes #3942

Bounded first slice toward moving PluginBase.cs into headless Gum.Presentation (physical move is a separate follow-up issue). In-place restructuring only, no behavior change:

1. Retyped `CreateTab`/`AddControl` params `FrameworkElement` -> `object` (ITabManager already takes `object`).
2. Fixed the `TreeNode` -> `ITreeNode` leak on `TreeNodeSelected`/`StateWindowTreeNodeSelected` (+ 2 `Call*` forwarders), matching the sibling `GetTreeNodeOver`/`GetSelectedNodes` pattern already on the class.
3. Fixed the `InputLibrary.Cursor` -> `IGumCursorState` leak on `GetWorldCursorPosition` (+ 1 `Call*` forwarder). `InputLibrary.Cursor` already implements `IGumCursorState`, so this is a pure widen.
4. Extracted `WpfPluginBase : PluginBase` (stays in Gum.csproj) holding the genuinely-WPF Menu Items region and the 2 Delete-dialog events (+ forwarders).
5. Retargeted `PriorityPlugin -> WpfPluginBase`. Of the 9 plugins that inherit `PluginBase` directly, retargeted the 4 that actually use menu items or the delete dialog (`MainGumFormsPlugin`, `MainSkiaPlugin`, `MainStateAnimationPlugin`, `MainImportFromGumxPlugin`) to `WpfPluginBase`; left the other 5 (`MainCodeOutputPlugin`, `MainWindowPlugin`, `MainTextureCoordinatePlugin`, `MainEventOutputPlugin`, `MainPlugin`/PerformanceMeasurementPlugin) on `PluginBase`.

Six downstream handlers (`TreeNode`/`TreeNode?` params) retyped to `ITreeNode`/`ITreeNode?` to match; none touch WinForms-specific members so this is mechanical. `PluginManager.ShowDeleteDialog`/`DeleteConfirmed` now guard with `plugin as WpfPluginBase` since those Call* methods moved off the common `PluginBase` type they iterate over - behavior-preserving, since only WpfPluginBase-derived plugins could ever have subscribed to those events anyway.

## Testing
- `AllPluginsCompositionTests` and `PluginBaseCompositionTests` green (the latter updated: `MenuStripManager` now reached via a `WpfPluginBase` cast).
- New `WpfPluginBaseTests` pins the three retyped members (TreeNode/Cursor/object) plus the two extracted Delete-dialog events, all via direct instantiation (no MEF needed). Mutation-tested one pin (`CallGetWorldCursorPosition`) - broke it, confirmed red, reverted.
- Full `GumToolUnitTests` suite: 1071 passed, 2 pre-existing skips, 0 failures.
- `dotnet build GumFull.sln`: clean, 0 errors.

Manual test: not needed - behavior-preserving restructure, proven by compile + pinning tests + composition test.