### PR TITLE
Converge XNA render-target sprites onto raylib's pull model (#3986)

### DIFF
--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -444,10 +444,10 @@ public class SpriteRuntime : GraphicalUiElement
 #endif
 
 #if XNALIKE
-    // IRenderTargetTextureReferencer (RenderingLibrary/Graphics/Sprite.cs) is XNA-only — its
-    // Texture member is typed to XNA's Texture2D, which raylib doesn't have. Raylib resolves its
-    // render-target source directly in Gum.Renderables.Sprite.Render via
-    // Renderer.TryGetBakedRenderTargetFor instead of this interface.
+    // The XNA Renderer's render-target detection walk (CollectReferencedRenderTargets) tests for
+    // IRenderTargetTextureReferencer, so a nested SpriteRuntime must implement it. Raylib's Renderer
+    // resolves the source via concrete Gum.Renderables.Sprite type checks instead, so it doesn't need
+    // this interface. Both backends pull the baked target via Renderer.TryGetBakedRenderTargetFor.
     IRenderableIpso? IRenderTargetTextureReferencer.RenderTargetTextureSource =>
         ContainedSprite.RenderTargetTextureSource;
 #endif

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -519,12 +519,6 @@ public class Renderer : IRenderer
             SetFilteringForLayer(layers[i]);
             PreRender(layers[i].Renderables);
         }
-
-        for (int i = 0; i < layers.Count; i++)
-        {
-            SetFilteringForLayer(layers[i]);
-            PreRenderWithSourceRenderTargets(layers[i].Renderables);
-        }
     }
 
     private void SetFilteringForLayer(Layer layer)
@@ -587,7 +581,6 @@ public class Renderer : IRenderer
 
             SetFilteringForLayer(layer);
             PreRender(layer.Renderables);
-            PreRenderWithSourceRenderTargets(layer.Renderables);
 
             SetFilteringForLayer(layer);
             RenderLayer(managers, layer, prerender:false);
@@ -648,8 +641,6 @@ public class Renderer : IRenderer
         if (prerender)
         {
             PreRender(layer.Renderables);
-
-            PreRenderWithSourceRenderTargets(layer.Renderables);
         }
 
         SpriteBatchStack.PerformStartOfLayerRenderingLogic();
@@ -843,31 +834,15 @@ public class Renderer : IRenderer
         return _referencedRenderTargetOwners.Contains(ResolveRenderTargetCacheOwner(renderable));
     }
 
-    private void PreRenderWithSourceRenderTargets(IList<IRenderableIpso> renderables)
+    /// <summary>
+    /// Returns the baked offscreen render target cached for the given render-target container, or
+    /// null if none exists. A <see cref="Sprite"/> pulls its
+    /// <see cref="Sprite.RenderTargetTextureSource"/> content through this at draw time — the sprite's
+    /// pixel source. Mirrors raylib's <c>Renderer.TryGetBakedRenderTargetFor</c>.
+    /// </summary>
+    public RenderTarget2D? TryGetBakedRenderTargetFor(IRenderableIpso container)
     {
-        var count = renderables.Count;
-        if (count == 0)
-        {
-            return;
-        }
-
-
-        for (int i = 0; i < count; i++)
-        {
-            var renderable = renderables[i];
-            if (renderable.Visible && renderable is IRenderTargetTextureReferencer textureReferencer &&
-                textureReferencer.RenderTargetTextureSource != null)
-            {
-                IRenderableIpso cacheOwner = ResolveRenderTargetCacheOwner(
-                    textureReferencer.RenderTargetTextureSource);
-                textureReferencer.Texture = renderTargetService.GetExistingRenderTarget(cacheOwner);
-            }
-
-            if (renderable.Visible && renderable.Children != null)
-            {
-                PreRenderWithSourceRenderTargets(renderable.Children);
-            }
-        }
+        return renderTargetService.GetExistingRenderTarget(ResolveRenderTargetCacheOwner(container));
     }
 
     private static IRenderableIpso ResolveRenderTargetCacheOwner(IRenderableIpso source)
@@ -910,7 +885,7 @@ public class Renderer : IRenderer
         var oldCameraY = Camera.Y;
         var oldViewport = GraphicsDevice.Viewport;
 
-        // Cache key must match what PreRenderWithSourceRenderTargets resolves for a
+        // Cache key must match what TryGetBakedRenderTargetFor resolves for a
         // RenderTargetTextureSource reference (#3451) — always the contained renderable, not the
         // GraphicalUiElement wrapper a nested container is walked as (#816). Unresolved, a nested
         // source bakes under the wrapper while the referencing Sprite looks up the raw renderable

--- a/RenderingLibrary/Graphics/Sprite.cs
+++ b/RenderingLibrary/Graphics/Sprite.cs
@@ -386,7 +386,7 @@ public class Sprite : SpriteBatchRenderableBase,
             var systemManagers = managers as SystemManagers;
             var renderer = systemManagers.Renderer;
             bool shouldTileByMultipleCalls = this.Wrap && (this as IRenderable).Wrap == false;
