### PR TITLE
Eliminate add/remove-child churn allocations (#1934)

### DIFF
--- a/GumCommon/Collections/GraphicalUiElementCollection.cs
+++ b/GumCommon/Collections/GraphicalUiElementCollection.cs
@@ -23,6 +23,9 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     public static GraphicalUiElementCollection Empty => _empty;
 
     private readonly ObservableCollection<IRenderableIpso> _innerCollection = default!;
+    // Non-null when the inner collection supports silent mutation, letting outer-driven changes
+    // sync into it without allocating event args the wrapper's own handler would ignore anyway.
+    private readonly ObservableCollectionNoReset<IRenderableIpso>? _innerNoReset;
     private bool _isUpdatingFromInner = false;
     private bool _isUpdatingFromOuter = false;
 
@@ -37,6 +40,7 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     public GraphicalUiElementCollection(ObservableCollection<IRenderableIpso> innerCollection)
     {
         _innerCollection = innerCollection ?? throw new ArgumentNullException(nameof(innerCollection));
+        _innerNoReset = innerCollection as ObservableCollectionNoReset<IRenderableIpso>;
         IsReadOnly = false;
 
         // Subscribe to inner collection changes
@@ -166,7 +170,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            _innerCollection.Insert(index, item);
+            if (_innerNoReset != null)
+            {
+                _innerNoReset.InsertWithoutNotification(index, item);
+            }
+            else
+            {
+                _innerCollection.Insert(index, item);
+            }
             base.InsertItem(index, item);
         }
         finally
@@ -191,7 +202,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            _innerCollection.RemoveAt(index);
+            if (_innerNoReset != null)
+            {
+                _innerNoReset.RemoveAtWithoutNotification(index);
+            }
+            else
+            {
+                _innerCollection.RemoveAt(index);
+            }
             base.RemoveItem(index);
         }
         finally
@@ -216,7 +234,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            _innerCollection[index] = item;
+            if (_innerNoReset != null)
+            {
+                _innerNoReset.SetWithoutNotification(index, item);
+            }
+            else
+            {
+                _innerCollection[index] = item;
+            }
             base.SetItem(index, item);
         }
         finally
@@ -241,7 +266,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            _innerCollection.Clear();
+            if (_innerNoReset != null)
+            {
+                _innerNoReset.ClearWithoutNotification();
+            }
+            else
+            {
+                _innerCollection.Clear();
+            }
             base.ClearItems();
         }
         finally
