### PR TITLE
Eliminate per-frame Text layout allocations in the wrapping/measure path (#1934)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -232,6 +232,67 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         result.TotalBytes.ShouldBe(0);
     }
 
+    // #1934 allocation pass: the genuinely-wrapping path (text that does NOT fit on one line, so it
+    // can't take the single-line fast path) was the residual full-relayout allocator — it re-tokenized
+    // via String.Split, allocated a fresh List, and concatenated a throwaway "currentLine + currentWord"
+    // string on every word just to measure the candidate line. The only allocation a genuine wrap can't
+    // avoid is the output line strings themselves (one string per wrapped line); everything else — the
+    // Split array, the word List, and the per-word measurement concatenations — is pure per-frame garbage
+    // that must be eliminated. This pins the wrapping path to at most the output-line cost plus headroom.
+    [Fact]
+    public void UpdateWrappedText_WhenTextWrapsToMultipleLines_AllocatesOnlyOutputLines()
+    {
+        const int advance = 10;
+        BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: 20));
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        // Width 25 fits one two-char word (20) but not two words with a space ("AA BB" = 50), so the
+        // three words wrap to three lines: "AA ", "BB ", "CC".
+        text.Width = 25;
+        text.RawText = "AA BB CC";
+        text.WrappedText.Count.ShouldBe(3); // liveness guard: the scenario really does wrap word-by-word
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => text.UpdateWrappedText(),
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        // What remains is the three output line strings ("AA ", "BB ", "CC") plus the per-word substrings
+        // the tokenizer produces (~160 B/frame locally, down from ~360). The word List is pooled, the
+        // Split array is gone, and the per-word measurement concatenations no longer allocate — those were
+        // the eliminated waste. The bound pins that win with headroom for runtime/runner variance.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(200);
+    }
+
+    // #1934 allocation pass: UpdatePreRenderDimensions runs during layout whenever a Text's size changes,
+    // and it measures the wrapped lines via BitmapFont.GetRequiredWidthAndHeight. WrappedText is a
+    // List<string>, but the only no-widths overload took IEnumerable<string>, so the foreach boxed the
+    // List's struct enumerator — ~40 bytes of garbage per Text per frame (the actual residual in the
+    // realistic-Forms full relayout, NOT the word-by-word wrap path). Routing to a List<string> overload
+    // removes the boxing, so re-measuring an unchanged wrapped Text is allocation-free.
+    [Fact]
+    public void UpdatePreRenderDimensions_DoesNotAllocate()
+    {
+        const int advance = 10;
+        BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: 20));
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.Width = 25;
+        text.RawText = "AA BB CC"; // wraps to three lines, so measurement iterates a multi-entry List
+        text.WrappedText.Count.ShouldBe(3);
+
+        AllocationResult result = AllocationMeasurer.Measure(
+            () => text.UpdatePreRenderDimensions(),
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        result.TotalBytes.ShouldBe(0);
+    }
+
     // #3520: a base run that FOLLOWS a font-swap run (like " text." after [FontSize=40]big[/FontSize])
     // must be measured at the base size. Reproduces the residual under-measurement the manual test
     // showed: the mid-line swap grows the box, but the trailing run was still being dropped/mismeasured.

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -1134,6 +1134,18 @@ public class BitmapFont : IDisposable
         GetRequiredWidthAndHeight(lines, out requiredWidth, out requiredHeight, null);
     }
 
+    /// <inheritdoc cref="GetRequiredWidthAndHeight(List{string}, out int, out int, List{int}?)"/>
+    /// <remarks>
+    /// A <see cref="List{T}"/> overload so callers passing a concrete <see cref="List{String}"/> (e.g. a
+    /// Text's WrappedText) route to the indexed, non-boxing loop instead of the <see cref="IEnumerable{T}"/>
+    /// overload, whose foreach boxes the list's struct enumerator every call — ~40 bytes of per-frame layout
+    /// garbage (issue #1934).
+    /// </remarks>
+    public void GetRequiredWidthAndHeight(List<string> lines, out int requiredWidth, out int requiredHeight)
+    {
+        GetRequiredWidthAndHeight(lines, out requiredWidth, out requiredHeight, null);
+    }
+
     // This sucks, but if we pass an IEnumerable, it allocates memory like crazy. Duplicate code to handle List to reduce alloc
     //public void GetRequiredWidthAndHeight(IEnumerable<string> lines, out int requiredWidth, out int requiredHeight, List<int> widths)
     /// <summary>

