### PR TITLE
Reduce per-notification binding allocations (#1934)

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -45,6 +45,10 @@ Every `StateSave` must have `ParentContainer` set — `GetValueRecursive` traver
 
 `InternalsVisibleTo` is set up in `Gum.ProjectServices.csproj` for `Gum.ProjectServices.Tests` — internal members are directly accessible.
 
+## Headless Forms allocation tests: install a real Cursor
+
+`BaseTestClass` installs a Moq mock as `FrameworkElement.MainCursor`, and each proxied member access allocates (~296 B). Any control that reads `MainCursor` (e.g. a `ScrollBar` value setter) then pollutes an `AllocationMeasurer` result with a pure test artifact. Assign a real `MonoGameGum.Input.Cursor(null)` before measuring — production always uses a real cursor. See `ListBoxScrollAllocationTests`.
+
 ## WPF-touching tool code (GumToolUnitTests) needs an STA thread
 
 xUnit's runner is **MTA**, but WPF `FrameworkElement`s (`MenuItem`, `Menu`, `ComboBox`, …) throw `InvalidOperationException: The calling thread must be STA` when constructed. If a tool class news up a WPF control — often a ViewModel building right-click `MenuItem`s in its constructor — build it inside a `RunOnSta(() => { ... })` helper that runs the body on an `ApartmentState.STA` thread and rethrows. Copy the helper from `MenuStripManagerTests` / `RenameManagerTests`; there is no shared base for it.

--- a/Gum/Mvvm/ViewModel.cs
+++ b/Gum/Mvvm/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -154,18 +155,20 @@ namespace Gum.Mvvm
             }
         }
 
+        // PropertyChangedEventArgs is immutable, so one instance per property name is reused across
+        // all notifications and all ViewModel instances instead of allocating one per notification.
+        private static readonly ConcurrentDictionary<string, PropertyChangedEventArgs> _eventArgsCache = new();
+
         protected virtual void NotifyPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             System.Diagnostics.Debug.Assert(propertyName != null, "propertyName should not be null");
             if (PropertyChanged != null)
             {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+                PropertyChanged(this, _eventArgsCache.GetOrAdd(propertyName, static name => new PropertyChangedEventArgs(name)));
             }
 
