### PR TITLE
Pool per-realization width buffer in BitmapFont; remove dead ImageData render path (#1934)

### DIFF
--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary.Math;
 using RenderingLibrary.Math.Geometry;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -586,9 +585,6 @@ public class BitmapFont : IDisposable
         return RenderToTexture2D(lines, horizontalAlignment, managers, null, objectRequestingRender);
     }
 
-    // To help out the GC, we're going to just use a Color that's 2048x2048
-    static Microsoft.Xna.Framework.Color[] mColorBuffer = new Microsoft.Xna.Framework.Color[2048 * 2048];
-
     /// <summary>
     /// Renders pre-split lines of text to a <see cref="RenderTarget2D"/>. If <paramref name="toReplace"/>
     /// is provided and has matching dimensions, it is reused to avoid allocating a new render target.
@@ -625,7 +621,8 @@ public class BitmapFont : IDisposable
 
         int requiredWidth;
         int requiredHeight;
-        List<int> widths = new List<int>();
+        var widths = sMeasuredLineWidths;
+        widths.Clear();
         GetRequiredWidthAndHeight(lines, out requiredWidth, out requiredHeight, widths);
 
         if (requiredWidth != 0)
@@ -683,6 +680,11 @@ public class BitmapFont : IDisposable
     }
 
     static List<LetterRenderInfo> letterInfos = new List<LetterRenderInfo>();
+
+    // Reused per-line width buffer for the realization passes. Rendering is single-threaded and
+    // non-reentrant (same assumption as letterInfos above), so a shared static avoids allocating a
+    // List every time a Text realizes its render target.
+    static List<int> sMeasuredLineWidths = new List<int>();
 
     /// <summary>
     /// Draws pre-split lines of text directly to the screen via the <paramref name="spriteRenderer"/>,
@@ -987,7 +989,8 @@ public class BitmapFont : IDisposable
         var point = new Vector2();
         int requiredWidth;
         int requiredHeight;
-        List<int> widths = new List<int>();
+        var widths = sMeasuredLineWidths;
+        widths.Clear();
         GetRequiredWidthAndHeight(lines, out requiredWidth, out requiredHeight, widths);
 
         int lineNumber = 0;
@@ -1206,120 +1209,6 @@ public class BitmapFont : IDisposable
         if (requiredWidth != 0 && mOutlineThickness != 0)
         {
             requiredWidth += mOutlineThickness * 2;
-        }
-    }
-
-    private Texture2D RenderToTexture2DUsingImageData(IEnumerable lines, HorizontalAlignment horizontalAlignment, SystemManagers managers)
-    {
-        ImageData[] imageDatas = new ImageData[this.mTextures.Length];
-
-        for (int i = 0; i < imageDatas.Length; i++)
-        {
-            // Only use the existing buffer on one-page fonts
-            var bufferToUse = mColorBuffer;
-            if (i > 0)
-            {
-                bufferToUse = null;
-            }
-            imageDatas[i] = ImageData.FromTexture2D(this.mTextures[i], managers, bufferToUse);
-        }
-
-        Point point = new Point();
-
-        int maxWidthSoFar = 0;
-        int requiredWidth = 0;
-        int requiredHeight = 0;
-
-        List<int> widths = new List<int>();
-
-        foreach (string line in lines)
-        {
-            requiredHeight += LineHeightInPixels;
-            requiredWidth = 0;
-
-            requiredWidth = MeasureString(line);
-            widths.Add(requiredWidth);
-            maxWidthSoFar = System.Math.Max(requiredWidth, maxWidthSoFar);
-        }
-
-        const int MaxWidthAndHeight = 2048; // change this later?
-        maxWidthSoFar = System.Math.Min(maxWidthSoFar, MaxWidthAndHeight);
-        requiredHeight = System.Math.Min(requiredHeight, MaxWidthAndHeight);
-
-
-
-        ImageData imageData = null;
-
-        if (maxWidthSoFar != 0)
-        {
-            imageData = new ImageData(maxWidthSoFar, requiredHeight, managers);
-
-            int lineNumber = 0;
-
-            foreach (string line in lines)
-            {
-                point.X = 0;
-
-                if (horizontalAlignment == HorizontalAlignment.Right)
-                {
-                    point.X = maxWidthSoFar - widths[lineNumber];
-                }
-                else if (horizontalAlignment == HorizontalAlignment.Center)
-                {
-                    point.X = (maxWidthSoFar - widths[lineNumber]) / 2;
-                }
-
-                foreach (char c in line)
-                {
-
-                    BitmapCharacterInfo characterInfo = GetCharacterInfo(c);
-
-                    int sourceLeft = characterInfo.PixelLeft;
-                    int sourceTop = characterInfo.PixelTop;
-                    int sourceWidth = characterInfo.PixelRight - sourceLeft;
-                    int sourceHeight = characterInfo.PixelBottom - sourceTop;
-
-                    int distanceFromTop = characterInfo.GetPixelDistanceFromTop(LineHeightInPixels);
-
-                    // There could be some offset for this character
-                    //int xOffset = characterInfo.GetPixelXOffset(LineHeightInPixels);
-                    int xOffset = characterInfo.XOffsetInPixels;
-                    point.X += xOffset;
-
-                    point.Y = lineNumber * LineHeightInPixels + distanceFromTop;
-
-                    Rectangle sourceRectangle = new Rectangle(sourceLeft, sourceTop, sourceWidth, sourceHeight);
-
-                    int pageIndex = characterInfo.PageNumber;
-
-                    imageData.Blit(imageDatas[pageIndex], sourceRectangle, point);
-
-                    point.X -= xOffset;
-                    //point.X += characterInfo.GetXAdvanceInPixels(LineHeightInPixels);
-                    point.X += characterInfo.XAdvance;
-
-                }
-                point.X = 0;
-                lineNumber++;
-            }
-        }
-
-
-        if (imageData != null)
-        {
-            // We don't want
-            // to generate mipmaps
-            // because text is usually
-            // rendered pixel-perfect.
-
-            const bool generateMipmaps = false;
-
-
-            return imageData.ToTexture2D(generateMipmaps);
-        }
-        else
-        {
-            return null;
         }
     }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/FontRealizationAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/FontRealizationAllocationTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Reflection;
