### PR TITLE
Move IRenderTargetTextureReferencer to GumCommon; unify RT-sprite detection (#3992)

### DIFF
--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -42,7 +42,7 @@ namespace Gum.GueDeriving;
 /// Provides a unified API for common Sprite properties across different rendering platforms.
 /// </summary>
 public class SpriteRuntime : GraphicalUiElement
-#if XNALIKE
+#if XNALIKE || RAYLIB || SKIA
     , IRenderTargetTextureReferencer
 #endif
 {
@@ -442,15 +442,6 @@ public class SpriteRuntime : GraphicalUiElement
             }
         }
     }
-#endif
-
-#if XNALIKE
-    // The XNA Renderer's render-target detection walk (CollectReferencedRenderTargets) tests for
-    // IRenderTargetTextureReferencer, so a nested SpriteRuntime must implement it. The raylib and Skia
-    // Renderers resolve the source via concrete Sprite type checks instead, so they don't need this
-    // interface. All three backends pull the baked target via Renderer.TryGetBakedRenderTargetFor.
-    IRenderableIpso? IRenderTargetTextureReferencer.RenderTargetTextureSource =>
-        ContainedSprite.RenderTargetTextureSource;
 #endif
 
 

--- a/RenderingLibrary/Graphics/IRenderableIpso.cs
+++ b/RenderingLibrary/Graphics/IRenderableIpso.cs
@@ -48,6 +48,19 @@ public interface IRenderTargetRenderable
     object? RenderTargetEffect { get; set; }
 }
 
+/// <summary>
+/// Implemented by a renderable (or its runtime wrapper) that displays another container's baked
+/// render-target texture as its pixel source. The <c>Renderer</c>'s render-target detection walk
+/// (<c>CollectReferencedRenderTargets</c>) tests for this interface to discover which containers
+/// must bake this frame — even invisible ones, as long as a visible referencer points at them.
+/// Type-neutral (the source is an <see cref="IRenderableIpso"/>, not a backend texture type) so it
+/// lives here in GumCommon and every backend — xnalike, raylib, Skia — implements the one path.
+/// </summary>
+public interface IRenderTargetTextureReferencer
+{
+    IRenderableIpso? RenderTargetTextureSource { get; }
+}
+
 
 public static class IRenderableIpsoExtensions
 {

--- a/RenderingLibrary/Graphics/Sprite.cs
+++ b/RenderingLibrary/Graphics/Sprite.cs
@@ -933,10 +933,3 @@ public class Sprite : SpriteBatchRenderableBase,
         return Clone();
     }
 }
-
-
-
-public interface IRenderTargetTextureReferencer
-{
-    IRenderableIpso? RenderTargetTextureSource { get; }
-}

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -14,7 +14,7 @@ using ToolsUtilitiesStandard.Helpers;
 using static Raylib_cs.Raylib;
 
 namespace Gum.Renderables;
-public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAnimatable, IRenderableIpso
+public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAnimatable, IRenderableIpso, IRenderTargetTextureReferencer
 {
     public Texture2D? Texture { get; set; }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -323,10 +323,9 @@ public class Renderer : IRenderer
 
     // Populates _referencedRenderTargetOwners with the cache owner of every render-target container
     // referenced by a visible Sprite's RenderTargetTextureSource. Both a top-level Sprite (the walk
-    // hands the contained Sprite directly) and a nested one (a GraphicalUiElement wrapping the Sprite)
-    // are handled. Mirrors MonoGame's CollectReferencedRenderTargets, but resolves the raylib
-    // Gum.Renderables.Sprite concretely — raylib has no IRenderTargetTextureReferencer interface (its
-    // Texture member is XNA-typed). See #3452 / #1643.
+    // hands the contained Sprite directly) and a nested one (a SpriteRuntime wrapping the Sprite)
+    // implement IRenderTargetTextureReferencer, so one interface test covers both — the same detection
+    // path the xnalike and Skia Renderers use (#3992). See #3452 / #1643.
     private void CollectReferencedRenderTargets(System.Collections.Generic.IList<IRenderableIpso> renderables)
     {
         for (int i = 0; i < renderables.Count; i++)
@@ -337,12 +336,11 @@ public class Renderer : IRenderer
                 continue;
             }
 
-            Sprite? sprite = renderable as Sprite
-                ?? (renderable as GraphicalUiElement)?.RenderableComponent as Sprite;
-            if (sprite?.RenderTargetTextureSource != null)
+            if (renderable is IRenderTargetTextureReferencer textureReferencer &&
+                textureReferencer.RenderTargetTextureSource != null)
             {
                 _referencedRenderTargetOwners.Add(
-                    ResolveRenderTargetCacheOwner(sprite.RenderTargetTextureSource));
+                    ResolveRenderTargetCacheOwner(textureReferencer.RenderTargetTextureSource));
             }
 
             if (renderable.Children != null)