--- a/RenderingLibrary/Graphics/IWrappedText.cs
+++ b/RenderingLibrary/Graphics/IWrappedText.cs
@@ -42,13 +42,34 @@ public interface IWrappedText : IText
     /// </summary>
     float MeasureString(string text, int absoluteStartIndexInStrippedText) => MeasureString(text);
 
+    /// <summary>
+    /// Returns the full-advance width of <paramref name="text"/> — every glyph counted at its full advance,
+    /// with NO trailing-glyph trim — or a negative value if the backend can't provide it. This lets the
+    /// wrapping loop measure a candidate line incrementally (full advance of the already-committed line plus
+    /// the next word's own width) instead of concatenating <c>currentLine + currentWord</c> just to measure
+    /// it, so that throwaway string is only built when the word is actually appended, never on the overflow
+    /// branch (issue #1934). Because the committed line's last glyph is NOT the line's last glyph once a word
+    /// follows it, its full advance is what the concatenation would measure. A backend must return negative
+    /// whenever it can't guarantee that equivalence — most importantly when an inline BBCode run is active,
+    /// since the whole line must then be measured together for per-run sizing — so the caller falls back to
+    /// exact concatenation. The default implementation opts out (returns -1).
+    /// </summary>
+    float MeasureStringFullAdvance(string text) => -1;
+
     bool IsMidWordLineBreakEnabled { get; }
 }
 
 public static class IWrappedTextExtensions
 {
     const string ellipsis = "...";
-    static char[] whatToSplitOn = new char[] { ' ' };
+
+    // Reusable word buffer for the word-by-word wrapping path (issue #1934). UpdateLines runs every
+    // layout frame for constrained Text; renting and clearing a single per-thread list avoids allocating
+    // a fresh List plus the throwaway array String.Split returns on each call. Thread-static so concurrent
+    // layout on separate threads doesn't share the buffer; a null field marks it "rented" so a reentrant
+    // call on the same thread transparently falls back to a fresh list instead of corrupting the shared one.
+    [ThreadStatic]
+    static List<string>? _pooledWordList;
 
     public static void UpdateLines(this IWrappedText textInstance, List<string> lines)
     {
@@ -123,9 +144,12 @@ public static class IWrappedTextExtensions
         // measured at the run's real size while wrapping.
         int absoluteLineStartIndex = 0;
 
-        // The words to process, including the current word
-        List<string> remainingWordsToProcess = new();
-        remainingWordsToProcess.AddRange(stringToUse.Split(whatToSplitOn));
+        // The words to process, including the current word. Tokenize directly into a pooled list rather
+        // than String.Split (which allocates a throwaway array) + a fresh List every call — this is the
+        // genuinely-wrapping path that runs every layout frame for constrained Text (issue #1934). The
+        // list is returned to the pool at the single exit point after the loop below.
+        List<string> remainingWordsToProcess = RentWordList();
+        SplitOnSpaces(remainingWordsToProcess, stringToUse);
 
 
         bool isLastLine = false;
@@ -157,7 +181,35 @@ public static class IWrappedTextExtensions
             // If it's not the last word, we show ellipsis, and the last word plus ellipsis won't fit, then we need
             // to include part of the word:
 
-            float linePlusWordWidth = textInstance.MeasureString(currentLine + currentWord, absoluteLineStartIndex);
+            // Measure the candidate line (currentLine + currentWord) to decide whether the word fits.
+            // linePlusWord is the concatenated string; it is built lazily so the overflow branch — which
+            // measures but then discards the candidate — never allocates it (issue #1934). When the line is
+            // empty the candidate IS the word (no concat). When the backend can report a line's full-advance
+            // width (the XNA/BitmapFont path with no inline run), measure incrementally so the concatenation
+            // is only built if the word is actually appended below; otherwise fall back to exact concatenation.
+            string? linePlusWord;
+            float linePlusWordWidth;
+            if (currentLine.Length == 0)
+            {
+                linePlusWord = currentWord;
+                linePlusWordWidth = textInstance.MeasureString(currentWord, absoluteLineStartIndex);
+            }
+            else
+            {
+                float lineFullAdvance = textInstance.MeasureStringFullAdvance(currentLine);
+                if (lineFullAdvance >= 0)
+                {
+                    // No inline run active: the candidate width is the committed line's full advance (its
+                    // last glyph isn't trimmed because the word follows it) plus the word's own width.
+                    linePlusWord = null;
+                    linePlusWordWidth = lineFullAdvance + textInstance.MeasureString(currentWord);
+                }
+                else
+                {
+                    linePlusWord = currentLine + currentWord;
+                    linePlusWordWidth = textInstance.MeasureString(linePlusWord, absoluteLineStartIndex);
+                }
+            }
 
             var shouldAddEllipsis =
                 textInstance.IsTruncatingWithEllipsisOnLastLine &&
@@ -314,11 +366,13 @@ public static class IWrappedTextExtensions
                         // hit this branch via `currentWord == ""`, appending a phantom extra
                         // space. That made WrappedText longer than RawText and pushed TextBox
                         // caretIndex past Text.Length on click — see issue #2617.
-                        currentLine = currentLine + currentWord + ' ';
+                        // linePlusWord is null only on the incremental-measure path; build the concat now
+                        // (it's the committed output, so it is not throwaway here).
+                        currentLine = (linePlusWord ?? currentLine + currentWord) + ' ';
                     }
                     else
                     {
-                        currentLine = currentLine + currentWord;
+                        currentLine = linePlusWord ?? currentLine + currentWord;
                     }
                 }
 
