### PR TITLE
Document Silk.NET as a fully-supported Gum runtime

### DIFF
--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -8,6 +8,8 @@ tools: Read, Grep, Glob, Edit, Write
 
 Write task-focused docs: prerequisites, steps, screenshots placeholders, common pitfalls, and troubleshooting. Assume beginner unless told otherwise; keep it skimmable. Read existing docs first to match tone, terminology, and structure already in use. Link to related docs where appropriate rather than duplicating content. Can create new documentation files from scratch.
 
+Before writing any claim about what a runtime/feature does or doesn't support, verify it against the relevant domain skill (e.g. `gum-runtime-fonts`, `gum-cross-platform-unification`) or source — don't infer a capability gap just because one platform lacks another platform's package. See `gum-docs-writing`'s "Verify Behavior Claims" section.
+
 ## Documentation Location
 All .docs files are located in the `docs/` folder in the repository.
 

--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -6,6 +6,10 @@ type: skill
 
 # Gum Docs Writing Reference
 
+## Verify Behavior Claims Before Writing Them
+
+Before writing a claim like "X isn't available on backend Y" or "X requires package Z," verify it against the relevant domain skill (e.g. `gum-runtime-fonts`, `gum-kernsmith-integrations`, `gum-cross-platform-unification`) or source — this skill covers GitBook mechanics only, not product behavior. A missing per-platform package is not proof of a capability gap: the platform may get the capability another way (Silk.NET has no KernSmith package because it renders through SkiaSharp, which rasterizes fonts natively — parity, not a gap).
+
 ## File Location and SUMMARY.md
 
 All docs live under `docs/`. `docs/SUMMARY.md` is the master table of contents — GitBook navigation is built entirely from it. A file not listed in SUMMARY.md is unreachable from the nav even if it exists on disk.

--- a/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
+++ b/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
@@ -205,6 +205,11 @@ public class BmfcSave
     /// Returns whether the given font value represents a .ttf font file path
     /// rather than a system font family name.
     /// </summary>
+    /// <remarks>
+    /// This is a pure suffix check, not a path-shape check -- a bare filename with no directory
+    /// (e.g. "MyFont.ttf") counts as a file path just as much as "fonts/MyFont.ttf" does. There is
+    /// no slash/path-separator detection involved.
+    /// </remarks>
     /// <param name="fontValue">The font value to check (e.g., "Arial" or "fonts/MyFont.ttf").</param>
     /// <returns>True if the value ends with ".ttf" (case-insensitive); false if null, empty, or not a .ttf path.</returns>
     public static bool IsFontFilePath(string? fontValue)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 <figure><img src=".gitbook/assets/gum-logo-normal-512.png" alt=""><figcaption></figcaption></figure>
 
