### PR TITLE
Fix DisplayReferencesDialog's [DependsOn] resolving to WPF's attribute

### DIFF
--- a/Gum/Dialogs/DisplayReferencesDialog.cs
+++ b/Gum/Dialogs/DisplayReferencesDialog.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Mvvm;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System;
@@ -9,7 +10,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Markup;
 
 namespace Gum.Dialogs;
 

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/DisplayReferencesDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/DisplayReferencesDialogTests.cs
@@ -1,0 +1,38 @@
+using Gum.DataTypes;
+using Gum.Dialogs;
+using Gum.Managers;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class DisplayReferencesDialogTests : BaseTestClass
+{
+    private readonly Mock<ISelectedState> _selectedState;
+
+    public DisplayReferencesDialogTests()
+    {
+        _selectedState = new Mock<ISelectedState>();
+
+        // GetElementReferencesToThis reads ObjectFinder.Self.GumProjectSave directly,
+        // so it must not be null when ElementSave is set.
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave();
+    }
+
+    private DisplayReferencesDialog CreateSut() => new(_selectedState.Object);
+
+    [Fact]
+    public void Message_RaisesPropertyChanged_WhenElementSaveChanges()
+    {
+        DisplayReferencesDialog sut = CreateSut();
+        ScreenSave screen = new ScreenSave { Name = "MyScreen" };
+
+        List<string> raisedPropertyNames = new List<string>();
+        sut.PropertyChanged += (_, e) => raisedPropertyNames.Add(e.PropertyName!);
+
+        sut.ElementSave = screen;
+
+        raisedPropertyNames.ShouldContain(nameof(DisplayReferencesDialog.Message));
+    }
+}


### PR DESCRIPTION
Closes #3947

DisplayReferencesDialog.cs imported System.Windows.Markup but not Gum.Mvvm, so [DependsOn] on Message silently bound to System.Windows.Markup.DependsOnAttribute instead of Gum.Mvvm.DependsOnAttribute — the type Gum.Mvvm.ViewModel's reflection-based wiring actually looks for. Message's change notification never fired.

Fix: add `using Gum.Mvvm;`, drop the now-unused System.Windows.Markup import.

Regression test constructs the VM, sets ElementSave, and asserts PropertyChanged fires for Message — red before the fix, green after.