@@ -349,8 +403,59 @@ public static class IWrappedTextExtensions
             lines.Add(currentLine);
         }
 
+        // Single exit point: the loop above only ever breaks or falls through here, so returning the
+        // buffer once is sufficient (no early return threads past this).
+        ReturnWordList(remainingWordsToProcess);
+
         // This is up to the implementer to set:
         //mNeedsBitmapFontRefresh = true;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="value"/> on the space character into <paramref name="destination"/>,
+    /// preserving empty entries exactly as <c>string.Split(' ')</c> does (leading, interior, and trailing
+    /// spaces each produce an empty token). The wrapping algorithm relies on those empty tokens — a
+    /// trailing space is significant for TextBox caret indexing (issue #2617).
+    /// </summary>
+    static void SplitOnSpaces(List<string> destination, string value)
+    {
+        int start = 0;
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] == ' ')
+            {
+                destination.Add(value.Substring(start, i - start));
+                start = i + 1;
+            }
+        }
+        destination.Add(value.Substring(start, value.Length - start));
+    }
+
+    /// <summary>
+    /// Rents the per-thread word buffer, clearing it for reuse. A reentrant call (the buffer is already
+    /// rented on this thread) gets a fresh list so the two calls don't corrupt each other's state.
+    /// </summary>
+    static List<string> RentWordList()
+    {
+        List<string>? rented = _pooledWordList;
+        if (rented == null)
+        {
+            return new List<string>();
+        }
+
+        _pooledWordList = null;
+        rented.Clear();
+        return rented;
+    }
+
+    /// <summary>
+    /// Returns a list previously obtained from <see cref="RentWordList"/> to the per-thread pool. A list
+    /// from the reentrant fallback (pool already occupied) is simply dropped for the GC to reclaim.
+    /// </summary>
+    static void ReturnWordList(List<string> list)
+    {
+        list.Clear();
+        _pooledWordList ??= list;
     }
 
     static string SubstringEnd(this string value, int lettersToRemove)

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1675,6 +1675,23 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
         return MeasureStyledLineInBaseUnits(substrings, out _);
     }
+
+    /// <inheritdoc/>
+    public float MeasureStringFullAdvance(string whatToMeasure)
+    {
+        // Opt into the wrapping loop's incremental candidate measurement (issue #1934) only when it is
+        // exactly equivalent to measuring the full concatenation: a BitmapFont must be available (so the
+        // Full style — no trailing-glyph trim — is honored), and no inline BBCode run may be active (an
+        // inline [FontSize]/[FontScale] run has to be measured across the whole line, not word-by-word).
+        // Otherwise return -1 so UpdateLines falls back to exact concatenation.
+        var bitmapFontToUse = BitmapFont ?? DefaultBitmapFont;
+        if (bitmapFontToUse == null || InlineVariables.Count > 0)
+        {
+            return -1;
+        }
+
+        return bitmapFontToUse.MeasureString(whatToMeasure, HorizontalMeasurementStyle.Full);
+    }
     #endregion
 
     void IRenderableIpso.SetParentDirect(IRenderableIpso? parent)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
