### PR TITLE
Clamp StrokeWidth to a minimum of 0 in the variable grid (#3969)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -152,6 +152,12 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
                 variable.PropertiesToSetOnDisplayer["MaxValue"] = 255.0;
                 variable.PreferredDisplayer = typeof(SliderDisplay);
             }
+            else if (variable.Name == "StrokeWidth")
+            {
+                // Stroke width has no meaningful negative value but no natural maximum either, so it
+                // stays a plain numeric field (not a slider) with only a floor of 0.
+                variable.PropertiesToSetOnDisplayer["MinValue"] = 0.0;
+            }
         }
         foreach (var variableList in state.VariableLists)
         {

--- a/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
@@ -122,4 +122,29 @@ public class TextBoxDisplayLogicTests
     {
         TextBoxDisplayLogic.SnapDraggedValue(12.8, null).ShouldBe(12.8);
     }
+
+    [Fact]
+    public void ClampToRange_MinOnly_RaisesBelowMinToMin()
+    {
+        // StrokeWidth-style floor: a min with no max still clamps negatives to the floor.
+        TextBoxDisplayLogic.ClampToRange(-5, 0m, null).ShouldBe(0m);
+    }
+
+    [Fact]
+    public void ClampToRange_MinOnly_LeavesValueAtOrAboveMinUnchanged()
+    {
+        TextBoxDisplayLogic.ClampToRange(10, 0m, null).ShouldBe(10m);
+    }
+
+    [Fact]
+    public void ClampToRange_MaxOnly_LowersAboveMaxToMax()
+    {
+        TextBoxDisplayLogic.ClampToRange(300, null, 255m).ShouldBe(255m);
+    }
+
+    [Fact]
+    public void ClampToRange_NoBounds_LeavesNegativeUnchanged()
+    {
+        TextBoxDisplayLogic.ClampToRange(-5, null, null).ShouldBe(-5m);
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayMinMaxTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayMinMaxTests.cs
@@ -1,0 +1,21 @@
+using Shouldly;
+using WpfDataUi.Controls;
+
+namespace GumToolUnitTests.Controls;
+
+/// <summary>
+/// Pins the reflection-safe MinValue/MaxValue passthrough on the plain numeric field. A variable such
+/// as StrokeWidth has a floor of 0 but no natural maximum, so it renders as a TextBoxDisplay with only
+/// MinValue set (no slider). PropertiesToSetOnDisplayer pushes a boxed double via raw reflection
+/// SetValue, so the exposed property must be double? (not decimal?) or the assignment throws.
+/// </summary>
+public class TextBoxDisplayMinMaxTests : BaseTestClass
+{
+    [StaFact]
+    public void MinValue_Passthrough_RoundTripsThroughReflectionFriendlyDoubleType()
+    {
+        TextBoxDisplay display = new TextBoxDisplay { MinValue = 0.0 };
+
+        display.MinValue.ShouldBe(0.0);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -37,6 +37,22 @@ public class StandardElementsManagerTests : BaseTestClass
         variable.PropertiesToSetOnDisplayer["MaxValue"].ShouldBe(255.0);
     }
 
+    // StrokeWidth has a meaningful floor of 0 but no natural maximum, so it stays a plain numeric
+    // textbox (no SliderDisplay, which would require an arbitrary max) and only gets a MinValue.
+    [Fact]
+    public void SetPreferredDisplayers_ClampsStrokeWidthToMinZero_AsPlainTextBox()
+    {
+        var state = new StateSave();
+        state.Variables.Add(new VariableSave { Type = "float", Name = "StrokeWidth" });
+
+        CreateSut().SetPreferredDisplayers(state);
+
+        var variable = state.Variables.First();
+        variable.PreferredDisplayer.ShouldBeNull();
+        variable.PropertiesToSetOnDisplayer["MinValue"].ShouldBe(0.0);
+        variable.PropertiesToSetOnDisplayer.ContainsKey("MaxValue").ShouldBeFalse();
+    }
+
     // Pins the static->instance drain: the Parent variable's type converter is built from the
     // injected ISelectedState. Before the drain SetPreferredDisplayers pulled ISelectedState from
     // the static Locator (which throws in a unit test); now it must come from the constructor.

--- a/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/TextBoxDisplay.xaml.cs
@@ -35,6 +35,27 @@ namespace WpfDataUi.Controls
         public bool EnableLabelDragValueChange { get; set; } = true;
 
         /// <summary>
+        /// Optional inclusive lower bound for a numeric field. When set, values are clamped up to this
+        /// floor on every write (typing, tab-away, label-drag) so an unbounded field like StrokeWidth
+        /// can still refuse negatives without becoming a slider. Exposed as double? (not decimal?)
+        /// because PropertiesToSetOnDisplayer pushes a boxed double via raw reflection SetValue.
+        /// </summary>
+        public double? MinValue
+        {
+            get => mTextBoxLogic.MinValue.HasValue ? (double)mTextBoxLogic.MinValue.Value : null;
+            set => mTextBoxLogic.MinValue = value.HasValue ? (decimal)value.Value : null;
+        }
+
+        /// <summary>
+        /// Optional inclusive upper bound for a numeric field. See <see cref="MinValue"/>.
+        /// </summary>
+        public double? MaxValue
+        {
+            get => mTextBoxLogic.MaxValue.HasValue ? (double)mTextBoxLogic.MaxValue.Value : null;
+            set => mTextBoxLogic.MaxValue = value.HasValue ? (decimal)value.Value : null;
+        }
+
+        /// <summary>
         /// Resets the label-drag scrub configuration to its declared defaults when this control is
         /// returned to the SingleDataUiContainer pool. TextBoxDisplay controls are recycled across
         /// variables, and only the keys a variable lists in PropertiesToSetOnDisplayer get re-applied
@@ -49,6 +70,8 @@ namespace WpfDataUi.Controls
             LabelDragValueRounding = 1;
             LabelDragChangeMultiplier = 1;
             EnableLabelDragValueChange = true;
+            MinValue = null;
+            MaxValue = null;
         }
 
         public InstanceMember? InstanceMember
@@ -355,6 +378,9 @@ namespace WpfDataUi.Controls
             {
                 // Check if the text has actually changed. If it hasn't, we don't
                 // want to forcefully set the text on a lost focus.
+                // Clamp first so a typed-then-tabbed-away value honors the min/max (Enter already
+                // clamps in HandlePreviewKeydown; this covers the tab-away / click-away path).
+                mTextBoxLogic.ClampTextBoxValuesToMinMax();
                 lastApplyValueResult = mTextBoxLogic.TryApplyToInstance();
             }
 
@@ -458,6 +484,11 @@ namespace WpfDataUi.Controls
                         // 1px-rounded variable still landed on values like 12.8 on a scaled display
                         // (issue #3191). unroundedValue already includes this tick's movement.
                         var rounded = TextBoxDisplayLogic.SnapDraggedValue(unroundedValue, LabelDragValueRounding);
+
+                        // Respect a min/max floor while scrubbing so the field visibly sticks at the
+                        // bound (e.g. StrokeWidth can't be dragged below 0) instead of applying a
+                        // clamped value while the text keeps counting past the limit.
+                        rounded = (double)TextBoxDisplayLogic.ClampToRange(rounded, mTextBoxLogic.MinValue, mTextBoxLogic.MaxValue);
 
                         var getValueStatus = TryGetValueOnUi(out _);
 

--- a/WpfDataUi/Controls/TextBoxDisplayLogic.cs
+++ b/WpfDataUi/Controls/TextBoxDisplayLogic.cs
@@ -79,16 +79,33 @@ namespace WpfDataUi.Controls
 
                 if (decimal.TryParse(mAssociatedTextBox.Text, out parsedDecimal))
                 {
-                    if (MinValue.HasValue && parsedDecimal < MinValue)
+                    decimal clamped = ClampToRange((double)parsedDecimal, MinValue, MaxValue);
+                    if (clamped != parsedDecimal)
                     {
-                        mAssociatedTextBox.Text = MinValue.ToString();
-                    }
-                    if (MaxValue.HasValue && parsedDecimal > MaxValue)
-                    {
-                        mAssociatedTextBox.Text = MaxValue.ToString();
+                        mAssociatedTextBox.Text = clamped.ToString();
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Clamps a value into an optional [min, max] range. Either bound may be null (an unbounded
+        /// side), so a variable like StrokeWidth can enforce a floor of 0 with no upper limit.
+        /// </summary>
+        public static decimal ClampToRange(double value, decimal? min, decimal? max)
+        {
+            decimal result = (decimal)value;
+
+            if (min.HasValue && result < min.Value)
+            {
+                result = min.Value;
+            }
+            if (max.HasValue && result > max.Value)
+            {
+                result = max.Value;
+            }
+
+            return result;
         }
 
         private void HandlePreviewKeydown(object? sender, System.Windows.Input.KeyEventArgs e)


### PR DESCRIPTION
## Problem
StrokeWidth's numeric field in the variable grid had no minimum — it could be dragged or typed below zero, which is meaningless for a stroke.

## Fix
The plain numeric field (`TextBoxDisplay`) had no min/max support at all; clamping only existed on `SliderDisplay`, which needs a finite max. StrokeWidth has no natural maximum, so a slider is wrong.

- Add reflection-safe `MinValue`/`MaxValue` passthrough on `TextBoxDisplay` (`double?`, reset on pooling so a floor doesn't leak to the next variable).
- Clamp on **all** write paths — Enter (already did), tab/click-away, and label-drag scrub — so the field visibly sticks at the bound.
- Extract a pure `ClampToRange` static (min-only / max-only / both) as the testable seam.
- Wire `StrokeWidth` to a floor of 0 with no max, keeping it a text field.

## Tests
6 new, all green: `ClampToRange` cases, the StrokeWidth wiring, and the `double?` reflection-safety of the passthrough. `GumFull.sln` builds clean. Manually verified in the tool: dragging/typing StrokeWidth negative now sticks at 0.

Closes #3969
