### PR TITLE
Remove dead System.Windows usings in GuiCommands and AnimationCopyPasteManager

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -22,13 +22,10 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
-using System.Windows.Forms;
-using System.Windows.Media;
 using System.Xml.Linq;
 using ToolsUtilities;
 using WpfDataUi.DataTypes;
 using static System.ComponentModel.Design.ObjectSelectorEditor;
-using DialogResult = System.Windows.Forms.DialogResult;
 
 namespace Gum.Commands;
 

--- a/Gum/StateAnimationPlugin/Managers/AnimationCopyPasteManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/AnimationCopyPasteManager.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using ToolsUtilities;


### PR DESCRIPTION
Closes #3944

Removes confirmed-dead `System.Windows*` usings from 2 of the 3 files listed in the issue:

- `Gum/Commands/GuiCommands.cs` — `System.Windows.Forms`, `System.Windows.Media`, `DialogResult` alias
- `Gum/StateAnimationPlugin/Managers/AnimationCopyPasteManager.cs` — `System.Windows`

**`Gum/Dialogs/DisplayReferencesDialog.cs` deliberately left untouched.** The survey was wrong: removing `using System.Windows.Markup;` fails the build with CS0246 on `[DependsOn(...)]`. The file has no `using Gum.Mvvm;`, so `DependsOn` currently resolves to `System.Windows.Markup.DependsOnAttribute` (a same-named but unrelated WPF attribute) — not Gum's own `Gum.Mvvm.DependsOnAttribute`, which is what `ViewModel`'s reflection actually checks for. That means the using is load-bearing for compilation, but the `[DependsOn]` metadata on `Message` is currently inert (resolves to the wrong attribute, so `ElementSave`/`References` changes don't raise `Message`'s change notification) — a real pre-existing bug, out of scope here since fixing it changes behavior.

Zero-behavior-change deletion (removing unused usings can't change behavior) — verified by `dotnet build GumFull.sln` succeeding with 0 errors.