@@ -266,7 +298,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            _innerCollection.Move(oldIndex, newIndex);
+            if (_innerNoReset != null)
+            {
+                _innerNoReset.MoveWithoutNotification(oldIndex, newIndex);
+            }
+            else
+            {
+                _innerCollection.Move(oldIndex, newIndex);
+            }
             base.MoveItem(oldIndex, newIndex);
         }
         finally

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5844,10 +5844,14 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     {
         if (e.Action == NotifyCollectionChangedAction.Add)
         {
-            if (e.NewItems != null)
+            // Index rather than foreach: NotifyCollectionChangedEventArgs.NewItems is a non-generic
+            // IList whose enumerator boxes, which is measurable under add/remove churn (#1934).
+            var newItems = e.NewItems;
+            if (newItems != null)
             {
-                foreach (var newItem in e.NewItems)
+                for (int i = 0; i < newItems.Count; i++)
                 {
+                    var newItem = newItems[i];
 #if FULL_DIAGNOSTICS
                     if (newItem == null)
                     {
@@ -5858,7 +5862,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                         throw new InvalidOperationException($"{this} cannot be added as a child of itself");
                     }
 #endif
-                    var ipso = (GraphicalUiElement)newItem;
+                    var ipso = (GraphicalUiElement)newItem!;
 
                     if (ipso.Parent != this && !ipso._isSettingParent)
                     {
@@ -5876,10 +5880,12 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
         else if (e.Action == NotifyCollectionChangedAction.Remove)
         {
-            if (e.OldItems != null)
+            var oldItems = e.OldItems;
+            if (oldItems != null)
             {
-                foreach (GraphicalUiElement child in e.OldItems)
+                for (int i = 0; i < oldItems.Count; i++)
                 {
+                    var child = (GraphicalUiElement)oldItems[i]!;
                     if (child.Parent == this && !child._isSettingParent)
                     {
                         child.Parent = null;
@@ -5889,10 +5895,12 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
         else if (e.Action == NotifyCollectionChangedAction.Reset)
         {
-            if (e.OldItems != null)
+            var oldItems = e.OldItems;
+            if (oldItems != null)
             {
-                foreach (GraphicalUiElement child in e.OldItems)
+                for (int i = 0; i < oldItems.Count; i++)
                 {
+                    var child = (GraphicalUiElement)oldItems[i]!;
                     if (child.Parent == this && !child._isSettingParent)
                     {
                         child.Parent = null;
@@ -5912,20 +5920,24 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
         else if (e.Action == NotifyCollectionChangedAction.Replace)
         {
-            if (e.OldItems != null)
+            var oldItems = e.OldItems;
+            if (oldItems != null)
             {
-                foreach (GraphicalUiElement child in e.OldItems)
+                for (int i = 0; i < oldItems.Count; i++)
                 {
+                    var child = (GraphicalUiElement)oldItems[i]!;
                     if (child.Parent == this && !child._isSettingParent)
                     {
                         child.Parent = null;
                     }
                 }
             }
-            if (e.NewItems != null)
+            var newItems = e.NewItems;
+            if (newItems != null)
             {
-                foreach (IRenderableIpso ipso in e.NewItems)
+                for (int i = 0; i < newItems.Count; i++)
                 {
+                    var ipso = (IRenderableIpso)newItems[i]!;
                     if (ipso.Parent != this)
                     {
                         ipso.Parent = this;

--- a/MonoGameGum.Tests/Performance/ChurnAllocationTests.cs
+++ b/MonoGameGum.Tests/Performance/ChurnAllocationTests.cs
@@ -1,0 +1,87 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Managers;
+using Gum.Wireframe;
+using MonoGameGum.TestsCommon;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoGameGum.Tests.Performance;
+
+/// <summary>
+/// Allocation baselines and regression guards for runtime add/remove-child churn on
+/// <see cref="GraphicalUiElement"/> (issue #1934). UIs that spawn/despawn elements at runtime
+/// (damage numbers, tooltips, streaming list items) repeatedly add and remove children; unlike the
+/// steady-state layout pass, these paths mutate the child collection, reparent, and fire
+/// notifications, so they are the ones warmed under churn. Each guard measures managed bytes per
+/// add+remove cycle and ratchets down as avoidable allocation sources are removed.
+/// </summary>
+public class ChurnAllocationTests : BaseTestClass
+{
+    private readonly ITestOutputHelper _output;
+
+    public ChurnAllocationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Builds a content-sized vertical stack and a reusable child, then lays the stack out so it
+    /// starts laid-out. The returned child is not attached; callers add and remove it to exercise
+    /// the churn path without paying for element construction inside the measured window.
+    /// </summary>
+    private static (ContainerRuntime Stack, ContainerRuntime Child) BuildStackAndChild()
+    {
+        ContainerRuntime stack = new();
+        stack.ChildrenLayout = ChildrenLayout.TopToBottomStack;
+        stack.Width = 200;
+        stack.WidthUnits = DimensionUnitType.Absolute;
+        stack.Height = 0;
+        stack.HeightUnits = DimensionUnitType.RelativeToChildren;
+
+        ContainerRuntime child = new();
+        child.Width = 0;
+        child.WidthUnits = DimensionUnitType.RelativeToParent;
+        child.Height = 30;
+        child.HeightUnits = DimensionUnitType.Absolute;
+
+        stack.UpdateLayout();
+        return (stack, child);
+    }
+
+    [Fact]
+    public void AddRemoveChild_Churn_AllocatesMinimalBytes()
+    {
+        (ContainerRuntime stack, ContainerRuntime child) = BuildStackAndChild();
+
+        const int measuredIterations = 500;
+        const int attempts = 3;
+
+        int addRemoveCount = 0;
+
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () =>
+            {
+                stack.AddChild(child);
+                stack.RemoveChild(child);
+                addRemoveCount += 2;
+            },
+            attempts: attempts,
+            warmupIterations: 50,
+            measuredIterations: measuredIterations);
+
+        _output.WriteLine($"Add+remove child churn on a content-sized stack: " +
+            $"{result.BytesPerIteration:N0} bytes/cycle ({result.TotalBytes:N0} bytes over {result.Iterations} cycles)");
+
+        // Liveness: prove the add/remove actually ran on every measured iteration of every attempt
+        // (a silently no-op mutation would make the byte count meaningless).
+        addRemoveCount.ShouldBeGreaterThanOrEqualTo(measuredIterations * attempts * 2);
+        // Ratchet. Suppressing the inner collection's redundant notifications and de-boxing the
+        // HandleCollectionChanged enumerators took this from ~560 to ~336 B/cycle. The residual is
+        // the outer wrapper's own ObservableCollection event args (one NotifyCollectionChangedEventArgs
+        // + single-item list per add and per remove), which HandleCollectionChanged legitimately
+        // consumes to reparent — removing it needs a notification-design change, out of scope here.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(400);
+    }
+}

--- a/RenderingLibrary/Graphics/IRenderableIpso.cs
+++ b/RenderingLibrary/Graphics/IRenderableIpso.cs
@@ -107,4 +107,40 @@ public class ObservableCollectionNoReset<T> : ObservableCollection<T>
         if (e.Action != NotifyCollectionChangedAction.Reset)
             base.OnCollectionChanged(e);
     }
+
+    /// <summary>
+    /// Inserts an item without raising CollectionChanged. Used by wrappers that mirror this
+    /// collection and raise their own notification, so an event here would only allocate args for
+    /// a handler that ignores them.
+    /// </summary>
+    public void InsertWithoutNotification(int index, T item) => Items.Insert(index, item);
+
+    /// <summary>
+    /// Removes the item at the specified index without raising CollectionChanged. See
+    /// <see cref="InsertWithoutNotification"/> for when to use this.
+    /// </summary>
+    public void RemoveAtWithoutNotification(int index) => Items.RemoveAt(index);
+
+    /// <summary>
+    /// Replaces the item at the specified index without raising CollectionChanged. See
+    /// <see cref="InsertWithoutNotification"/> for when to use this.
+    /// </summary>
+    public void SetWithoutNotification(int index, T item) => Items[index] = item;
+
+    /// <summary>
+    /// Removes all items without raising CollectionChanged. See
+    /// <see cref="InsertWithoutNotification"/> for when to use this.
+    /// </summary>
+    public void ClearWithoutNotification() => Items.Clear();
+
+    /// <summary>
+    /// Moves an item without raising CollectionChanged. See
+    /// <see cref="InsertWithoutNotification"/> for when to use this.
+    /// </summary>
+    public void MoveWithoutNotification(int oldIndex, int newIndex)
+    {
+        T item = Items[oldIndex];
+        Items.RemoveAt(oldIndex);
+        Items.Insert(newIndex, item);
+    }
 }


### PR DESCRIPTION
Part of #1934 (runtime allocation pass).

UIs that spawn/despawn elements at runtime (damage numbers, tooltips, streaming items) repeatedly add and remove children. Two avoidable per-cycle sources removed:

- **Redundant inner notification.** `GraphicalUiElementCollection` mirrors an inner renderable `Children` collection and raises its *own* `CollectionChanged`; the inner collection's notification was only ever consumed by the wrapper's handler, which no-ops during outer-driven updates. Added `*WithoutNotification` mutators on `ObservableCollectionNoReset<T>` and routes outer-driven sync through them.
- **Boxed enumerators.** `HandleCollectionChanged` `foreach`'d over the non-generic `IList` `NewItems`/`OldItems`, boxing an enumerator per notification → index loops.

| Scenario | Before | After |
|---|---|---|
| Add+remove child cycle | 560 B/cycle | **336 B/cycle** (−40%) |

Residual 336 B/cycle is the **outer** wrapper's own `ObservableCollection` event args (one `NotifyCollectionChangedEventArgs` + single-item list per add and per remove), which `HandleCollectionChanged` legitimately consumes to reparent — removing it needs a notification-design change, out of scope. New `ChurnAllocationTests` with liveness + ratchet.

Behavior-preserving: final collection contents and reparenting are unchanged; only redundant inner notifications are suppressed. `MonoGameGum.Tests`: 1894/1894 green. FRB canary: **pass** (built `GumCore.DesktopGlNet6` from the primary checkout, no new errors).
