### PR TITLE
Relocate 6 MainXPlugin business-logic handlers into headless Gum.Presentation

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -30,6 +30,7 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 - Always use **Shouldly** — never xUnit `Assert`. Alphabetize test methods within a class.
 - Disable parallel execution in every test project (`[assembly: CollectionBehavior(DisableTestParallelization = true)]`) — Gum uses global singletons.
 - A test asserting on an absolute path must not use a Windows-style `"C:\..."` literal — `Path.IsPathRooted` doesn't recognize a drive letter as rooted on Unix, so macOS/Linux CI treats it as relative and silently prepends the runner's real working directory, corrupting the path. Use a leading-slash literal (e.g. `"/game/Content/"`) instead — rooted on both platforms.
+  - If the assertion compares against `ToolsUtilities.FilePath.FullPath`, a bare leading-slash literal still isn't safe: `FilePath` normalizes slashes to `Path.DirectorySeparatorChar`, so `fullPath == "/ProjectA.gumx"` passes on Unix but fails on Windows. Route the literal through `new FilePath(...).FullPath` on both sides of the comparison instead.
 - Use named parameters for boolean literals.
 
 ## Test at production defaults

--- a/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
+++ b/Gum/GumFormsPlugin/MainGumFormsPlugin.cs
@@ -1,26 +1,22 @@
-﻿using Gum;
+using Gum;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using GumFormsPlugin.Services;
-using GumFormsPlugin.ViewModels;
-using GumFormsPlugin.Views;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Gum.Services;
-using Gum.Services.Dialogs;
-using ToolsUtilities;
 using Gum.Logic;
 using Gum.Logic.FileWatch;
 
 namespace GumFormsPlugin;
 
