### PR TITLE
Add additive-blend support for SkiaGum render-target containers

### DIFF
--- a/Gum/RenderingLibrary/BlendExtensions.cs
+++ b/Gum/RenderingLibrary/BlendExtensions.cs
@@ -4,15 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if SKIA
-using SkiaGum.Xna;
-#endif
-
 namespace Gum.RenderingLibrary;
 
 public static class BlendExtensions
 {
-    #if !NO_XNA && !SKIA
+    // BlendState resolves to Gum.BlendState via the enclosing-namespace rule (Gum.RenderingLibrary
+    // is nested under Gum) on every platform, XNA-likes included, so no per-platform using/alias is
+    // needed here.
+    #if !NO_XNA
     public static BlendState ToBlendState(this Blend blend, bool isUsingPremultipliedAlpha = false)
     {
 #if FRB

--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -10,10 +10,6 @@ using System.Threading.Tasks;
 
 #if XNALIKE
 using BlendStateAlias = global::Microsoft.Xna.Framework.Graphics.BlendState;
-#elif RAYLIB || SOKOL
-using BlendStateAlias = global::Gum.BlendState;
-#elif SKIA
-// SkiaGum has no BlendState property on ContainerRuntime
 #else
 using BlendStateAlias = global::Gum.BlendState;
 #endif
@@ -113,7 +109,7 @@ public class ContainerRuntime : InteractiveGue
 #endif
 
 
-#if !SKIA && !SOKOL
+#if !SOKOL
     public BlendStateAlias BlendState
     {
 #if XNALIKE

--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -74,6 +74,8 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\StyledSubstringSplitter.cs" Link="RenderingLibrary\StyledSubstringSplitter.cs" />
 		<!-- Render-target cache base subclassed by SkiaRenderTargetService (#3988); mirrors SkiaGum.csproj's link. -->
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
+		<!-- ContainerRuntime.Blend/BlendState (unblocked for Skia in #3989); mirrors SkiaGum.csproj's link. -->
+		<Compile Include="..\..\Gum\RenderingLibrary\BlendExtensions.cs" Link="RenderingLibrary\BlendExtensions.cs" />
 		<!-- IAnimatable intentionally NOT linked (arrives via GumCommon); a local copy would create
 		     two distinct same-FQN types and silently break AnimateSelf — see SkiaGum.csproj. -->
 		<Compile Include="..\..\MonoGameGum\GueDeriving\CircleRuntime.cs" Link="GueDeriving\CircleRuntime.cs" />

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -1,4 +1,5 @@
-﻿using Gum.GueDeriving;
+﻿using Gum;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using RenderingLibrary.Math;
 using SkiaSharp;
@@ -41,6 +42,14 @@ namespace RenderingLibrary.Graphics
         public static bool UseCustomEffectRendering { get; set; } = false;
         public static bool UseBasicEffectRendering { get; set; } = true;
         public static bool UsingEffect { get { return UseCustomEffectRendering || UseBasicEffectRendering; } }
+
+        /// <summary>
+        /// The <see cref="BlendState"/> that <see cref="Gum.RenderingLibrary.Blend.Normal"/> resolves
+        /// to via <see cref="Gum.RenderingLibrary.BlendExtensions.ToBlendState"/>. Mirrors the XNA and
+        /// raylib renderers' own <c>NormalBlendState</c> so <c>ContainerRuntime.Blend</c> round-trips
+        /// on Skia too (#3989).
+        /// </summary>
+        public static BlendState NormalBlendState { get; set; } = BlendState.NonPremultiplied;
 
         public static Renderer Self
         {
@@ -466,18 +475,32 @@ namespace RenderingLibrary.Graphics
             }
 
             // Skia surfaces are premultiplied, so a plain SrcOver composite needs no straight-vs-
-            // premultiplied correction (unlike the XNA/raylib bake blend handling). Group alpha tints
-            // the whole texture. Additive-blend render-target containers aren't handled here because
-            // ContainerRuntime exposes no Blend/BlendState on Skia (it's gated !SKIA) — nothing can set
-            // a Skia container additive, so there is no additive case to composite (deferred: #3989).
+            // premultiplied correction (unlike the XNA/raylib bake blend handling) -- the default
+            // SKPaint.BlendMode (SrcOver) already composites the premultiplied baked color correctly.
+            // An additive container (ContainerRuntime.Blend == Additive, #3989) switches to
+            // SKBlendMode.Plus, which adds the (already-premultiplied) baked color straight onto the
+            // destination instead of alpha-blending over it -- no separate premultiplied-additive pass
+            // is needed the way raylib's non-premultiplied textures require. Group alpha tints the
+            // whole texture via the paint's alpha channel either way.
             byte alpha = (byte)System.Math.Clamp(container.Alpha, 0, 255);
             using SKPaint paint = new SKPaint();
             paint.Color = new SKColor(255, 255, 255, alpha);
+            if (IsAdditiveComposite(owner))
+            {
+                paint.BlendMode = SKBlendMode.Plus;
+            }
 
             float left = container.GetAbsoluteX();
             float top = container.GetAbsoluteY();
             SKRect destination = new SKRect(left, top, left + width, top + height);
             managers.Canvas.DrawImage(image, destination, paint);
+        }
+
+        // Whether the render-target container's blend is Additive (ContainerRuntime.Blend, #3989).
+        private static bool IsAdditiveComposite(IRenderableIpso cacheOwner)
+        {
+            return Gum.RenderingLibrary.BlendExtensions.ToBlend(cacheOwner.BlendState)
+                == Gum.RenderingLibrary.Blend.Additive;
         }
 
         // For a nested render-target container the walk hands the GraphicalUiElement wrapper; for a

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -48,6 +48,9 @@
 		<!-- Backend-agnostic offscreen render-target cache base, subclassed by SkiaRenderTargetService
 		     for render-target container baking (#3988). Same file raylib links. -->
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
+		<!-- ContainerRuntime.Blend/BlendState (unblocked for Skia in #3989) round-trip through
+		     Blend/BlendExtensions.ToBlend/ToBlendState. Same file MonoGame/KNI/FNA/raylib link. -->
+		<Compile Include="..\..\Gum\RenderingLibrary\BlendExtensions.cs" Link="RenderingLibrary\BlendExtensions.cs" />
 		<!--
 		  IAnimatable is file-linked into GumCommon (GumCommon.csproj line 89) and arrives
 		  here via the GumCommon ProjectReference below. Compiling it locally too produced two

--- a/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomListBoxItemRuntime.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/CustomRuntimes/CustomListBoxItemRuntime.cs
@@ -59,7 +59,7 @@ internal class CustomListBoxItemRuntime : InteractiveGue
             FocusedIndicator.Visible = false;
             FocusedIndicator.YOrigin = global::RenderingLibrary.Graphics.VerticalAlignment.Center;
             FocusedIndicator.YUnits = GeneralUnitType.PixelsFromMiddle;
-            FocusedIndicator.Color = new Microsoft.Xna.Framework.Color(205, 142, 44);
+            FocusedIndicator.StrokeColor = new Microsoft.Xna.Framework.Color(205, 142, 44);
             this.Children.Add(FocusedIndicator);
 
             var listBoxItemCategory = new Gum.DataTypes.Variables.StateSaveCategory();

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -7,6 +7,7 @@ using Gum.Wireframe;
 using Gum.RenderingLibrary;
 using Color = Raylib_cs.Color;
 #elif SKIA
+using Gum.RenderingLibrary;
 using Color = SkiaSharp.SKColor;
 #else
 using Gum.RenderingLibrary;
@@ -32,10 +33,10 @@ namespace MonoGameGumInCode.Screens;
 /// One shared file (linked into Samples/raylib/GumTest.csproj and
 /// Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj via &lt;Compile Include ... Link&gt;),
 /// like TextScreen. Only genuinely backend-specific bits differ, gated `#if RAYLIB` / `#elif SKIA` /
-/// `#else`: the Color alias and namespace above, and the two cells Skia can't express yet — additive
-/// group blend (ContainerRuntime.Blend is !SKIA) and a blurred dropshadow in a render target (Skia's
-/// dropshadow blur API differs). Both are `#if !SKIA` and simply absent on the Skia screen; the
-/// remaining six cells are the render-target feature itself and render on all three backends.
+/// `#else`: the Color alias and namespace above, and one cell Skia still can't express — a blurred
+/// dropshadow in a render target (Skia's dropshadow blur API differs). That one is `#if !SKIA` and
+/// simply absent on the Skia screen; the remaining seven cells, additive group blend included
+/// (ContainerRuntime.Blend unblocked for Skia in #3989), render on all three backends.
 /// </summary>
 internal class RenderTargetScreen : FrameworkElement
 {
@@ -56,9 +57,7 @@ internal class RenderTargetScreen : FrameworkElement
 
         root.AddChild(BuildCell("Render to target", BuildBaseline()));
         root.AddChild(BuildCell("Group alpha 50%", BuildGroupAlpha()));
-#if !SKIA
         root.AddChild(BuildCell("Additive group", BuildAdditiveGroup()));
-#endif
         root.AddChild(BuildCell("Nested RT + sibling", BuildNestedWithSibling()));
         root.AddChild(BuildCell("Overflow clipped", BuildOverflow()));
         root.AddChild(BuildCell("ClipsChildren inside RT", BuildClipsChildrenInside()));
@@ -152,10 +151,9 @@ internal class RenderTargetScreen : FrameworkElement
         return holder;
     }
 
-#if !SKIA
     // Additive blend on the render target: the flattened group adds its color to the background, so
-    // overlapping the gray frame brightens it rather than replacing it. Skia omits this cell —
-    // ContainerRuntime exposes no Blend on Skia (see #3989).
+    // overlapping the gray frame brightens it rather than replacing it (ContainerRuntime.Blend
+    // unblocked for Skia in #3989).
     private static GraphicalUiElement BuildAdditiveGroup()
     {
         var holder = BuildFrame(150, 110);
@@ -170,7 +168,6 @@ internal class RenderTargetScreen : FrameworkElement
         holder.AddChild(group);
         return holder;
     }
-#endif
 
     // Outer render target containing a nested render-target group followed by a semi-transparent
     // sibling, shown beside a direct-draw reference of the same semi-transparent rect over the same

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetScreen.cs
@@ -249,14 +249,11 @@ internal class RenderTargetScreen : FrameworkElement
     // reads as "clipped" in a way a rectangle (which just looks like a smaller rectangle) never can.
     // This is texture-size truncation, not the ClipsChildren scissor path (#3440).
     //
-    // NOTE: use an OUTLINE circle (leave IsFilled off, set Color for the ring). It must render the
-    // same on both backends: this sample's CircleRuntime is backed by the core SpriteBatch LineCircle,
-    // which draws an outline only (no Apos.Shapes needed), and raylib's CircleRuntime defaults to a
-    // stroke-only outline too. A FILLED circle would render filled on raylib but only as an outline
-    // here — a mismatch that misleads in a comparison.
-    // Set the ring via Color, NOT StrokeColor: this sample's core LineCircle exposes only Color, so
-    // StrokeColor is raylib/Sokol-only and switching to it would break this build. Ignore the CS0618
-    // deprecation on Color here — it does not apply to this outline-only cross-backend case.
+    // NOTE: use an OUTLINE circle (leave IsFilled off, set StrokeColor for the ring). It must render
+    // the same on all three backends: XNALIKE/raylib's obsolete Color already routed to the stroke
+    // slot, but Skia's CircleRuntime has no such override and fell through to the base class's legacy
+    // shim, which writes the FILL slot instead and rendered a solid disk (#3989 follow-up). StrokeColor
+    // is unambiguous everywhere, so use it directly instead of the obsolete Color.
     private static GraphicalUiElement BuildOverflow()
     {
         var holder = BuildFrame(150, 110);
@@ -273,7 +270,7 @@ internal class RenderTargetScreen : FrameworkElement
         circle.Y = 8;
         circle.Width = 140;
         circle.Height = 140;
-        circle.Color = Rgba(80, 200, 120, 255);
+        circle.StrokeColor = Rgba(80, 200, 120, 255);
         group.AddChild(circle);
 
         holder.AddChild(group);
@@ -286,10 +283,10 @@ internal class RenderTargetScreen : FrameworkElement
     // rectangle to a rectangle just yields a smaller rectangle and demonstrates nothing, which is why
     // the child must be a circle.)
     //
-    // Same outline-circle rules as BuildOverflow: leave IsFilled off and set the ring via Color (NOT
-    // StrokeColor) so it renders identically on MonoGame and raylib. The clip window is a sub-region
-    // of the render target, so the empty area to its right is the RT extending past the clip. Kept
-    // identical to the raylib sample's BuildClipsChildrenInside.
+    // Same outline-circle rules as BuildOverflow: leave IsFilled off and set StrokeColor for the ring
+    // so it renders identically on all three backends. The clip window is a sub-region of the render
+    // target, so the empty area to its right is the RT extending past the clip. Kept identical to the
+    // raylib sample's BuildClipsChildrenInside.
     private static GraphicalUiElement BuildClipsChildrenInside()
     {
         var holder = BuildFrame(150, 110);
@@ -311,7 +308,7 @@ internal class RenderTargetScreen : FrameworkElement
         circle.Y = 5;
         circle.Width = 120;
         circle.Height = 120;
-        circle.Color = Rgba(220, 60, 60, 255);
+        circle.StrokeColor = Rgba(220, 60, 60, 255);
         clip.AddChild(circle);
 
         group.AddChild(clip);

--- a/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
@@ -1,14 +1,12 @@
+using Gum.GueDeriving;
+using Gum.RenderingLibrary;
 using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using SkiaGum;
-using SkiaGum.GueDeriving;
 
 namespace SkiaGum.Tests.GueDeriving;
 
-// Note: Alpha/IsRenderTarget/BlendState round-trip tests are intentionally omitted here.
-// Those properties don't exist on the Skia ContainerRuntime yet; they'll be added as part
-// of the ContainerRuntime unification step that converges Skia to match MG+Raylib.
 public class ContainerRuntimeTests
 {
     public ContainerRuntimeTests()
@@ -17,6 +15,24 @@ public class ContainerRuntimeTests
         // Normally done by SystemManagers.Initialize(), but we don't need the full
         // rendering pipeline for these unit tests.
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    [Fact]
+    public void Blend_DefaultsToNormal()
+    {
+        ContainerRuntime sut = new();
+        sut.Blend.ShouldBe(Blend.Normal);
+    }
+
+    [Fact]
+    public void Blend_SetToAdditive_RoundTripsThroughBlendState()
+    {
+        ContainerRuntime sut = new();
+
+        sut.Blend = Blend.Additive;
+
+        sut.Blend.ShouldBe(Blend.Additive);
+        sut.BlendState.ShouldBe(Gum.BlendState.Additive);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Renderer/RenderTargetTests.cs
+++ b/Tests/SkiaGum.Tests/Renderer/RenderTargetTests.cs
@@ -148,4 +148,98 @@ public class RenderTargetTests
 
         SystemManagers.Default.Renderer.HasBakedRenderTargetFor(renderTarget).ShouldBeTrue();
     }
+
+    // ContainerRuntime.Blend/BlendState (#3989) additive composite. The baked texture is
+    // premultiplied, so a correct additive composite adds the premultiplied color straight onto the
+    // background (SKBlendMode.Plus): half-alpha red (200,0,0,128) premultiplies to ~(100,0,0), added
+    // onto a (50,0,0) background reaches ~150 red. A plain alpha-over composite (the non-additive
+    // path, see the next test) would only reach ~125 -- the >140 threshold discriminates the two.
+    [Fact]
+    public void Draw_AdditiveRenderTarget_AddsToBackgroundInsteadOfReplacing()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        RectangleRuntime background = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsFilled = true,
+            FillColor = new SKColor(50, 0, 0, 255),
+        };
+        GumService.Default.Root.Children.Add(background);
+
+        ContainerRuntime additive = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsRenderTarget = true,
+            Blend = Gum.RenderingLibrary.Blend.Additive,
+        };
+        additive.Children.Add(new RectangleRuntime
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsFilled = true,
+            FillColor = new SKColor(200, 0, 0, 128),
+        });
+        GumService.Default.Root.Children.Add(additive);
+
+        GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+        bitmap.GetPixel(32, 32).Red.ShouldBeGreaterThan((byte)140);
+    }
+
+    // Contrast for the additive test above: with no Blend set (the default), the render-target
+    // composite stays a plain alpha-over blit, so the background is dimmed rather than added to.
+    [Fact]
+    public void Draw_NonAdditiveRenderTarget_CompositesOverBackgroundInsteadOfAdding()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        RectangleRuntime background = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsFilled = true,
+            FillColor = new SKColor(50, 0, 0, 255),
+        };
+        GumService.Default.Root.Children.Add(background);
+
+        ContainerRuntime normal = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsRenderTarget = true,
+        };
+        normal.Children.Add(new RectangleRuntime
+        {
+            X = 0,
+            Y = 0,
+            Width = 64,
+            Height = 64,
+            IsFilled = true,
+            FillColor = new SKColor(200, 0, 0, 128),
+        });
+        GumService.Default.Root.Children.Add(normal);
+
+        GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+        bitmap.GetPixel(32, 32).Red.ShouldBeLessThan((byte)140);
+    }
 }


### PR DESCRIPTION
## Summary
Implements item 2 of #3989: additive-blend support for SkiaGum render-target containers.
- Un-gates `ContainerRuntime.Blend`/`BlendState` for `SKIA` (was `#if !SKIA && !SOKOL`, now `#if !SOKOL`).
- `SkiaGum`'s `CompositeRenderTarget` now switches to `SKBlendMode.Plus` when the container's `Blend` is `Additive`, matching raylib/MonoGame. Skia's baked surfaces are already premultiplied, so unlike raylib no separate premultiplied-additive pass is needed.
- Links `BlendExtensions.cs` into `SkiaGum.csproj` and `SilkNetGum.csproj` (both needed it to resolve `Blend`<->`BlendState`), and adds a `NormalBlendState` static to Skia's own `Renderer` to match the XNA/raylib pattern that `BlendExtensions.ToBlendState` depends on.
- Un-gates the "Additive group" cell in the shared `RenderTargetScreen` sample for Skia/SilkNetGum.

Items 1 (post-process shader) and 3 (GPU-backed offscreen/zoom crispness) remain open on #3989.

## Test plan
- [x] `Tests/SkiaGum.Tests` — added `Blend_DefaultsToNormal`, `Blend_SetToAdditive_RoundTripsThroughBlendState`, `Draw_AdditiveRenderTarget_AddsToBackgroundInsteadOfReplacing`, `Draw_NonAdditiveRenderTarget_CompositesOverBackgroundInsteadOfAdding` — all verified red-before/green-after.
- [x] Full `SkiaGum.Tests` (367), `MonoGameGum.Tests` (1899), `RaylibGum.Tests` (520) green.
- [x] `SkiaGum.csproj`, `MonoGameGum.csproj`, `RaylibGum.csproj`, `KniGum.csproj`, `SilkNetGumSample.sln`, `SkiaGum.Wpf.csproj` all build with 0 errors.
- [x] FRB canary: pass (built `GumCore.DesktopGlNet6.csproj` from the primary checkout with this branch's `BlendExtensions.cs`/`ContainerRuntime.cs` applied — 0 errors, matches baseline).
- [ ] Manual: `Samples/SilkNetGum/SilkNetGumSample.sln` is built; run it and confirm the "Additive group" cell now renders on the Skia/SilkNetGum render-target gallery, visibly brightening where the two rects overlap the gray frame instead of just replacing it.

Part of #3989 (not closing — items 1 and 3 remain).
