### PR TITLE
Halve idle-frame Update allocations (128->64 B/f) for #1934

### DIFF
--- a/GumRuntime/InteractiveGue.cs
+++ b/GumRuntime/InteractiveGue.cs
@@ -1185,11 +1185,9 @@ public interface IInputReceiverKeyboard
 
 
 
-// A per-frame bag of "already handled" flags threaded through the DoUiActivityRecursively walk.
-// It is a struct passed by ref so the top-level walk allocates it on the stack (zero managed
-// bytes per idle frame, issue #1934) and each Update call gets its own instance (reentrancy-safe),
-// while the ref threading preserves the original shared-mutable-reference semantics through the
-// recursion.
+// "Already handled" flags threaded through the DoUiActivityRecursively walk. A struct passed by ref
+// so the walk allocates it on the stack rather than the heap each frame; ref threading preserves the
+// shared-mutable-reference semantics the class had, and each Update gets its own instance.
 struct HandledActions
 {
     public bool HandledMouseWheel;

--- a/GumRuntime/InteractiveGue.cs
+++ b/GumRuntime/InteractiveGue.cs
@@ -334,15 +334,8 @@ public partial class InteractiveGue : GraphicalUiElement
 
     #endregion
 
-    private bool DoUiActivityRecursively(ICursor cursor, Layer layer, HandledActions? handledActions = null)
+    internal static bool DoUiActivityRecursively(ICursor cursor, ref HandledActions handledActions, GraphicalUiElement currentItem, Layer? layer)
     {
-        return DoUiActivityRecursively(cursor, handledActions, this, layer);
-
-    }
-
-    internal static bool DoUiActivityRecursively(ICursor cursor, HandledActions? handledActions, GraphicalUiElement currentItem, Layer? layer)
-    {
-        handledActions = handledActions ?? new HandledActions();
         bool handledByChild = false;
         bool handledByThis = false;
 
@@ -392,7 +385,7 @@ public partial class InteractiveGue : GraphicalUiElement
 
                     if (child != null && HasCursorOver(cursor, child, layer))
                     {
-                        handledByChild = DoUiActivityRecursively(cursor, handledActions, child, layer);
+                        handledByChild = DoUiActivityRecursively(cursor, ref handledActions, child, layer);
 
                         if (handledByChild)
                         {
@@ -423,7 +416,7 @@ public partial class InteractiveGue : GraphicalUiElement
                     }
                     if (hasCursorOver)
                     {
-                        handledByChild = DoUiActivityRecursively(cursor, handledActions, child, layer);
+                        handledByChild = DoUiActivityRecursively(cursor, ref handledActions, child, layer);
 
                         if (handledByChild)
                         {
@@ -1192,7 +1185,12 @@ public interface IInputReceiverKeyboard
 
 
 
-class HandledActions
+// A per-frame bag of "already handled" flags threaded through the DoUiActivityRecursively walk.
+// It is a struct passed by ref so the top-level walk allocates it on the stack (zero managed
+// bytes per idle frame, issue #1934) and each Update call gets its own instance (reentrancy-safe),
+// while the ref threading preserves the original shared-mutable-reference semantics through the
+// recursion.
+struct HandledActions
 {
     public bool HandledMouseWheel;
     public bool HandledRollOver;
@@ -1266,7 +1264,7 @@ public static class GueInteractiveExtensionMethods
             if(gue.EffectiveManagers != null)
 #endif
             {
-                InteractiveGue.DoUiActivityRecursively(cursor, actions, gue, gue.Layer);
+                InteractiveGue.DoUiActivityRecursively(cursor, ref actions, gue, gue.Layer);
             }
             if(cursor.VisualOver != null)
             {

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1179,9 +1179,8 @@ public partial class GumService : IGumService
     // Platform-agnostic tail of every frame's Update: advance AnimationChain playback on each root.
     private void AnimateRoots(double difference, IEnumerable<GraphicalUiElement> roots)
     {
-        // The internal callers always pass the reused List field, so take an index-based fast path
-        // that avoids boxing the List enumerator every idle frame (issue #1934). foreach over the
-        // IEnumerable parameter would box List<T>.Enumerator (~40 bytes/frame).
+        // Internal callers pass the reused List field; take an index-based fast path so we don't box
+        // the List enumerator each frame that foreach over the IEnumerable parameter would (#1934).
         if (roots is IList<GraphicalUiElement> list)
         {
             for (int i = 0; i < list.Count; i++)

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -1179,9 +1179,22 @@ public partial class GumService : IGumService
     // Platform-agnostic tail of every frame's Update: advance AnimationChain playback on each root.
     private void AnimateRoots(double difference, IEnumerable<GraphicalUiElement> roots)
     {
-        foreach (var item in roots)
+        // The internal callers always pass the reused List field, so take an index-based fast path
+        // that avoids boxing the List enumerator every idle frame (issue #1934). foreach over the
+        // IEnumerable parameter would box List<T>.Enumerator (~40 bytes/frame).
+        if (roots is IList<GraphicalUiElement> list)
         {
-            item.AnimateSelf(difference);
+            for (int i = 0; i < list.Count; i++)
+            {
+                list[i].AnimateSelf(difference);
+            }
+        }
+        else
+        {
+            foreach (var item in roots)
+            {
+                item.AnimateSelf(difference);
+            }
         }
     }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -57,16 +57,11 @@ public class DrawAllocationTests : BaseTestClass
         // roots on every FormsUtilities.Update call.
         global::Gum.Forms.FormsUtilities.LastEventRoots.Count.ShouldBeGreaterThan(0);
 
-        // Ratchet (#1934): the idle-frame input/cursor pass (GumService.Update over an unchanging
-        // Forms scene). Down from 128 B/f after removing the two Gum-owned per-frame allocations:
-        // the HandledActions class allocated by every DoUiActivityRecursively walk (now a stack
-        // struct passed by ref, 24 B/f) and the boxed List enumerator in AnimateRoots' foreach over
-        // the IEnumerable roots (now an index-based fast path, 40 B/f). The deterministic ~64 B/f
-        // residual is MonoGame's per-frame GamePad.GetState (4 pads x 16 bytes) inside
-        // FormsUtilities.UpdateGamepads — framework-internal, not removable without changing input
-        // polling behavior. This guard owns the idle-Update residual (separate from the text /
-        // full-relayout ratchets) and is set just above the residual so a regression that
-        // re-introduces either removed source (88 or 104 B/f) fails the build.
+        // Ratchet (#1934): the idle-frame input/cursor pass (GumService.Update over an unchanging Forms
+        // scene). The ~64 B/f residual is MonoGame's per-frame GamePad.GetState (4 pads) inside
+        // FormsUtilities.UpdateGamepads — framework-internal, not removable here. This guard owns the
+        // idle-Update residual (separate from the text/full-relayout ratchets); set just above the
+        // residual so re-introducing a removed allocation source fails the build.
         result.BytesPerIteration.ShouldBeLessThanOrEqualTo(80);
     }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -30,6 +30,47 @@ public class DrawAllocationTests : BaseTestClass
     }
 
     [Fact]
+    public void IdleUpdate_RepresentativeFormsScene_AllocationBaseline()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        BuildScene();
+
+        // A single fixed GameTime reused every frame keeps the scene idle (no time advance, no
+        // animation) and avoids allocating a GameTime per iteration, so the measured delta reflects
+        // only the Update walk itself (the FormsUtilities input/cursor pass) with Draw excluded.
+        GameTime gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(1.0 / 60.0));
+
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () => global::Gum.GumService.Default.Update(gameTime),
+            attempts: 3,
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        _output.WriteLine($"Idle Update (no Draw) of a representative Forms scene (20-item ListBox, labels, " +
+            $"a Text, and a filled rectangle): {result.BytesPerIteration:N0} bytes/frame " +
+            $"({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // Liveness: prove the Update pass actually walked the scene roots (a silent early-return
+        // would make a low allocation result meaningless). LastEventRoots is repopulated from the
+        // roots on every FormsUtilities.Update call.
+        global::Gum.Forms.FormsUtilities.LastEventRoots.Count.ShouldBeGreaterThan(0);
+
+        // Ratchet (#1934): the idle-frame input/cursor pass (GumService.Update over an unchanging
+        // Forms scene). Down from 128 B/f after removing the two Gum-owned per-frame allocations:
+        // the HandledActions class allocated by every DoUiActivityRecursively walk (now a stack
+        // struct passed by ref, 24 B/f) and the boxed List enumerator in AnimateRoots' foreach over
+        // the IEnumerable roots (now an index-based fast path, 40 B/f). The deterministic ~64 B/f
+        // residual is MonoGame's per-frame GamePad.GetState (4 pads x 16 bytes) inside
+        // FormsUtilities.UpdateGamepads — framework-internal, not removable without changing input
+        // polling behavior. This guard owns the idle-Update residual (separate from the text /
+        // full-relayout ratchets) and is set just above the residual so a regression that
+        // re-introduces either removed source (88 or 104 B/f) fails the build.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(80);
+    }
+
+    [Fact]
     public void IdleUpdateAndDraw_RepresentativeFormsScene_AllocationBaseline()
     {
         using MinimalGame game = new();


### PR DESCRIPTION
Part of #1934 (allocation pass).

## What

Idle `GumService.Update` over an unchanging Forms scene (GraphicsDevice-backed integration harness, 20-item ListBox + labels + Text + rectangle) allocated **128 B/f**. This removes the two Gum-owned per-frame allocations, cutting it to **64 B/f**.

## Sources removed

- **`HandledActions` class (24 B/f)** — allocated by every `DoUiActivityRecursively` walk (the core cursor/input dispatch). Converted to a `struct` passed by `ref`, so the top-level walk allocates it on the stack (zero heap) and each `Update` gets its own instance (reentrancy-safe), preserving the shared-mutable-reference semantics through the recursion. Also removed a dead private `DoUiActivityRecursively` overload.
- **`AnimateRoots` enumerator boxing (40 B/f)** — `foreach` over the `IEnumerable<GraphicalUiElement>` roots boxed `List<T>.Enumerator`. Added an index-based `IList` fast path (internal callers always pass the reused `List` field).

## Residual

The remaining deterministic **~64 B/f** is MonoGame's per-frame `GamePad.GetState` (4 pads × 16 bytes) inside `FormsUtilities.UpdateGamepads` — confirmed steady-state (invariant across warmup 50/500/3000), and our own driver code measures 0 in isolation. It's framework-internal, not removable without changing input-polling behavior.

## Before / after

| | idle Update B/f |
|---|---|
| before | 128 |
| after | 64 |

## Test

Added an isolated idle-`Update()` ratchet (`IdleUpdate_RepresentativeFormsScene_AllocationBaseline`, `<= 80`) with a liveness guard, separate from the text / full-relayout ratchets. Full `MonoGameGum.Tests` (1889) green; integration Performance suite (6) green; KniGum/RaylibGum/SkiaGum build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