@@ -96,13 +96,15 @@ public class RealisticLayoutAllocationTests : BaseTestClass
             $"({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
 
         // Ratchet (#1934): a full relayout of a real Forms tree with Text allocates a deterministic
-        // 240 bytes/frame locally — down from 1,584 after the single-line-wrap fast path in
-        // IWrappedTextExtensions.UpdateLines (pinned by
-        // TextTests.UpdateWrappedText_WhenTextFitsOnOneLine_DoesNotAllocate). The residual is the one
-        // genuinely-wrapping Text — the TextBox content re-wrapping at its constrained width each frame,
-        // which still tokenizes/Splits/concatenates; tighten further as that word-by-word path is made
-        // allocation-free. Pins the current cost plus headroom for runtime/runner variance.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(400);
+        // 80 bytes/frame locally — down from 1,584 (single-line-wrap fast path, #3538) then 240
+        // (removing the per-Text enumerator boxing in BitmapFont.GetRequiredWidthAndHeight, pinned by
+        // TextTests.UpdatePreRenderDimensions_DoesNotAllocate). Note the earlier theory that the residual
+        // was the genuinely-wrapping TextBox re-wrapping word-by-word was wrong — nothing in this tree
+        // wraps word-by-word; the residual was Text size measurement boxing a List<string> enumerator.
+        // The word-by-word path was still made near-allocation-free separately (TextTests
+        // .UpdateWrappedText_WhenTextWrapsToMultipleLines_AllocatesOnlyOutputLines). Pins the current cost
+        // plus headroom for runtime/runner variance; tighten further as remaining sources are removed.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(160);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #1934.

## What & why

Targeted the residual ~240 B/frame in the realistic-Forms full relayout. The premise handed to me (that the 240 came from the one genuinely-wrapping TextBox going through the word-by-word wrap path) turned out to be **wrong** — instrumenting the tree showed the word-by-word path runs **0 times**; nothing there wraps word-by-word. The real 240 was **enumerator boxing**.

Two independent fixes:

### 1. The actual 240: enumerator boxing in Text size measurement
`Text.UpdatePreRenderDimensions` (runs during layout whenever a Text's size changes) measures `WrappedText` (a `List<string>`) via `BitmapFont.GetRequiredWidthAndHeight`. The only no-widths overload took `IEnumerable<string>`, so the `foreach` boxed the list's struct enumerator — ~40 B per Text per frame × ~6 Text controls = 240. The file even had a comment noting they'd already de-`IEnumerable`'d the *widths* overload for this reason but missed the no-widths one. Added a `List<string>` overload so the concrete-typed call routes to the indexed, non-boxing loop.

**Full relayout: 240 → 80 B/frame.**

### 2. Made the word-by-word wrap path near-allocation-free anyway
Still a real, separate win for constrained/wrapping Text:
- Pool the word buffer (`[ThreadStatic]`, rented + cleared) — no fresh `List`, no `String.Split` array.
- Measure the candidate line **incrementally** (committed line's full advance + word width) so the throwaway `currentLine + currentWord` concatenation is built **only when the word is actually appended**, never on the overflow branch. Backends that can't report a full-advance width (or with an active inline BBCode run) return a negative sentinel and fall back to exact concatenation — behavior preserved.

**Wrapping a 3-line string: 360 → 160 B/frame.** The residual is the output line strings + per-word substrings, which a genuine wrap can't avoid.

## Tests
- `TextTests.UpdatePreRenderDimensions_DoesNotAllocate` — pins the boxing fix (0 alloc; was 40 B/call).
- `TextTests.UpdateWrappedText_WhenTextWrapsToMultipleLines_AllocatesOnlyOutputLines` — pins the wrap path (≤200 B/frame; was 360).
- Tightened the realistic-Forms full-relayout ratchet 400 → 160 and corrected its comment (the residual was boxing, not wrapping).

Full `MonoGameGum.Tests` (1891), integration (66), `RaylibGum.Tests` (519), `SkiaGum.Tests` (358) all green. FRB canary (`GumCore.DesktopGlNet6`) builds clean.

## Notes
- Added a default interface method `IWrappedText.MeasureStringFullAdvance` (returns -1) — same default-interface-method pattern already used in that file; Raylib/Sokol/Skia inherit the safe fallback.
- No new files, no `#if` guards, no new `using`/NuGet deps → no projitems/csproj sync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