-            if (notifyRelationships.ContainsKey(propertyName))
+            if (notifyRelationships.TryGetValue(propertyName, out var childPropertyNames))
             {
-                var childPropertyNames = notifyRelationships[propertyName];
-
                 foreach (var childPropertyName in childPropertyNames)
                 {
                     // todo - worry about recursive notifications?

--- a/GumRuntime/GraphicalUiElement.Binding.cs
+++ b/GumRuntime/GraphicalUiElement.Binding.cs
@@ -2,6 +2,7 @@ using Gum.Mvvm;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
@@ -538,13 +539,43 @@ public partial class GraphicalUiElement
 
     private void TryPushBindingContextChangeToChildren(string vmPropertyName)
     {
-        foreach (GraphicalUiElement descendent in GetAllBindableDescendents())
+        // Walks every descendant with index-based loops rather than a yield iterator so a VM
+        // notification allocates nothing when descending the tree. Each descendant is matched
+        // against this element's BindingContext (the root of the push), mirroring the original
+        // flat-visitation semantics.
+        object? rootContext = BindingContext;
+        PushBindingContextChangeToDescendents(vmPropertyName, rootContext);
+    }
+
+    private void PushBindingContextChangeToDescendents(string vmPropertyName, object? rootContext)
+    {
+        if (Children != null)
         {
-            if (descendent.BindingContextBinding == vmPropertyName && descendent.BindingContextBindingPropertyOwner == BindingContext)
+            ObservableCollection<GraphicalUiElement> children = Children;
+            int count = children.Count;
+            for (int i = 0; i < count; i++)
             {
-                descendent.UpdateToVmProperty(vmPropertyName);
+                children[i].MatchAndPushBindingContextChange(vmPropertyName, rootContext);
             }
         }
+        else
+        {
+            IList<GraphicalUiElement> contained = ContainedElements;
+            int count = contained.Count;
+            for (int i = 0; i < count; i++)
+            {
+                contained[i].MatchAndPushBindingContextChange(vmPropertyName, rootContext);
+            }
+        }
+    }
+
+    private void MatchAndPushBindingContextChange(string vmPropertyName, object? rootContext)
+    {
+        if (BindingContextBinding == vmPropertyName && BindingContextBindingPropertyOwner == rootContext)
+        {
+            UpdateToVmProperty(vmPropertyName);
+        }
+        PushBindingContextChangeToDescendents(vmPropertyName, rootContext);
     }
 
     protected void PushValueToViewModel([CallerMemberName] string? uiPropertyName = null)
@@ -626,19 +657,6 @@ public partial class GraphicalUiElement
     {
         if (Children != null) return Children;
         else return ContainedElements;
-    }
-
-    private IEnumerable<GraphicalUiElement> GetAllBindableDescendents()
-    {
-        foreach (GraphicalUiElement child in GetAllBindableChildren())
-        {
-            yield return child;
-
-            foreach (GraphicalUiElement subChild in child.GetAllBindableDescendents())
-            {
-                yield return subChild;
-            }
-        }
     }
 
     public static object? ConvertValue(object? value, Type desiredType, string? format)

--- a/MonoGameGum.Tests/Performance/BindingAllocationTests.cs
+++ b/MonoGameGum.Tests/Performance/BindingAllocationTests.cs
@@ -1,0 +1,73 @@
+using Gum.GueDeriving;
+using Gum.Mvvm;
+using Gum.Wireframe;
+using MonoGameGum.TestsCommon;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.Tests.Performance;
+
+/// <summary>
+/// Per-notification allocation baseline and regression guard for the runtime data-binding path
+/// (issue #1934): a <see cref="ViewModel"/> raising <c>INotifyPropertyChanged</c> that propagates
+/// through <see cref="GraphicalUiElement.SetBinding(string, string, string)"/> to a bound visual
+/// property. The zero-allocation guards use <see cref="AllocationMeasurer.MeasureMinimum"/> so a
+/// one-off environmental blip does not fail the guard.
+/// </summary>
+public class BindingAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public BindingAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private class BindingViewModel : ViewModel
+    {
+        public int IntProperty
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
+    }
+
+    [Fact]
+    public void PropertyChange_PropagatingToBoundVisual_IsLowAllocation()
+    {
+        BindingViewModel vm = new();
+        ContainerRuntime container = new();
+        container.BindingContext = vm;
+        container.SetBinding(nameof(container.X), nameof(vm.IntProperty));
+
+        int value = 0;
+        const int measuredIterations = 500;
+        const int attempts = 3;
+
+        // Alternate the value every notification so each Set genuinely changes the VM and fires
+        // PropertyChanged (a no-op Set would notify nothing and make the result meaningless).
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () =>
+            {
+                value = value == 1 ? 2 : 1;
+                vm.IntProperty = value;
+            },
+            attempts: attempts,
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        _output.WriteLine($"VM property change propagating to a bound visual property: " +
+            $"{result.BytesPerIteration:N0} bytes/notification ({result.TotalBytes:N0} bytes over {result.Iterations} notifications)");
+
+        // Liveness: prove the notification actually propagated all the way to the bound UI property.
+        container.X.ShouldBe(value);
+
+        // The residual per-notification cost is the value-type boxing inherent to the reflection-based
+        // flat binding and the ViewModel's object-dictionary storage (VM int stored/read as object, and
+        // int-to-float ConvertValue). Structural allocations (the descendant-walk iterator and a fresh
+        // PropertyChangedEventArgs per notification) have been removed. This guards against a regression
+        // reintroducing them (#1934).
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(104);
+    }
+}


### PR DESCRIPTION
Part of #1934 (runtime allocation pass).

Measures and reduces per-notification managed allocations in the data-binding path (`ViewModel` raising `INotifyPropertyChanged` → `SetProperty`/`UpdateToVmProperty` → bound `GraphicalUiElement` property).

## Result
**200 → 104 bytes/notification** for a VM int property bound to a visual `X` (float), measured via `AllocationMeasurer.MeasureMinimum`.

## Allocation sources removed
- **Descendant-walk iterator** in `TryPushBindingContextChangeToChildren` — the `yield` iterator state machine plus a boxed `ObservableCollection` enumerator allocated on every notification even with zero children. Replaced with index-based loops (pre-order DFS preserved). **-72 B**
- **`PropertyChangedEventArgs` per notification** in `ViewModel.NotifyPropertyChanged` — args are immutable, so one instance per property name is now reused from a static cache. **-24 B**

## Residual (104 B)
Value-type boxing inherent to the reflection-based flat binding and the `ViewModel` object-dictionary storage (VM int stored/read as `object`, int→float `ConvertValue`). Eliminating it needs a compiled-getter/setter-delegate rewrite of the GUE flat-binding path — out of scope here. Confirmed the reflection member lookups (`GetProperty`/`GetField`/`GetEvent`) do **not** allocate (runtime-cached), so caching them was measured and reverted as no-benefit.

## Tests
- New `MonoGameGum.Tests/Performance/BindingAllocationTests.cs` — liveness guard (bound `X` reflects the last value) + a ≤104 B/notification ratchet.
- Full `MonoGameGum.Tests` green (1893).

Also adds a `gum-unit-tests` note: install a real `Cursor` for headless Forms allocation tests (the Moq mock cursor allocates per proxied access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