+// As of ADR-0005 Phase 3, the "has forms"/"needs to save"/view-model-factory decisions live in
+// GumFormsLogic (Gum.Presentation) so they can be unit tested headlessly. This plugin keeps only
+// the WPF menu-presence wiring and the dialog-show call.
 [Export(typeof(PluginBase))]
 internal class MainGumFormsPlugin : PluginBase
 {
@@ -30,10 +26,7 @@ internal class MainGumFormsPlugin : PluginBase
     public override bool ShutDown(PluginShutDownReason shutDownReason) => true;
 
     System.Windows.Controls.MenuItem _addFormsMenuItem;
-    private readonly IFormsFileService _formsFileService;
-    private readonly IImportLogic _importLogic;
-    private readonly IFileWatchManager _fileWatchManager;
-    private readonly IProjectState _projectState;
+    private readonly GumFormsLogic _gumFormsLogic;
 
     #endregion
 
@@ -41,17 +34,27 @@ internal class MainGumFormsPlugin : PluginBase
     public MainGumFormsPlugin(
         IImportLogic importLogic,
         IFileWatchManager fileWatchManager,
-        IProjectState projectState)
+        IProjectState projectState,
+        IFileCommands fileCommands,
+        IDialogService dialogService)
     {
-        _projectState = projectState;
-        _formsFileService = new FormsFileService(_projectState);
-        _importLogic = importLogic;
-        _fileWatchManager = fileWatchManager;
+        // Note: PluginBase's own _fileCommands/_dialogService [Import] properties aren't set until
+        // after construction, so these must be taken as explicit ctor params here (both are already
+        // bridged into the plugin container for other plugins).
+        IFormsFileService formsFileService = new FormsFileService(projectState);
+        _gumFormsLogic = new GumFormsLogic(
+            formsFileService,
+            projectState,
+            importLogic,
+            fileCommands,
+            fileWatchManager,
+            dialogService,
+            Locator.GetRequiredService<ISkiaShapeStandardsLogic>());
     }
 
     public override void StartUp()
     {
-        _addFormsMenuItem = 
+        _addFormsMenuItem =
             this.AddMenuItemTo("Add Forms Components", HandleAddFormsComponents, "Content");
 
         this.ProjectLoad += HandleProjectLoaded;
@@ -70,12 +73,10 @@ internal class MainGumFormsPlugin : PluginBase
 
     private void RefreshAddFormsMenuPresence(GumProjectSave save)
     {
-        // A newly created project has no FullFileName yet, so it cannot have forms.
-        // Checking the save parameter directly avoids any stale state in projectState.
-        var hasForms = !string.IsNullOrEmpty(save?.FullFileName) && GetIfProjectHasForms();
+        bool shouldShow = _gumFormsLogic.ShouldShowAddFormsMenuItem(save);
 
         var parent = _addFormsMenuItem.Parent as System.Windows.Controls.ItemsControl;
-        if (hasForms)
+        if (!shouldShow)
         {
             if (parent != null)
             {
@@ -92,45 +93,14 @@ internal class MainGumFormsPlugin : PluginBase
         }
     }
 
-    private bool GetIfProjectHasForms()
-    {
-        // Whether the project already has forms imported is independent of the theme picker,
-        // so use the default theme's destination set. The same destination paths get written
-        // regardless of which theme produced them.
-        var files = _formsFileService.GetSourceDestinations(_formsFileService.DefaultThemeName, isIncludeDemoScreenGum: false);
-
-        var firstMatch = files.Values
-            .FirstOrDefault(item => 
-                item.Extension != "png" && 
-                item.Extension != "gutx" &&
-                item.Extension != "fnt" && 
-                item.Extension != "bmfc" &&
-                item.Extension != "setj" &&
-                item.Extension != "json" &&
-                item.Exists());
-
-        return firstMatch != null;
-    }
-
     private void HandleAddFormsComponents(object? sender, System.Windows.RoutedEventArgs e)
     {
-        #region Early Out
-
-        if (_projectState.NeedsToSaveProject)
+        if (!_gumFormsLogic.TryCreateAddFormsViewModel(out var viewModel, out var blockedMessage))
         {
-            _dialogService.ShowMessage("You must first save the project before importing forms");
+            _dialogService.ShowMessage(blockedMessage);
             return;
         }
-        #endregion
 
-        var viewModel = new AddFormsViewModel(
-            _formsFileService,
-            _dialogService,
-            _fileCommands,
-            _importLogic,
-            _projectState,
-            _fileWatchManager,
-            Locator.GetRequiredService<ISkiaShapeStandardsLogic>());
         _dialogService.Show(viewModel);
     }
 

--- a/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
+++ b/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
@@ -1,25 +1,37 @@
-using Gum;
 using Gum.Commands;
-using Gum.DataTypes;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.Plugins.ImportPlugin.Manager;
-using Gum.Plugins.ImportPlugin.Services;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
-using ImportFromGumxPlugin.Services;
-using ImportFromGumxPlugin.ViewModels;
 using System.ComponentModel.Composition;
 using System.Windows;
 
 namespace ImportFromGumxPlugin;
 
+// As of ADR-0005 Phase 3, the "needs to save" guard + view-model wiring live in ImportFromGumxLogic
+// (Gum.Presentation) so they can be unit tested headlessly. This plugin keeps only the WPF dialog
+// window plumbing.
 [Export(typeof(PluginBase))]
 internal class MainImportFromGumxPlugin : PluginBase
 {
     public override string FriendlyName => "Import from .gumx Plugin";
     public override bool ShutDown(PluginShutDownReason shutDownReason) => true;
+
+    private readonly ImportFromGumxLogic _importFromGumxLogic;
+
+    [ImportingConstructor]
+    public MainImportFromGumxPlugin(
+        IProjectState projectState,
+        IImportLogic importLogic,
+        IFileCommands fileCommands,
+        IDialogService dialogService,
+        IDispatcher dispatcher)
+    {
+        _importFromGumxLogic = new ImportFromGumxLogic(
+            projectState, importLogic, fileCommands, dialogService, dispatcher);
+    }
 
     public override void StartUp()
     {
@@ -28,28 +40,13 @@ internal class MainImportFromGumxPlugin : PluginBase
 
     private void HandleImportFromGumx(object? sender, System.Windows.RoutedEventArgs e)
     {
-        var projectState = Locator.GetRequiredService<IProjectState>();
-        var importLogic = Locator.GetRequiredService<IImportLogic>();
-        var fileCommands = Locator.GetRequiredService<IFileCommands>();
-        var dispatcher = Locator.GetRequiredService<IDispatcher>();
-
-        if (projectState.NeedsToSaveProject)
+        if (!_importFromGumxLogic.CanImport)
         {
             _dialogService.ShowMessage("You must first save the project before importing.");
             return;
         }
 
-        var sourceService = new GumxSourceService();
-        var dependencyResolver = new GumxDependencyResolver();
-        var importService = new GumxImportService(importLogic, projectState, fileCommands, sourceService);
-
-        var viewModel = new ImportFromGumxViewModel(
-            sourceService,
-            dependencyResolver,
-            importService,
-            projectState,
-            _dialogService,
-            dispatcher);
+        var viewModel = _importFromGumxLogic.CreateImportViewModel();
 
         var window = new Gum.Services.Dialogs.DialogWindow
         {

--- a/Gum/Plugins/Fonts/MainFontPlugin.cs
+++ b/Gum/Plugins/Fonts/MainFontPlugin.cs
@@ -1,10 +1,8 @@
-﻿using Gum.Commands;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
-using System;
 using System.ComponentModel.Composition;
-using System.Windows;
 using System.Threading.Tasks;
 using Gum.Services.Dialogs;
 using System.Diagnostics;
@@ -12,14 +10,16 @@ using Gum.Services.Fonts;
 
 namespace Gum.Plugins.Fonts;
 
+// As of ADR-0005 Phase 3, the font-cache logic lives in FontCacheLogic (Gum.Presentation) so it can
+// be unit tested headlessly. This plugin keeps only menu wiring; HandleClearFontCache stays here
+// unchanged since its catch block reads the handler's own RoutedEventArgs parameter, not the caught
+// exception - extracting it would either leak a WPF type into Gum.Presentation or change behavior.
 [Export(typeof(PluginBase))]
 public class MainFontPlugin : PriorityPlugin
 {
-
-    private readonly IGuiCommands _guiCommands;
     private readonly IFontManager _fontManager;
     private readonly IDialogService _dialogService;
-    private readonly IProjectState _projectState;
+    private readonly FontCacheLogic _fontCacheLogic;
 
     [ImportingConstructor]
     public MainFontPlugin(
@@ -28,10 +28,9 @@ public class MainFontPlugin : PriorityPlugin
         IDialogService dialogService,
         IProjectState projectState)
     {
-        _guiCommands = guiCommands;
         _fontManager = fontManager;
         _dialogService = dialogService;
-        _projectState = projectState;
+        _fontCacheLogic = new FontCacheLogic(fontManager, dialogService, projectState);
     }
 
     public override void StartUp()
@@ -64,11 +63,8 @@ public class MainFontPlugin : PriorityPlugin
 
     }
 
-    private async void HandleProjectLoaded(GumProjectSave save)
-    {
-        await _fontManager.CreateAllMissingFontFiles(
-            _projectState.GumProjectSave);
-    }
+    private async void HandleProjectLoaded(GumProjectSave save) =>
+        await _fontCacheLogic.CreateMissingFontFilesForLoadedProject();
 
     private void HandleClearFontCache(object? sender, System.Windows.RoutedEventArgs e)
     {
@@ -84,37 +80,17 @@ public class MainFontPlugin : PriorityPlugin
 
     private void HandleViewFontCache(object? sender, System.Windows.RoutedEventArgs e)
     {
-        if(!System.IO.Directory.Exists(_fontManager.AbsoluteFontCacheFolder))
-        {
-            System.IO.Directory.CreateDirectory(_fontManager.AbsoluteFontCacheFolder);
-        }
+        string folder = _fontCacheLogic.GetOrCreateFontCacheFolder();
 
         var processStartInfo = new ProcessStartInfo
         {
-            FileName = _fontManager.AbsoluteFontCacheFolder,
+            FileName = folder,
             UseShellExecute = true
         };
 
-        System.Diagnostics.Process.Start(processStartInfo);
+        Process.Start(processStartInfo);
     }
 
-    private async Task HandleRefreshFontCache(bool forceRecreate)
-    {
-        var gumProjectSave = _projectState.GumProjectSave;
-        if(gumProjectSave == null)
-        {
-            _dialogService.ShowMessage(
-                "A Gum project must first be loaded before recreating font files");
-        }
-        else
-        {
-            var before = DateTime.Now;
-            await _fontManager.CreateAllMissingFontFiles(
-                _projectState.GumProjectSave, forceRecreate:forceRecreate);
-            var after = DateTime.Now;
-
-            var difference = after - before;
-            System.Diagnostics.Debug.WriteLine($"Total time: {difference.TotalMilliseconds:N0}");
-        }
-    }
+    private async Task HandleRefreshFontCache(bool forceRecreate) =>
+        await _fontCacheLogic.RefreshFontCache(forceRecreate);
 }

--- a/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/HideShowTools/MainHideShowToolsPlugin.cs
@@ -1,25 +1,23 @@
-﻿using Gum.Plugins.BaseClasses;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Controls;
 using Gum.Controls;
+using Gum.Plugins.BaseClasses;
+using System.ComponentModel.Composition;
+using System.Windows.Controls;
 
 namespace Gum.Plugins.InternalPlugins.HideShowTools;
 
+// As of ADR-0005 Phase 3, the toggle decision lives in HideShowToolsLogic (Gum.Presentation) so it
+// can be unit tested headlessly. MainPanelViewModel itself is WPF-typed, so it's narrowed to
+// IToolsVisibility for that logic.
 [Export(typeof(PluginBase))]
 internal class MainHideShowToolsPlugin : PriorityPlugin
 {
     private MenuItem _hideShowMenuItem;
-    private readonly MainPanelViewModel _mainPanelViewModel;
+    private readonly HideShowToolsLogic _hideShowToolsLogic;
 
     [ImportingConstructor]
     public MainHideShowToolsPlugin(MainPanelViewModel mainPanelViewModel)
     {
-        _mainPanelViewModel = mainPanelViewModel;
+        _hideShowToolsLogic = new HideShowToolsLogic(mainPanelViewModel);
     }
 
     public override void StartUp()
@@ -30,13 +28,8 @@ internal class MainHideShowToolsPlugin : PriorityPlugin
 
     private void HandleMenuItemClick(object? sender, System.Windows.RoutedEventArgs e)
     {
-        _mainPanelViewModel.IsToolsVisible = !_mainPanelViewModel.IsToolsVisible;
+        bool isVisible = _hideShowToolsLogic.ToggleToolsVisibility();
 
-        if(_mainPanelViewModel.IsToolsVisible)
-        {
-            _mainPanelViewModel.EnsureMinimumWidth();
-        }
-
-        _hideShowMenuItem.Header = _mainPanelViewModel.IsToolsVisible ? "Hide Tools" : "Show Tools";
+        _hideShowMenuItem.Header = isVisible ? "Hide Tools" : "Show Tools";
     }
 }

--- a/Gum/Plugins/InternalPlugins/LoadRecentFilesPlugin/MainRecentFilesPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/LoadRecentFilesPlugin/MainRecentFilesPlugin.cs
@@ -1,21 +1,30 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
-using Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin.ViewModels;
-using Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin.Views;
-using Gum.Services;
-using System;
+using Gum.Services.Dialogs;
+using Gum.Settings;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows.Controls;
-using ToolsUtilities;
 
 namespace Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin
 {
+    // As of ADR-0005 Phase 3, the display/filtering/dialog logic for the "Load Recent" menu lives in
+    // RecentFilesLogic (Gum.Presentation) so it can be unit tested headlessly. This plugin builds only
+    // the actual WPF MenuItems and forwards clicks into that logic.
     [Export(typeof(PluginBase))]
     internal class MainRecentFilesPlugin : PriorityPlugin
     {
         MenuItem recentFilesMenuItem;
+        private readonly RecentFilesLogic _recentFilesLogic;
+
+        [ImportingConstructor]
+        public MainRecentFilesPlugin(IProjectManager projectManager, IFileCommands fileCommands, IDialogService dialogService)
+        {
+            _recentFilesLogic = new RecentFilesLogic(projectManager, fileCommands, dialogService);
+        }
+
         public override void StartUp()
         {
             recentFilesMenuItem = this.AddMenuItemTo("Load Recent", null, "File", preferredIndex: 2);
@@ -32,44 +41,26 @@ namespace Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin
 
         private void RefreshMenuItems()
         {
-            var recentFiles = Locator.GetRequiredService<IProjectManager>().RecentProjects;
-
             recentFilesMenuItem.Items.Clear();
 
-            foreach (var item in recentFiles.Where(item => item.IsFavorite))
+            var favorites = _recentFilesLogic.GetFavoriteProjects().ToList();
+            foreach (var item in favorites)
             {
-                var filePath = item.FilePath;
-                string name = GetDisplayedNameForGumxFilePath(filePath);
-
-                var mi = new MenuItem { Header = name };
-                mi.Click += (_, _) => _fileCommands.LoadProject(filePath.FullPath);
-                recentFilesMenuItem.Items.Add(mi);
+                AddMenuItemFor(item);
             }
 
-            var hasFavorites = recentFiles.Any(item => item.IsFavorite);
-            var nonFavorites = recentFiles.Where(item => !item.IsFavorite).ToArray();
-
-            var hasNonFavorites = nonFavorites.Length > 0;
-
-            if (hasNonFavorites)
+            var nonFavorites = _recentFilesLogic.GetNonFavoriteProjectsForMenu().ToList();
+            if (nonFavorites.Count > 0)
             {
-                if (hasFavorites)
+                if (favorites.Count > 0)
                 {
                     recentFilesMenuItem.Items.Add(new Separator());
                 }
 
-                foreach (var item in nonFavorites.Take(5))
+                foreach (var item in nonFavorites)
                 {
-                    var filePath = item.FilePath;
-
-                    string name = GetDisplayedNameForGumxFilePath(filePath);
-
-                    var mi = new MenuItem { Header = name };
-                    mi.Click += (_, _) => _fileCommands.LoadProject(filePath.FullPath);
-                    recentFilesMenuItem.Items.Add(mi);
+                    AddMenuItemFor(item);
                 }
-
-
             }
 
             recentFilesMenuItem.Items.Add(new Separator());
@@ -78,74 +69,19 @@ namespace Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin
             recentFilesMenuItem.Items.Add(moreItem);
         }
 
-        private static string GetDisplayedNameForGumxFilePath(FilePath filePath)
+        private void AddMenuItemFor(RecentProjectReference item)
         {
-            var name = filePath.RemoveExtension().FileNameNoPath;
+            var filePath = item.FilePath;
+            string name = RecentFilesLogic.GetDisplayedNameForGumxFilePath(filePath);
 
-            // It's common to have lots of same-named projects so let's see if this is in a csproj somewhere:
-            var parentDirectory = filePath.GetDirectoryContainingThis();
-            if (parentDirectory != null)
-            {
-                string? foundCsproj = null;
-                while (parentDirectory?.Exists() == true)
-                {
-                    foundCsproj = System.IO.Directory.GetFiles(parentDirectory.FullPath, "*.csproj").FirstOrDefault();
-
-                    if (foundCsproj == null)
-                    {
-                        parentDirectory = parentDirectory.GetDirectoryContainingThis();
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(foundCsproj))
-                {
-                    var fullPath = new FilePath(foundCsproj);
-                    name += $" ({fullPath.FileNameNoPath})";
-                }
-            }
-
-            return name;
+            var mi = new MenuItem { Header = name };
+            mi.Click += (_, _) => _recentFilesLogic.LoadProject(filePath.FullPath);
+            recentFilesMenuItem.Items.Add(mi);
         }
 
-        private async void HandleLoadRecentClicked(object? sender, System.Windows.RoutedEventArgs e)
+        private void HandleLoadRecentClicked(object? sender, System.Windows.RoutedEventArgs e)
         {
-            var viewModel = new LoadRecentViewModel();
-            var recentFiles = Locator.GetRequiredService<IProjectManager>().RecentProjects;
-            viewModel.AllItems.Clear();
-            foreach (var recentFile in recentFiles)
-            {
-                var vm = new RecentItemViewModel()
-                {
-                    FullPath = recentFile.FilePath.FullPath,
-                    IsFavorite = recentFile.IsFavorite
-                };
-                viewModel.AllItems.Add(vm);
-            }
-
-            viewModel.RefreshFilteredItems();
-
-            if (_dialogService.Show(viewModel))
-            {
-                var fileToLoad = viewModel.SelectedItem.FullPath;
-
-                _fileCommands.LoadProject(fileToLoad);
-
-            }
-
-            foreach (var item in viewModel.FilteredItems)
-            {
-                var matching = recentFiles.FirstOrDefault(candidate => candidate.FilePath == item.FullPath);
-
-                if (matching != null)
-                {
-                    matching.IsFavorite = item.IsFavorite;
-                }
-            }
-            _fileCommands.SaveGeneralSettings();
+            _recentFilesLogic.ShowLoadRecentDialog();
             RefreshMenuItems();
         }
     }

--- a/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/SvgExportPlugin/MainSvgExportPlugin.cs
@@ -8,13 +8,15 @@ using System.Windows.Controls;
 
 namespace Gum.Plugins.InternalPlugins.SvgExportPlugin;
 
+// As of ADR-0005 Phase 3, the exportability/guard decisions live in SvgExportMenuLogic
+// (Gum.Presentation) so they can be unit tested headlessly. This plugin builds the WPF menu item
+// and forwards clicks; the actual gumcli invocation stays in SvgExportCommand.
 [Export(typeof(PluginBase))]
 internal class MainSvgExportPlugin : PriorityPlugin
 {
     private MenuItem _exportSvgMenuItem;
-    private readonly ISelectedState _selectedState;
-    private readonly IProjectState _projectState;
     private readonly ISvgExportCommand _svgExportCommand;
+    private readonly SvgExportMenuLogic _svgExportMenuLogic;
 
     [ImportingConstructor]
     public MainSvgExportPlugin(
@@ -23,12 +25,11 @@ internal class MainSvgExportPlugin : PriorityPlugin
         ISelectedState selectedState,
         IProjectState projectState)
     {
-        _selectedState = selectedState;
-        _projectState = projectState;
         // SVG export is plugin-specific, so the command is instantiated here rather than
         // registered app-wide. These services are injected (they are also property-injected
         // into PluginBase for use in StartUp()/handlers).
         _svgExportCommand = new SvgExportCommand(dialogService, guiCommands);
+        _svgExportMenuLogic = new SvgExportMenuLogic(selectedState, projectState, guiCommands);
     }
 
     public override void StartUp()
@@ -49,37 +50,19 @@ internal class MainSvgExportPlugin : PriorityPlugin
 
     private void RefreshMenuItem()
     {
-        var element = _selectedState.SelectedElement;
+        bool isExportable = _svgExportMenuLogic.GetIsExportable(out var element);
 
-        bool isExportable = element is ScreenSave or ComponentSave;
-
-        if (isExportable)
-        {
-            _exportSvgMenuItem.Header = $"Export {element!.Name} to SVG";
-            _exportSvgMenuItem.IsEnabled = true;
-        }
-        else
-        {
-            _exportSvgMenuItem.Header = "Export to SVG";
-            _exportSvgMenuItem.IsEnabled = false;
-        }
+        _exportSvgMenuItem.Header = isExportable ? $"Export {element!.Name} to SVG" : "Export to SVG";
+        _exportSvgMenuItem.IsEnabled = isExportable;
     }
 
     private void HandleExportSvgClicked(object? sender, System.Windows.RoutedEventArgs e)
     {
-        var element = _selectedState.SelectedElement;
-        if (element is not (ScreenSave or ComponentSave))
+        if (!_svgExportMenuLogic.TryPrepareExport(out var element, out var projectSave))
         {
             return;
         }
 
-        var projectSave = _projectState.GumProjectSave;
-        if (projectSave == null)
-        {
-            _guiCommands.PrintOutput("No project is loaded.");
-            return;
-        }
-
-        _svgExportCommand.ExportElementToSvg(element, projectSave);
+        _svgExportCommand.ExportElementToSvg(element!, projectSave!);
     }
 }

--- a/Gum/ViewModels/MainPanelViewModel.cs
+++ b/Gum/ViewModels/MainPanelViewModel.cs
@@ -11,13 +11,14 @@ using Gum.Controls;
 using Gum.Managers;
 using Gum.Mvvm;
 using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.HideShowTools;
 using Gum.Services;
 using Gum.Settings;
 using Microsoft.Extensions.Options;
 
 namespace Gum.Controls;
 
-public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<ApplicationTeardownMessage>
+public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<ApplicationTeardownMessage>, IToolsVisibility
 {
     private readonly IWritableOptions<LayoutSettings> _layoutSettings;
 
@@ -128,7 +129,8 @@ public class MainPanelViewModel : ViewModel, ITabManager, IRecipient<Application
         message.OnTearDown(SaveLayoutSettings);
     }
 
-    internal void EnsureMinimumWidth()
+    /// <inheritdoc/>
+    public void EnsureMinimumWidth()
     {
         const int minWidth = 20;
         LeftColumnWidth = Math.Max(LeftColumnWidth, minWidth);

--- a/Tests/Gum.Presentation.Tests/FontCacheLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/FontCacheLogicTests.cs
@@ -1,0 +1,75 @@
+using Gum.DataTypes;
+using Gum.Plugins.Fonts;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainFontPlugin into the headless Gum.Presentation assembly
+/// (ADR-0005 Phase 3) so this business logic is unit testable. The "Clear Font Cache" handler stays
+/// on the plugin (see FontCacheLogic's summary) and isn't exercised here.
+/// </summary>
+public class FontCacheLogicTests
+{
+    private readonly Mock<IFontManager> _fontManager = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IProjectState> _projectState = new();
+    private readonly FontCacheLogic _logic;
+
+    public FontCacheLogicTests()
+    {
+        _logic = new FontCacheLogic(_fontManager.Object, _dialogService.Object, _projectState.Object);
+    }
+
+    [Fact]
+    public async Task CreateMissingFontFilesForLoadedProject_CreatesMissingFontsForLoadedProject()
+    {
+        GumProjectSave project = new();
+        _projectState.Setup(x => x.GumProjectSave).Returns(project);
+
+        await _logic.CreateMissingFontFilesForLoadedProject();
+
+        _fontManager.Verify(x => x.CreateAllMissingFontFiles(project, false), Times.Once);
+    }
+
+    [Fact]
+    public void GetOrCreateFontCacheFolder_ReturnsAbsoluteFontCacheFolder()
+    {
+        _fontManager.Setup(x => x.AbsoluteFontCacheFolder).Returns(System.IO.Path.GetTempPath());
+
+        string folder = _logic.GetOrCreateFontCacheFolder();
+
+        folder.ShouldBe(System.IO.Path.GetTempPath());
+    }
+
+    [Fact]
+    public async Task RefreshFontCache_NoProjectLoaded_ShowsMessageAndDoesNotCreateFonts()
+    {
+        _projectState.Setup(x => x.GumProjectSave).Returns((GumProjectSave?)null);
+
+        await _logic.RefreshFontCache(forceRecreate: false);
+
+        _dialogService.Verify(
+            x => x.ShowMessage("A Gum project must first be loaded before recreating font files", null, null),
+            Times.Once);
+        _fontManager.Verify(
+            x => x.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshFontCache_ProjectLoaded_CreatesMissingFontFilesWithForceRecreateFlag()
+    {
+        GumProjectSave project = new();
+        _projectState.Setup(x => x.GumProjectSave).Returns(project);
+
+        await _logic.RefreshFontCache(forceRecreate: true);
+
+        _fontManager.Verify(x => x.CreateAllMissingFontFiles(project, true), Times.Once);
+        _dialogService.Verify(
+            x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/GumFormsLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/GumFormsLogicTests.cs
@@ -1,0 +1,133 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Logic;
+using Gum.Logic.FileWatch;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using GumFormsPlugin;
+using GumFormsPlugin.Services;
+using GumFormsPlugin.ViewModels;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using ToolsUtilities;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainGumFormsPlugin into the headless Gum.Presentation assembly
+/// (ADR-0005 Phase 3) so this business logic is unit testable.
+/// </summary>
+public class GumFormsLogicTests
+{
+    private readonly Mock<IFormsFileService> _formsFileService = new();
+    private readonly Mock<IProjectState> _projectState = new();
+    private readonly Mock<IImportLogic> _importLogic = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IFileWatchManager> _fileWatchManager = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<ISkiaShapeStandardsLogic> _skiaShapeStandardsLogic = new();
+    private readonly GumFormsLogic _logic;
+
+    public GumFormsLogicTests()
+    {
+        _formsFileService.Setup(x => x.DefaultThemeName).Returns("Standard");
+        _projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave());
+
+        _logic = new GumFormsLogic(
+            _formsFileService.Object,
+            _projectState.Object,
+            _importLogic.Object,
+            _fileCommands.Object,
+            _fileWatchManager.Object,
+            _dialogService.Object,
+            _skiaShapeStandardsLogic.Object);
+    }
+
+    [Fact]
+    public void GetIfProjectHasForms_NoMatchingDestinationFilesExist_ReturnsFalse()
+    {
+        _formsFileService.Setup(x => x.GetSourceDestinations("Standard", false))
+            .Returns(new Dictionary<string, FilePath>
+            {
+                ["a"] = @"C:\nonexistent\SomeScreen.gutx",
+                ["b"] = @"C:\nonexistent\logo.png",
+            });
+
+        _logic.GetIfProjectHasForms().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetIfProjectHasForms_AMatchingDestinationFileExistsOnDisk_ReturnsTrue()
+    {
+        string existingFile = Path.GetTempFileName();
+        try
+        {
+            _formsFileService.Setup(x => x.GetSourceDestinations("Standard", false))
+                .Returns(new Dictionary<string, FilePath>
+                {
+                    ["a"] = existingFile,
+                });
+
+            _logic.GetIfProjectHasForms().ShouldBeTrue();
+        }
+        finally
+        {
+            File.Delete(existingFile);
+        }
+    }
+
+    [Fact]
+    public void ShouldShowAddFormsMenuItem_ProjectHasNoFullFileName_ReturnsTrue()
+    {
+        GumProjectSave save = new() { FullFileName = "" };
+
+        _logic.ShouldShowAddFormsMenuItem(save).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldShowAddFormsMenuItem_ProjectAlreadyHasForms_ReturnsFalse()
+    {
+        string existingFile = Path.GetTempFileName();
+        try
+        {
+            _formsFileService.Setup(x => x.GetSourceDestinations("Standard", false))
+                .Returns(new Dictionary<string, FilePath> { ["a"] = existingFile });
+            GumProjectSave save = new() { FullFileName = @"C:\SomeProject.gumx" };
+
+            _logic.ShouldShowAddFormsMenuItem(save).ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(existingFile);
+        }
+    }
+
+    [Fact]
+    public void TryCreateAddFormsViewModel_ProjectNeedsToSave_ReturnsFalseWithBlockedMessage()
+    {
+        _projectState.Setup(x => x.NeedsToSaveProject).Returns(true);
+
+        bool result = _logic.TryCreateAddFormsViewModel(out AddFormsViewModel? viewModel, out string? blockedMessage);
+
+        result.ShouldBeFalse();
+        viewModel.ShouldBeNull();
+        blockedMessage.ShouldBe("You must first save the project before importing forms");
+    }
+
+    [Fact]
+    public void TryCreateAddFormsViewModel_ProjectSaved_ReturnsTrueWithViewModel()
+    {
+        _projectState.Setup(x => x.NeedsToSaveProject).Returns(false);
+        _formsFileService.Setup(x => x.GetAvailableThemes()).Returns(new List<string> { "Standard" });
+        _formsFileService.Setup(x => x.GetThemeDirectory(It.IsAny<string>())).Returns("C:/nonexistent-theme/");
+
+        bool result = _logic.TryCreateAddFormsViewModel(out AddFormsViewModel? viewModel, out string? blockedMessage);
+
+        result.ShouldBeTrue();
+        viewModel.ShouldNotBeNull();
+        blockedMessage.ShouldBeNull();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/HideShowToolsLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/HideShowToolsLogicTests.cs
@@ -1,0 +1,45 @@
+using Gum.Plugins.InternalPlugins.HideShowTools;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainHideShowToolsPlugin into the headless Gum.Presentation
+/// assembly (ADR-0005 Phase 3) so this business logic is unit testable. MainPanelViewModel itself
+/// is WPF-typed, so the dependency is narrowed to <see cref="IToolsVisibility"/>.
+/// </summary>
+public class HideShowToolsLogicTests
+{
+    private readonly Mock<IToolsVisibility> _toolsVisibility = new();
+    private readonly HideShowToolsLogic _logic;
+
+    public HideShowToolsLogicTests()
+    {
+        _logic = new HideShowToolsLogic(_toolsVisibility.Object);
+    }
+
+    [Fact]
+    public void ToggleToolsVisibility_WhenHidden_ShowsAndEnsuresMinimumWidth()
+    {
+        _toolsVisibility.SetupProperty(x => x.IsToolsVisible, false);
+
+        bool result = _logic.ToggleToolsVisibility();
+
+        result.ShouldBeTrue();
+        _toolsVisibility.Object.IsToolsVisible.ShouldBeTrue();
+        _toolsVisibility.Verify(x => x.EnsureMinimumWidth(), Times.Once);
+    }
+
+    [Fact]
+    public void ToggleToolsVisibility_WhenVisible_HidesAndDoesNotEnsureMinimumWidth()
+    {
+        _toolsVisibility.SetupProperty(x => x.IsToolsVisible, true);
+
+        bool result = _logic.ToggleToolsVisibility();
+
+        result.ShouldBeFalse();
+        _toolsVisibility.Object.IsToolsVisible.ShouldBeFalse();
+        _toolsVisibility.Verify(x => x.EnsureMinimumWidth(), Times.Never);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ImportFromGumxLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ImportFromGumxLogicTests.cs
@@ -1,0 +1,54 @@
+using Gum.Commands;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using ImportFromGumxPlugin;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainImportFromGumxPlugin into the headless Gum.Presentation
+/// assembly (ADR-0005 Phase 3) so this business logic is unit testable.
+/// </summary>
+public class ImportFromGumxLogicTests
+{
+    private readonly Mock<IProjectState> _projectState = new();
+    private readonly Mock<IImportLogic> _importLogic = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IDispatcher> _dispatcher = new();
+    private readonly ImportFromGumxLogic _logic;
+
+    public ImportFromGumxLogicTests()
+    {
+        _logic = new ImportFromGumxLogic(
+            _projectState.Object, _importLogic.Object, _fileCommands.Object, _dialogService.Object, _dispatcher.Object);
+    }
+
+    [Fact]
+    public void CanImport_ProjectNeedsToSave_ReturnsFalse()
+    {
+        _projectState.Setup(x => x.NeedsToSaveProject).Returns(true);
+
+        _logic.CanImport.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanImport_ProjectSaved_ReturnsTrue()
+    {
+        _projectState.Setup(x => x.NeedsToSaveProject).Returns(false);
+
+        _logic.CanImport.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CreateImportViewModel_ReturnsNonNullViewModel()
+    {
+        var viewModel = _logic.CreateImportViewModel();
+
+        viewModel.ShouldNotBeNull();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
@@ -1,0 +1,125 @@
+using Gum.Commands;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin;
+using Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin.ViewModels;
+using Gum.Services.Dialogs;
+using Gum.Settings;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainRecentFilesPlugin into the headless Gum.Presentation
+/// assembly (ADR-0005 Phase 3) so this business logic is unit testable.
+/// </summary>
+public class RecentFilesLogicTests
+{
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly RecentFilesLogic _logic;
+
+    public RecentFilesLogicTests()
+    {
+        _logic = new RecentFilesLogic(_projectManager.Object, _fileCommands.Object, _dialogService.Object);
+    }
+
+    private static RecentProjectReference MakeRecentProject(string path, bool isFavorite)
+    {
+        return new RecentProjectReference { AbsoluteFileName = path, IsFavorite = isFavorite };
+    }
+
+    [Fact]
+    public void GetFavoriteProjects_ReturnsOnlyFavorites()
+    {
+        List<RecentProjectReference> recentProjects = new()
+        {
+            MakeRecentProject(@"C:\ProjectA.gumx", isFavorite: true),
+            MakeRecentProject(@"C:\ProjectB.gumx", isFavorite: false),
+            MakeRecentProject(@"C:\ProjectC.gumx", isFavorite: true),
+        };
+        _projectManager.Setup(x => x.RecentProjects).Returns(recentProjects);
+
+        List<RecentProjectReference> result = _logic.GetFavoriteProjects().ToList();
+
+        result.Count.ShouldBe(2);
+        result.ShouldContain(recentProjects[0]);
+        result.ShouldContain(recentProjects[2]);
+    }
+
+    [Fact]
+    public void GetNonFavoriteProjectsForMenu_CapsAtMaxCount()
+    {
+        List<RecentProjectReference> recentProjects = Enumerable.Range(0, 7)
+            .Select(i => MakeRecentProject($@"C:\Project{i}.gumx", isFavorite: false))
+            .ToList();
+        _projectManager.Setup(x => x.RecentProjects).Returns(recentProjects);
+
+        List<RecentProjectReference> result = _logic.GetNonFavoriteProjectsForMenu(maxCount: 5).ToList();
+
+        result.Count.ShouldBe(5);
+        result.ShouldBe(recentProjects.Take(5));
+    }
+
+    [Fact]
+    public void LoadProject_DelegatesToFileCommands()
+    {
+        _logic.LoadProject(@"C:\SomeProject.gumx");
+
+        _fileCommands.Verify(x => x.LoadProject(@"C:\SomeProject.gumx"), Times.Once);
+    }
+
+    [Fact]
+    public void ShowLoadRecentDialog_Confirmed_LoadsSelectedProjectAndPersistsFavoriteChanges()
+    {
+        List<RecentProjectReference> recentProjects = new()
+        {
+            MakeRecentProject(@"C:\ProjectA.gumx", isFavorite: false),
+            MakeRecentProject(@"C:\ProjectB.gumx", isFavorite: false),
+        };
+        _projectManager.Setup(x => x.RecentProjects).Returns(recentProjects);
+
+        _dialogService
+            .Setup(x => x.Show(It.IsAny<LoadRecentViewModel>()))
+            .Callback<LoadRecentViewModel>(vm =>
+            {
+                RecentItemViewModel itemA = vm.FilteredItems.Single(item => item.FullPath == @"C:\ProjectA.gumx");
+                itemA.IsFavorite = true;
+                vm.SelectedItem = itemA;
+            })
+            .Returns(true);
+
+        _logic.ShowLoadRecentDialog();
+
+        _fileCommands.Verify(x => x.LoadProject(@"C:\ProjectA.gumx"), Times.Once);
+        recentProjects[0].IsFavorite.ShouldBeTrue();
+        _fileCommands.Verify(x => x.SaveGeneralSettings(), Times.Once);
+    }
+
+    [Fact]
+    public void ShowLoadRecentDialog_Cancelled_DoesNotLoadButStillPersistsFavoriteChanges()
+    {
+        List<RecentProjectReference> recentProjects = new()
+        {
+            MakeRecentProject(@"C:\ProjectA.gumx", isFavorite: false),
+        };
+        _projectManager.Setup(x => x.RecentProjects).Returns(recentProjects);
+
+        _dialogService
+            .Setup(x => x.Show(It.IsAny<LoadRecentViewModel>()))
+            .Callback<LoadRecentViewModel>(vm =>
+            {
+                vm.FilteredItems.Single().IsFavorite = true;
+            })
+            .Returns(false);
+
+        _logic.ShowLoadRecentDialog();
+
+        _fileCommands.Verify(x => x.LoadProject(It.IsAny<string>()), Times.Never);
+        recentProjects[0].IsFavorite.ShouldBeTrue();
+        _fileCommands.Verify(x => x.SaveGeneralSettings(), Times.Once);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Shouldly;
 using System.Collections.Generic;
 using System.Linq;
+using ToolsUtilities;
 
 namespace Gum.Presentation.Tests;
 
@@ -75,10 +76,17 @@ public class RecentFilesLogicTests
     [Fact]
     public void ShowLoadRecentDialog_Confirmed_LoadsSelectedProjectAndPersistsFavoriteChanges()
     {
+        // A leading-slash literal is rooted per Path.IsPathRooted on both Windows and Unix. We still
+        // route it through FilePath.FullPath rather than comparing to the raw literal, because
+        // FilePath normalizes slashes to the platform's own separator - a raw "/..." literal would
+        // match on Unix but not on Windows, where FullPath comes back with backslashes.
+        string projectAPath = new FilePath("/ProjectA.gumx").FullPath;
+        string projectBPath = new FilePath("/ProjectB.gumx").FullPath;
+
         List<RecentProjectReference> recentProjects = new()
         {
-            MakeRecentProject(@"C:\ProjectA.gumx", isFavorite: false),
-            MakeRecentProject(@"C:\ProjectB.gumx", isFavorite: false),
+            MakeRecentProject(projectAPath, isFavorite: false),
+            MakeRecentProject(projectBPath, isFavorite: false),
         };
         _projectManager.Setup(x => x.RecentProjects).Returns(recentProjects);
 
@@ -86,7 +94,7 @@ public class RecentFilesLogicTests
             .Setup(x => x.Show(It.IsAny<LoadRecentViewModel>()))
             .Callback<LoadRecentViewModel>(vm =>
             {
-                RecentItemViewModel itemA = vm.FilteredItems.Single(item => item.FullPath == @"C:\ProjectA.gumx");
+                RecentItemViewModel itemA = vm.FilteredItems.Single(item => item.FullPath == projectAPath);
                 itemA.IsFavorite = true;
                 vm.SelectedItem = itemA;
             })
@@ -94,7 +102,7 @@ public class RecentFilesLogicTests
 
         _logic.ShowLoadRecentDialog();
 
-        _fileCommands.Verify(x => x.LoadProject(@"C:\ProjectA.gumx"), Times.Once);
+        _fileCommands.Verify(x => x.LoadProject(projectAPath), Times.Once);
         recentProjects[0].IsFavorite.ShouldBeTrue();
         _fileCommands.Verify(x => x.SaveGeneralSettings(), Times.Once);
     }

--- a/Tests/Gum.Presentation.Tests/SvgExportMenuLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/SvgExportMenuLogicTests.cs
@@ -1,0 +1,90 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.SvgExportPlugin;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Relocated out of the WPF-hosted MainSvgExportPlugin into the headless Gum.Presentation assembly
+/// (ADR-0005 Phase 3) so this decision logic is unit testable. The actual gumcli invocation
+/// (SvgExportCommand) is a separate, plugin-side class and is not exercised here.
+/// </summary>
+public class SvgExportMenuLogicTests
+{
+    private readonly Mock<ISelectedState> _selectedState = new();
+    private readonly Mock<IProjectState> _projectState = new();
+    private readonly Mock<IGuiCommands> _guiCommands = new();
+    private readonly SvgExportMenuLogic _logic;
+
+    public SvgExportMenuLogicTests()
+    {
+        _logic = new SvgExportMenuLogic(_selectedState.Object, _projectState.Object, _guiCommands.Object);
+    }
+
+    [Fact]
+    public void GetIsExportable_ScreenSelected_ReturnsTrue()
+    {
+        ScreenSave screen = new() { Name = "MyScreen" };
+        _selectedState.Setup(x => x.SelectedElement).Returns(screen);
+
+        bool result = _logic.GetIsExportable(out ElementSave? element);
+
+        result.ShouldBeTrue();
+        element.ShouldBe(screen);
+    }
+
+    [Fact]
+    public void GetIsExportable_NothingSelected_ReturnsFalse()
+    {
+        _selectedState.Setup(x => x.SelectedElement).Returns((ElementSave?)null);
+
+        bool result = _logic.GetIsExportable(out ElementSave? element);
+
+        result.ShouldBeFalse();
+        element.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryPrepareExport_ComponentSelectedAndProjectLoaded_ReturnsTrue()
+    {
+        ComponentSave component = new() { Name = "MyComponent" };
+        GumProjectSave project = new();
+        _selectedState.Setup(x => x.SelectedElement).Returns(component);
+        _projectState.Setup(x => x.GumProjectSave).Returns(project);
+
+        bool result = _logic.TryPrepareExport(out ElementSave? element, out GumProjectSave? projectSave);
+
+        result.ShouldBeTrue();
+        element.ShouldBe(component);
+        projectSave.ShouldBe(project);
+        _guiCommands.Verify(x => x.PrintOutput(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void TryPrepareExport_NoElementSelected_ReturnsFalseAndPrintsNothing()
+    {
+        _selectedState.Setup(x => x.SelectedElement).Returns((ElementSave?)null);
+
+        bool result = _logic.TryPrepareExport(out _, out _);
+
+        result.ShouldBeFalse();
+        _guiCommands.Verify(x => x.PrintOutput(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void TryPrepareExport_NoProjectLoaded_ReturnsFalseAndPrintsMessage()
+    {
+        ComponentSave component = new() { Name = "MyComponent" };
+        _selectedState.Setup(x => x.SelectedElement).Returns(component);
+        _projectState.Setup(x => x.GumProjectSave).Returns((GumProjectSave?)null);
+
+        bool result = _logic.TryPrepareExport(out _, out GumProjectSave? projectSave);
+
+        result.ShouldBeFalse();
+        projectSave.ShouldBeNull();
+        _guiCommands.Verify(x => x.PrintOutput("No project is loaded."), Times.Once);
+    }
+}

--- a/Tools/Gum.Presentation/GumForms/GumFormsLogic.cs
+++ b/Tools/Gum.Presentation/GumForms/GumFormsLogic.cs
@@ -1,0 +1,104 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Logic;
+using Gum.Logic.FileWatch;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using GumFormsPlugin.Services;
+using GumFormsPlugin.ViewModels;
+using System.Collections.Generic;
+using System.Linq;
+using ToolsUtilities;
+
+namespace GumFormsPlugin;
+
+/// <summary>
+/// Business logic behind the "Add Forms Components" menu item, relocated out of the WPF-hosted
+/// <c>MainGumFormsPlugin</c> (ADR-0005 Phase 3) so it can be unit tested headlessly.
+/// </summary>
+public class GumFormsLogic
+{
+    private readonly IFormsFileService _formsFileService;
+    private readonly IProjectState _projectState;
+    private readonly IImportLogic _importLogic;
+    private readonly IFileCommands _fileCommands;
+    private readonly IFileWatchManager _fileWatchManager;
+    private readonly IDialogService _dialogService;
+    private readonly ISkiaShapeStandardsLogic _skiaShapeStandardsLogic;
+
+    public GumFormsLogic(
+        IFormsFileService formsFileService,
+        IProjectState projectState,
+        IImportLogic importLogic,
+        IFileCommands fileCommands,
+        IFileWatchManager fileWatchManager,
+        IDialogService dialogService,
+        ISkiaShapeStandardsLogic skiaShapeStandardsLogic)
+    {
+        _formsFileService = formsFileService;
+        _projectState = projectState;
+        _importLogic = importLogic;
+        _fileCommands = fileCommands;
+        _fileWatchManager = fileWatchManager;
+        _dialogService = dialogService;
+        _skiaShapeStandardsLogic = skiaShapeStandardsLogic;
+    }
+
+    /// <summary>
+    /// Whether the project already has Forms components imported. Independent of the theme picker -
+    /// the default theme's destination set is used since the same destination paths get written
+    /// regardless of which theme produced them.
+    /// </summary>
+    public bool GetIfProjectHasForms()
+    {
+        Dictionary<string, FilePath> files =
+            _formsFileService.GetSourceDestinations(_formsFileService.DefaultThemeName, isIncludeDemoScreenGum: false);
+
+        return files.Values
+            .Any(item =>
+                item.Extension != "png" &&
+                item.Extension != "gutx" &&
+                item.Extension != "fnt" &&
+                item.Extension != "bmfc" &&
+                item.Extension != "setj" &&
+                item.Extension != "json" &&
+                item.Exists());
+    }
+
+    /// <summary>
+    /// Whether the "Add Forms Components" menu item should be present for the given project. A
+    /// newly created project has no <c>FullFileName</c> yet, so it cannot have forms - checking the
+    /// save parameter directly avoids any stale <see cref="IProjectState"/> state.
+    /// </summary>
+    public bool ShouldShowAddFormsMenuItem(GumProjectSave? save)
+    {
+        bool hasForms = !string.IsNullOrEmpty(save?.FullFileName) && GetIfProjectHasForms();
+        return !hasForms;
+    }
+
+    /// <summary>
+    /// Builds the "Add Forms" dialog view model, or returns false with an explanatory message if
+    /// the project must be saved first.
+    /// </summary>
+    public bool TryCreateAddFormsViewModel(out AddFormsViewModel? viewModel, out string? blockedMessage)
+    {
+        if (_projectState.NeedsToSaveProject)
+        {
+            viewModel = null;
+            blockedMessage = "You must first save the project before importing forms";
+            return false;
+        }
+
+        viewModel = new AddFormsViewModel(
+            _formsFileService,
+            _dialogService,
+            _fileCommands,
+            _importLogic,
+            _projectState,
+            _fileWatchManager,
+            _skiaShapeStandardsLogic);
+        blockedMessage = null;
+        return true;
+    }
+}

--- a/Tools/Gum.Presentation/ImportFromGumx/ImportFromGumxLogic.cs
+++ b/Tools/Gum.Presentation/ImportFromGumx/ImportFromGumxLogic.cs
@@ -1,0 +1,61 @@
+using Gum.Commands;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Plugins.ImportPlugin.Services;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using ImportFromGumxPlugin.Services;
+using ImportFromGumxPlugin.ViewModels;
+
+namespace ImportFromGumxPlugin;
+
+/// <summary>
+/// Business logic behind the "Import from .gumx" menu item, relocated out of the WPF-hosted
+/// <c>MainImportFromGumxPlugin</c> (ADR-0005 Phase 3) so it can be unit tested headlessly.
+/// </summary>
+public class ImportFromGumxLogic
+{
+    private readonly IProjectState _projectState;
+    private readonly IImportLogic _importLogic;
+    private readonly IFileCommands _fileCommands;
+    private readonly IDialogService _dialogService;
+    private readonly IDispatcher _dispatcher;
+
+    public ImportFromGumxLogic(
+        IProjectState projectState,
+        IImportLogic importLogic,
+        IFileCommands fileCommands,
+        IDialogService dialogService,
+        IDispatcher dispatcher)
+    {
+        _projectState = projectState;
+        _importLogic = importLogic;
+        _fileCommands = fileCommands;
+        _dialogService = dialogService;
+        _dispatcher = dispatcher;
+    }
+
+    /// <summary>
+    /// Whether an import dialog can be shown right now (the project has no unsaved changes).
+    /// </summary>
+    public bool CanImport => !_projectState.NeedsToSaveProject;
+
+    /// <summary>
+    /// Builds a fully-wired view model for the "Import from .gumx" dialog. Call only after
+    /// checking <see cref="CanImport"/>.
+    /// </summary>
+    public ImportFromGumxViewModel CreateImportViewModel()
+    {
+        GumxSourceService sourceService = new();
+        GumxDependencyResolver dependencyResolver = new();
+        GumxImportService importService = new(_importLogic, _projectState, _fileCommands, sourceService);
+
+        return new ImportFromGumxViewModel(
+            sourceService,
+            dependencyResolver,
+            importService,
+            _projectState,
+            _dialogService,
+            _dispatcher);
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/Fonts/FontCacheLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/Fonts/FontCacheLogic.cs
@@ -1,0 +1,72 @@
+using Gum.DataTypes;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Gum.Plugins.Fonts;
+
+/// <summary>
+/// Font-cache business logic relocated out of the WPF-hosted <c>MainFontPlugin</c> (ADR-0005 Phase
+/// 3) so it can be unit tested headlessly. Menu wiring, and the "Clear Font Cache" handler (which
+/// reads its own <c>RoutedEventArgs</c> parameter rather than the caught exception - a pre-existing
+/// quirk left unchanged), stay on the plugin.
+/// </summary>
+public class FontCacheLogic
+{
+    private readonly IFontManager _fontManager;
+    private readonly IDialogService _dialogService;
+    private readonly IProjectState _projectState;
+
+    public FontCacheLogic(IFontManager fontManager, IDialogService dialogService, IProjectState projectState)
+    {
+        _fontManager = fontManager;
+        _dialogService = dialogService;
+        _projectState = projectState;
+    }
+
+    /// <summary>
+    /// Creates any missing font files for the just-loaded project.
+    /// </summary>
+    public Task CreateMissingFontFilesForLoadedProject() =>
+        _fontManager.CreateAllMissingFontFiles(_projectState.GumProjectSave);
+
+    /// <summary>
+    /// Returns the font cache folder path, creating it first if it doesn't already exist.
+    /// </summary>
+    public string GetOrCreateFontCacheFolder()
+    {
+        if (!Directory.Exists(_fontManager.AbsoluteFontCacheFolder))
+        {
+            Directory.CreateDirectory(_fontManager.AbsoluteFontCacheFolder);
+        }
+
+        return _fontManager.AbsoluteFontCacheFolder;
+    }
+
+    /// <summary>
+    /// Re-creates missing (or, if <paramref name="forceRecreate"/>, all) font files for the loaded
+    /// project. Shows a message instead if no project is loaded.
+    /// </summary>
+    public async Task RefreshFontCache(bool forceRecreate)
+    {
+        GumProjectSave? gumProjectSave = _projectState.GumProjectSave;
+        if (gumProjectSave == null)
+        {
+            _dialogService.ShowMessage(
+                "A Gum project must first be loaded before recreating font files");
+        }
+        else
+        {
+            DateTime before = DateTime.Now;
+            await _fontManager.CreateAllMissingFontFiles(gumProjectSave, forceRecreate: forceRecreate);
+            DateTime after = DateTime.Now;
+
+            TimeSpan difference = after - before;
+            Debug.WriteLine($"Total time: {difference.TotalMilliseconds:N0}");
+        }
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/HideShowTools/HideShowToolsLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/HideShowTools/HideShowToolsLogic.cs
@@ -1,0 +1,31 @@
+namespace Gum.Plugins.InternalPlugins.HideShowTools;
+
+/// <summary>
+/// Business logic behind the "Hide Tools"/"Show Tools" menu item, relocated out of the WPF-hosted
+/// <c>MainHideShowToolsPlugin</c> (ADR-0005 Phase 3) so it can be unit tested headlessly.
+/// </summary>
+public class HideShowToolsLogic
+{
+    private readonly IToolsVisibility _toolsVisibility;
+
+    public HideShowToolsLogic(IToolsVisibility toolsVisibility)
+    {
+        _toolsVisibility = toolsVisibility;
+    }
+
+    /// <summary>
+    /// Toggles tool-panel visibility, restoring a sane minimum column/row size when tools are shown
+    /// again. Returns the new visibility state.
+    /// </summary>
+    public bool ToggleToolsVisibility()
+    {
+        _toolsVisibility.IsToolsVisible = !_toolsVisibility.IsToolsVisible;
+
+        if (_toolsVisibility.IsToolsVisible)
+        {
+            _toolsVisibility.EnsureMinimumWidth();
+        }
+
+        return _toolsVisibility.IsToolsVisible;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/HideShowTools/IToolsVisibility.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/HideShowTools/IToolsVisibility.cs
@@ -1,0 +1,14 @@
+namespace Gum.Plugins.InternalPlugins.HideShowTools;
+
+/// <summary>
+/// Narrow, headless-safe seam over <c>MainPanelViewModel</c> for logic that only needs to toggle
+/// tool-panel visibility. <c>MainPanelViewModel</c> itself is WPF-typed (exposes
+/// <c>System.Windows.FrameworkElement</c>/<c>ICollectionView</c> members), which would block
+/// referencing it from <c>Gum.Presentation</c> even though this seam's members don't touch WPF at
+/// all - same shape as <c>ITabVisibility</c>.
+/// </summary>
+public interface IToolsVisibility
+{
+    bool IsToolsVisible { get; set; }
+    void EnsureMinimumWidth();
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/LoadRecentFilesPlugin/RecentFilesLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/LoadRecentFilesPlugin/RecentFilesLogic.cs
@@ -1,0 +1,132 @@
+using Gum.Commands;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin.ViewModels;
+using Gum.Services.Dialogs;
+using Gum.Settings;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ToolsUtilities;
+
+namespace Gum.Plugins.InternalPlugins.LoadRecentFilesPlugin;
+
+/// <summary>
+/// Business logic behind the "Load Recent" menu, relocated out of the WPF-hosted
+/// <c>MainRecentFilesPlugin</c> (ADR-0005 Phase 3) so it can be unit tested headlessly. The plugin
+/// stays a thin wrapper: it builds the actual WPF <c>MenuItem</c>s and forwards clicks here.
+/// </summary>
+public class RecentFilesLogic
+{
+    private readonly IProjectManager _projectManager;
+    private readonly IFileCommands _fileCommands;
+    private readonly IDialogService _dialogService;
+
+    public RecentFilesLogic(IProjectManager projectManager, IFileCommands fileCommands, IDialogService dialogService)
+    {
+        _projectManager = projectManager;
+        _fileCommands = fileCommands;
+        _dialogService = dialogService;
+    }
+
+    /// <summary>
+    /// Recent projects the user has favorited, in their stored order.
+    /// </summary>
+    public IEnumerable<RecentProjectReference> GetFavoriteProjects() =>
+        _projectManager.RecentProjects.Where(item => item.IsFavorite);
+
+    /// <summary>
+    /// The most recently opened non-favorited projects, capped at <paramref name="maxCount"/>.
+    /// </summary>
+    public IEnumerable<RecentProjectReference> GetNonFavoriteProjectsForMenu(int maxCount = 5) =>
+        _projectManager.RecentProjects.Where(item => !item.IsFavorite).Take(maxCount);
+
+    /// <summary>
+    /// Loads the project at the given path.
+    /// </summary>
+    public void LoadProject(string filePath) => _fileCommands.LoadProject(filePath);
+
+    /// <summary>
+    /// Computes the display name for a recent project's file path, disambiguating same-named
+    /// projects by appending the name of the nearest containing .csproj, if any.
+    /// </summary>
+    public static string GetDisplayedNameForGumxFilePath(FilePath filePath)
+    {
+        string name = filePath.RemoveExtension().FileNameNoPath;
+
+        // It's common to have lots of same-named projects so let's see if this is in a csproj somewhere:
+        FilePath? parentDirectory = filePath.GetDirectoryContainingThis();
+        if (parentDirectory != null)
+        {
+            string? foundCsproj = null;
+            while (parentDirectory?.Exists() == true)
+            {
+                foundCsproj = Directory.GetFiles(parentDirectory.FullPath, "*.csproj").FirstOrDefault();
+
+                if (foundCsproj == null)
+                {
+                    parentDirectory = parentDirectory.GetDirectoryContainingThis();
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(foundCsproj))
+            {
+                FilePath fullPath = new FilePath(foundCsproj);
+                name += $" ({fullPath.FileNameNoPath})";
+            }
+        }
+
+        return name;
+    }
+
+    /// <summary>
+    /// Builds and populates the "Load Recent" dialog's view model from the current recent-projects
+    /// list.
+    /// </summary>
+    public LoadRecentViewModel BuildLoadRecentViewModel()
+    {
+        LoadRecentViewModel viewModel = new();
+
+        foreach (RecentProjectReference recentFile in _projectManager.RecentProjects)
+        {
+            viewModel.AllItems.Add(new RecentItemViewModel
+            {
+                FullPath = recentFile.FilePath.FullPath,
+                IsFavorite = recentFile.IsFavorite
+            });
+        }
+
+        viewModel.RefreshFilteredItems();
+
+        return viewModel;
+    }
+
+    /// <summary>
+    /// Shows the "Load Recent" dialog, loads the selected project if the user confirms, and
+    /// persists any favorite toggles the user made regardless of whether they confirmed.
+    /// </summary>
+    public void ShowLoadRecentDialog()
+    {
+        LoadRecentViewModel viewModel = BuildLoadRecentViewModel();
+
+        if (_dialogService.Show(viewModel))
+        {
+            _fileCommands.LoadProject(viewModel.SelectedItem.FullPath);
+        }
+
+        IReadOnlyList<RecentProjectReference> recentFiles = _projectManager.RecentProjects;
+        foreach (RecentItemViewModel item in viewModel.FilteredItems)
+        {
+            RecentProjectReference? matching = recentFiles.FirstOrDefault(candidate => candidate.FilePath == item.FullPath);
+            if (matching != null)
+            {
+                matching.IsFavorite = item.IsFavorite;
+            }
+        }
+
+        _fileCommands.SaveGeneralSettings();
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/SvgExportPlugin/SvgExportMenuLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/SvgExportPlugin/SvgExportMenuLogic.cs
@@ -1,0 +1,58 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.ToolStates;
+
+namespace Gum.Plugins.InternalPlugins.SvgExportPlugin;
+
+/// <summary>
+/// Decision logic behind the "Export to SVG" menu item, relocated out of the WPF-hosted
+/// <c>MainSvgExportPlugin</c> (ADR-0005 Phase 3) so it can be unit tested headlessly. The actual
+/// export (shelling out to gumcli) stays in <c>SvgExportCommand</c>, which this class does not
+/// invoke - the plugin calls it once this class confirms the export can proceed.
+/// </summary>
+public class SvgExportMenuLogic
+{
+    private readonly ISelectedState _selectedState;
+    private readonly IProjectState _projectState;
+    private readonly IGuiCommands _guiCommands;
+
+    public SvgExportMenuLogic(ISelectedState selectedState, IProjectState projectState, IGuiCommands guiCommands)
+    {
+        _selectedState = selectedState;
+        _projectState = projectState;
+        _guiCommands = guiCommands;
+    }
+
+    /// <summary>
+    /// Whether the currently-selected element can be exported to SVG (Screens and Components
+    /// only), along with the element itself (null when nothing exportable is selected).
+    /// </summary>
+    public bool GetIsExportable(out ElementSave? element)
+    {
+        element = _selectedState.SelectedElement;
+        return element is ScreenSave or ComponentSave;
+    }
+
+    /// <summary>
+    /// Validates that an export can proceed: the selection is exportable and a project is loaded.
+    /// Prints an explanatory message via <see cref="IGuiCommands"/> and returns false if not.
+    /// </summary>
+    public bool TryPrepareExport(out ElementSave? element, out GumProjectSave? projectSave)
+    {
+        element = _selectedState.SelectedElement;
+        if (element is not (ScreenSave or ComponentSave))
+        {
+            projectSave = null;
+            return false;
+        }
+
+        projectSave = _projectState.GumProjectSave;
+        if (projectSave == null)
+        {
+            _guiCommands.PrintOutput("No project is loaded.");
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
Same recipe as prior Phase 3 extractions (StateTreeController, BehaviorsLogic). Pulls each plugin's WPF-free decision logic into a headless, ctor-injected, unit-tested class in `Gum.Presentation`. Each plugin keeps only its own menu/tab WPF wiring and delegates to the new class.

Extracted (6 of 8):
- `MainRecentFilesPlugin` → `RecentFilesLogic`
- `MainHideShowToolsPlugin` → `HideShowToolsLogic` (+ new `IToolsVisibility` seam, since `MainPanelViewModel` itself is WPF-typed)
- `MainSvgExportPlugin` → `SvgExportMenuLogic` (exportability/guard checks only; the gumcli invocation stays in the existing `SvgExportCommand`)
- `MainFontPlugin` → `FontCacheLogic`
- `MainGumFormsPlugin` → `GumFormsLogic`
- `MainImportFromGumxPlugin` → `ImportFromGumxLogic`

Skipped (2 of 8) — no extractable decision logic, both pure WPF wiring:
- `MainHotkeyPlugin` — a one-line visibility toggle + header text swap, no decision logic worth a class.
- `MainOutputPlugin` — literally just constructs a view and adds it to a tab.

## Gotcha found
`MainFontPlugin.HandleClearFontCache`'s `catch` block reads `e.ToString()` where `e` is the handler's own `RoutedEventArgs` parameter, not the caught exception (no catch variable is declared). Pre-existing latent bug, left unchanged — extracting it would either leak `RoutedEventArgs` into the headless assembly or silently change the error text shown to the user. Noted in a code comment on the plugin.

## Testing
- One test class per extracted `*Logic` class in `Tests/Gum.Presentation.Tests` (Moq + Shouldly).
- Mutation-test proof done on `RecentFilesLogic.ShowLoadRecentDialog` (inverted the dialog-confirmed branch, confirmed 2 tests went red, reverted).
- `dotnet build GumFull.sln`: 0 errors.
- `AllPluginsCompositionTests`: green (MEF composes all plugins with the new/changed ctors).
- Full `GumToolUnitTests`: 1065 passed, 2 pre-existing skips, 0 failed.
- Full `Gum.Presentation.Tests`: 692 passed, 0 failed.

Manual test: not needed — behavior-preserving extraction, proven by compile + pinning/unit tests + MEF composition test.

Closes #3946
