### PR TITLE
Remove color-conversion #if from Sprite/Text/NineSlice runtimes

### DIFF
--- a/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/NineSliceRuntimeTests.cs
@@ -78,6 +78,21 @@ public class NineSliceRuntimeTests
     }
 
     [Fact]
+    public void Color_ShouldRoundTrip_ThroughContainedRenderable()
+    {
+        // Pins the System.Drawing <-> XNA conversion in the Color property (ToUserColor/
+        // ToContainerColor on XNALIKE). Distinct channels catch any R/B swap or dropped alpha.
+        NineSliceRuntime sut = new();
+
+        sut.Color = new Microsoft.Xna.Framework.Color(10, 20, 30, 40);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+        sut.Color.A.ShouldBe((byte)40);
+    }
+
+    [Fact]
     public void Constructor_ShouldDefaultSizeTo100()
     {
         // Bucket 1 (#2908): all backends should default a NineSliceRuntime to 100x100.

--- a/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -142,6 +142,21 @@ public class SpriteRuntimeTests : BaseTestClass
     }
 
     [Fact]
+    public void Color_ShouldRoundTrip_ThroughContainedRenderable()
+    {
+        // Pins the System.Drawing <-> XNA conversion in the Color property (ToUserColor/
+        // ToContainerColor on XNALIKE). Distinct channels catch any R/B swap or dropped alpha.
+        SpriteRuntime sut = new();
+
+        sut.Color = new Microsoft.Xna.Framework.Color(10, 20, 30, 40);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+        sut.Color.A.ShouldBe((byte)40);
+    }
+
+    [Fact]
     public void CurrentFrameIndex_ShouldSyncTimeIntoAnimation()
     {
         // 3 frames: 0.5s, 1.0s, 0.75s

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -84,6 +84,25 @@ $"chars count=223\r\n";
 
     #endregion
 
+    #region Color
+
+    [Fact]
+    public void Color_ShouldRoundTrip_ThroughContainedRenderable()
+    {
+        // Pins the System.Drawing <-> XNA conversion in the Color property (ToUserColor/
+        // ToContainerColor on XNALIKE). Distinct channels catch any R/B swap or dropped alpha.
+        TextRuntime sut = new();
+
+        sut.Color = new Microsoft.Xna.Framework.Color(10, 20, 30, 40);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+        sut.Color.A.ShouldBe((byte)40);
+    }
+
+    #endregion
+
     #region FontScale Inline Measurement (issue #3481)
 
     // Issue #3481: an inline [FontScale=N] run renders larger but the Text used to report its

--- a/MonoGameGum/GueDeriving/NineSliceRuntime.cs
+++ b/MonoGameGum/GueDeriving/NineSliceRuntime.cs
@@ -5,18 +5,21 @@ using System;
 #if RAYLIB
 using Gum.Graphics.Animation;
 using Gum.Renderables;
+using RaylibGum.Helpers;
 using Color = Raylib_cs.Color;
 using Texture2D = Raylib_cs.Texture2D;
 using ContainedNineSliceType = Gum.Renderables.NineSlice;
 #elif SOKOL
 using Gum.Graphics.Animation;
 using Gum.Renderables;
+using SokolGum.Helpers;
 using Color = SokolGum.Color;
 using Texture2D = SokolGum.Texture2D;
 using ContainedNineSliceType = Gum.Renderables.NineSlice;
 #elif SKIA
 using Gum.Graphics.Animation;
 using SkiaGum.Renderables;
+using SkiaGum.Helpers;
 using Color = SkiaSharp.SKColor;
 using Texture2D = SkiaSharp.SKBitmap;
 using ContainedNineSliceType = SkiaGum.Renderables.NineSlice;
@@ -171,21 +174,12 @@ public class NineSliceRuntime : InteractiveGue
 
     public Color Color
     {
-#if XNALIKE
-        get => global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedNineSlice.Color);
+        get => ContainedNineSlice.Color.ToUserColor();
         set
         {
-            ContainedNineSlice.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedNineSlice.Color = value.ToContainerColor();
             NotifyPropertyChanged();
         }
-#else
-        get => ContainedNineSlice.Color;
-        set
-        {
-            ContainedNineSlice.Color = value;
-            NotifyPropertyChanged();
-        }
-#endif
     }
 
     #endregion

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -12,12 +12,14 @@ using System.Threading.Tasks;
 #if RAYLIB
 using Gum.Renderables;
 using RenderingLibrary.Graphics;
+using RaylibGum.Helpers;
 using Color = Raylib_cs.Color;
 using Rectangle = Raylib_cs.Rectangle;
 using Texture2D = Raylib_cs.Texture2D;
 using ContainedSpriteType = Gum.Renderables.Sprite;
 #elif SKIA
 using SkiaGum.Renderables;
+using SkiaGum.Helpers;
 using RenderingLibrary.Graphics;
 using Color = SkiaSharp.SKColor;
 using Rectangle = SkiaSharp.SKRect;
