### PR TITLE
Extract ScrollBarLogic math into headless Gum.Presentation

### DIFF
--- a/Gum/TextureCoordinateSelectionPlugin/Logic/ScrollBarLogicWpf.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/Logic/ScrollBarLogicWpf.cs
@@ -1,9 +1,4 @@
 ﻿using RenderingLibrary;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 
@@ -11,12 +6,14 @@ namespace TextureCoordinateSelectionPlugin.Logic;
 
 public class ScrollBarLogicWpf
 {
+    private readonly ScrollBarLogic _scrollBarLogic;
     private ScrollBar _verticalScrollBar;
     private ScrollBar _horizontalScrollBar;
     private Camera _camera;
 
-    public ScrollBarLogicWpf()
+    public ScrollBarLogicWpf(ScrollBarLogic scrollBarLogic)
     {
+        _scrollBarLogic = scrollBarLogic;
     }
 
     public void Initialize (ScrollBar verticalScrollBar, ScrollBar horizontalScrollBar, Camera camera)
@@ -46,20 +43,19 @@ public class ScrollBarLogicWpf
     public void UpdateScrollBarsToCamera(int spriteWidth, int spriteHeight)
     {
         isInScrollBarUpdate = true;
-        var viewableArea = _camera.ClientWidth / _camera.Zoom;
-        _horizontalScrollBar.Minimum = -viewableArea / 2;
-        var maximum = spriteWidth + viewableArea / 2;
-        _horizontalScrollBar.Maximum = Math.Max(_horizontalScrollBar.Minimum, maximum - viewableArea);
-        _horizontalScrollBar.ViewportSize = viewableArea;
-        _horizontalScrollBar.Value = _camera.X;
 
-        viewableArea = _camera.ClientHeight / _camera.Zoom;
-        _verticalScrollBar.Minimum = -viewableArea / 2;
-        maximum = spriteHeight + viewableArea / 2;
-        _verticalScrollBar.Maximum = Math.Max(_verticalScrollBar.Minimum, maximum - viewableArea);
-        _verticalScrollBar.ViewportSize = viewableArea;
-        _verticalScrollBar.Value = _camera.Y;
+        ScrollBarRange horizontalRange = _scrollBarLogic.CalculateHorizontalRange(_camera, spriteWidth);
+        _horizontalScrollBar.Minimum = horizontalRange.Minimum;
+        _horizontalScrollBar.Maximum = horizontalRange.Maximum;
+        _horizontalScrollBar.ViewportSize = horizontalRange.ViewportSize;
+        _horizontalScrollBar.Value = horizontalRange.Value;
+
+        ScrollBarRange verticalRange = _scrollBarLogic.CalculateVerticalRange(_camera, spriteHeight);
+        _verticalScrollBar.Minimum = verticalRange.Minimum;
+        _verticalScrollBar.Maximum = verticalRange.Maximum;
+        _verticalScrollBar.ViewportSize = verticalRange.ViewportSize;
+        _verticalScrollBar.Value = verticalRange.Value;
+
         isInScrollBarUpdate = false;
-
     }
 }

--- a/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/MainTextureCoordinatePlugin.cs
@@ -72,7 +72,7 @@ public class MainTextureCoordinatePlugin : PluginBase, IRecipient<UiBaseFontSize
             setVariableLogic,
             tabManager,
             hotkeyManager,
-            new ScrollBarLogicWpf(),
+            new ScrollBarLogicWpf(new ScrollBarLogic()),
             messenger,
             themingService);
 

--- a/Tests/Gum.Presentation.Tests/ScrollBarLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ScrollBarLogicTests.cs
@@ -1,0 +1,58 @@
+using RenderingLibrary;
+using Shouldly;
+using TextureCoordinateSelectionPlugin.Logic;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins <see cref="ScrollBarLogic"/>'s min/max/viewport/value math after its extraction from
+/// <c>ScrollBarLogicWpf</c> (ADR-0005) — the math previously lived mixed in with direct WPF
+/// <c>ScrollBar</c> property writes.
+/// </summary>
+public class ScrollBarLogicTests
+{
+    [Fact]
+    public void CalculateHorizontalRange_ReturnsRangeBasedOnCameraXAndContentWidth()
+    {
+        Camera camera = new Camera { ClientWidth = 800, Zoom = 2f };
+        camera.X = 100f;
+        ScrollBarLogic scrollBarLogic = new ScrollBarLogic();
+
+        ScrollBarRange range = scrollBarLogic.CalculateHorizontalRange(camera, contentWidth: 1000);
+
+        range.Minimum.ShouldBe(-200);
+        range.Maximum.ShouldBe(800);
+        range.ViewportSize.ShouldBe(400);
+        range.Value.ShouldBe(100);
+    }
+
+    [Fact]
+    public void CalculateVerticalRange_ReturnsRangeBasedOnCameraYAndContentHeight()
+    {
+        Camera camera = new Camera { ClientHeight = 600, Zoom = 2f };
+        camera.Y = 50f;
+        ScrollBarLogic scrollBarLogic = new ScrollBarLogic();
+
+        ScrollBarRange range = scrollBarLogic.CalculateVerticalRange(camera, contentHeight: 500);
+
+        range.Minimum.ShouldBe(-150);
+        range.Maximum.ShouldBe(350);
+        range.ViewportSize.ShouldBe(300);
+        range.Value.ShouldBe(50);
+    }
+
+    [Fact]
+    public void CalculateHorizontalRange_ClampsMaximumToMinimum_WhenContentIsSmallerThanViewableArea()
+    {
+        Camera camera = new Camera { ClientWidth = 800, Zoom = 2f };
+        ScrollBarLogic scrollBarLogic = new ScrollBarLogic();
+
+        // contentWidth is deliberately negative to force the raw (unclamped) maximum below the
+        // minimum, exercising the Math.Max clamp in CalculateRange.
+        ScrollBarRange range = scrollBarLogic.CalculateHorizontalRange(camera, contentWidth: -1000);
+
+        range.Minimum.ShouldBe(-200);
+        range.Maximum.ShouldBe(-200);
+    }
+}