--- a/Runtimes/SkiaGum/Renderables/Sprite.cs
+++ b/Runtimes/SkiaGum/Renderables/Sprite.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace SkiaGum.Renderables;
 
-public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAnimatable, ICloneable
+public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAnimatable, ICloneable, IRenderTargetTextureReferencer
 {
     public object Clone()
     {

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -325,7 +325,9 @@ namespace RenderingLibrary.Graphics
 
         // Populates _referencedRenderTargetOwners with the cache owner of every render-target
         // container referenced by a visible Sprite's RenderTargetTextureSource. Both a top-level
-        // Sprite (handed directly) and a nested one (wrapped in a GraphicalUiElement) are handled.
+        // Sprite (handed directly) and a nested one (a SpriteRuntime wrapping the Sprite) implement
+        // IRenderTargetTextureReferencer, so one interface test covers both — the same detection path
+        // the xnalike and raylib Renderers use (#3992).
         private void CollectReferencedRenderTargets(IList<IRenderableIpso> renderables)
         {
             for (int i = 0; i < renderables.Count; i++)
@@ -336,11 +338,10 @@ namespace RenderingLibrary.Graphics
                     continue;
                 }
 
-                SkiaGum.Renderables.Sprite sprite = renderable as SkiaGum.Renderables.Sprite
-                    ?? (renderable as GraphicalUiElement)?.RenderableComponent as SkiaGum.Renderables.Sprite;
-                if (sprite?.RenderTargetTextureSource != null)
+                if (renderable is IRenderTargetTextureReferencer textureReferencer &&
+                    textureReferencer.RenderTargetTextureSource != null)
                 {
-                    _referencedRenderTargetOwners.Add(ResolveRenderTargetCacheOwner(sprite.RenderTargetTextureSource));
+                    _referencedRenderTargetOwners.Add(ResolveRenderTargetCacheOwner(textureReferencer.RenderTargetTextureSource));
                 }
 
                 if (renderable.Children != null)


### PR DESCRIPTION
Closes #3992.

`IRenderTargetTextureReferencer` became type-neutral in #3987 (`IRenderableIpso? RenderTargetTextureSource`, no XNA `Texture2D`), but still lived in the xnalike-only `RenderingLibrary/Graphics/Sprite.cs` — so raylib/Skia couldn't implement it and detected referencing sprites via concrete `Sprite` type checks instead.

**Change:** moved the interface to `IRenderableIpso.cs` (GumCommon, same `RenderingLibrary.Graphics` namespace, alongside `IRenderTargetRenderable`). raylib and Skia `Sprite` renderables + `SpriteRuntime` now implement it, and both renderers' `CollectReferencedRenderTargets` switch to the `is IRenderTargetTextureReferencer` test the xnalike `Renderer` already uses. Also dropped `SpriteRuntime`'s now-redundant explicit interface impl — the public property (gated for all three backends) satisfies the interface directly.

Result: one detection path across xnalike, raylib, and Skia instead of one interface-based + two concrete. Interface home moved to base library as suggested — no `#if` needed since it carries no backend texture type.

**Tests:** behavior-preserving; existing render-target pins cover it (raylib 23, Skia 5, MonoGame integration 35 — all green). Confirmed the `SpriteRuntime` interface impl is load-bearing by inverting it and watching the referencer tests go red on both raylib and Skia.

FRB canary: pass (`GumCore.DesktopGlNet6`, clean against baseline).