@@ -121,21 +123,10 @@ public class SpriteRuntime : GraphicalUiElement
     /// </summary>
     public Color Color
     {
-        get
-        {
-#if RAYLIB || SKIA
-            return ContainedSprite.Color;
-#else
-            return global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedSprite.Color);
-#endif
-        }
+        get => ContainedSprite.Color.ToUserColor();
         set
         {
-#if RAYLIB || SKIA
-            ContainedSprite.Color = value;
-#else
-            ContainedSprite.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
-#endif
+            ContainedSprite.Color = value.ToContainerColor();
             NotifyPropertyChanged();
         }
     }

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -1,8 +1,10 @@
 ﻿using Gum.DataTypes;
 #if RAYLIB
 using Gum.Renderables;
+using RaylibGum.Helpers;
 #elif SKIA
 using SkiaGum;
+using SkiaGum.Helpers;
 using SkiaSharp;
 #else
 using Gum.Graphics;
@@ -138,21 +140,12 @@ public class TextRuntime : InteractiveGue
     /// </summary>
     public Color Color
     {
-#if XNALIKE
-        get => global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(ContainedText.Color);
+        get => ContainedText.Color.ToUserColor();
         set
         {
-            ContainedText.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToSystemDrawing(value);
+            ContainedText.Color = value.ToContainerColor();
             NotifyPropertyChanged();
         }
-#else
-        get => ContainedText.Color;
-        set
-        {
-            ContainedText.Color = value;
-            NotifyPropertyChanged();
-        }
-#endif
     }
 
     /// <summary>

--- a/Runtimes/SkiaGum/Helpers/ColorExtensions.cs
+++ b/Runtimes/SkiaGum/Helpers/ColorExtensions.cs
@@ -53,4 +53,17 @@ public static class ColorExtensions
     {
         return new SKColor(value.R, value.G, value.B, value.A);
     }
+
+    /// <summary>
+    /// Converts a contained renderable's color to the user-facing color. On Skia both are
+    /// <see cref="SKColor"/>, so this is identity — it exists only so shared runtime source can
+    /// call the same member name that needs a real conversion on the XNA backend.
+    /// </summary>
+    public static SKColor ToUserColor(this SKColor value) => value;
+
+    /// <summary>
+    /// Converts a user-facing color to the contained renderable's color. Identity on Skia; see
+    /// <see cref="ToUserColor(SKColor)"/>.
+    /// </summary>
+    public static SKColor ToContainerColor(this SKColor value) => value;
 }

--- a/Runtimes/SokolGum/Helpers/ColorExtensions.cs
+++ b/Runtimes/SokolGum/Helpers/ColorExtensions.cs
@@ -1,0 +1,23 @@
+namespace SokolGum.Helpers;
+
+/// <summary>
+/// Extension helpers for the Sokol <see cref="Color"/> type. Mirrors the surface of
+/// <c>RaylibGum.Helpers.ColorExtensions</c>, <c>SkiaGum.Helpers.ColorExtensions</c>, and the
+/// XNA-side <c>RenderingLibrary.Graphics.XNAExtensions</c> so shared runtime code can call the
+/// same members on any backend.
+/// </summary>
+public static class ColorExtensions
+{
+    /// <summary>
+    /// Converts a contained renderable's color to the user-facing color. On Sokol both are
+    /// <see cref="Color"/>, so this is identity — it exists only so shared runtime source can
+    /// call the same member name that needs a real conversion on the XNA backend.
+    /// </summary>
+    public static Color ToUserColor(this Color value) => value;
+
+    /// <summary>
+    /// Converts a user-facing color to the contained renderable's color. Identity on Sokol; see
+    /// <see cref="ToUserColor(Color)"/>.
+    /// </summary>
+    public static Color ToContainerColor(this Color value) => value;
+}


### PR DESCRIPTION
Removes the color-conversion `#if` from `SpriteRuntime`, `TextRuntime`, and `NineSliceRuntime`.

Each gated its `Color` property's `System.Drawing.Color` ↔ platform-color conversion behind `#if XNALIKE` (real `ToXNA`/`ToSystemDrawing`) with an identity passthrough on the other backends. All three now use the unguarded `.ToUserColor()` / `.ToContainerColor()` extension pair from #2757 — already the pattern in `PolygonRuntime` — so each `Color` body is backend-identical with no `#if`.

Completes the per-backend helper mirror so the pair resolves everywhere:
- **Skia**: adds the missing `ToUserColor`/`ToContainerColor` identity overloads on `SKColor` (its `ColorExtensions` doc comment already claimed the mirror).
- **Sokol**: adds `SokolGum.Helpers.ColorExtensions` with identity overloads on `SokolGum.Color` (Sokol links the shared `NineSliceRuntime.cs`, unlike Sprite/Text which it overrides).
- Raylib had the pair; XNALIKE resolves via `XNAExtensions`.

**Out of scope:** `ColoredRectangleRuntime` keeps its `#if` — it is obsolete and slated for removal, so it's not worth the churn.

**Verification:** all CI backends green — MonoGameGum.Tests XNALIKE (incl. new `Color` round-trip pins on all three runtimes, none of which were covered before); RaylibGum, SkiaGum, KniGum build clean. Sokol is experimental / not in CI and was not built; its edit mirrors the verified Raylib/Skia identity overloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