--- a/Tools/Gum.Presentation/TextureCoordinateSelectionPlugin/Logic/ScrollBarLogic.cs
+++ b/Tools/Gum.Presentation/TextureCoordinateSelectionPlugin/Logic/ScrollBarLogic.cs
@@ -1,0 +1,40 @@
+using RenderingLibrary;
+
+namespace TextureCoordinateSelectionPlugin.Logic;
+
+/// <summary>
+/// The min/max/viewport/value a scrollbar should show for a given <see cref="Camera"/> axis and
+/// content size. Framework-neutral so it can be applied to any scrollbar widget by the view-side
+/// caller (e.g. <c>ScrollBarLogicWpf</c>).
+/// </summary>
+public record ScrollBarRange(double Minimum, double Maximum, double ViewportSize, double Value);
+
+/// <summary>
+/// Computes scrollbar ranges from a <see cref="Camera"/>'s position/zoom and the size of the
+/// content being scrolled (e.g. the texture being edited in the Texture Coordinate Selection tab).
+/// Extracted from <c>ScrollBarLogicWpf</c> (ADR-0005) so the math is testable independent of WPF.
+/// </summary>
+public class ScrollBarLogic
+{
+    /// <summary>Computes the horizontal scrollbar range for the camera's X axis.</summary>
+    public ScrollBarRange CalculateHorizontalRange(Camera camera, int contentWidth)
+    {
+        return CalculateRange(camera.X, camera.ClientWidth, camera.Zoom, contentWidth);
+    }
+
+    /// <summary>Computes the vertical scrollbar range for the camera's Y axis.</summary>
+    public ScrollBarRange CalculateVerticalRange(Camera camera, int contentHeight)
+    {
+        return CalculateRange(camera.Y, camera.ClientHeight, camera.Zoom, contentHeight);
+    }
+
+    private ScrollBarRange CalculateRange(float cameraPosition, int clientSize, float zoom, int contentSize)
+    {
+        double viewableArea = clientSize / zoom;
+        double minimum = -viewableArea / 2;
+        double maximum = contentSize + viewableArea / 2;
+        maximum = System.Math.Max(minimum, maximum - viewableArea);
+
+        return new ScrollBarRange(minimum, maximum, viewableArea, cameraPosition);
+    }
+}


### PR DESCRIPTION
Closes #3958 (partially — see below).

## Done: ScrollBarLogicWpf math extraction

`UpdateScrollBarsToCamera` mixed scrollbar min/max/viewport/value math with direct WPF `ScrollBar` property writes. Extracted the math into `ScrollBarLogic` (`Tools/Gum.Presentation/TextureCoordinateSelectionPlugin/Logic/ScrollBarLogic.cs`, headless), leaving `ScrollBarLogicWpf` a thin adapter that calls the headless calculation and writes the results onto the real `ScrollBar` controls. Pinning tests + a mutation-test proof (dropped the `Math.Max` clamp, confirmed red, reverted) in `Tests/Gum.Presentation.Tests/ScrollBarLogicTests.cs`.

## Deferred: PropertyGridManager.RightClick ToolStripMenuItem retype

`HandleFileFromProjectSelect` in `Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.RightClick.cs` is dead code — grepped the whole repo, it's never wired to any menu item's `Click` event (nothing subscribes to it, not even via a designer file). There's no call site to move the `ToolStripMenuItem` extraction to, so the described refactor doesn't apply. Leaving it as-is rather than force a change; happy to delete it as a follow-up if wanted.

## Manual test verdict

Not needed — behavior-preserving extraction, covered by the pinning tests + `GumFull.sln` build.
