### PR TITLE
Eliminate per-frame boxed enumerator in stacked-layout relayout (#1934)

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -4429,9 +4429,13 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                 // This child's dimension is less than the stored max. It may have been
                 // the previous max-holder and shrunk, so we must rescan all siblings
                 // in this row/column up to and including this child to find the true max.
+                // Indexed loop rather than foreach so iterating the Children
+                // ObservableCollection does not box its enumerator on this hot path.
                 parentGue.StackedRowOrColumnDimensions[indexToUpdate] = 0;
-                foreach (GraphicalUiElement child in parentGue.Children)
+                var siblings = parentGue.Children;
+                for (int i = 0; i < siblings.Count; i++)
                 {
+                    GraphicalUiElement child = siblings[i];
                     if (child.Visible)
                     {
                         if (child.StackedRowOrColumnIndex == indexToUpdate)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -97,14 +97,11 @@ public class DrawAllocationTests : BaseTestClass
         // no-op would make a low/zero allocation result meaningless.
         drawStateCount.ShouldBeGreaterThan(0);
 
-        // Baseline ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene.
-        // The Draw walk's ~752 bytes/frame were eliminated by fixing an unbounded SpriteBatchStack
-        // state-stack leak and a per-frame clip-exit string interpolation (see SpriteBatchStack /
-        // Renderer). The remaining cost is the per-frame input/cursor pass in GumService.Update
-        // (FormsUtilities.Update). This guard pins the current cost so a regression that grows it
-        // fails the build; tighten the bound further as sources are removed. Headroom is for
-        // JIT/runner variance.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(200);
+        // Ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene. The Draw walk
+        // itself is zero-alloc; the residual is the per-frame input/cursor pass in GumService.Update
+        // (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState). Bound sits just above
+        // that residual with headroom for JIT/runner variance.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(120);
     }
 
     private static void BuildScene()

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/LayoutAllocationTests.cs
@@ -86,8 +86,9 @@ public class RealisticLayoutAllocationTests : BaseTestClass
         BuildRealisticTree();
         global::Gum.GumService.Default.Root.UpdateLayout();
 
-        AllocationResult result = AllocationMeasurer.Measure(
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
             () => global::Gum.GumService.Default.Root.UpdateLayout(),
+            attempts: 3,
             warmupIterations: 50,
             measuredIterations: 500);
 
@@ -95,9 +96,10 @@ public class RealisticLayoutAllocationTests : BaseTestClass
             $"{result.BytesPerIteration:N0} bytes/frame " +
             $"({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
 
-        // Ratchet (#1934): a full relayout of a real Forms tree with Text allocates ~80 bytes/frame locally.
-        // Pins that with headroom for runner variance; tighten as remaining sources are removed.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(160);
+        // Ratchet (#1934): a steady-state full relayout of a real Forms tree allocates nothing. The
+        // bound sits below the cost of a single boxed IEnumerable enumerator so re-introducing a
+        // foreach over an interface-typed collection on the layout hot path fails the build.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(24);
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #1934.

## What

Removes the last per-frame boxed-enumerator allocation in the steady-state layout hot path.

`GraphicalUiElement.RefreshParentRowColumnDimensionForThis`'s O(n) shrink-fallback rescanned the parent's `Children` (an `ObservableCollection<GraphicalUiElement>`) with a `foreach`, which boxes `List<T>.Enumerator` (~40 B). On a stacked container that fallback fires for the first child narrower than the current column/row max; a full relayout runs the child pass twice (an Absolute pre-pass plus the main pass), so a realistic Forms tree paid it twice per frame. Converted to an index loop.

## Numbers (bytes/frame, realistic Forms tree)

| Scenario | Before | After |
|---|---|---|
| Full relayout (`LayoutAllocationTests`) | 80 | **0** |
| Idle Update+Draw (`DrawAllocationTests`) | 64 | 64 (unchanged) |

The idle Update+Draw residual is MonoGame's per-frame `GamePad.GetState` in `FormsUtilities.Update` (framework-internal, not removable here); the Draw walk itself allocates nothing.

## Ratchets

- `UpdateLayout_RealisticTree` full-relayout guard: 160 → **24** (below one boxed enumerator), switched to `MeasureMinimum` for robustness.
- `IdleUpdateAndDraw` guard: 200 → **120** (draw adds 0 over the gamepad-poll residual); dropped its stale war-story comment.
- Left the property-change (`floatingWindow.Height`) guard at 200 — that 40 B/f residual is a different scenario I did not profile here.

## Verification

- `MonoGameGum.IntegrationTests` Performance suite: 6/6 pass.
- Full `MonoGameGum.Tests`: 1892/1892 pass.
- RaylibGum / KniGum / SkiaGum build clean (shared `GraphicalUiElement` source), no new warnings.

Behavior-preserving (foreach → index loop over the same collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
