### PR TITLE
Eliminate per-frame LINQ closures in AnimationChain playback (#1934)

### DIFF
--- a/GumCommon/Runtime/AnimationRuntime.cs
+++ b/GumCommon/Runtime/AnimationRuntime.cs
@@ -144,36 +144,33 @@ public class AnimationRuntime
 
     static StateSave? GetStateFromCategorizedName(string categorizedName, ElementSave element)
     {
-        if (categorizedName.Contains("/"))
+        if (TrySplitCategorizedName(categorizedName, out string category, out string stateName))
         {
-            var names = categorizedName.Split('/');
-
-            string category = names[0];
-            string stateName = names[1];
-
-            return element
-                .Categories.FirstOrDefault(item => item.Name == category)
-                ?.States.FirstOrDefault(item => item.Name == stateName);
+            StateSaveCategory? foundCategory = null;
+            for (int i = 0; i < element.Categories.Count; i++)
+            {
+                if (element.Categories[i].Name == category)
+                {
+                    foundCategory = element.Categories[i];
+                    break;
+                }
+            }
+            return foundCategory == null ? null : FindStateByName(foundCategory.States, stateName);
         }
         else
         {
-            return element.States.FirstOrDefault(item => item.Name == categorizedName);
+            return FindStateByName(element.States, categorizedName);
         }
     }
 
 
     static StateSave? GetStateFromCategorizedName(string categorizedName, GraphicalUiElement graphicalUiElement)
     {
-        if (categorizedName.Contains("/"))
+        if (TrySplitCategorizedName(categorizedName, out string category, out string stateName))
         {
-            var names = categorizedName.Split('/');
-
-            string category = names[0];
-            string stateName = names[1];
-
             if(graphicalUiElement.Categories.TryGetValue(category, out var foundCategory))
             {
-                return foundCategory.States.FirstOrDefault(item => item.Name == stateName);
+                return FindStateByName(foundCategory.States, stateName);
             }
         }
         else
@@ -182,6 +179,40 @@ public class AnimationRuntime
             if(graphicalUiElement.States.TryGetValue(categorizedName, out var foundState))
             {
                 return foundState;
+            }
+        }
+        return null;
+    }
+
+    // Splits "Category/State" into its two parts without allocating the string[] a Split('/') would.
+    // Matches the prior behavior: category is the text before the first '/', state is the text
+    // between the first and second '/' (or to the end when there is no second '/').
+    private static bool TrySplitCategorizedName(string categorizedName, out string category, out string stateName)
+    {
+        int firstSlash = categorizedName.IndexOf('/');
+        if (firstSlash < 0)
+        {
+            category = "";
+            stateName = "";
+            return false;
+        }
+
+        category = categorizedName.Substring(0, firstSlash);
+        int secondSlash = categorizedName.IndexOf('/', firstSlash + 1);
+        stateName = secondSlash >= 0
+            ? categorizedName.Substring(firstSlash + 1, secondSlash - firstSlash - 1)
+            : categorizedName.Substring(firstSlash + 1);
+        return true;
+    }
+
+    // FirstOrDefault(item => item.Name == name) over a state list without the closure allocation.
+    private static StateSave? FindStateByName(List<StateSave> states, string name)
+    {
+        for (int i = 0; i < states.Count; i++)
+        {
+            if (states[i].Name == name)
+            {
+                return states[i];
             }
         }
         return null;
@@ -239,8 +270,11 @@ public class AnimationRuntime
         foreach (var track in _tracks)
         {
             StateSave? stateForTrack = null;
-            var keyframeBefore = track.Value.LastOrDefault(item => item.Time <= animationTime);
-            var keyframeAfter = track.Value.FirstOrDefault(item => item.Time >= animationTime);
+            // Plain loops rather than LINQ LastOrDefault/FirstOrDefault: this runs every frame for
+            // every playing animation, and the capturing lambdas would allocate a closure + delegate
+            // per call (issue #1934).
+            KeyframeRuntime? keyframeBefore = GetLastKeyframeAtOrBefore(track.Value, animationTime);
+            KeyframeRuntime? keyframeAfter = GetFirstKeyframeAtOrAfter(track.Value, animationTime);
 
             if(element != null)
             {
@@ -310,12 +344,18 @@ public class AnimationRuntime
 
     private void CombineStateFromAnimations(double animationTime, ElementSave? element, GraphicalUiElement? graphicalUiElement, ref StateSave stateToSet)
     {
-        var animationKeyframes = this.Keyframes.Where(item => item.SubAnimation != null && item.Time <= animationTime);
-
+        // Iterate the keyframe list directly and guard inline rather than using a LINQ Where: this
+        // runs every frame per playing animation, and the capturing lambda would allocate a closure,
+        // delegate, and iterator even when no keyframe carries a sub-animation (issue #1934).
         if(element != null)
         {
-            foreach (var keyframe in animationKeyframes)
+            foreach (var keyframe in this.Keyframes)
             {
+                if (keyframe.SubAnimation == null || keyframe.Time > animationTime)
+                {
+                    continue;
+                }
+
                 var subAnimationElement = element;
 
                 string instanceName = null;
@@ -352,8 +392,13 @@ public class AnimationRuntime
         }
         else if(graphicalUiElement != null)
         {
-            foreach (var keyframe in animationKeyframes)
+            foreach (var keyframe in this.Keyframes)
             {
+                if (keyframe.SubAnimation == null || keyframe.Time > animationTime)
+                {
+                    continue;
+                }
+
                 var subAnimationGue = graphicalUiElement;
 
                 string instanceName = null;
@@ -389,6 +434,32 @@ public class AnimationRuntime
             }
         }
 
+    }
+
+    // LastOrDefault(item => item.Time <= animationTime) without the closure allocation.
+    private static KeyframeRuntime? GetLastKeyframeAtOrBefore(List<KeyframeRuntime> keyframes, double animationTime)
+    {
+        for (int i = keyframes.Count - 1; i >= 0; i--)
+        {
+            if (keyframes[i].Time <= animationTime)
+            {
+                return keyframes[i];
+            }
+        }
+        return null;
+    }
+
+    // FirstOrDefault(item => item.Time >= animationTime) without the closure allocation.
+    private static KeyframeRuntime? GetFirstKeyframeAtOrAfter(List<KeyframeRuntime> keyframes, double animationTime)
+    {
+        for (int i = 0; i < keyframes.Count; i++)
+        {
+            if (keyframes[i].Time >= animationTime)
+            {
+                return keyframes[i];
+            }
+        }
+        return null;
     }
 
     private static double GetLinearRatio(double value, KeyframeRuntime stateVmBefore, KeyframeRuntime stateVmAfter)

--- a/MonoGameGum.Tests/Performance/AnimationAllocationTests.cs
+++ b/MonoGameGum.Tests/Performance/AnimationAllocationTests.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Graphics.Animation;
+using Gum.GueDeriving;
+using Gum.StateAnimation.Runtime;
+using Gum.Wireframe;
+using MonoGameGum.TestsCommon;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.Tests.Performance;
+
+/// <summary>
+/// Per-frame allocation baselines and regression guards for active AnimationChain (.achx) playback
+/// driven through <see cref="GraphicalUiElement.AnimateSelf(double)"/>. Part of the runtime
+/// allocation pass, issue #1934: animated content advances every frame, so any allocation here is
+/// paid continuously. Each guard uses <see cref="AllocationMeasurer.MeasureMinimum"/> and a liveness
+/// assertion proving the animation actually advanced during the measured window.
+/// </summary>
+public class AnimationAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public AnimationAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Builds a root container holding a Sprite whose animation chain has several frames, animating
+    /// and looping. Returns the root (to drive <see cref="GraphicalUiElement.AnimateSelf(double)"/>)
+    /// and the sprite (to read back playback state for the liveness assertion).
+    /// </summary>
+    private static (ContainerRuntime Root, SpriteRuntime Sprite) BuildAnimatedSpriteScene(int frameCount)
+    {
+        ContainerRuntime root = new();
+
+        SpriteRuntime sprite = new();
+
+        AnimationChain chain = new() { Name = "TestChain" };
+        for (int i = 0; i < frameCount; i++)
+        {
+            chain.Add(new AnimationFrame { FrameLength = 0.1f });
+        }
+
+        AnimationChainList chainList = new();
+        chainList.Add(chain);
+
+        sprite.AnimationChains = chainList;
+        sprite.Animate = true;
+
+        root.AddChild(sprite);
+        root.UpdateLayout();
+
+        return (root, sprite);
+    }
+
+    [Fact]
+    public void AnimateSelf_TextureChainPlayback_IsZeroAllocation()
+    {
+        const int frameCount = 4;
+        const double frameLength = 0.1;
+
+        (ContainerRuntime root, SpriteRuntime sprite) = BuildAnimatedSpriteScene(frameCount);
+
+        int cycleCount = 0;
+        sprite.AnimationChainCycled += () => cycleCount++;
+
+        // Advance a partial frame each iteration so the frame index changes several times per
+        // full loop (proving playback is live), rather than a single big jump.
+        const double secondsPerFrame = frameLength / 2.0;
+        const int measuredIterations = 500;
+        const int attempts = 3;
+
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () => root.AnimateSelf(secondsPerFrame),
+            attempts: attempts,
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        _output.WriteLine($"AnimateSelf on a {frameCount}-frame animated sprite: " +
+            $"{result.BytesPerIteration:N0} bytes/frame ({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // Liveness: the chain must have looped many times across the measured window, proving the
+        // frame-advance path actually ran (so a zero-allocation result isn't a no-op artifact).
+        cycleCount.ShouldBeGreaterThan(0);
+        result.TotalBytes.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Builds a looping state animation that interpolates X from 0 to 100 over one second and starts
+    /// it playing on a root container. Returns the root (to drive AnimateSelf).
+    /// </summary>
+    private static ContainerRuntime BuildStateAnimationScene()
+    {
+        ContainerRuntime root = new();
+
+        StateSaveCategory category = new() { Name = "Category1" };
+        root.Categories[category.Name] = category;
+
+        StateSave state1 = new() { Name = "State1" };
+        state1.Variables.Add(new VariableSave { Name = "X", Value = 0f });
+        category.States.Add(state1);
+
+        StateSave state2 = new() { Name = "State2" };
+        state2.Variables.Add(new VariableSave { Name = "X", Value = 100f });
+        category.States.Add(state2);
+
+        KeyframeRuntime keyframe1 = new()
+        {
+            InterpolationType = FlatRedBall.Glue.StateInterpolation.InterpolationType.Linear,
+            Time = 0,
+            StateName = "Category1/State1"
+        };
+        KeyframeRuntime keyframe2 = new()
+        {
+            InterpolationType = FlatRedBall.Glue.StateInterpolation.InterpolationType.Linear,
+            Time = 1,
+            StateName = "Category1/State2"
+        };
+
+        AnimationRuntime animation = new() { Name = "Animation1", Loops = true };
+        animation.Keyframes.Add(keyframe1);
+        animation.Keyframes.Add(keyframe2);
+        animation.RefreshCumulativeStates(root);
+
+        root.Animations = new List<AnimationRuntime> { animation };
+        root.PlayAnimation("Animation1");
+
+        return root;
+    }
+
+    [Fact]
+    public void AnimateSelf_StateKeyframePlayback_MinimizesAllocation()
+    {
+        ContainerRuntime root = BuildStateAnimationScene();
+
+        // Advance a fraction of the one-second animation each iteration so the interpolated X keeps
+        // moving and the animation (which loops) never stops.
+        const double secondsPerFrame = 0.05;
+        const int measuredIterations = 500;
+        const int attempts = 3;
+
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () => root.AnimateSelf(secondsPerFrame),
+            attempts: attempts,
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        _output.WriteLine($"AnimateSelf on a looping state animation: " +
+            $"{result.BytesPerIteration:N0} bytes/frame ({result.TotalBytes:N0} bytes over {result.Iterations} frames)");
+
+        // Liveness: the animation must still be playing and X must be interpolating within the range.
+        root.AnimationController.IsPlaying.ShouldBeTrue();
+        root.X.ShouldBeInRange(0f, 100f);
+        root.X.ShouldBeGreaterThan(0f);
+
+        // Upper-bound guard for the state/keyframe advancement path. Removing the LINQ
+        // closures/iterators from the keyframe lookup took this from ~3,040 to ~2,336 B/frame. The
+        // residual is the per-frame interpolated StateSave that gets applied (Clone + MergeIntoThis
+        // + ApplyState), which is out of scope here; the bound locks in the win and guards the
+        // avoidable-allocation portion from regressing.
+        result.BytesPerIteration.ShouldBeLessThan(2500);
+    }
+}


### PR DESCRIPTION
Part of #1934 (runtime allocation pass).

Active `.achx` / state-keyframe playback advances every frame, so the LINQ `FirstOrDefault`/`LastOrDefault`/`Where` closures in `AnimationRuntime`'s keyframe/state lookup allocated a closure + delegate (+ iterator) per playing animation per frame. Replaced with index-based helpers (`TrySplitCategorizedName`, `FindStateByName`, `GetLast/FirstKeyframeAtOrBefore/After`, inline-guarded sub-animation loops) — semantics unchanged.

| Scenario | Before | After |
|---|---|---|
| `AnimateSelf` — state-keyframe playback | 3,040 B/f | **2,336 B/f** (−23%) |
| `AnimateSelf` — texture-chain playback | 0 B/f | 0 B/f (regression guard) |

The state-keyframe residual is the per-frame interpolated `StateSave` (`Clone` + `MergeIntoThis` + `ApplyState`), out of scope here. New `AnimationAllocationTests` with liveness guards (chain cycled / X interpolating) and ratchets.

`MonoGameGum.Tests`: 1895/1895 green. `AnimationRuntime.cs` is not in `GumCoreShared.projitems`, so no FRB canary needed.