-            if (shouldTileByMultipleCalls && (this.Texture != null))
+            if (shouldTileByMultipleCalls && this.Texture != null && RenderTargetTextureSource == null)
             {
                 RenderTiledSprite(renderer.SpriteRenderer, systemManagers);
             }
@@ -394,6 +394,19 @@ public class Sprite : SpriteBatchRenderableBase,
             {
                 Rectangle? sourceRectangle = EffectiveRectangle;
                 Texture2D texture = Texture;
+
+                if (RenderTargetTextureSource != null)
+                {
+                    // Pull the baked render target at draw time (converged onto raylib's model, #3986).
+                    // A null result means nothing baked (off-camera / degenerate / removed source);
+                    // draw nothing rather than stale content.
+                    var baked = renderer.TryGetBakedRenderTargetFor(RenderTargetTextureSource);
+                    if (baked == null)
+                    {
+                        return;
+                    }
+                    texture = baked;
+                }
 
                 var oldX = this.X;
                 var oldY = this.Y;
@@ -926,6 +939,4 @@ public class Sprite : SpriteBatchRenderableBase,
 public interface IRenderTargetTextureReferencer
 {
     IRenderableIpso? RenderTargetTextureSource { get; }
-
-    Texture2D? Texture { get; set; }
 }

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetTextureSourceSpriteTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetTextureSourceSpriteTests.cs
@@ -1,0 +1,329 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins how a <see cref="SpriteRuntime"/> that references a render-target container via
+/// <see cref="Sprite.RenderTargetTextureSource"/> renders the baked content: differing sprite
+/// size, multiple sprites sharing one source, an explicit sub-region, size derivation, and the
+/// unbaked-source case. Guards the push→pull convergence (issue #3986).
+/// </summary>
+public class RenderTargetTextureSourceSpriteTests : BaseTestClass
+{
+    [Fact]
+    public void SpriteReferencingUnbakedSource_DrawsNothing()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        // Not a render target and invisible → nothing bakes and it never composites itself.
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 64;
+        container.Height = 64;
+        container.Visible = false;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime red = new();
+#pragma warning restore CS0618
+        red.Width = 64;
+        red.Height = 64;
+        red.Color = Color.Red;
+        container.AddChild(red);
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        Color sampled = SampleCapturePixel(gd, renderer, managers, 32, 32);
+        sampled.R.ShouldBeLessThan((byte)50);
+    }
+
+    [Fact]
+    public void SpriteSmallerThanSource_DrawsAtSpriteRect()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.Visible = false;
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 40;
+        sprite.Height = 40;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        Color inside = SampleCapturePixel(gd, renderer, managers, 10, 10);
+        inside.R.ShouldBeGreaterThan((byte)150);
+        ((int)inside.R - inside.G).ShouldBeGreaterThan(80);
+
+        // The sprite is 40x40 — the source is 64x64. If placement used the source/texture size the
+        // sprite would fill 64x64 and this pixel would be red.
+        Color outside = SampleCapturePixel(gd, renderer, managers, 55, 55);
+        outside.R.ShouldBeLessThan((byte)50);
+    }
+
+    [Fact]
+    public void TwoSpritesReferencingSameSource_BothRenderBakedContent()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.Visible = false;
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        SpriteRuntime spriteLeft = new();
+        spriteLeft.X = 0;
+        spriteLeft.Y = 0;
+        spriteLeft.Width = 64;
+        spriteLeft.Height = 64;
+        spriteLeft.RenderTargetTextureSource = container;
+        spriteLeft.AddToManagers(managers, null);
+        spriteLeft.UpdateLayout();
+
+        SpriteRuntime spriteRight = new();
+        spriteRight.X = 64;
+        spriteRight.Y = 0;
+        spriteRight.Width = 64;
+        spriteRight.Height = 64;
+        spriteRight.RenderTargetTextureSource = container;
+        spriteRight.AddToManagers(managers, null);
+        spriteRight.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        Color leftSample = SampleCapturePixel(gd, renderer, managers, 16, 16);
+        leftSample.R.ShouldBeGreaterThan((byte)150);
+        ((int)leftSample.R - leftSample.G).ShouldBeGreaterThan(80);
+
+        Color rightSample = SampleCapturePixel(gd, renderer, managers, 80, 16);
+        rightSample.R.ShouldBeGreaterThan((byte)150);
+        ((int)rightSample.R - rightSample.G).ShouldBeGreaterThan(80);
+    }
+
+    [Fact]
+    public void SpriteWithSourceRectangle_SamplesSubRegionOfBakedTarget()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        // Baked target: red left half, green right half.
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 64;
+        container.Height = 64;
+        container.IsRenderTarget = true;
+        container.Visible = false;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime redLeft = new();
+        ColoredRectangleRuntime greenRight = new();
+#pragma warning restore CS0618
+        redLeft.X = 0;
+        redLeft.Width = 32;
+        redLeft.Height = 64;
+        redLeft.Color = Color.Red;
+        container.AddChild(redLeft);
+        greenRight.X = 32;
+        greenRight.Width = 32;
+        greenRight.Height = 64;
+        greenRight.Color = Color.Green;
+        container.AddChild(greenRight);
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        SpriteRuntime sprite = new();
+        sprite.X = 0;
+        sprite.Y = 0;
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        // Only the left (red) half of the baked target, stretched over the whole 64x64 sprite.
+        sprite.SourceRectangle = new Rectangle(0, 0, 32, 64);
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        // The selected sub-region (left, red) is what the sprite samples.
+        Color redRegion = SampleCapturePixel(gd, renderer, managers, 10, 32);
+        redRegion.R.ShouldBeGreaterThan((byte)150);
+        ((int)redRegion.R - redRegion.G).ShouldBeGreaterThan(80);
+
+        // The green right half is excluded by the source rectangle — if it were ignored the whole
+        // red|green texture would draw and this pixel would read green.
+        Color excludedRegion = SampleCapturePixel(gd, renderer, managers, 48, 32);
+        ((int)excludedRegion.G - excludedRegion.R).ShouldBeLessThan(80);
+    }
+
+    [Fact]
+    public void SpriteReferencingRenderTarget_ResolvesBakedTargetViaRendererPull()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime container = CreateRedRenderTargetContainer();
+        container.Visible = false;
+        container.AddToManagers(managers, null);
+        container.UpdateLayout();
+
+        IRenderableIpso cacheOwner = (IRenderableIpso)container.RenderableComponent;
+
+        SpriteRuntime sprite = new();
+        sprite.Width = 64;
+        sprite.Height = 64;
+        sprite.RenderTargetTextureSource = container;
+        sprite.AddToManagers(managers, null);
+        sprite.UpdateLayout();
+
+        AdvanceHostFrame(managers, ref _hostTime);
+        renderer.Draw(managers);
+
+        // Pull model: the sprite resolves the baked target from the renderer at draw time; the
+        // renderer never pushes a Texture onto the sprite.
+        renderer.TryGetBakedRenderTargetFor(cacheOwner).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void SpriteTextureSize_DerivesFromRenderTargetSource()
+    {
+        Sprite sprite = new(null);
+        InvisibleRenderable source = new();
+        source.Width = 80;
+        source.Height = 40;
+
+        sprite.RenderTargetTextureSource = source;
+
+        sprite.TextureWidth.ShouldBe(80f);
+        sprite.TextureHeight.ShouldBe(40f);
+        ((IAspectRatio)sprite).AspectRatio.ShouldBe(2f);
+    }
+
+    private static double _hostTime;
+
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0;
+        managers.Activity(hostTime);
+    }
+
+    private static ContainerRuntime CreateRedRenderTargetContainer()
+    {
+        ContainerRuntime container = new();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 64;
+        container.Height = 64;
+        container.IsRenderTarget = true;
+
+#pragma warning disable CS0618
+        ColoredRectangleRuntime red = new();
+#pragma warning restore CS0618
+        red.Width = 64;
+        red.Height = 64;
+        red.Color = Color.Red;
+        container.AddChild(red);
+
+        return container;
+    }
+
+    private static Color SampleCapturePixel(GraphicsDevice gd, Renderer renderer, SystemManagers managers, int x, int y)
+    {
+        const int w = 128;
+        const int h = 128;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.Black);
+        renderer.Draw(managers);
+        gd.SetRenderTarget(null);
+
+        Color[] pixels = new Color[w * h];
+        capture.GetData(pixels);
+        return pixels[y * w + x];
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Converges XNA (MonoGame/KNI/FNA) render-target-sprite resolution onto raylib's **pull** model.

