### PR TITLE
Add ICodeOutputTabView/ITabSelectionState seam interfaces

### DIFF
--- a/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
+++ b/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
@@ -3,6 +3,7 @@ using CodeOutputPlugin.ViewModels;
 using Gum;
 using Gum.Managers;
 using Gum.Mvvm;
+using Gum.Plugins;
 using Gum.Services;
 using Gum.ToolStates;
 using System;
@@ -30,7 +31,7 @@ namespace CodeOutputPlugin.Views;
 /// <summary>
 /// Interaction logic for CodeWindow.xaml
 /// </summary>
-public partial class CodeWindow : UserControl
+public partial class CodeWindow : UserControl, ICodeOutputTabView
 {
     #region Fields/Properties
 

--- a/Gum/Plugins/PluginTab.cs
+++ b/Gum/Plugins/PluginTab.cs
@@ -7,7 +7,7 @@ using Gum.Plugins;
 
 namespace Gum.Plugins
 {
-    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate, ITabDockingCandidate, ITabVisibility
+    public partial class PluginTab : ViewModel, IRecipient<TabSelectedMessage>, ITabAutoSelectCandidate, ITabDockingCandidate, ITabVisibility, ITabSelectionState
     {
         private readonly IMessenger _messenger;
         public event Action? TabShown;

--- a/Tools/Gum.Presentation/Plugins/ICodeOutputTabView.cs
+++ b/Tools/Gum.Presentation/Plugins/ICodeOutputTabView.cs
@@ -1,0 +1,18 @@
+using Gum.ProjectServices.CodeGeneration;
+
+namespace Gum.Plugins;
+
+/// <summary>
+/// Narrow, headless-safe seam over the WPF <c>Views.CodeWindow</c> control for the code-output tab's
+/// element/project settings. <c>CodeOutputElementSettings</c> is read back mid-logic (a live fallback
+/// default, not just a sink), so its accessor is two-way; <c>CodeOutputProjectSettings</c> is only ever
+/// pushed onto the control and never read back, so its accessor is write-only. Both settings types
+/// already live in the headless <c>Gum.ProjectServices</c> assembly (no WPF dependency), so they're
+/// safe to expose directly - same shape as <see cref="ITabVisibility"/>/<see cref="Gum.Wireframe.IContextMenuState"/>.
+/// </summary>
+public interface ICodeOutputTabView
+{
+    CodeOutputElementSettings? CodeOutputElementSettings { get; set; }
+
+    CodeOutputProjectSettings? CodeOutputProjectSettings { set; }
+}

--- a/Tools/Gum.Presentation/Plugins/ITabSelectionState.cs
+++ b/Tools/Gum.Presentation/Plugins/ITabSelectionState.cs
@@ -1,0 +1,12 @@
+namespace Gum.Plugins;
+
+/// <summary>
+/// Narrow, headless-safe seam over a plugin's own tab (<c>PluginTab</c>) for logic that only needs to
+/// know whether the tab is currently selected. Kept separate from <see cref="ITabVisibility"/>:
+/// selection and visibility are different concerns, and <see cref="ITabVisibility"/> already has a
+/// consumer that has no need to care about selection.
+/// </summary>
+public interface ITabSelectionState
+{
+    bool IsSelected { get; }
+}


### PR DESCRIPTION
Bounded first slice of #3917: adds the view-state seam interfaces the design pass found, without moving any logic yet.

- `ICodeOutputTabView` (Tools/Gum.Presentation/Plugins/ICodeOutputTabView.cs) - two-way `CodeOutputElementSettings`, write-only `CodeOutputProjectSettings`. Implemented on `Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs`.
- `ITabSelectionState` (Tools/Gum.Presentation/Plugins/ITabSelectionState.cs) - `IsSelected` get-only, kept separate from `ITabVisibility`. Implemented on `Gum/Plugins/PluginTab.cs`.

Pure interface declarations on members that already exist with matching signatures - zero behavior change, proven by compilation (`GumFull.sln` builds clean).

`MainCodeOutputPlugin`'s logic relocation into a ctor-injected `CodeOutputTabController` (mirroring `AnimationTabController`) is a follow-up, not part of this PR - #3917 stays open for that.

Part of #3917