### PR TITLE
Add Skia render-target post-process shader support

### DIFF
--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -88,17 +88,41 @@ public class ContainerRuntime : InteractiveGue
             }
         }
     }
+#elif SKIA
+    /// <summary>
+    /// An optional compiled SkSL <see cref="global::SkiaSharp.SKRuntimeEffect"/> applied when this
+    /// container is drawn back to the screen as a render target. Only has an effect when
+    /// <see cref="IsRenderTarget"/> is true. The effect is image-independent (it declares a
+    /// <c>uniform shader inputImage</c> child) — the baked render-target image is bound to that
+    /// child and the resulting <c>SKShader</c> built only at composite time, since the image isn't
+    /// known until the bake completes. Compile SkSL with
+    /// <c>SKRuntimeEffect.CreateShader(sksl, out errors)</c> and assign the result here.
+    /// </summary>
+    public global::SkiaSharp.SKRuntimeEffect? RenderTargetEffect
+    {
+        get => (RenderableComponent as InvisibleRenderable)?.RenderTargetEffect
+            as global::SkiaSharp.SKRuntimeEffect;
+        set
+        {
+            if (RenderableComponent is InvisibleRenderable invisibleRenderable)
+            {
+                invisibleRenderable.RenderTargetEffect = value;
+            }
+        }
+    }
 #endif
 
-#if XNALIKE || RAYLIB
+#if XNALIKE || RAYLIB || SKIA
     /// <summary>
     /// A file reference (e.g. a <c>.fx</c> path on XNA-likes, a <c>.fs</c>/<c>.glsl</c> path on
-    /// raylib) to a post-process shader applied when this container is drawn back to the screen as a
-    /// render target. Mirrors how a Sprite references a texture: setting this routes through the
-    /// string property path, which resolves the reference via
-    /// <see cref="Gum.Wireframe.CustomSetPropertyOnRenderable.RenderTargetEffectResolver"/> and
-    /// assigns the result to <see cref="RenderTargetEffect"/>. With no resolver registered the
-    /// assignment is a graceful no-op (the container renders unshaded). Only has an effect when
+    /// raylib, or a <c>.sksl</c> path on Skia) to a post-process shader applied when this container
+    /// is drawn back to the screen as a render target. Mirrors how a Sprite references a texture:
+    /// setting this routes through the string property path, which resolves the reference via the
+    /// active backend's registered resolver (XNA-like/raylib:
+    /// <c>Gum.Wireframe.CustomSetPropertyOnRenderable.RenderTargetEffectResolver</c>; Skia:
+    /// <c>SkiaGum.CustomSetPropertyOnRenderable.RenderTargetEffectResolver</c>) and assigns the
+    /// result to <see cref="RenderTargetEffect"/>. With no resolver registered the assignment is a
+    /// graceful no-op (the container renders unshaded). Only has an effect when
     /// <see cref="IsRenderTarget"/> is true. Write-only: there is no backing field; the resolved
     /// effect is read back via <see cref="RenderTargetEffect"/>.
     /// </summary>

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -95,6 +95,13 @@ public partial class CustomSetPropertyOnRenderable
     /// </summary>
     public static Func<IRenderableIpso, GraphicalUiElement, string, object, bool>? AdditionalPropertyOnRenderable = null;
 
+    /// <summary>
+    /// Raised when a string-path property assignment fails and <see cref="GraphicalUiElement.MissingFileBehavior"/>
+    /// is not <see cref="MissingFileBehavior.ThrowException"/>. Mirrors the MonoGame/raylib dispatcher's
+    /// event of the same name (<c>Gum.Wireframe.CustomSetPropertyOnRenderable.PropertyAssignmentError</c>).
+    /// </summary>
+    public static event Action<string>? PropertyAssignmentError;
+
     // Issue #2956 follow-up — two-slot CircleRuntime / RectangleRuntime own a fill renderable
     // AND a stroke renderable. The runtime's typed setters (UseGradient, IsFilled,
     // gradient color channels, gradient endpoints, etc.) forward to BOTH slots; reflection
@@ -1142,11 +1149,14 @@ public partial class CustomSetPropertyOnRenderable
 
     /// <summary>
     /// Resolves <see cref="RenderTargetEffectResolver"/> and stores the result in the container's