+using Microsoft.Xna.Framework;
+using MonoGameGum.TestsCommon;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Performance;
+
+/// <summary>
+/// Per-realization allocation baseline and regression guard for font/string realization on the Text
+/// path (issue #1934): rebuilding a Text's render target from its wrapped lines. This is the
+/// RenderTarget path (<see cref="Text.UpdateTextureToRender"/> → <see cref="BitmapFont"/>'s
+/// RenderToTexture2D), which needs a live GraphicsDevice, hence the integration project rather than
+/// the headless suite. The target is zero managed bytes per realization when the text and its
+/// dimensions are unchanged (the render target is reused); the guard ratchets down as allocation
+/// sources are removed.
+/// </summary>
+public class FontRealizationAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public FontRealizationAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void RenderTargetRealization_UnchangedText_IsZeroAllocation()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        FieldInfo needsRefreshField = typeof(Text).GetField(
+            "mNeedsBitmapFontRefresh", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        TextRenderingMode originalMode = Text.TextRenderingMode;
+        Text.TextRenderingMode = TextRenderingMode.RenderTarget;
+        try
+        {
+            Text text = new Text();
+            text.BitmapFont = Text.DefaultBitmapFont;
+            text.Width = null; // size to content so wrapping stays single-line
+            text.RawText = "Realize this text";
+
+            // Warm up so the render target exists and is reused (its dimensions do not change
+            // across iterations because the text is constant).
+            text.SetNeedsRefreshToTrue();
+            text.TryUpdateTextureToRender();
+
+            // Liveness: a realization must actually run — the refresh flag we set is consumed
+            // (true -> false) and a texture is produced. A silent no-op would make the
+            // zero-allocation result meaningless.
+            text.SetNeedsRefreshToTrue();
+            ((bool)needsRefreshField.GetValue(text)!).ShouldBeTrue();
+            text.TryUpdateTextureToRender();
+            ((bool)needsRefreshField.GetValue(text)!).ShouldBeFalse();
+            text.WrappedTextWidth.ShouldBeGreaterThan(0);
+
+            Renderer renderer = SystemManagers.Default.Renderer;
+
+            AllocationResult result = AllocationMeasurer.MeasureMinimum(
+                () =>
+                {
+                    // Reset the per-frame render-state recording so the SpriteBatch machinery (pooled
+                    // change-record lists, the per-frame draw-state list) does not accumulate across
+                    // iterations — a real frame does this reset, and it isolates the measurement to the
+                    // Text/BitmapFont realization work this test targets.
+                    SpriteBatchStack.PerformStartOfLayerRenderingLogic();
+                    renderer.ClearPerformanceRecordingVariables();
+
+                    text.SetNeedsRefreshToTrue();
+                    text.TryUpdateTextureToRender();
+                },
+                warmupIterations: 50,
+                measuredIterations: 300);
+
+            _output.WriteLine($"Render-target realization of an unchanged single-line Text: " +
+                $"{result.BytesPerIteration:N0} bytes/realization " +
+                $"({result.TotalBytes:N0} bytes over {result.Iterations} realizations)");
+
+            result.TotalBytes.ShouldBe(0);
+        }
+        finally
+        {
+            Text.TextRenderingMode = originalMode;
+        }
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes the default <see cref="global::Gum.GumService"/> against a
+    /// live device so text realization (which requires a GraphicsDevice) can be driven manually.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, global::Gum.Forms.DefaultVisualsVersion.Newest);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Part of #1934 (runtime allocation pass).

## What
Font/string realization on the Text **render-target** path allocated a fresh `List<int>` for per-line widths every time a Text rebuilt its render target — in `BitmapFont.RenderToTexture2D` and the obsolete `RenderAtlasedTextureToScreen`. Both now reuse a single static buffer, matching the existing static `letterInfos` pattern (rendering is single-threaded and non-reentrant).

Also removed dead code found while in the area: the unreferenced private `RenderToTexture2DUsingImageData` method and its exclusively-used **16 MB** static `mColorBuffer` (a `2048x2048` `Color[]`), plus the now-unused `using System.Collections;`.

## Allocation measurement
Isolated render-target realization of an unchanged single-line Text (per-frame render-state recording reset each iteration so the measurement reflects only the Text/BitmapFont work, not SpriteBatch machinery):

| | bytes/realization |
|---|---|
| before | 72 |
| after | **0** |

The character-by-character render path was already allocation-free (static `widths` + static `letterInfos` from earlier PRs); this covers the render-target realization those didn't.

## Test
New `FontRealizationAllocationTests` (integration project — realization needs a live `GraphicsDevice`). Red at 72 B/realization before the fix, green at 0 after. Liveness guard proves realization actually ran each iteration (the refresh flag is consumed true→false and a texture is produced).

## Verification
- `MonoGameGum.Tests`: 1892 passed
- Text/render/font/allocation integration tests: 46 passed
- KniGum / RaylibGum / SkiaGum build clean (no new warnings)

Behavior-preserving.
