### PR TITLE
Make SilkNetGumSample's Forms screen match MonoGameGumInCode

### DIFF
--- a/Samples/SilkNetGum/SilkNetGumSample.sln
+++ b/Samples/SilkNetGum/SilkNetGumSample.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LibraryProjects", "LibraryP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{2ABFB42D-954D-4429-8B01-397581BC8C9D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.Themes.Editor.SilkNet", "..\..\Themes\Gum.Themes.Editor.SilkNet\Gum.Themes.Editor.SilkNet.csproj", "{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,6 +36,10 @@ Global
 		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -42,6 +48,7 @@ Global
 		{8F2E4B71-3C9A-4D6E-B5F1-7A0C2E8D9B34} = {269E6100-C1A6-41C2-971C-7C5B32987775}
 		{C8415A14-F48F-47E3-914D-79C44434CB77} = {269E6100-C1A6-41C2-971C-7C5B32987775}
 		{2ABFB42D-954D-4429-8B01-397581BC8C9D} = {269E6100-C1A6-41C2-971C-7C5B32987775}
+		{7A6E5C4D-8B1A-4F3E-9C7D-2E5B1A9F6C3D} = {269E6100-C1A6-41C2-971C-7C5B32987775}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B84D31CC-187A-41E1-B88E-8EB5BFED24E0}

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -97,10 +97,6 @@ unsafe class Program
         // Registers GumUI.Keyboard for Tab / Shift+Tab focus traversal between Forms controls.
         GumUI.UseKeyboardDefaults();
 
-        // #3671 proof of concept: the Editor theme ported to Skia/SilkNet. Visible on the "Forms"
-        // nav button (FormsScreen), which already exercises every control Editor restyles.
-        Gum.Themes.Editor.EditorTheme.Apply();
-
         GraphicalUiElement.CanvasWidth = windowWidth;
         GraphicalUiElement.CanvasHeight = windowHeight;
 

--- a/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
+++ b/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
@@ -47,12 +47,6 @@
 	  <ProjectReference Include="..\..\..\Runtimes\SilkNetGum\SilkNetGum.csproj" />
 	</ItemGroup>
 
-	<!-- Editor theme, ported to Skia/SilkNet as the #3671 proof of concept: exercised via the
-	     Forms screen's Button/CheckBox/ComboBox/ListBox/RadioButton/Slider/TextBox controls. -->
-	<ItemGroup>
-	  <ProjectReference Include="..\..\..\Themes\Gum.Themes.Editor.SilkNet\Gum.Themes.Editor.SilkNet.csproj" />
-	</ItemGroup>
-
 	<!-- Shared with MonoGameGumInCode (the reference feature sample) so Forms control rendering
 	     can be compared side by side between backends. See #3652. -->
 	<ItemGroup>


### PR DESCRIPTION
Originally this fixed a missing .sln entry for the Editor theme (#3671 proof of concept) the sample was applying. On review, decided the sample shouldn't apply that theme at all — FormsScreen.cs is already linked verbatim from MonoGameGumInCode, so the theme call was the only thing making the two backends' Forms screens render differently. Removed it (and its now-unneeded ProjectReference) instead, so both samples show identical controls with identical default styling.

Verified: cold build of the sample's .sln is clean, 0 errors.