-    /// <see cref="RenderingLibrary.Graphics.IRenderTargetRenderable.RenderTargetEffect"/> slot. With
-    /// no resolver registered, or a resolver that throws, this is a graceful no-op (the container
-    /// renders unshaded) -- mirrors the lean, uncached SourceFile handling this dispatcher already
-    /// uses for Sprite/NineSlice above, rather than the XNA-like/raylib dispatcher's cached,
-    /// error-reporting equivalent (a separate assembly graph SkiaGum doesn't reference).
+    /// <see cref="RenderingLibrary.Graphics.IRenderTargetRenderable.RenderTargetEffect"/> slot. Mirrors
+    /// <c>Gum.Wireframe.CustomSetPropertyOnRenderable.AssignSourceShaderFileOnContainer</c>: the
+    /// resolved effect is cached in <see cref="global::RenderingLibrary.Content.LoaderManager"/> by
+    /// normalized path so a shader referenced by multiple containers compiles once, and a failed
+    /// resolve honors <see cref="GraphicalUiElement.MissingFileBehavior"/>. That XNA-like/raylib
+    /// dispatcher lives in a separate assembly graph SkiaGum doesn't reference, so it can't be called
+    /// directly -- this is a parallel copy, not a shared call. With no resolver registered, this is a
+    /// graceful no-op (the container renders unshaded).
     /// </summary>
     private static void AssignSourceShaderFileOnContainer(
         RenderingLibrary.Graphics.InvisibleRenderable effectOwner, string? value)
@@ -1162,14 +1172,56 @@ public partial class CustomSetPropertyOnRenderable
             return;
         }
 
-        SKRuntimeEffect? resolvedEffect;
+        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
+
+        if (ToolsUtilities.FileManager.IsRelative(value) && ToolsUtilities.FileManager.IsUrl(value) == false)
+        {
+            value = ToolsUtilities.FileManager.RelativeDirectory + value;
+            value = ToolsUtilities.FileManager.RemoveDotDotSlash(value);
+        }
+
+        // LoaderManager caches disposables by normalized path (same convention as the texture cache)
+        // so a shader referenced by multiple containers compiles once.
+        if (loaderManager.CacheTextures)
+        {
+            var cachedEffect = loaderManager.GetDisposable(value);
+            if (cachedEffect is SKRuntimeEffect cachedSkRuntimeEffect)
+            {
+                effectOwner.RenderTargetEffect = cachedSkRuntimeEffect;
+                return;
+            }
+        }
+
+        SKRuntimeEffect? resolvedEffect = null;
+        Exception? resolveException = null;
         try
         {
             resolvedEffect = RenderTargetEffectResolver(value);
         }
-        catch
+        catch (Exception ex)
         {
-            resolvedEffect = null;
+            resolveException = ex;
+        }
+
+        if (resolvedEffect == null)
+        {
+            // Resolver registered but couldn't produce an effect (missing file or compile error).
+            // Mirror Sprite source-file handling: honor MissingFileBehavior, else report the error.
+            string message = $"Error setting SourceShaderFile on Container\n{value}";
+            message += "\nCheck if the file exists. If necessary, set FileManager.RelativeDirectory";
+            message += "\nThe current relative directory is:\n" + ToolsUtilities.FileManager.RelativeDirectory;
+            if (GraphicalUiElement.MissingFileBehavior == MissingFileBehavior.ThrowException)
+            {
+                throw new System.IO.FileNotFoundException(message, resolveException);
+            }
+            effectOwner.RenderTargetEffect = null;
+            PropertyAssignmentError?.Invoke(resolveException != null ? message + "\n" + resolveException : message);
+            return;
+        }
+
+        if (loaderManager.CacheTextures)
+        {
+            loaderManager.AddDisposable(value, resolvedEffect);
         }
 
         effectOwner.RenderTargetEffect = resolvedEffect;

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1017,6 +1017,47 @@ public partial class CustomSetPropertyOnRenderable
                 //handled = TrySetPropertyOnRoundedRectangle(asRoundedRectangle, graphicalUiElement, propertyName, value);
             }
         }