Before, XNA *pushed*: a renderer pre-pass wrote the baked `Texture2D` onto the sprite via `IRenderTargetTextureReferencer.Texture`. raylib *pulled* the baked target at draw time. Two mechanisms for one behavior.

Now XNA pulls too — `Sprite.Render` calls the new `Renderer.TryGetBakedRenderTargetFor` at draw time (null → draws nothing, no stale content). Removes the write-back pass (`PreRenderWithSourceRenderTargets`) and slims `IRenderTargetTextureReferencer` to the type-neutral `RenderTargetTextureSource` getter — dropping the XNA-typed `Texture` setter that only existed to serve push.

Pull has no cross-pass ordering hazard, no per-frame sprite mutation, and leaves the interface type-neutral so a future Skia render target can join with its own `SKImage` lookup instead of a third platform-typed setter.

**Tests:** 5 characterization pins (differing sprite size, two sprites/one source, `SourceRectangle` sub-region, size-from-source, unbaked-draws-nothing) + 1 red-first mechanism pin. Existing 29 RT tests unchanged.

**Verified:** MonoGame 35 RT + 74 integration + 1896 unit green; SkiaGum/KniGum/RaylibGum build clean; FRB1 canary pass (net6.0 + net8.0); manual — the sample's sprite-from-RT cell and a real game (Kid Defense) render targets render correctly.

Follow-up (not this PR): relocate the now-type-neutral interface to a shared file and have raylib implement it instead of concrete `Sprite` type-checks.

Closes #3986
