### PR TITLE
Fix stale TimeManager.cs path in GumCoreShared.projitems

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -75,7 +75,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\CustomSetPropertyOnRenderable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\ElementWithState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\FallbackRenderableFactory.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\TimeManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tools\Gum.Presentation\Wireframe\TimeManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ILocalizationService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MonoGameIntegration\RuntimeLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Camera.cs" />


### PR DESCRIPTION
PR #3894 moved \`TimeManager.cs\` from \`Gum/Wireframe/\` to \`Tools/Gum.Presentation/Wireframe/\` but never updated this shared-items \`<Compile Include>\`, so any FRB1/GumCore consumer (e.g. \`GumCore.DesktopGlNet6\`) fails with CS2001.

Verified: FRB canary (\`GumCore.DesktopGlNet6.csproj\`) reproduces the error on main and builds clean with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)