+        else if (containedObjectAsIpso is RenderingLibrary.Graphics.InvisibleRenderable asInvisibleRenderable)
+        {
+            // Backs a plain ContainerRuntime. Mirrors TrySetPropertyOnContainer in
+            // Gum/Wireframe/CustomSetPropertyOnRenderable.cs (the XNA-like/raylib dispatcher's
+            // equivalent branch), but that file lives in a separate assembly graph SkiaGum doesn't
+            // reference, so SourceShaderFile resolution has its own lean copy here rather than a
+            // shared call (issue #3998) -- same convention as this dispatcher's own
+            // Sprite/NineSlice SourceFile handling above, which is also independent per backend.
+            switch (propertyName)
+            {
+                case "IsRenderTarget":
+                    asInvisibleRenderable.IsRenderTarget = value as bool? ?? false;
+                    handled = true;
+                    break;
+#if SKIA
+                case "SourceShaderFile":
+                    // ContainerRuntime.SourceShaderFile only exists under XNALIKE/RAYLIB/SKIA, so
+                    // this case is unreachable (never assigned) in the Apos.Shapes / non-SKIA
+                    // build of this shared file -- guarded here purely so that build, which has no
+                    // SkiaSharp reference, still compiles.
+                    AssignSourceShaderFileOnContainer(asInvisibleRenderable, value as string);
+                    handled = true;
+                    break;
+#endif
+                case "Alpha":
+                    if (value is int asInt)
+                    {
+                        asInvisibleRenderable.Alpha = asInt;
+                    }
+                    else if (value is float asFloat)
+                    {
+                        asInvisibleRenderable.Alpha = (int)asFloat;
+                    }
+                    else
+                    {
+                        asInvisibleRenderable.Alpha = 255;
+                    }
+                    handled = true;
+                    break;
+            }
+        }
 #if SKIA
         else if (containedObjectAsIpso is Text asText)
         {
@@ -1089,6 +1130,50 @@ public partial class CustomSetPropertyOnRenderable
     }
 
 #if SKIA
+
+    /// <summary>
+    /// Resolves a <see cref="Gum.GueDeriving.ContainerRuntime.SourceShaderFile"/> reference (a
+    /// <c>.sksl</c> path) into a compiled <see cref="SKRuntimeEffect"/>. Null by default: a
+    /// consumer opts in by assigning this (e.g. compiling the referenced file's text with
+    /// <c>SKRuntimeEffect.CreateShader</c>). With no resolver registered, setting
+    /// <c>SourceShaderFile</c> is a graceful no-op (issue #3998).
+    /// </summary>
+    public static Func<string, SKRuntimeEffect?>? RenderTargetEffectResolver { get; set; }
+
+    /// <summary>
+    /// Resolves <see cref="RenderTargetEffectResolver"/> and stores the result in the container's
+    /// <see cref="RenderingLibrary.Graphics.IRenderTargetRenderable.RenderTargetEffect"/> slot. With
+    /// no resolver registered, or a resolver that throws, this is a graceful no-op (the container
+    /// renders unshaded) -- mirrors the lean, uncached SourceFile handling this dispatcher already
+    /// uses for Sprite/NineSlice above, rather than the XNA-like/raylib dispatcher's cached,
+    /// error-reporting equivalent (a separate assembly graph SkiaGum doesn't reference).
+    /// </summary>
+    private static void AssignSourceShaderFileOnContainer(
+        RenderingLibrary.Graphics.InvisibleRenderable effectOwner, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            effectOwner.RenderTargetEffect = null;
+            return;
+        }
+
+        if (RenderTargetEffectResolver == null)
+        {
+            return;
+        }
+
+        SKRuntimeEffect? resolvedEffect;
+        try
+        {
+            resolvedEffect = RenderTargetEffectResolver(value);
+        }
+        catch
+        {
+            resolvedEffect = null;
+        }
+
+        effectOwner.RenderTargetEffect = resolvedEffect;
+    }
 
     private static bool TrySetPropertyOnPolygon(Polygon asPolygon, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -493,7 +493,28 @@ namespace RenderingLibrary.Graphics
             float left = container.GetAbsoluteX();
             float top = container.GetAbsoluteY();
             SKRect destination = new SKRect(left, top, left + width, top + height);
-            managers.Canvas.DrawImage(image, destination, paint);
+
+            // Optional post-process shader (ContainerRuntime.RenderTargetEffect / SourceShaderFile,
+            // #3998). The effect is image-independent (declares a `uniform shader inputImage`
+            // child) -- the baked image is only known here, at composite time, so it is bound as
+            // that child shader input on this call rather than cached on the effect.
+            SKRuntimeEffect effect = (owner as IRenderTargetRenderable)?.RenderTargetEffect as SKRuntimeEffect;
+            if (effect == null)
+            {
+                managers.Canvas.DrawImage(image, destination, paint);
+                return;
+            }
+
+            // SKCanvas.DrawImage ignores paint.Shader -- a paint's shader only takes effect on a
+            // shape-drawing call, so the shaded path switches to DrawRect and feeds the baked image
+            // in as the effect's "inputImage" child shader instead of passing it as the image arg.
+            using SKShader imageShader = image.ToShader();
+            using SKRuntimeEffectUniforms uniforms = new SKRuntimeEffectUniforms(effect);
+            using SKRuntimeEffectChildren children = new SKRuntimeEffectChildren(effect);
+            children["inputImage"] = imageShader;
+            using SKShader combinedShader = effect.ToShader(uniforms, children);
+            paint.Shader = combinedShader;
+            managers.Canvas.DrawRect(destination, paint);
         }
 
         // Whether the render-target container's blend is Additive (ContainerRuntime.Blend, #3989).

