### PR TITLE
Extract shared BmfcSave builder for inline BBCode font runs

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1301,6 +1301,38 @@ public partial class CustomSetPropertyOnRenderable
         return bmfcSave;
     }
 
+    /// <summary>
+    /// Builds the <see cref="BmfcSave"/> for a family-name/CustomFontFile font sync - shared by
+    /// <c>GetOrCreateBakedFont</c> (both its in-memory and disk/FontService branches) and its Raylib
+    /// mirror inside <c>ApplyFontVariables</c>. Identical on every platform: copies
+    /// <paramref name="textRuntime"/>'s font generation fields (size, outline, bold, italic,
+    /// dropshadow - via <c>CopyFontGenerationFieldsTo</c>) plus the current project's font
+    /// ranges/spacing.
+    /// </summary>
+    /// <remarks>
+    /// Same dual signature as <c>GetOrCreateBakedFont</c>: under FRB, <c>CopyFontGenerationFieldsTo</c>
+    /// is the FRB-only extension method on <see cref="GraphicalUiElement"/> (FRB has no TextRuntime);
+    /// everywhere else it's an instance method on <see cref="Gum.GueDeriving.TextRuntime"/> itself, so
+    /// the parameter must stay typed as TextRuntime there or overload resolution fails to find it.
+    /// </remarks>
+#if FRB
+    static BmfcSave BuildFontSyncBmfcSave(GraphicalUiElement textRuntime, string? fontFilePath)
+#else
+    static BmfcSave BuildFontSyncBmfcSave(Gum.GueDeriving.TextRuntime textRuntime, string? fontFilePath)
+#endif
+    {
+        BmfcSave bmfcSave = new BmfcSave();
+        textRuntime.CopyFontGenerationFieldsTo(
+            bmfcSave, fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
+
+        var gumProject = ObjectFinder.Self.GumProjectSave;
+        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+        return bmfcSave;
+    }
+
     static List<TagInfo> allTags = new List<TagInfo>();
 
     /// <summary>
@@ -2045,15 +2077,7 @@ public partial class CustomSetPropertyOnRenderable
         {
             try
             {
-                BmfcSave bmfcSave = new BmfcSave();
-                textRuntime.CopyFontGenerationFieldsTo(
-                    bmfcSave,
-                    fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
-
-                var gumProject = ObjectFinder.Self.GumProjectSave;
-                bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-                bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+                BmfcSave bmfcSave = BuildFontSyncBmfcSave(textRuntime, fontFilePath);
 
                 font = InMemoryFontCreator.TryCreateFont(bmfcSave);
                 if (font != null)
@@ -2075,15 +2099,7 @@ public partial class CustomSetPropertyOnRenderable
         {
             try
             {
-                BmfcSave bmfcSave = new BmfcSave();
-                textRuntime.CopyFontGenerationFieldsTo(
-                    bmfcSave,
-                    fontFilePath != null ? ResolveFontFilePath(fontFilePath) : null);
-
-                var gumProject = ObjectFinder.Self.GumProjectSave;
-                bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-                bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+                BmfcSave bmfcSave = BuildFontSyncBmfcSave(textRuntime, fontFilePath);
 
                 FontService.CreateFontIfNecessary(bmfcSave);
             }
@@ -2362,21 +2378,15 @@ public partial class CustomSetPropertyOnRenderable
                         return;
                     }
 
-                    // In-memory font creation (no disk I/O). The BmfcSave construction below is kept
-                    // byte-identical to the MonoGame path in Gum/Wireframe/CustomSetPropertyOnRenderable.cs;
-                    // only the created-font type (Raylib_cs.Font vs BitmapFont) and how it is cached are
-                    // necessarily platform-gated. Null/failure falls through to the FontCache .fnt path.
+                    // In-memory font creation (no disk I/O). BuildFontSyncBmfcSave is shared with the
+                    // MonoGame path in GetOrCreateBakedFont; only the created-font type (Raylib_cs.Font
+                    // vs BitmapFont) and how it is cached are necessarily platform-gated. Null/failure
+                    // falls through to the FontCache .fnt path.
                     if (InMemoryFontCreator != null)
                     {
                         try
                         {
-                            BmfcSave bmfcSave = new BmfcSave();
-                            textRuntime.CopyFontGenerationFieldsTo(bmfcSave, resolvedFontFilePath: null);
-
-                            var gumProject = ObjectFinder.Self.GumProjectSave;
-                            bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-                            bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                            bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+                            BmfcSave bmfcSave = BuildFontSyncBmfcSave(textRuntime, fontFilePath: null);
 
                             Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
                             if (createdFont.HasValue && createdFont.Value.BaseSize != 0)

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1265,6 +1265,42 @@ public partial class CustomSetPropertyOnRenderable
         bmfcSave.DropshadowAlpha = currentDropshadowAlpha;
     }
 
+    /// <summary>
+    /// Builds the <see cref="BmfcSave"/> for an in-memory inline-run font creation inside
+    /// <c>GetAndCreateFontIfNecessary</c>. Identical on every platform - only the created font's type
+    /// (<c>BitmapFont</c> vs <c>Raylib_cs.Font</c>) and how it's cached differ, which stay #if-gated in
+    /// the caller.
+    /// </summary>
+    static BmfcSave BuildInlineRunBmfcSave(
+        int fontSize, int outlineThickness, bool useFontSmoothing, bool isItalic, bool isBold,
+        string? fontFilePath, string fontName)
+    {
+        BmfcSave bmfcSave = new BmfcSave();
+        bmfcSave.FontSize = fontSize;
+        bmfcSave.OutlineThickness = outlineThickness;
+        bmfcSave.UseSmoothing = useFontSmoothing;
+        bmfcSave.IsItalic = isItalic;
+        bmfcSave.IsBold = isBold;
+        ApplyCurrentDropshadowTo(bmfcSave);
+
+        if (fontFilePath != null)
+        {
+            bmfcSave.FontFile = ResolveFontFilePath(fontFilePath);
+            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(fontFilePath);
+        }
+        else
+        {
+            bmfcSave.FontName = fontName;
+        }
+
+        var gumProject = ObjectFinder.Self.GumProjectSave;
+        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
+        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
+        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+
+        return bmfcSave;
+    }
+
     static List<TagInfo> allTags = new List<TagInfo>();
 
     /// <summary>
@@ -1734,28 +1770,9 @@ public partial class CustomSetPropertyOnRenderable
                     {
                         string? bbFontFile = BmfcSave.IsFontFilePath(fontNameStack.Peek()) ? fontNameStack.Peek() : null;
 
-                        BmfcSave bmfcSave = new BmfcSave();
-                        bmfcSave.FontSize = fontSizeStack.Peek();
-                        bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
-                        bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
-                        bmfcSave.IsItalic = isItalicStack.Peek();
-                        bmfcSave.IsBold = isBoldStack.Peek();
-                        ApplyCurrentDropshadowTo(bmfcSave);
-
-                        if (bbFontFile != null)
-                        {
-                            bmfcSave.FontFile = ResolveFontFilePath(bbFontFile);
-                            bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbFontFile);
-                        }
-                        else
-                        {
-                            bmfcSave.FontName = fontNameStack.Peek();
-                        }
-
-                        var gumProject = ObjectFinder.Self.GumProjectSave;
-                        bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-                        bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                        bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+                        BmfcSave bmfcSave = BuildInlineRunBmfcSave(
+                            fontSizeStack.Peek(), outlineThicknessStack.Peek(), useFontSmoothingStack.Peek(),
+                            isItalicStack.Peek(), isBoldStack.Peek(), bbFontFile, fontNameStack.Peek());
 
                         font = InMemoryFontCreator.TryCreateFont(bmfcSave);
                         if (font != null)
@@ -1890,28 +1907,9 @@ public partial class CustomSetPropertyOnRenderable
                     return cachedManagedFont.Font;
                 }
 
-                BmfcSave bmfcSave = new BmfcSave();
-                bmfcSave.FontSize = fontSizeStack.Peek();
-                bmfcSave.OutlineThickness = outlineThicknessStack.Peek();
-                bmfcSave.UseSmoothing = useFontSmoothingStack.Peek();
-                bmfcSave.IsItalic = isItalicStack.Peek();
-                bmfcSave.IsBold = isBoldStack.Peek();
-                ApplyCurrentDropshadowTo(bmfcSave);
-
-                if (bbCodeFontFilePath != null)
-                {
-                    bmfcSave.FontFile = ResolveFontFilePath(bbCodeFontFilePath);
-                    bmfcSave.FontName = System.IO.Path.GetFileNameWithoutExtension(bbCodeFontFilePath);
-                }
-                else
-                {
-                    bmfcSave.FontName = fontName;
-                }
-
-                var gumProject = ObjectFinder.Self.GumProjectSave;
-                bmfcSave.Ranges = gumProject?.FontRanges ?? BmfcSave.GetEffectiveDefaultRanges();
-                bmfcSave.SpacingHorizontal = gumProject?.FontSpacingHorizontal ?? 1;
-                bmfcSave.SpacingVertical = gumProject?.FontSpacingVertical ?? 1;
+                BmfcSave bmfcSave = BuildInlineRunBmfcSave(
+                    fontSizeStack.Peek(), outlineThicknessStack.Peek(), useFontSmoothingStack.Peek(),
+                    isItalicStack.Peek(), isBoldStack.Peek(), bbCodeFontFilePath, fontName);
 
                 Raylib_cs.Font? createdFont = InMemoryFontCreator.TryCreateFont(bmfcSave);
                 if (createdFont.HasValue && createdFont.Value.BaseSize != 0)

--- a/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
@@ -2,6 +2,7 @@ using Gum.GueDeriving;
 using RaylibGum.Renderables;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
+using System;
 using Xunit;
 
 namespace RaylibGum.Tests.Renderables;
@@ -26,6 +27,14 @@ public class InMemoryFontCreatorTests : BaseTestClass
     [Fact]
     public void UpdateToFontValues_WhenInMemoryFontCreatorSet_ConsultsItWithCurrentFontProperties()
     {
+        // A GUID-suffixed font name, not a fixed one like "Arial": LoaderManager's font cache is a
+        // process-wide static that TextMarkupTests (which doesn't inherit BaseTestClass and never
+        // resets it) can populate with a real Arial+Bold+20 font from a working font creator. If this
+        // test also requests Arial+Bold+20, a cache-hit early-return in UpdateToFontValues can return
+        // before ever consulting THIS test's creator, leaving LastReceived stale from an earlier
+        // property assignment - order-dependent, so it passed locally but failed in CI (whichever test
+        // happens to run first differs by environment). A name unique to this test can never collide.
+        string uniqueFontName = "GumInMemoryFontCreatorTest_" + Guid.NewGuid().ToString("N");
         RecordingFontCreator creator = new RecordingFontCreator();
         IRaylibFontCreator? saved = CustomSetPropertyOnRenderable.InMemoryFontCreator;
         try
@@ -33,13 +42,13 @@ public class InMemoryFontCreatorTests : BaseTestClass
             CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
 
             TextRuntime textRuntime = new TextRuntime();
-            textRuntime.Font = "Arial";
+            textRuntime.Font = uniqueFontName;
             textRuntime.IsBold = true;
             textRuntime.FontSize = 20;
 
             creator.CallCount.ShouldBeGreaterThan(0);
             creator.LastReceived.ShouldNotBeNull();
-            creator.LastReceived!.FontName.ShouldBe("Arial");
+            creator.LastReceived!.FontName.ShouldBe(uniqueFontName);
             creator.LastReceived.FontSize.ShouldBe(20);
             creator.LastReceived.IsBold.ShouldBeTrue();
         }

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeBbCodeDropshadowRegressionTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeBbCodeDropshadowRegressionTests.cs
@@ -1,0 +1,78 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using KernSmith.Gum;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// #3625 parity (Raylib): mirrors MonoGameGum.Tests.Runtimes.TextRuntimeBbCodeDropshadowRegressionTests.
+// GetAndCreateFontIfNecessary's Raylib branch shares BuildInlineRunBmfcSave with the MonoGame branch
+// (Gum/Wireframe/CustomSetPropertyOnRenderable.cs) - a base TextRuntime with HasDropshadow=true must
+// propagate its dropshadow fields onto an inline BBCode font run's BmfcSave here too, not just on
+// MonoGame. Previously untested on this platform.
+public class TextRuntimeBbCodeDropshadowRegressionTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithBbCodeBoldRun_WhenBaseHasDropshadow_PropagatesDropshadowToInlineRunFont()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            RecordingRaylibFontCreator recordingCreator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.HasDropshadow = true;
+            textRuntime.DropshadowOffsetX = 2f;
+            textRuntime.DropshadowOffsetY = 3f;
+            textRuntime.DropshadowBlur = 1.5f;
+            textRuntime.DropshadowRed = 10;
+            textRuntime.DropshadowGreen = 20;
+            textRuntime.DropshadowBlue = 30;
+            textRuntime.DropshadowAlpha = 200;
+
+            textRuntime.Text = "normal [IsBold=true]bold[/IsBold] normal";
+
+            // The base-font resolution and the inline-bold-run resolution both call the creator; only
+            // the bold request exercises the per-run path this issue is about.
+            BmfcSave boldRequest = recordingCreator.Requests.Single(r => r.IsBold);
+            boldRequest.HasDropshadow.ShouldBeTrue();
+            boldRequest.DropshadowOffsetX.ShouldBe(2f);
+            boldRequest.DropshadowOffsetY.ShouldBe(3f);
+            boldRequest.DropshadowBlur.ShouldBe(1.5f);
+            boldRequest.DropshadowRed.ShouldBe((byte)10);
+            boldRequest.DropshadowGreen.ShouldBe((byte)20);
+            boldRequest.DropshadowBlue.ShouldBe((byte)30);
+            boldRequest.DropshadowAlpha.ShouldBe((byte)200);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator (rather than a hand-built Raylib_cs.Font, whose
+    // unmanaged Recs/Glyphs pointers would need to be valid for UnloadFont to safely dispose it later)
+    // so it produces a genuinely usable, disposable font while recording every BmfcSave requested -
+    // mirrors TextMarkupTests.RecordingRaylibFontCreator.
+    private sealed class RecordingRaylibFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public List<BmfcSave> Requests { get; } = new();
+
+        public Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            return _inner.TryCreateFont(bmfcSave);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GetAndCreateFontIfNecessary`'s MonoGame and Raylib branches built an identical `BmfcSave` for inline-BBCode-run font creation, duplicated across the `#if RAYLIB` / `#if !RAYLIB` split. Extracted into `BuildInlineRunBmfcSave`.
- `GetOrCreateBakedFont`'s two branches (in-memory, disk/FontService) and its Raylib mirror built an identical `BmfcSave` via `CopyFontGenerationFieldsTo` + project ranges/spacing, three times over. Extracted into `BuildFontSyncBmfcSave` - kept `GetOrCreateBakedFont`'s existing `#if FRB` dual-signature split (`GraphicalUiElement` vs `Gum.GueDeriving.TextRuntime`), since `CopyFontGenerationFieldsTo` is an FRB-only extension method on `GraphicalUiElement` and an instance method on `TextRuntime` everywhere else - collapsing to one signature breaks overload resolution on both builds (caught by the FRB canary before push, fixed).
- Added a Raylib-side dropshadow-propagation regression test mirroring the existing MonoGame one (#3625) - a coverage-parity gap the first extraction surfaced, since both platforms now share the exact code path.

## Test plan
- [x] `MonoGameGum.Tests` full suite: 1899/1899 passing
- [x] `RaylibGum.Tests` full suite: 520/520 passing
- [x] New test verified red (dropshadow forwarding temporarily broken) then green
- [x] Gum tool builds via `GumFull.sln`, KniGum builds
- [x] FRB canary: pass on both commits (0 errors, matches `main` baseline)

Manual test: not needed - behavior-preserving extraction, covered by unit tests + compilation + FRB canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