-Gum is the best Game UI Layout tool available. It provides a flexible, efficient layout engine capable of producing virtually any layout. Gum can be used in a variety of contexts including in the [FlatRedBall game engine](https://docs.flatredball.com/gum/), [MonoGame](code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/), [raylib](code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md), and more. Gum can also be rendered on Skia so it can be used in any environment that supports Skia such as [WPF](code/getting-started/setup/adding-initializing-gum/wpf.md), [Silk.NET](code/getting-started/setup/adding-initializing-gum/silk.net.md), and Avalonia.
+Gum is the best Game UI Layout tool available. It provides a flexible, efficient layout engine capable of producing virtually any layout. Gum can be used in a variety of contexts including in the [FlatRedBall game engine](https://docs.flatredball.com/gum/), [MonoGame](code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/), [raylib](code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md), [Silk.NET](code/getting-started/setup/adding-initializing-gum/silk.net.md), and more. Gum can also be rendered on Skia so it can be used in any environment that supports Skia such as [WPF](code/getting-started/setup/adding-initializing-gum/wpf.md) and Avalonia.
 
 The Gum layout engine can also be included in any .NET project without requiring the use of a particular graphical API.
 
@@ -28,7 +28,7 @@ Adjust an object’s origin, position units, size units, and stacking to create 
 
 ### Simple Integration - Gum Supports Many Runtimes
 
-Grab the NuGet, add a few lines of code, see your Gum project in game! You can use Gum with MonoGame, KNI, FNA, raylib, SkiaSharp, and many more platforms. For more information on our runtimes, see the [Getting Started](code/getting-started/) page.
+Grab the NuGet, add a few lines of code, see your Gum project in game! You can use Gum with MonoGame, KNI, FNA, raylib, Silk.NET, SkiaSharp, and many more platforms. For more information on our runtimes, see the [Getting Started](code/getting-started/) page.
 
 <figure><img src=".gitbook/assets/image (29).png" alt=""><figcaption><p>Gum UI in game</p></figcaption></figure>
 

--- a/docs/code/about/README.md
+++ b/docs/code/about/README.md
@@ -22,8 +22,9 @@ Gum runtimes can be used to load Gum projects or create code-only UI in many pop
 
 * MonoGame/KNI/FNA
 * raylib
+* Silk.NET
 * FlatRedBall
-* SkiaSharp (Silk.NET, WPF, .NET Maui)
+* SkiaSharp (WPF, .NET Maui)
 * Pygame
 * Meadow
 

--- a/docs/code/about/for-wpf-users.md
+++ b/docs/code/about/for-wpf-users.md
@@ -107,6 +107,7 @@ Before creating any controls, you must initialize Gum. This registers the defaul
 
 * **MonoGame/KNI/FNA:** `GumService.Default.Initialize(this)` in your Game's `Initialize` method
 * **raylib:** `GumService.Default.Initialize()` after calling `Raylib.InitWindow`. See [raylib setup](../getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md) for a full example.
+* **Silk.NET:** `GumService.Default.Initialize(canvas, inputContext)`, passed an `SKCanvas` and `IInputContext` your project owns. See [Silk.NET setup](../getting-started/setup/adding-initializing-gum/silk.net.md) for a full example.
 {% endhint %}
 
 ```csharp

--- a/docs/code/async-programming.md
+++ b/docs/code/async-programming.md
@@ -50,4 +50,4 @@ If you want to take ownership of the context for advanced reasons (custom queuei
 
 ## Platform Coverage
 
-`UseSingleThreadedAsync` is available on MonoGame, KNI, FNA, Raylib, and Sokol. Under FlatRedBall, the FRB runtime supplies its own thread/instruction model; this opt-in is intentionally not exposed there — use FRB's own facilities (e.g. `InstructionManager`) for primary-thread work.
+`UseSingleThreadedAsync` is available on MonoGame, KNI, FNA, Raylib, Silk.NET, and Sokol. Under FlatRedBall, the FRB runtime supplies its own thread/instruction model; this opt-in is intentionally not exposed there — use FRB's own facilities (e.g. `InstructionManager`) for primary-thread work.

--- a/docs/code/events-and-interactivity/gamepad-support.md
+++ b/docs/code/events-and-interactivity/gamepad-support.md
@@ -11,7 +11,7 @@ For information on using gamepads for tabbing, see the [Tabbing](tabbing-moving-
 To enable gamepad support in your screen:
 
 1. Be sure to have a gamepad plugged in. Any gamepad that is usable in MonoGame will also work as a gamepad in Gum Forms
-2. Add the gamepad to the FrameworkElement.GamepadsForUiControl. You can add multiple gamepads for multiplayer games.
+2. Add the gamepad to the FrameworkElement.GamePadsForUiControl. You can add multiple gamepads for multiplayer games.
 3. Set the initial control to have focus by setting its `IsFocused = true`
 
 For example, the following code enables gamepad control for a game assuming MyButton is a valid button:
@@ -34,8 +34,7 @@ By default a gamepad's A button can be used to select the focused control. If th
 
 ```csharp
 // Initialize
-FrameworkElement.GamePadsForUiControl.AddRange(
-    GumUI.Gamepads);
+GumUI.UseGamepadDefaults();
 
 TopButton.IsFocused = true;
 TopButton.Click += (_, _) =>

--- a/docs/code/events-and-interactivity/tabbing-moving-focus.md
+++ b/docs/code/events-and-interactivity/tabbing-moving-focus.md
@@ -56,7 +56,7 @@ Despite its name, the GamepadTabbingFocusBehavior property controls tabbing for 
 To enable gamepad support in your game:
 
 1. Be sure to have a gamepad plugged in. Any gamepad that is usable in MonoGame will also work as a gamepad in Gum Forms
-2. Add the gamepad to the FrameworkElement.GamepadsForUiControl. You can add multiple gamepads for multiplayer games.
+2. Add the gamepad to the FrameworkElement.GamePadsForUiControl. You can add multiple gamepads for multiplayer games.
 3. Set the initial control to have focus by setting its `IsFocused = true`
 
 For example, the following code enables gamepad control for a game assuming MyButton is a valid button:

--- a/docs/code/files-and-fonts/animation-chains.md
+++ b/docs/code/files-and-fonts/animation-chains.md
@@ -29,7 +29,7 @@ This conversion happens once, when the `.achx` loads — not every frame during 
 
 ## Loading in Code
 
-There are two ways to get an `.achx` onto a `SpriteRuntime` or `NineSliceRuntime`. Both work the same way on either type, and both work across MonoGame, KNI, FNA, Raylib, and Skia.
+There are two ways to get an `.achx` onto a `SpriteRuntime` or `NineSliceRuntime`. Both work the same way on either type, and both work across MonoGame, KNI, FNA, Raylib, Skia, and Silk.NET.
 
 ### Auto-Load via SourceFileName
 

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -219,7 +219,7 @@ text.FontSize = 24;
 For a font loaded from bytes (an embedded resource, for example) rather than a file on disk, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` directly and then assign `Font = familyName`.
 
 {% hint style="info" %}
-Only the `.ttf` extension is recognized — `.otf` files are not auto-routed through this path today and resolve as a (likely-missing) system font family name instead.
+`Font`/`CustomFontFile` is detected as a file path purely by whether the string ends in `.ttf` — not by whether it looks like a path. A bare filename with no directory (`"MyFont.ttf"`) is loaded from disk the same as a full path; there's no slash detection involved, and it never falls through to an OS font-name lookup. Only the `.ttf` extension is recognized — `.otf` files are not auto-routed through this path today and resolve as a (likely-missing) system font family name instead.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -7,7 +7,7 @@ This page covers each font loading strategy in detail with code samples and trad
 The strategies are:
 
 * [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation) — recommended for MonoGame, KNI, and Raylib.
-* [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum) — SkiaGum rasterizes glyphs itself, separate from KernSmith.
+* [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum) — SkiaGum and Silk.NET rasterize glyphs themselves via SkiaSharp, separate from KernSmith.
 * [Custom Font File](font-strategies.md#custom-font-file) — load a specific `.fnt` file you ship with the game.
 * [Direct BitmapFont Assignment](font-strategies.md#direct-bitmapfont-assignment) — fully manual.
 * [Build-Time Font Cache](font-strategies.md#build-time-font-cache) — pre-baked atlases from the Gum tool.
@@ -22,6 +22,7 @@ The strategies are:
 | FNA      | Not yet. If you need it, let us know on Discord or [open an issue](https://github.com/vchelaru/Gum/issues).                            |
 | Sokol    | Not yet. Use the [Build-Time Font Cache](font-strategies.md#build-time-font-cache) for now.                                            |
 | SkiaGum  | Yes — uses SkiaSharp's own glyph rasterization. See [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum). |
+| Silk.NET | Yes — renders through SkiaGum and shares its glyph rasterization; no KernSmith package needed. See [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum). |
 
 ## Dynamic KernSmith Generation
 
@@ -137,7 +138,7 @@ For these reasons, registering your own `.ttf` (or `.otf`) files is recommended 
 ### Registering Custom .ttf Fonts
 
 {% hint style="info" %}
-Registering `.ttf` files is supported on MonoGame and KNI. SkiaGum uses system fonts directly and does not currently support `RegisterFont`.
+This section covers MonoGame/KNI's `KernSmithFontCreator.RegisterFont`. SkiaGum and Silk.NET load a `.ttf` file a different way — point `Font`/`CustomFontFile` directly at the `.ttf` path instead of calling a register method; see [Custom .ttf Files](font-strategies.md#custom-ttf-files) under Dynamic Generation on SkiaGum.
 {% endhint %}
 
 To use a `.ttf` file with KernSmith:
@@ -188,9 +189,11 @@ Registered fonts take priority over system fonts. If you register a font with th
 
 ## Dynamic Generation on SkiaGum
 
-SkiaGum is its own thing. It does **not** use KernSmith — SkiaSharp rasterizes glyphs directly, so dynamic font generation works out of the box. No NuGet package to install, no `InMemoryFontCreator` to assign.
+SkiaGum is its own thing, and Silk.NET (`Gum.SilkNet`) shares this exact same font path since it renders through SkiaGum. Neither uses KernSmith — SkiaSharp rasterizes glyphs directly, so dynamic font generation works out of the box. No NuGet package to install, no `InMemoryFontCreator` to assign.
 
-Assign the font properties directly on the `TextRuntime`:
+### System Fonts
+
+Assign the font properties directly on the `TextRuntime`; the family name must be installed on the system to resolve:
 
 ```csharp
 // Initialize
@@ -201,7 +204,23 @@ text.FontSize = 24;
 text.IsBold = true;
 ```
 
-The font must be installed on the system to be used. SkiaGum does not currently support `RegisterFont`-style registration of shipped `.ttf` files.
+### Custom .ttf Files
+
+Point `Font` (or `CustomFontFile` with `UseCustomFont = true`) at a `.ttf` path instead of a family name — SkiaGum/Silk.NET load and cache the file automatically, the same way KernSmith's `RegisterFont` does for MonoGame/KNI:
+
+```csharp
+// Initialize
+var text = new TextRuntime();
+text.Text = "Hello, World!";
+text.Font = "Content/Fonts/Bungee-Regular.ttf";
+text.FontSize = 24;
+```
+
+For a font loaded from bytes (an embedded resource, for example) rather than a file on disk, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` directly and then assign `Font = familyName`.
+
+{% hint style="info" %}
+Only the `.ttf` extension is recognized — `.otf` files are not auto-routed through this path today and resolve as a (likely-missing) system font family name instead.
+{% endhint %}
 
 {% hint style="info" %}
 A dedicated SkiaGum fonts page is planned. For now, this section is the canonical reference. If something is unclear, ask on Discord or [open an issue](https://github.com/vchelaru/Gum/issues).
@@ -385,7 +404,7 @@ foreach (var label in titleLabels)
 ## Build-Time Font Cache
 
 {% hint style="info" %}
-This approach is primarily useful when your project already has pre-generated font files from the Gum tool, or when dynamic font generation is not yet available for your runtime (Sokol and FNA today). For MonoGame, KNI, and Raylib, [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation) is the recommended approach; for SkiaGum see [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum).
+This approach is primarily useful when your project already has pre-generated font files from the Gum tool, or when dynamic font generation is not yet available for your runtime (Sokol and FNA today). For MonoGame, KNI, and Raylib, [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation) is the recommended approach; for SkiaGum or Silk.NET see [Dynamic Generation on SkiaGum](font-strategies.md#dynamic-generation-on-skiagum).
 {% endhint %}
 
 If `UseCustomFont` is `false` (the default) and no `InMemoryFontCreator` is registered, a `TextRuntime`'s font is determined by its font component values. These values combine to produce a file name, and the corresponding `.fnt` file must already exist in a `FontCache` folder.

--- a/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
@@ -89,6 +89,43 @@ GumService.Default.Update(totalSeconds);
 The `IInputContext` you pass to `Initialize` must come from a window that `Silk.NET.Windowing` created and initialized itself — `Window.Create(options)` followed by `window.Initialize()`, then `window.CreateInput()`. Building an `IInputContext` by wrapping a window you created another way (for example via `SdlWindowing.CreateFrom(existingHandle)`) skips the normal event-subscription path. The resulting `IInputContext` looks valid, but it silently never receives events — no exception is thrown, and clicks, key presses, and typed text simply do nothing.
 {% endhint %}
 
+## Adding Expression Support (Optional)
+
+If your Gum project uses arithmetic expressions in variable references (such as `Width = OtherInstance.Width + 20`), you can add the `Gum.Expressions` NuGet package for full expression evaluation at runtime. Without this package, simple variable references like `Width = OtherInstance.Width` still work.
+
+Add the NuGet package:
+
+```bash
+dotnet add package Gum.Expressions
+```
+
+Then call `GumExpressionService.Initialize()` after `GumService.Default.Initialize`. Expression support is typically used with a Gum project that has variable references defined in the tool:
+
+```csharp
+// Initialize
+GumService.Default.Initialize(canvas, inputContext, "Content/GumProject/GumProject.gumx");
+GumExpressionService.Initialize();
+```
+
+If linking to source instead of NuGet, add `<Gum Root>/Runtimes/GumExpressions/GumExpressions.csproj` to your solution.
+
+For more information, see the [Runtime Variable References](../../../styling/runtime-variable-references.md) page.
+
+## Adding a Button (Testing the Setup)
+
+Gum can be tested by adding a Button after Gum is initialized. To do so, add code to create a `Button` as shown in the following block of code after Gum is initialized:
+
+```csharp
+// Initialize
+GumService.Default.Initialize(canvas, inputContext);
+
+var button = new Button();
+button.AddToRoot();
+button.Width = 200;
+button.Anchor(Anchor.Center);
+button.Click += (_, _) => button.Text = $"Clicked\n{System.DateTime.Now}";
+```
+
 For a working project, see the Gum Silk.NET sample:
 
 {% embed url="https://github.com/vchelaru/Gum/tree/main/Samples/SilkNetGum" %}

--- a/docs/code/getting-started/setup/empty-project-before-adding-gum/silk.net.md
+++ b/docs/code/getting-started/setup/empty-project-before-adding-gum/silk.net.md
@@ -2,6 +2,58 @@
 
 ## Introduction
 
-Gum can be used in Silk.NET projects by importing Gum's `Gum.SilkNet` NuGet package. To get a Silk.NET project set up, see the Silk.NET documentation: [https://dotnet.github.io/Silk.NET/docs/v3/](https://dotnet.github.io/Silk.NET/docs/v3/)
+Gum can be used in Silk.NET projects by importing Gum's `Gum.SilkNet` NuGet package. `Gum.SilkNet` renders through SkiaSharp and adds real Forms input via `Silk.NET.Input`; your project still owns window creation and the render loop.
+
+## Creating an New Project
+
+Before using Gum, you should first verify that you can create a normal windowed Silk.NET project. For the full API reference, see the Silk.NET documentation: [https://dotnet.github.io/Silk.NET/docs/v3/](https://dotnet.github.io/Silk.NET/docs/v3/)
+
+If you are starting a brand new Silk.NET project from scratch, you can follow these steps:
+
+{% tabs %}
+{% tab title="Visual Studio" %}
+First, create an empty console project
+
+1. Open Visual Studio
+2. Select File -> New Project, or select the **Create a new project** option in the popup window.
+3. Select the option to create a **Console App**
+4. Enter a name, select a location, then click **Next**
+5. Select the desired **Framework** and other options, then click **Create**
+
+Next, add the needed NuGet package:
+
+1. Expand your game project in the Solution Explorer
+2. Right-click on **Dependencies** and select **Manage NuGet Packages**
+3. Search for and install `Silk.NET.Windowing`
+{% endtab %}
+{% endtabs %}
+
+Once you have your project set up, it might look similar to the following code block — a window that opens and clears to a solid color every frame:
+
+```csharp
+using Silk.NET.Windowing;
+using Silk.NET.Maths;
+
+namespace SilkNetExample1;
+
+public class Program
+{
+    public static void Main()
+    {
+        var options = WindowOptions.Default;
+        options.Size = new Vector2D<int>(800, 480);
+        options.Title = "Gum Sample";
+
+        using var window = Window.Create(options);
+
+        window.Render += delta =>
+        {
+            // Per-frame rendering goes here.
+        };
+
+        window.Run();
+    }
+}
+```
 
 Next, you can begin adding Gum to your project. For more information see the [Adding/Initializing Gum](../adding-initializing-gum/silk.net.md) page.

--- a/docs/code/getting-started/setup/loading-a-gum-project-.gumx.md
+++ b/docs/code/getting-started/setup/loading-a-gum-project-.gumx.md
@@ -32,6 +32,10 @@ Create a folder inside of your game's Content folder, such as `Content/GumProjec
 Create a folder inside of your game's resources folder, such as `resources/GumProject`, then save the file in the newly-created folder.
 {% endtab %}
 
+{% tab title="Silk.NET" %}
+Create a folder inside of your game's Content folder, such as `Content/GumProject`, then save the file in the newly-created folder.
+{% endtab %}
+
 {% tab title="MonoGame/KNI Web" %}
 Web targets (KNI BlazorGL and other WebAssembly hosts) must serve the Gum project from `wwwroot`. Create a folder inside your web project's `wwwroot/Content` folder, such as `wwwroot/Content/GumProject`, then save the file in the newly-created folder.
 
@@ -79,6 +83,16 @@ If you are using the Contentless project ([https://github.com/Ellpeck/Contentles
 ```xml
 <ItemGroup>
     <None Update="resources\GumProject\**\*.*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+</ItemGroup>
+```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
+```xml
+<ItemGroup>
+    <None Update="Content\GumProject\**\*.*">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 </ItemGroup>
@@ -195,6 +209,26 @@ public static void Main()
     // Additional initialization logic goes here
 }
 ```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
+```csharp
+// Initialize
+GumService.Default.Initialize(canvas, inputContext, "Content/GumProject/GumProject.gumx");
+
+// This assumes that your project has at least 1 screen
+if (ObjectFinder.Self.GumProjectSave.Screens.Count == 0)
+{
+    throw new Exception(
+        "No screen found in the Gum project, " +
+        "did you add a Screen in the Gum tool?");
+}
+var screen = ObjectFinder.Self.GumProjectSave.Screens[0]
+    .ToGraphicalUiElement();
+screen.AddToRoot();
+```
+
+See the [Silk.NET setup page](adding-initializing-gum/silk.net.md) for where `canvas` and `inputContext` come from — window/GL/Skia surface setup is elided here since it's the same regardless of whether you load a `.gumx` project.
 {% endtab %}
 
 {% tab title=".NET MAUI" %}

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
@@ -280,6 +280,32 @@ for (int i = 0; i < 3; i++)
 }
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```csharp
+// Initialize
+FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+FrameworkElement.TabKeyCombos.Add(new KeyCombo()
+{
+    PushedKey = Gum.Forms.Input.Keys.Down
+});
+FrameworkElement.TabReverseKeyCombos.Add(new KeyCombo()
+{
+    PushedKey = Gum.Forms.Input.Keys.Up
+});
+
+var mainPanel = new StackPanel();
+mainPanel.AddToRoot();
+mainPanel.Spacing = 6;
+for (int i = 0; i < 3; i++)
+{
+    var button = new Button();
+    button.Text = $"Button {i + 1}";
+    if (i == 0) button.IsFocused = true;
+    mainPanel.AddChild(button);
+}
+```
+{% endtab %}
 {% endtabs %}
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACrVSTUvDQBC991cMwUNKZVEED2oP2lopIpR-gIdcNsnELk1myu6mVUv-u5M0bRX06F6GfW_mvWHf7joAwdg9lUVwA96WeF4Dhow3OjefKGiw0RYKbWiiCXPoA-EWZl4nqwYIu7cRHWl1n6ZznjL7Bh9ZXeCW7eoxxwLJq2f8iFnb1I3YLsyAyVtuhkJZYYZ2YxJUQ8x0mZ-af1Wa61j4ARcxu0agXuuAhN2IdhGBnEnplpgKIZu_mMSy48yrV9LqKKnGtC4bO6eGvKWIqr8sp7hB6_A_nBfr1vf7c87WOjH0JgrXwmRsITTkwQhwcSvlDq6k9Hon1zqtuPSeqY3qobk0cdT8nlNzfPfScBYFex52BnpwWUVB22cysYK--HQPM2NJLSkdpjJY_5W280f4g6XJ03A_UFtWQafqfAE2d5mXZgIAAA)
 
@@ -323,6 +349,38 @@ void HandleTabKeyDown(object sender, KeyEventArgs args)
 {% endtab %}
 
 {% tab title="Raylib" %}
+```csharp
+// Initialize
+var mainPanel = new StackPanel();
+mainPanel.AddToRoot();
+
+var slider = new Slider();
+mainPanel.AddChild(slider);
+
+var button = new Button();
+button.IsFocused = true;
+button.KeyDown += HandleTabKeyDown;
+mainPanel.AddChild(button);
+
+var button2 = new Button();
+button2.KeyDown += HandleTabKeyDown;
+mainPanel.AddChild(button2);
+
+void HandleTabKeyDown(object sender, KeyEventArgs args)
+{
+    if(args.Key == Gum.Forms.Input.Keys.Right)
+    {
+        ((FrameworkElement)sender).HandleTab(TabDirection.Down);
+    }
+    else if(args.Key == Gum.Forms.Input.Keys.Left)
+    {
+        ((FrameworkElement)sender).HandleTab(TabDirection.Up);
+    }
+}
+```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
 ```csharp
 // Initialize
 var mainPanel = new StackPanel();

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/input-in-forms.md
@@ -60,23 +60,27 @@ By default Gum controls work with the mouse and touch screen. The mouse automati
 
 Gum supports applying input from the keyboard and gamepads. By default the TextBox and PasswordBox forms types automatically receive input from the keyboard without any additional setup. All other interactive Forms controls can receive input from the keyboard and gamepads, but this input must be enabled.
 
-To enable keyboard input, add the keyboard to the FrameworkElement.KeyboardsForUiControl list as shown in the following code block:
+To enable keyboard input, call `GumService.Default.UseKeyboardDefaults()`:
 
 ```csharp
 // Initialize
-FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+GumService.Default.UseKeyboardDefaults();
 ```
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACl2Qy07DMBBF9_mKwatEVPmAVkGC0KKKTUXKLlLlxoOw4tjVeNzyEP-O41YEdekzZ66v_Z0BiLV_CoOYA1PA2Qi01ayl0V8YqThKgkFqu5EWDVRg8QQNy65PIC8Wrf0bl_dKbd2Lc5z4iuSAJ0f90uCAlstn_Nw7ScqvHL3q2lkml5byWKFBOuoOy0d8k8FM8pg0ltgHZmcvDR7SId1y5uUWPzgOW7Eh9B6ag-wQHMHSMlIrJrE2uuvhtoJ8N4NdAdXdJXqKSAqqm_9r61i6Cx5VNMavun53_a6Nys9ysRDZT_YLwXDrNF4BAAA)
 
-To enable gamepad input, add the gamepad to the FrameworkElement.GamePadsForUiControl list as shown in the following code block:
+`UseKeyboardDefaults()` is shorthand for `FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard)`.
+
+To enable gamepad input, call `GumService.Default.UseGamepadDefaults()`:
 
 ```csharp
 // Initialize
-FrameworkElement.GamePadsForUiControl.AddRange(GumService.Default.Gamepads);
+GumService.Default.UseGamepadDefaults();
 ```
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACl2QwU7DMAyG730Kk1Mrpj4AU5FGYdNu1TZulabQeGA1TVDibAjEu5OmFUMc_fv_7N_-ygDE1m_CIO6AXcDFKJAhJqnpE6MqztLBIMk00qCGCgxeYM-y65OQF8vW_LbLlVIHu7OWk752csCLdf2TxgENl5tYN1L5tXXPVFvDziZmJ80r5jHGHt2ZOiwf8SSDnoD3CIzTxiAvgdmaOcVDKtKmSS8P-MGx2YrGofcw07BqxdVTa-p6uK0gPy7gWEB1P0-90smC6uYvto2hu-BRRcf4qf9n12-kVT6Zi6XIvrMfW6v54F0BAAA)
 
-Notice that both KeyboardsForUiControl and GamePadsForUiControl are lists. If you do not want your game to support keyboard input you can keep the KeyboardsForUiControl empty. You can selectively add gamepads to GamePadsForUiControl depending on whether you only want some of the gamepads to control UI. For example, you may only want to read input from gamepads which have joined the game.
+`UseGamepadDefaults()` is shorthand for `FrameworkElement.GamePadsForUiControl.AddRange(GumService.Default.Gamepads)`.
+
+Both `KeyboardsForUiControl` and `GamePadsForUiControl` are plain lists, and the default methods above just add to them — you can bypass the defaults and manipulate the lists directly for advanced scenarios. If you do not want your game to support keyboard input, skip `UseKeyboardDefaults()` and keep `KeyboardsForUiControl` empty. For gamepads, you can selectively `Add` individual pads to `GamePadsForUiControl` instead of calling `UseGamepadDefaults()`, if you only want some of the gamepads to control UI — for example, only gamepads which have joined the game.
 
 {% hint style="info" %}
 Most games either support the main keyboard or no keyboard input. KeyboardsForUiControl is a list, allowing for advanced scenarios such as controlling UI using a virtual keyboard. This advanced scenario is not covered in this tutorial.
@@ -86,8 +90,8 @@ Once keyboard and gamepads are added to their appropriate lists, focused forms c
 
 ```csharp
 // Initialize
-FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
-FrameworkElement.GamePadsForUiControl.AddRange(GumService.Default.Gamepads);
+GumService.Default.UseKeyboardDefaults();
+GumService.Default.UseGamepadDefaults();
 
 var mainPanel = new StackPanel();
 mainPanel.AddToRoot();
@@ -232,7 +236,7 @@ For example, the following code adds the ability to tab by pressing the up and d
 {% tab title="MonoGame" %}
 ```csharp
 // Initialize
-FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+GumService.Default.UseKeyboardDefaults();
 FrameworkElement.TabKeyCombos.Add(new KeyCombo()
 {
     PushedKey = Microsoft.Xna.Framework.Input.Keys.Down
@@ -258,7 +262,7 @@ for (int i = 0; i < 3; i++)
 {% tab title="Raylib" %}
 ```csharp
 // Initialize
-FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+GumService.Default.UseKeyboardDefaults();
 FrameworkElement.TabKeyCombos.Add(new KeyCombo()
 {
     PushedKey = Gum.Forms.Input.Keys.Down
@@ -284,7 +288,7 @@ for (int i = 0; i < 3; i++)
 {% tab title="Silk.NET" %}
 ```csharp
 // Initialize
-FrameworkElement.KeyboardsForUiControl.Add(GumService.Default.Keyboard);
+GumService.Default.UseKeyboardDefaults();
 FrameworkElement.TabKeyCombos.Add(new KeyCombo()
 {
     PushedKey = Gum.Forms.Input.Keys.Down

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
@@ -168,6 +168,57 @@ public class Program
 }
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+A full Silk.NET project requires more setup than fits cleanly in a tutorial snippet (window creation, GL/ANGLE backend selection, wiring the SkiaSharp surface) — see the [Silk.NET setup page](../../setup/adding-initializing-gum/silk.net.md) for that detail and a link to a working sample. Once the window, `SKCanvas`, and `IInputContext` exist, the Gum-specific calls are the same shape as MonoGame/Raylib:
+
+```csharp
+using Gum;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Silk.NET.Windowing;
+using Silk.NET.Input;
+using SkiaSharp;
+
+namespace MyGumProject;
+
+public class Program
+{
+    static GumService GumUI => GumService.Default;
+
+    public static void Main()
+    {
+        Silk.NET.Windowing.Sdl.SdlWindowing.Use();
+
+        IWindow window = Window.Create(WindowOptions.Default);
+        window.Initialize();
+
+        // SkiaSharp GL surface/canvas creation is omitted here for brevity -- see the
+        // Silk.NET setup page and sample for the full ANGLE/backend setup.
+        SKCanvas canvas = CreateSkiaCanvas(window);
+        IInputContext inputContext = window.CreateInput();
+
+        GumUI.Initialize(canvas, inputContext);
+
+        var mainPanel = new StackPanel();
+        mainPanel.AddToRoot();
+
+        var totalTime = System.Diagnostics.Stopwatch.StartNew();
+
+        while (!window.IsClosing)
+        {
+            window.DoEvents();
+
+            GumUI.Update(totalTime.Elapsed.TotalSeconds);
+
+            canvas.Clear(SKColors.CornflowerBlue);
+            GumUI.Draw();
+            // Present the frame (SwapBuffers) -- see the sample for the full call.
+        }
+    }
+}
+```
+{% endtab %}
 {% endtabs %}
 
 The code above includes the following sections:

--- a/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
+++ b/docs/code/getting-started/tutorials/code-only-gum-forms-tutorial/setup.md
@@ -10,7 +10,7 @@ This tutorial uses Gum's default visuals to keep the dependency footprint minima
 
 ## Introduction
 
-This tutorial walks you through turning an empty MonoGame or Raylib project into a code-only Gum project, which acts as a starting point for the rest of the tutorials.
+This tutorial walks you through turning an empty MonoGame, Raylib, or Silk.NET project into a code-only Gum project, which acts as a starting point for the rest of the tutorials.
 
 This tutorial covers:
 
@@ -18,7 +18,7 @@ This tutorial covers:
 * Adding the code to initialize, update, and draw Gum
 * Adding your first Gum control (Button)
 
-Everything after you have a root container is identical across MonoGame and Raylib. The only part that differs is the host application skeleton on this Setup page — once Gum is initialized, the rest of the tutorial series is fully shared.
+Everything after you have a root container is identical across MonoGame, Raylib, and Silk.NET. The only part that differs is the host application skeleton on this Setup page — once Gum is initialized, the rest of the tutorial series is fully shared.
 
 ## Adding Gum NuGet Packages
 
@@ -48,11 +48,27 @@ Or add through the command line:
 dotnet add package Gum.raylib
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+Add the `Gum.SilkNet` package to your game ([https://www.nuget.org/packages/Gum.SilkNet](https://www.nuget.org/packages/Gum.SilkNet)). For more information see the [Silk.NET setup page](../../setup/adding-initializing-gum/silk.net.md).
+
+Modify csproj:
+
+```xml
+<PackageReference Include="Gum.SilkNet" />
+```
+
+Or add through the command line:
+
+```bash
+dotnet add package Gum.SilkNet
+```
+{% endtab %}
 {% endtabs %}
 
 ## Adding Gum to Your Game
 
-Gum requires a few lines of code to get started. The host application skeleton differs by platform — MonoGame uses a `Game` subclass whose `Initialize`/`Update`/`Draw` methods the framework calls for you, while Raylib uses a `Program.Main` with a game loop you own. The Gum calls themselves are the same on both backends: initialize once, then update and draw each frame.
+Gum requires a few lines of code to get started. The host application skeleton differs by platform — MonoGame uses a `Game` subclass whose `Initialize`/`Update`/`Draw` methods the framework calls for you, Raylib uses a `Program.Main` with a game loop you own, and Silk.NET uses a `Program.Main` that creates its own window and hands Gum an `SKCanvas`/`IInputContext` pair. The Gum calls themselves follow the same shape on every backend: initialize once, then update and draw each frame.
 
 A simplified host with the required calls would look like the following code:
 

--- a/docs/code/monogame/README.md
+++ b/docs/code/monogame/README.md
@@ -14,7 +14,7 @@ This section uses screenshots of the Gum tool so you can see what is possible wi
 
 ### Sample Projects
 
-If you prefer to dive in and see things working, the Gum repository includes sample projects that show how to work with Gum purely in code, and also how to load a Gum project into a MonoGame project.
+If you prefer to dive in and see things working, the Gum repository includes sample projects that show how to work with Gum purely in code, and also how to load a Gum project into a MonoGame, raylib, or Silk.NET project — including `SilkNetGum` and `SilkNetGumThemesShowcase` for Silk.NET.
 
 You can clone the repository and open the projects in your favorite IDE (like Visual Studio) and try them out.
 

--- a/docs/code/monogame/layered-forms.md
+++ b/docs/code/monogame/layered-forms.md
@@ -16,6 +16,10 @@ button.AddToRoot();
 
 Although this is convenient, the Button must be drawn on the same layer as the root. Instead, we an create a custom layer and add the Button to the layer. However, controls which are not added to Root will not receive automatic updates, so they will not receive input events such as clicks from a cursor.
 
+{% hint style="info" %}
+Creating a `Layer` and setting `LayerCameraSettings` (steps 1-4 below) works the same on every backend. The custom-root-list `Update` overload shown in step 6 (`GumUI.Update(gameTime, itemsToUpdate)`) is available on MonoGame/KNI/FNA and raylib; Silk.NET's `Update(double totalSeconds)` does not currently accept a root list, so this exact multi-root update pattern isn't available there yet.
+{% endhint %}
+
 At a high level, the steps to creating a layered button are:
 
 1. Create a Layer

--- a/docs/code/standard-visuals/circleruntime.md
+++ b/docs/code/standard-visuals/circleruntime.md
@@ -15,7 +15,7 @@ A `CircleRuntime` also exposes a `Radius` property, but sizing through `Width` /
 {% endhint %}
 
 {% hint style="info" %}
-On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, and raylib support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
 {% endhint %}
 
 ### Code Example

--- a/docs/code/standard-visuals/circleruntime.md
+++ b/docs/code/standard-visuals/circleruntime.md
@@ -15,7 +15,9 @@ A `CircleRuntime` also exposes a `Radius` property, but sizing through `Width` /
 {% endhint %}
 
 {% hint style="info" %}
-On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. See the [Shapes](shapes-apos.shapes.md) page for setup.
+
+Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively — no additional package needed.
 {% endhint %}
 
 ### Code Example

--- a/docs/code/standard-visuals/rectangleruntime.md
+++ b/docs/code/standard-visuals/rectangleruntime.md
@@ -11,7 +11,7 @@ A freshly-constructed `RectangleRuntime` is 50 × 50 and renders as a **stroke-o
 For the full property surface — fill, outline, corner radius, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md#circleruntime-and-rectangleruntime) page. The examples below cover the common cases.
 
 {% hint style="info" %}
-On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, and raylib support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
 {% endhint %}
 
 ### Code Example

--- a/docs/code/standard-visuals/rectangleruntime.md
+++ b/docs/code/standard-visuals/rectangleruntime.md
@@ -11,7 +11,9 @@ A freshly-constructed `RectangleRuntime` is 50 × 50 and renders as a **stroke-o
 For the full property surface — fill, outline, corner radius, gradient, drop shadow, dashed stroke, and the platform/package requirements — see the [Shapes](shapes-apos.shapes.md#circleruntime-and-rectangleruntime) page. The examples below cover the common cases.
 
 {% hint style="info" %}
-On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively. See the [Shapes](shapes-apos.shapes.md) page for setup.
+On MonoGame, KNI, and FNA the outline and geometry render out of the box, but the **fill** and the richer effects (gradient, drop shadow, dashed stroke, anti-aliasing) only draw once the `Gum.Shapes.<platform>` package is added — otherwise they are stored and round-trip but silently do not draw. See the [Shapes](shapes-apos.shapes.md) page for setup.
+
+Skia, .NET MAUI, raylib, and Silk.NET support the full surface natively — no additional package needed.
 {% endhint %}
 
 ### Code Example

--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -102,7 +102,7 @@ BubblegumTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Bubblegum.Raylib --prerelease
+dotnet add package Gum.Themes.Bubblegum.Raylib
 ```
 
 ```csharp
@@ -185,7 +185,7 @@ DarkProTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.DarkPro.Raylib --prerelease
+dotnet add package Gum.Themes.DarkPro.Raylib
 ```
 
 ```csharp
@@ -264,7 +264,7 @@ EditorTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Editor.Raylib --prerelease
+dotnet add package Gum.Themes.Editor.Raylib
 ```
 
 ```csharp
@@ -346,7 +346,7 @@ ForestGladeTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.ForestGlade.Raylib --prerelease
+dotnet add package Gum.Themes.ForestGlade.Raylib
 ```
 
 ```csharp
@@ -435,7 +435,7 @@ HazardTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Hazard.Raylib --prerelease
+dotnet add package Gum.Themes.Hazard.Raylib
 ```
 
 ```csharp
@@ -527,7 +527,7 @@ MeadowTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Meadow.Raylib --prerelease
+dotnet add package Gum.Themes.Meadow.Raylib
 ```
 
 ```csharp
@@ -618,7 +618,7 @@ NeonTheme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Neon.Raylib --prerelease
+dotnet add package Gum.Themes.Neon.Raylib
 ```
 
 ```csharp
@@ -703,7 +703,7 @@ Retro95Theme.Apply();
 
 {% tab title="Raylib" %}
 ```bash
-dotnet add package Gum.Themes.Retro95.Raylib --prerelease
+dotnet add package Gum.Themes.Retro95.Raylib
 ```
 
 ```csharp
@@ -759,7 +759,7 @@ All bundled fonts are SIL Open Font License or the Bitstream Vera / DejaVu licen
 
 ## Supported backends
 
-Themes are published for **MonoGame**, **KNI**, **Raylib** (Raylib in preview — see the note under [Usage](./#usage)), and **Silk.NET**. If you'd like to see a theme published for **FNA** or **Skia** (WPF, .NET MAUI), please open an issue or start a discussion on the [Gum GitHub repo](https://github.com/vchelaru/Gum).
+Themes are published for **MonoGame**, **KNI**, **Raylib**, and **Silk.NET**. If you'd like to see a theme published for **FNA** or **Skia** (WPF, .NET MAUI), please open an issue or start a discussion on the [Gum GitHub repo](https://github.com/vchelaru/Gum).
 
 ## Requirements
 

--- a/docs/code/styling/themes/README.md
+++ b/docs/code/styling/themes/README.md
@@ -16,10 +16,10 @@ Here are six of Gum's built-in themes, each rendering the same sample settings p
 
 A **theme** is a per-backend NuGet package that restyles every default Gum Forms control with a single call. After calling `GumService.Default.Initialize(...)`, calling `<Name>Theme.Apply` swaps the default visuals for the theme's visuals — every `Button`, `TextBox`, `CheckBox`, `ComboBox`, etc. created afterward renders in that theme's style.
 
-Themes ship one NuGet per rendering backend (for example `Gum.Themes.DarkPro.MonoGame`, `Gum.Themes.DarkPro.Kni`, and `Gum.Themes.DarkPro.Raylib`) so each package only carries the assets and references it needs.
+Themes ship one NuGet per rendering backend (for example `Gum.Themes.DarkPro.MonoGame`, `Gum.Themes.DarkPro.Kni`, `Gum.Themes.DarkPro.Raylib`, and `Gum.Themes.DarkPro.SilkNet`) so each package only carries the assets and references it needs.
 
 {% hint style="warning" %}
-All themes install and initialize KernSmith for dynamic font generation. Also, all themes except `Editor` install and initialize Apos.Shapes for vector art rendering on MonoGame/KNI. For more information see the [KernSmith](../../files-and-fonts/font-strategies.md#dynamic-kernsmith-generation) and [Apos.Shapes](../../standard-visuals/shapes-apos.shapes.md) pages.
+On MonoGame, KNI, and Raylib, all themes install and initialize KernSmith for dynamic font generation, and all themes except `Editor` install and initialize Apos.Shapes for vector art rendering on MonoGame/KNI. Silk.NET themes need neither package — Silk.NET renders through SkiaSharp, which rasterizes fonts and vector art directly. For more information see the [KernSmith](../../files-and-fonts/font-strategies.md#dynamic-kernsmith-generation), [Dynamic Generation on SkiaGum](../../files-and-fonts/font-strategies.md#dynamic-generation-on-skiagum), and [Apos.Shapes](../../standard-visuals/shapes-apos.shapes.md) pages.
 {% endhint %}
 
 ## Usage
@@ -112,6 +112,19 @@ using Gum.Themes.Bubblegum;
 BubblegumTheme.Apply();
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Bubblegum.SilkNet
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Bubblegum;
+
+BubblegumTheme.Apply();
+```
+{% endtab %}
 {% endtabs %}
 
 #### How to customize
@@ -182,6 +195,19 @@ using Gum.Themes.DarkPro;
 DarkProTheme.Apply();
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.DarkPro.SilkNet
+```
+
+```csharp
+// Initialize
+using Gum.Themes.DarkPro;
+
+DarkProTheme.Apply();
+```
+{% endtab %}
 {% endtabs %}
 
 #### How to customize
@@ -239,6 +265,19 @@ EditorTheme.Apply();
 {% tab title="Raylib" %}
 ```bash
 dotnet add package Gum.Themes.Editor.Raylib --prerelease
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Editor;
+
+EditorTheme.Apply();
+```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Editor.SilkNet
 ```
 
 ```csharp
@@ -317,6 +356,19 @@ using Gum.Themes.ForestGlade;
 ForestGladeTheme.Apply();
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.ForestGlade.SilkNet
+```
+
+```csharp
+// Initialize
+using Gum.Themes.ForestGlade;
+
+ForestGladeTheme.Apply();
+```
+{% endtab %}
 {% endtabs %}
 
 {% hint style="info" %}
@@ -384,6 +436,19 @@ HazardTheme.Apply();
 {% tab title="Raylib" %}
 ```bash
 dotnet add package Gum.Themes.Hazard.Raylib --prerelease
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Hazard;
+
+HazardTheme.Apply();
+```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Hazard.SilkNet
 ```
 
 ```csharp
@@ -472,6 +537,19 @@ using Gum.Themes.Meadow;
 MeadowTheme.Apply();
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Meadow.SilkNet
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Meadow;
+
+MeadowTheme.Apply();
+```
+{% endtab %}
 {% endtabs %}
 
 {% hint style="info" %}
@@ -541,6 +619,19 @@ NeonTheme.Apply();
 {% tab title="Raylib" %}
 ```bash
 dotnet add package Gum.Themes.Neon.Raylib --prerelease
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Neon;
+
+NeonTheme.Apply();
+```
+{% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Neon.SilkNet
 ```
 
 ```csharp
@@ -622,6 +713,19 @@ using Gum.Themes.Retro95;
 Retro95Theme.Apply();
 ```
 {% endtab %}
+
+{% tab title="Silk.NET" %}
+```bash
+dotnet add package Gum.Themes.Retro95.SilkNet
+```
+
+```csharp
+// Initialize
+using Gum.Themes.Retro95;
+
+Retro95Theme.Apply();
+```
+{% endtab %}
 {% endtabs %}
 
 #### How to customize
@@ -655,11 +759,11 @@ All bundled fonts are SIL Open Font License or the Bitstream Vera / DejaVu licen
 
 ## Supported backends
 
-Themes are published for **MonoGame**, **KNI**, and **Raylib** (Raylib in preview — see the note under [Usage](./#usage)). If you'd like to see a theme published for **FNA** or **Skia**, please open an issue or start a discussion on the [Gum GitHub repo](https://github.com/vchelaru/Gum).
+Themes are published for **MonoGame**, **KNI**, **Raylib** (Raylib in preview — see the note under [Usage](./#usage)), and **Silk.NET**. If you'd like to see a theme published for **FNA** or **Skia** (WPF, .NET MAUI), please open an issue or start a discussion on the [Gum GitHub repo](https://github.com/vchelaru/Gum).
 
 ## Requirements
 
 * .NET 8.0+
-* MonoGame 3.8+ (for the MonoGame packages), KNI (for the KNI packages), or Raylib (for the Raylib packages)
-* [Gum.MonoGame](https://www.nuget.org/packages/Gum.MonoGame), [Gum.Kni](https://www.nuget.org/packages/Gum.Kni), or [Gum.raylib](https://www.nuget.org/packages/Gum.raylib)
-* [KernSmith.MonoGameGum](https://www.nuget.org/packages/KernSmith.MonoGameGum) — optional, only needed when using runtime in-memory font generation
+* MonoGame 3.8+ (for the MonoGame packages), KNI (for the KNI packages), Raylib (for the Raylib packages), or Silk.NET (for the Silk.NET packages)
+* [Gum.MonoGame](https://www.nuget.org/packages/Gum.MonoGame), [Gum.Kni](https://www.nuget.org/packages/Gum.Kni), [Gum.raylib](https://www.nuget.org/packages/Gum.raylib), or [Gum.SilkNet](https://www.nuget.org/packages/Gum.SilkNet)
+* [KernSmith.MonoGameGum](https://www.nuget.org/packages/KernSmith.MonoGameGum) or [KernSmith.RaylibGum](https://www.nuget.org/packages/KernSmith.RaylibGum) for the MonoGame/KNI/Raylib packages — optional, only needed for runtime font generation on those backends. Silk.NET renders through SkiaSharp, which rasterizes glyphs directly and needs no equivalent package — see [Dynamic Generation on SkiaGum](../../files-and-fonts/font-strategies.md#dynamic-generation-on-skiagum)

--- a/docs/gum-tool/animations/README.md
+++ b/docs/gum-tool/animations/README.md
@@ -17,5 +17,5 @@ Animations are defined per element (Screen, Component, or Standard element) and 
 The **Add Named Event** option places a named marker at a point in time on an animation.
 
 {% hint style="info" %}
-**Named Events** are not used by Gum's own runtimes (MonoGame, KNI, FNA, raylib, SkiaSharp) — they are saved and loaded but never raised. They exist for integration with FlatRedBall (FRB1). Unless you are using Gum with FlatRedBall (FRB1), you can ignore the **Add Named Event** option.
+**Named Events** are not used by Gum's own runtimes (MonoGame, KNI, FNA, raylib, SkiaSharp, Silk.NET) — they are saved and loaded but never raised. They exist for integration with FlatRedBall (FRB1). Unless you are using Gum with FlatRedBall (FRB1), you can ignore the **Add Named Event** option.
 {% endhint %}

--- a/docs/gum-tool/upgrading/migrating-to-2026-july-2nd-release.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-july-2nd-release.md
@@ -8,6 +8,8 @@ This page discusses breaking changes and other considerations when migrating fro
 
 This release renames the explicit-font-object property on `TextRuntime` to `Typeface`, unifying a name that previously differed per backend (`BitmapFont` on MonoGame/KNI/FNA, `CustomFont` on raylib) and adding the same capability to SkiaSharp for the first time. This is a **soft break**: the old names still compile and work, but now emit a `CS0618` obsolete warning.
 
+This release also promotes Silk.NET to a first-class Gum runtime — see "Silk.NET Is Now a First-Class Runtime" below. This is purely additive; no migration is required.
+
 ## Upgrading the Gum Tool
 
 {% tabs %}
@@ -32,12 +34,21 @@ This release's runtime ships as NuGet version **`2026.7.22.1`**. Upgrade your Gu
 * KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
 * FNA - [https://www.nuget.org/packages/Gum.FNA/](https://www.nuget.org/packages/Gum.FNA/)
 * raylib - [https://www.nuget.org/packages/Gum.raylib](https://www.nuget.org/packages/Gum.raylib)
+* Silk.NET - [https://www.nuget.org/packages/Gum.SilkNet](https://www.nuget.org/packages/Gum.SilkNet)
 * .NET MAUI - [https://www.nuget.org/packages/Gum.SkiaSharp.Maui](https://www.nuget.org/packages/Gum.SkiaSharp.Maui)
 * SkiaSharp - [https://www.nuget.org/packages/Gum.SkiaSharp/](https://www.nuget.org/packages/Gum.SkiaSharp/)
 
 If using GumCommon directly, you can update the GumCommon NuGet:
 
 * GumCommon - [https://www.nuget.org/packages/FlatRedBall.GumCommon](https://www.nuget.org/packages/FlatRedBall.GumCommon)
+
+## Silk.NET Is Now a First-Class Runtime
+
+Silk.NET moves from shared source (no dedicated package) to a real `Gum.SilkNet` NuGet package with real Forms input — mouse, keyboard, and focus — via `Silk.NET.Input`, rendering through SkiaGum. See the [Silk.NET setup page](../../code/getting-started/setup/adding-initializing-gum/silk.net.md) to get started.
+
+Eight built-in themes also gained a Silk.NET variant this release: Bubblegum, DarkPro, Editor, Forest Glade, Hazard, Meadow, Neon, and Retro95. See the [Themes reference](../../code/styling/themes/README.md) for install/usage per theme.
+
+This is purely additive — no existing code needs to change.
 
 ## Breaking Changes and Migrations
 

--- a/docs/gum-tool/upgrading/migrating-to-2026-july-2nd-release.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-july-2nd-release.md
@@ -8,8 +8,6 @@ This page discusses breaking changes and other considerations when migrating fro
 
 This release renames the explicit-font-object property on `TextRuntime` to `Typeface`, unifying a name that previously differed per backend (`BitmapFont` on MonoGame/KNI/FNA, `CustomFont` on raylib) and adding the same capability to SkiaSharp for the first time. This is a **soft break**: the old names still compile and work, but now emit a `CS0618` obsolete warning.
 
-This release also promotes Silk.NET to a first-class Gum runtime — see "Silk.NET Is Now a First-Class Runtime" below. This is purely additive; no migration is required.
-
 ## Upgrading the Gum Tool
 
 {% tabs %}
@@ -34,21 +32,12 @@ This release's runtime ships as NuGet version **`2026.7.22.1`**. Upgrade your Gu
 * KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
 * FNA - [https://www.nuget.org/packages/Gum.FNA/](https://www.nuget.org/packages/Gum.FNA/)
 * raylib - [https://www.nuget.org/packages/Gum.raylib](https://www.nuget.org/packages/Gum.raylib)
-* Silk.NET - [https://www.nuget.org/packages/Gum.SilkNet](https://www.nuget.org/packages/Gum.SilkNet)
 * .NET MAUI - [https://www.nuget.org/packages/Gum.SkiaSharp.Maui](https://www.nuget.org/packages/Gum.SkiaSharp.Maui)
 * SkiaSharp - [https://www.nuget.org/packages/Gum.SkiaSharp/](https://www.nuget.org/packages/Gum.SkiaSharp/)
 
 If using GumCommon directly, you can update the GumCommon NuGet:
 
 * GumCommon - [https://www.nuget.org/packages/FlatRedBall.GumCommon](https://www.nuget.org/packages/FlatRedBall.GumCommon)
-
-## Silk.NET Is Now a First-Class Runtime
-
-Silk.NET moves from shared source (no dedicated package) to a real `Gum.SilkNet` NuGet package with real Forms input — mouse, keyboard, and focus — via `Silk.NET.Input`, rendering through SkiaGum. See the [Silk.NET setup page](../../code/getting-started/setup/adding-initializing-gum/silk.net.md) to get started.
-
-Eight built-in themes also gained a Silk.NET variant this release: Bubblegum, DarkPro, Editor, Forest Glade, Hazard, Meadow, Neon, and Retro95. See the [Themes reference](../../code/styling/themes/README.md) for install/usage per theme.
-
-This is purely additive — no existing code needs to change.
 
 ## Breaking Changes and Migrations
 

--- a/docs/gum-tool/upgrading/syntax-versions.md
+++ b/docs/gum-tool/upgrading/syntax-versions.md
@@ -2,7 +2,7 @@
 
 ## What Is a Syntax Version?
 
-A syntax version is an integer stamped on each Gum runtime assembly (MonoGameGum, RaylibGum, SkiaGum) via the `GumSyntaxVersionAttribute`. It tells the Gum tool's code generator which namespaces and conventions to use when emitting C# code for your project.
+A syntax version is an integer stamped on each Gum runtime assembly (MonoGameGum, RaylibGum, SkiaGum, SilkNetGum) via the `GumSyntaxVersionAttribute`. It tells the Gum tool's code generator which namespaces and conventions to use when emitting C# code for your project.
 
 When the Gum team makes a breaking namespace change (such as moving enums to a unified namespace), the syntax version is incremented. The code generator reads the syntax version from the runtime your project references and emits code that matches.
 


### PR DESCRIPTION
## Summary
- Fills the docs gap left by Silk.NET's promotion to a first-class runtime (`Gum.SilkNet`, real Forms input, 8 theme ports): flagship tutorial, theme docs, .gumx loading, tab-key input, empty-project/adding-initializing setup pages, and platform-enumeration one-liners now include Silk.NET alongside MonoGame/raylib.
- Adds a changelog entry to `migrating-to-2026-july-2nd-release.md` (Silk.NET's promotion shipped in this release, per commit dates).
- Corrects `gum-docs-writing`/`docs-writer.md` to require checking the relevant domain skill/source before writing a runtime-capability claim — added after two wrong claims mid-session about Silk.NET's font support (it has full dynamic font generation + custom .ttf loading via SkiaSharp, same as SkiaGum; the only real gaps are no KernSmith and no `.otf` support).
- Notes one genuine (not doc-only) gap found along the way: Silk.NET's `Update(double)` has no multi-root overload, so the layered-forms "custom root list" pattern isn't available there yet — flagged in `layered-forms.md`, not silently glossed over.

## Test plan
- [x] Verified all `{% hint %}`/`{% endhint %}` and `{% tabs %}`/`{% endtabs %}` pairs balance in every changed doc file.
- [x] Cross-checked every capability claim (dynamic fonts, RegisterFont, UseSingleThreadedAsync, animation chains, syntax version attribute, .gumx loading signature, Keys enum) against source before writing it.
- Docs-only change; no runtime/tool code touched.