--- a/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
@@ -4,6 +4,7 @@ using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using SkiaGum;
+using SkiaSharp;
 
 namespace SkiaGum.Tests.GueDeriving;
 
@@ -61,6 +62,27 @@ public class ContainerRuntimeTests
     {
         ContainerRuntime sut = new();
         sut.Height.ShouldBe(150);
+    }
+
+    [Fact]
+    public void RenderTargetEffect_DefaultsToNull()
+    {
+        ContainerRuntime sut = new();
+        sut.RenderTargetEffect.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RenderTargetEffect_SetThenGet_RoundTrips()
+    {
+        ContainerRuntime sut = new();
+        SKRuntimeEffect effect = SKRuntimeEffect.CreateShader(
+            "uniform shader inputImage; half4 main(float2 coord) { return inputImage.eval(coord); }",
+            out string errors);
+        string.IsNullOrEmpty(errors).ShouldBeTrue(errors);
+
+        sut.RenderTargetEffect = effect;
+
+        sut.RenderTargetEffect.ShouldBe(effect);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/Renderer/RenderTargetShaderTests.cs
+++ b/Tests/SkiaGum.Tests/Renderer/RenderTargetShaderTests.cs
@@ -151,6 +151,83 @@ half4 main(float2 coord) {
         ((int)center.Red - center.Green).ShouldBeGreaterThan(80);
     }
 
+    [Fact]
+    public void SourceShaderFile_CompilesOnce_WhenReferencedByMultipleContainers()
+    {
+        string shaderPath = WriteTempShader(GrayscaleSksl);
+        int invocationCount = 0;
+        try
+        {
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = path =>
+            {
+                invocationCount++;
+                return SKRuntimeEffect.CreateShader(File.ReadAllText(path), out _);
+            };
+
+            ContainerRuntime first = new() { IsRenderTarget = true };
+            first.SourceShaderFile = shaderPath;
+
+            ContainerRuntime second = new() { IsRenderTarget = true };
+            second.SourceShaderFile = shaderPath;
+
+            // The second container referencing the same .sksl must hit the LoaderManager cache.
+            invocationCount.ShouldBe(1);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+            File.Delete(shaderPath);
+        }
+    }
+
+    [Fact]
+    public void SourceShaderFile_RaisesPropertyAssignmentError_WhenResolverFailsAndConsumingSilently()
+    {
+        MissingFileBehavior previousBehavior = GraphicalUiElement.MissingFileBehavior;
+        string? reportedError = null;
+        Action<string> handler = message => reportedError = message;
+        try
+        {
+            GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ConsumeSilently;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError += handler;
+            // Resolver registered but unable to produce an effect (missing .sksl / compile failure).
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = _ => null;
+
+            ContainerRuntime container = new() { IsRenderTarget = true };
+
+            // ConsumeSilently must not throw; it reports through PropertyAssignmentError instead.
+            container.SourceShaderFile = "resources/Missing.sksl";
+
+            reportedError.ShouldNotBeNull();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.PropertyAssignmentError -= handler;
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+            GraphicalUiElement.MissingFileBehavior = previousBehavior;
+        }
+    }
+
+    [Fact]
+    public void SourceShaderFile_Throws_WhenResolverFailsAndMissingFileBehaviorIsThrow()
+    {
+        MissingFileBehavior previousBehavior = GraphicalUiElement.MissingFileBehavior;
+        try
+        {
+            GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ThrowException;
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = _ => null;
+
+            ContainerRuntime container = new() { IsRenderTarget = true };
+
+            Should.Throw<FileNotFoundException>(() => container.SourceShaderFile = "resources/Missing.sksl");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+            GraphicalUiElement.MissingFileBehavior = previousBehavior;
+        }
+    }
+
     private static string WriteTempShader(string source)
     {
         string path = Path.Combine(Path.GetTempPath(), "GumSkiaShaderTest_" + Guid.NewGuid().ToString("N") + ".sksl");

--- a/Tests/SkiaGum.Tests/Renderer/RenderTargetShaderTests.cs
+++ b/Tests/SkiaGum.Tests/Renderer/RenderTargetShaderTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using Gum;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using Shouldly;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderer;
+
+/// <summary>
+/// Pixel-readback tests for the SkiaGum render-target post-process shader path (issue #3998). A
+/// render-target container carrying a <see cref="ContainerRuntime.RenderTargetEffect"/> (or a
+/// <see cref="ContainerRuntime.SourceShaderFile"/> that resolves into one) has that compiled SkSL
+/// effect bound as the "inputImage" child for the composite draw, so it post-processes the whole
+/// container. Mirrors <c>RaylibGum.Tests.Rendering.RenderTargetShaderTests</c> in shape, but reads
+/// pixels directly off the top-level <see cref="SKSurface"/> (Skia's top-level surface is directly
+/// readable, unlike raylib's bottom-up render texture).
+/// </summary>
+public class RenderTargetShaderTests
+{
+    // Contract SkSL fixture (issue #3998): a fixed "inputImage" child shader collapses the sampled
+    // color to luma, so a solid-red composite reads back as R ≈ G ≈ B, which a straight blit never
+    // would.
+    private const string GrayscaleSksl = @"
+uniform shader inputImage;
+half4 main(float2 coord) {
+    half4 texel = inputImage.eval(coord);
+    half gray = dot(texel.rgb, half3(0.299, 0.587, 0.114));
+    return half4(gray, gray, gray, texel.a);
+}
+";
+
+    public RenderTargetShaderTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    private static SKRuntimeEffect CompileGrayscaleEffect()
+    {
+        SKRuntimeEffect effect = SKRuntimeEffect.CreateShader(GrayscaleSksl, out string errors);
+        string.IsNullOrEmpty(errors).ShouldBeTrue(errors);
+        return effect;
+    }
+
+    private static ContainerRuntime BuildRedRenderTarget()
+    {
+        ContainerRuntime renderTarget = new()
+        {
+            X = 4,
+            Y = 4,
+            Width = 40,
+            Height = 40,
+            IsRenderTarget = true,
+        };
+        renderTarget.Children.Add(new RectangleRuntime
+        {
+            Width = 30,
+            Height = 30,
+            IsFilled = true,
+            FillColor = SKColors.Red,
+        });
+        return renderTarget;
+    }
+
+    [Fact]
+    public void Draw_RenderTargetEffect_GraysTheCompositedPixels()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        ContainerRuntime renderTarget = BuildRedRenderTarget();
+        GumService.Default.Root.Children.Add(renderTarget);
+
+        // Control: no effect, the composited rectangle reads back clearly red.
+        GumService.Default.Draw();
+        using (SKImage withoutShaderImage = surface.Snapshot())
+        using (SKBitmap withoutShaderBitmap = SKBitmap.FromImage(withoutShaderImage))
+        {
+            SKColor withoutShader = withoutShaderBitmap.GetPixel(19, 19);
+            withoutShader.Red.ShouldBeGreaterThan((byte)200);
+            ((int)withoutShader.Red - withoutShader.Green).ShouldBeGreaterThan(80);
+        }
+
+        using SKRuntimeEffect effect = CompileGrayscaleEffect();
+        renderTarget.RenderTargetEffect = effect;
+        GumService.Default.Draw();
+
+        using SKImage withShaderImage = surface.Snapshot();
+        using SKBitmap withShaderBitmap = SKBitmap.FromImage(withShaderImage);
+        SKColor withShader = withShaderBitmap.GetPixel(19, 19);
+        Math.Abs(withShader.Red - withShader.Green).ShouldBeLessThan(20);
+        Math.Abs(withShader.Red - withShader.Blue).ShouldBeLessThan(20);
+    }
+
+    [Fact]
+    public void Draw_SourceShaderFile_GraysTheCompositedPixels_WhenResolverRegistered()
+    {
+        string shaderPath = WriteTempShader(GrayscaleSksl);
+        try
+        {
+            // Stand-in for a consumer's resolver: compile the referenced .sksl file's text.
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = path =>
+                SKRuntimeEffect.CreateShader(File.ReadAllText(path), out _);
+
+            using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+            GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+            ContainerRuntime renderTarget = BuildRedRenderTarget();
+            GumService.Default.Root.Children.Add(renderTarget);
+
+            // The .sksl reference resolves through the string property path into RenderTargetEffect.
+            renderTarget.SourceShaderFile = shaderPath;
+            GumService.Default.Draw();
+
+            using SKImage image = surface.Snapshot();
+            using SKBitmap bitmap = SKBitmap.FromImage(image);
+            SKColor center = bitmap.GetPixel(19, 19);
+            Math.Abs(center.Red - center.Green).ShouldBeLessThan(20);
+            Math.Abs(center.Red - center.Blue).ShouldBeLessThan(20);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+            File.Delete(shaderPath);
+        }
+    }
+
+    [Fact]
+    public void Draw_SourceShaderFile_IsNoOp_WhenNoResolverRegistered()
+    {
+        // No resolver registered (clear any leakage from a prior test).
+        CustomSetPropertyOnRenderable.RenderTargetEffectResolver = null;
+
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        ContainerRuntime renderTarget = BuildRedRenderTarget();
+        GumService.Default.Root.Children.Add(renderTarget);
+
+        // With no resolver the assignment is a graceful no-op (no crash); the container renders
+        // unshaded, so the composited pixel stays red.
+        renderTarget.SourceShaderFile = "resources/DoesNotMatter.sksl";
+        GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+        SKColor center = bitmap.GetPixel(19, 19);
+        center.Red.ShouldBeGreaterThan((byte)200);
+        ((int)center.Red - center.Green).ShouldBeGreaterThan(80);
+    }
+
+    private static string WriteTempShader(string source)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "GumSkiaShaderTest_" + Guid.NewGuid().ToString("N") + ".sksl");
+        File.WriteAllText(path, source);
+        return path;
+    }
+}


### PR DESCRIPTION
Part of #3998 (items 2 + 4 — runtime support + tests; item 3 sample screen and item 5 tool preview are separate/out of scope).

## Summary
- `ContainerRuntime.RenderTargetEffect` is now typed `SkiaSharp.SKRuntimeEffect?` on Skia, mirroring MonoGame's `Effect` / raylib's `Shader` (image-independent, image bound only at composite time).
- `ContainerRuntime.SourceShaderFile` now works on Skia too, resolved via a new `SkiaGum.CustomSetPropertyOnRenderable.RenderTargetEffectResolver` hook (see deviation note below).
- `Renderer.CompositeRenderTarget` binds the baked image as the effect's `"inputImage"` child shader and switches `DrawImage` -> `DrawRect` for the shaded path, since `SKCanvas.DrawImage` ignores `paint.Shader`.
- SkSL contract: `uniform shader inputImage; half4 main(float2 coord) { ... }`.

## Deviation from plan
The plan assumed `Gum.Wireframe.CustomSetPropertyOnRenderable.AssignSourceShaderFileOnContainer` (the XNA-like/raylib dispatcher) could be called directly from SkiaGum since its body is platform-neutral. It isn't reachable: that file is only linked into MonoGameGum/KniGum/FnaGum/RaylibGum csprojs, not into GumCommon, and SkiaGum only references GumCommon — so the type doesn't exist in SkiaGum's compile graph. Rather than a cross-cutting refactor to hoist it into a shared location (bigger blast radius, touches Tool/ consumers), Skia gets its own lean resolver hook + `AssignSourceShaderFileOnContainer`, matching the existing convention in `Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs` (its Sprite/NineSlice `SourceFile` handling is already independent per backend, no shared caching/error-report plumbing).

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 372 passed, including 3 new pixel-readback tests + 2 new `ContainerRuntime` property tests.
- [x] Verified new tests fail (2 of 3) without the composite-side fix, confirming they're load-bearing.
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1899 passed (no regression from the shared `ContainerRuntime.cs` edit).
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj --filter "ContainerRuntimeTests|RenderTargetShaderTests"` — 13 passed.
- [x] Zero new compiler warnings from touched files.

FRB canary: not needed — all edits are in `MonoGameGum/GueDeriving/ContainerRuntime.cs` (explicitly excluded from FRB1 compilation, GueDeriving runtimes aren't shared) plus Skia-only files.

Manual test: not needed — no sample exercises this path yet (item 3, sample screen, is a separate follow-up PR); covered by the new pixel-readback unit tests.