### PR TITLE
HtmlToGum: support remote URL source and destination subfolder on import

### DIFF
--- a/.claude/skills/gum-tool-import-from-gumx/SKILL.md
+++ b/.claude/skills/gum-tool-import-from-gumx/SKILL.md
@@ -5,7 +5,7 @@ description: The "Import from .gumx" dialog. Triggers: ImportFromGumxPlugin, Gum
 
 # Import from .gumx Dialog
 
-Cross-project import dialog (Content menu → "Import from .gumx..."). Lets the user pick a source `.gumx` (local or URL), preview its Components/Screens/Behaviors/Standards in a checkbox TreeView, and import a selected subset into the currently open project.
+Cross-project import dialog (Content → Import → ".gumx…"). Lets the user pick a source `.gumx` (local or URL), preview its Components/Screens/Behaviors/Standards in a checkbox TreeView, and import a selected subset into the currently open project.
 
 ## Layout (one-screen map)
 

--- a/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
+++ b/Gum/ImportFromGumxPlugin/MainImportFromGumxPlugin.cs
@@ -35,7 +35,8 @@ internal class MainImportFromGumxPlugin : WpfPluginBase
 
     public override void StartUp()
     {
-        this.AddMenuItemTo("Import from .gumx...", HandleImportFromGumx, "Content");
+        var menuItem = this.AddMenuItem(new[] { "Content", "Import", ".gumx…" });
+        menuItem.Click += HandleImportFromGumx;
     }
 
     private void HandleImportFromGumx(object? sender, System.Windows.RoutedEventArgs e)

--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -440,7 +440,7 @@ namespace Gum.Managers
             ["Content"] = new[]
             {
                 new[] { "Find file references..." },
-                new[] { "Add Forms Components", "Import from .gumx..." },
+                new[] { "Add Forms Components", "Import" },
                 new[]
                 {
                     "Clear Font Cache",

--- a/Tool/HtmlToGum/HtmlImportNaming.cs
+++ b/Tool/HtmlToGum/HtmlImportNaming.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace HtmlToGumPlugin;
+
+/// <summary>
+/// Pure naming/conflict-resolution helpers for HTML import, kept separate from
+/// <see cref="MainHtmlToGumPlugin"/> so they can be unit tested without a WinForms/MEF host.
+/// </summary>
+public static class HtmlImportNaming
+{
+    private static readonly Regex UrlPattern = new(@"^https?://", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Whether <paramref name="source"/> is a remote http(s) URL rather than a local file path.</summary>
+    public static bool IsUrl(string source) => UrlPattern.IsMatch(source ?? "");
+
+    /// <summary>Prefixes <paramref name="screenName"/> with <paramref name="destinationSubfolder"/>, matching the "Screens/{subfolder}/{name}" convention used by the .gumx importer.</summary>
+    public static string QualifyScreenName(string screenName, string? destinationSubfolder) =>
+        string.IsNullOrWhiteSpace(destinationSubfolder)
+            ? screenName
+            : $"{destinationSubfolder.TrimEnd('/')}/{screenName}";
+
+    /// <summary>
+    /// Returns <paramref name="desiredScreenName"/> if its qualified name is free, otherwise appends
+    /// "_2", "_3", ... until <paramref name="nameExists"/> (checked against the qualified name) returns false.
+    /// </summary>
+    public static string ResolveUniqueScreenName(
+        string desiredScreenName, string? destinationSubfolder, Func<string, bool> nameExists)
+    {
+        if (!nameExists(QualifyScreenName(desiredScreenName, destinationSubfolder)))
+        {
+            return desiredScreenName;
+        }
+
+        int suffix = 2;
+        string candidate;
+        do
+        {
+            candidate = $"{desiredScreenName}_{suffix}";
+            suffix++;
+        } while (nameExists(QualifyScreenName(candidate, destinationSubfolder)));
+
+        return candidate;
+    }
+}

--- a/Tool/HtmlToGum/HtmlImportNaming.cs
+++ b/Tool/HtmlToGum/HtmlImportNaming.cs
@@ -14,6 +14,13 @@ public static class HtmlImportNaming
     /// <summary>Whether <paramref name="source"/> is a remote http(s) URL rather than a local file path.</summary>
     public static bool IsUrl(string source) => UrlPattern.IsMatch(source ?? "");
 
+    /// <summary>Prepends "https://" to <paramref name="source"/> if it doesn't already start with http(s)://, so a bare host like "example.com" is treated as a URL.</summary>
+    public static string NormalizeUrl(string source)
+    {
+        var trimmed = (source ?? "").Trim();
+        return trimmed.Length == 0 || IsUrl(trimmed) ? trimmed : $"https://{trimmed}";
+    }
+
     /// <summary>Prefixes <paramref name="screenName"/> with <paramref name="destinationSubfolder"/>, matching the "Screens/{subfolder}/{name}" convention used by the .gumx importer.</summary>
     public static string QualifyScreenName(string screenName, string? destinationSubfolder) =>
         string.IsNullOrWhiteSpace(destinationSubfolder)

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -18,7 +18,6 @@ using Gum.Plugins.ImportPlugin.Manager;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
-using ToolsUtilities;
 
 namespace HtmlToGumPlugin;
 
@@ -59,22 +58,17 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             return;
         }
 
-        using var dlg = new OpenFileDialog
-        {
-            Filter = "HTML (*.html;*.htm)|*.html;*.htm|All files (*.*)|*.*",
-            Title = "Import HTML into Gum",
-        };
-        if (dlg.ShowDialog() != DialogResult.OK) return;
-
         var prefs = ImportPrefs.Load();
         var defaults = new ImportOptions
         {
-            HtmlPath = dlg.FileName,
+            HtmlPath = prefs.LastSource,
+            IsUrl = prefs.LastIsUrl,
             Selector = string.IsNullOrWhiteSpace(prefs.Selector) ? "body" : prefs.Selector,
-            ScreenName = SanitizeScreenName(Path.GetFileNameWithoutExtension(dlg.FileName)),
+            ScreenName = DeriveDefaultScreenName(prefs.LastSource, prefs.LastIsUrl),
             Width = prefs.Width > 0 ? prefs.Width : 800,
             Height = prefs.Height > 0 ? prefs.Height : 600,
             NoResponsive = prefs.NoResponsive,
+            DestinationSubfolder = prefs.DestinationSubfolder,
         };
         if (!ImportOptionsForm.ShowDialog(defaults, out var opts) || opts is null) return;
 
@@ -82,7 +76,12 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         prefs.Width = opts.Width;
         prefs.Height = opts.Height;
         prefs.NoResponsive = opts.NoResponsive;
+        prefs.LastSource = opts.HtmlPath;
+        prefs.LastIsUrl = opts.IsUrl;
+        prefs.DestinationSubfolder = opts.DestinationSubfolder;
         prefs.Save();
+
+        var subfolder = string.IsNullOrWhiteSpace(opts.DestinationSubfolder) ? null : opts.DestinationSubfolder.Trim();
 
         var converterDir = ResolveConverterDir();
         var convertTs = Path.Combine(converterDir, "convert.ts");
@@ -118,16 +117,15 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             return;
         }
 
-        // Unique screen name if one already exists in the project.
-        var screenName = opts.ScreenName;
-        if (ObjectFinder.Self.GetElementSave(screenName) != null)
+        // Unique screen name if one already exists in the project (scoped to the destination subfolder, if any).
+        var screenName = HtmlImportNaming.ResolveUniqueScreenName(
+            opts.ScreenName, subfolder, name => ObjectFinder.Self.GetElementSave(name) != null);
+        if (screenName != opts.ScreenName)
         {
-            var baseName = screenName;
-            var n = 2;
-            while (ObjectFinder.Self.GetElementSave($"{baseName}_{n}") != null) n++;
-            screenName = $"{baseName}_{n}";
+            var existingQualifiedName = HtmlImportNaming.QualifyScreenName(opts.ScreenName, subfolder);
+            var newQualifiedName = HtmlImportNaming.QualifyScreenName(screenName, subfolder);
             if (!_dialogService.ShowYesNoMessage(
-                    $"Screen \"{baseName}\" already exists. Import as \"{screenName}\"?",
+                    $"Screen \"{existingQualifiedName}\" already exists. Import as \"{newQualifiedName}\"?",
                     FriendlyName))
             {
                 return;
@@ -179,7 +177,13 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             CopyAssetTree(Path.Combine(stageDir, "FontCache"), Path.Combine(projectDir, "FontCache"));
 
             progress.SetStatus("Importing screen into project…");
-            var imported = importLogic.ImportScreen(new FilePath(gusx), saveProject: false);
+            var screenSave = ElementReference.DeserializeElement<ScreenSave>(gusx, GumProjectSave.NativeVersion);
+            if (subfolder != null)
+            {
+                screenSave.Name = HtmlImportNaming.QualifyScreenName(screenSave.Name, subfolder);
+            }
+            var qualifiedScreenName = screenSave.Name;
+            var imported = importLogic.ImportScreen(screenSave, saveProject: false);
             if (imported is null)
             {
                 progress.Hide();
@@ -195,7 +199,7 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             }
 
             // Re-resolve after reload so selection points at the live ElementSave.
-            var live = ObjectFinder.Self.GetElementSave(screenName);
+            var live = ObjectFinder.Self.GetElementSave(qualifiedScreenName);
             if (live != null)
             {
                 selectedState.SelectedElement = live;
@@ -203,7 +207,7 @@ public class MainHtmlToGumPlugin : WpfPluginBase
 
             progress.Hide();
             _dialogService.ShowMessage(
-                $"Imported and selected screen \"{screenName}\".\n\n{SummarizeConverterLog(stdout)}");
+                $"Imported and selected screen \"{qualifiedScreenName}\".\n\n{SummarizeConverterLog(stdout)}");
         }
         catch (Exception ex)
         {
@@ -376,31 +380,48 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         return candidates[0];
     }
 
-    private static string SanitizeScreenName(string? raw)
+    internal static string SanitizeScreenName(string? raw)
     {
         var name = Regex.Replace(raw ?? "ImportedScreen", @"[^A-Za-z0-9_]", "_");
         if (string.IsNullOrEmpty(name)) name = "ImportedScreen";
         if (char.IsDigit(name[0])) name = "S_" + name;
         return name;
     }
+
+    private static string DeriveDefaultScreenName(string source, bool isUrl)
+    {
+        if (string.IsNullOrWhiteSpace(source)) return "ImportedScreen";
+        if (isUrl)
+        {
+            return Uri.TryCreate(source, UriKind.Absolute, out var uri)
+                ? SanitizeScreenName(uri.Host)
+                : "ImportedScreen";
+        }
+        return SanitizeScreenName(Path.GetFileNameWithoutExtension(source));
+    }
 }
 
 internal sealed class ImportOptions
 {
     public string HtmlPath { get; set; } = "";
+    public bool IsUrl { get; set; }
     public string Selector { get; set; } = "body";
     public string ScreenName { get; set; } = "ImportedScreen";
     public int Width { get; set; } = 800;
     public int Height { get; set; } = 600;
     public bool NoResponsive { get; set; }
+    public string DestinationSubfolder { get; set; } = "";
 }
 
 internal sealed class ImportPrefs
 {
+    public string LastSource { get; set; } = "";
+    public bool LastIsUrl { get; set; }
     public string Selector { get; set; } = "body";
     public int Width { get; set; } = 800;
     public int Height { get; set; } = 600;
     public bool NoResponsive { get; set; }
+    public string DestinationSubfolder { get; set; } = "";
 
     private static string PrefsPath =>
         Path.Combine(
@@ -478,7 +499,7 @@ internal sealed class ImportProgressForm : Form
     }
 }
 
-/// <summary>WinForms dialog for selector / screen name / viewport / responsive flag.</summary>
+/// <summary>WinForms dialog for HTML source (local file / URL) / selector / screen name / viewport / responsive flag / destination subfolder.</summary>
 internal static class ImportOptionsForm
 {
     public static bool ShowDialog(ImportOptions defaults, out ImportOptions? result)
@@ -491,67 +512,116 @@ internal static class ImportOptionsForm
             StartPosition = FormStartPosition.CenterParent,
             MinimizeBox = false,
             MaximizeBox = false,
-            ClientSize = new Size(460, 248),
+            ClientSize = new Size(460, 316),
             Font = new Font("Segoe UI", 9f),
         };
 
-        var lblHtml = new Label
-        {
-            Text = Path.GetFileName(defaults.HtmlPath),
-            Left = 12,
-            Top = 12,
-            Width = 436,
-            AutoEllipsis = true,
-        };
-        var lblSel = new Label { Text = "CSS root selector", Left = 12, Top = 44, Width = 140 };
-        var txtSel = new TextBox { Text = defaults.Selector, Left = 160, Top = 40, Width = 280 };
-        var lblName = new Label { Text = "Screen name", Left = 12, Top = 76, Width = 140 };
-        var txtName = new TextBox { Text = defaults.ScreenName, Left = 160, Top = 72, Width = 280 };
-        var lblSize = new Label { Text = "Viewport W×H", Left = 12, Top = 108, Width = 140 };
-        var txtW = new TextBox { Text = defaults.Width.ToString(), Left = 160, Top = 104, Width = 80 };
-        var txtH = new TextBox { Text = defaults.Height.ToString(), Left = 250, Top = 104, Width = 80 };
+        var radioLocal = new RadioButton { Text = "Local file", Left = 12, Top = 12, Width = 100, Checked = !defaults.IsUrl };
+        var radioUrl = new RadioButton { Text = "URL", Left = 116, Top = 12, Width = 80, Checked = defaults.IsUrl };
+        var txtSource = new TextBox { Text = defaults.HtmlPath, Left = 12, Top = 36, Width = 356 };
+        var btnBrowse = new Button { Text = "Browse…", Left = 372, Top = 34, Width = 76 };
+
+        var lblSel = new Label { Text = "CSS root selector", Left = 12, Top = 72, Width = 140 };
+        var txtSel = new TextBox { Text = defaults.Selector, Left = 160, Top = 68, Width = 280 };
+        var lblName = new Label { Text = "Screen name", Left = 12, Top = 104, Width = 140 };
+        var txtName = new TextBox { Text = defaults.ScreenName, Left = 160, Top = 100, Width = 280 };
+        var lblSize = new Label { Text = "Viewport W×H", Left = 12, Top = 136, Width = 140 };
+        var txtW = new TextBox { Text = defaults.Width.ToString(), Left = 160, Top = 132, Width = 80 };
+        var txtH = new TextBox { Text = defaults.Height.ToString(), Left = 250, Top = 132, Width = 80 };
         var chkNoResp = new CheckBox
         {
             Text = "Disable responsive units (--no-responsive)",
             Left = 160,
-            Top = 140,
+            Top = 168,
             Width = 280,
             Checked = defaults.NoResponsive,
         };
+        var lblSubfolder = new Label { Text = "Destination subfolder", Left = 12, Top = 200, Width = 140 };
+        var txtSubfolder = new TextBox { Text = defaults.DestinationSubfolder, Left = 160, Top = 196, Width = 280 };
         var hint = new Label
         {
-            Text = "Selector / viewport remembered for next import.",
+            Text = "Optional — avoids name conflicts by importing under Screens/<subfolder>/.",
             Left = 12,
-            Top = 172,
+            Top = 228,
             Width = 436,
             ForeColor = SystemColors.GrayText,
         };
-        var btnOk = new Button { Text = "Import", DialogResult = DialogResult.OK, Left = 264, Top = 204, Width = 88 };
-        var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Left = 360, Top = 204, Width = 88 };
+        var btnOk = new Button { Text = "Import", Left = 264, Top = 272, Width = 88 };
+        var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Left = 360, Top = 272, Width = 88 };
         form.Controls.AddRange(
         [
-            lblHtml, lblSel, txtSel, lblName, txtName, lblSize, txtW, txtH,
-            chkNoResp, hint, btnOk, btnCancel,
+            radioLocal, radioUrl, txtSource, btnBrowse,
+            lblSel, txtSel, lblName, txtName, lblSize, txtW, txtH,
+            chkNoResp, lblSubfolder, txtSubfolder, hint, btnOk, btnCancel,
         ]);
         form.AcceptButton = btnOk;
         form.CancelButton = btnCancel;
+
+        void UpdateBrowseEnabled() => btnBrowse.Enabled = radioLocal.Checked;
+        radioLocal.CheckedChanged += (_, _) => UpdateBrowseEnabled();
+        radioUrl.CheckedChanged += (_, _) => UpdateBrowseEnabled();
+        UpdateBrowseEnabled();
+
+        btnBrowse.Click += (_, _) =>
+        {
+            using var fileDlg = new OpenFileDialog
+            {
+                Filter = "HTML (*.html;*.htm)|*.html;*.htm|All files (*.*)|*.*",
+                Title = "Choose local HTML file",
+            };
+            if (fileDlg.ShowDialog(form) != DialogResult.OK) return;
+            txtSource.Text = fileDlg.FileName;
+            if (string.IsNullOrWhiteSpace(txtName.Text) || txtName.Text == "ImportedScreen")
+            {
+                txtName.Text = MainHtmlToGumPlugin.SanitizeScreenName(Path.GetFileNameWithoutExtension(fileDlg.FileName));
+            }
+        };
+
+        btnOk.Click += (_, _) =>
+        {
+            var source = txtSource.Text.Trim();
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                MessageBox.Show(form, "Enter a local HTML file path or a URL.", "Import HTML",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            if (radioUrl.Checked)
+            {
+                if (!HtmlImportNaming.IsUrl(source))
+                {
+                    MessageBox.Show(form, "URL must start with http:// or https://.", "Import HTML",
+                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+            }
+            else if (!File.Exists(source))
+            {
+                MessageBox.Show(form, $"File not found:\n{source}", "Import HTML",
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+            form.DialogResult = DialogResult.OK;
+            form.Close();
+        };
 
         if (form.ShowDialog() != DialogResult.OK) return false;
 
         if (!int.TryParse(txtW.Text.Trim(), out var w) || w < 1) w = defaults.Width;
         if (!int.TryParse(txtH.Text.Trim(), out var h) || h < 1) h = defaults.Height;
         var name = string.IsNullOrWhiteSpace(txtName.Text) ? defaults.ScreenName : txtName.Text.Trim();
-        name = Regex.Replace(name, @"[^A-Za-z0-9_]", "_");
-        if (char.IsDigit(name[0])) name = "S_" + name;
+        name = MainHtmlToGumPlugin.SanitizeScreenName(name);
 
         result = new ImportOptions
         {
-            HtmlPath = defaults.HtmlPath,
+            HtmlPath = txtSource.Text.Trim(),
+            IsUrl = radioUrl.Checked,
             Selector = string.IsNullOrWhiteSpace(txtSel.Text) ? "body" : txtSel.Text.Trim(),
             ScreenName = name,
             Width = w,
             Height = h,
             NoResponsive = chkNoResp.Checked,
+            DestinationSubfolder = txtSubfolder.Text.Trim(),
         };
         return true;
     }

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -351,6 +351,23 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         }
     }
 
+    /// <summary>
+    /// Candidate converter directories, in lookup order, given the plugin DLL's base directory
+    /// (<c>AppDomain.CurrentDomain.BaseDirectory</c>). <c>Gum.csproj</c> sets
+    /// <c>AppendTargetFrameworkToOutputPath=false</c>, so <c>baseDir</c> is <c>&lt;repo&gt;/Gum/bin/&lt;Config&gt;/</c>
+    /// with no TFM subfolder — three levels up reaches the repo (or worktree) root.
+    /// </summary>
+    public static string[] GetConverterDirCandidates(string baseDir) =>
+    [
+        Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "Tool", "HtmlToGum", "converter")),
+        Path.GetFullPath(Path.Combine(baseDir, "converter")),
+        // Legacy sibling html-to-gum repository layouts.
+        Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "html-to-gum", "converter")),
+        Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "html-to-gum", "converter")),
+        Path.GetFullPath(Path.Combine(baseDir, "..", "..", "html-to-gum", "converter")),
+        Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Repos", "html-to-gum", "converter")),
+    ];
+
     private static string ResolveConverterDir()
     {
         var env = Environment.GetEnvironmentVariable("HTMLTOGUM_CONVERTER");
@@ -359,17 +376,7 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             return Path.GetFullPath(env);
         }
 
-        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
-        string[] candidates =
-        [
-            Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Tool", "HtmlToGum", "converter")),
-            Path.GetFullPath(Path.Combine(baseDir, "converter")),
-            // Legacy sibling html-to-gum repository layouts.
-            Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "html-to-gum", "converter")),
-            Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "html-to-gum", "converter")),
-            Path.GetFullPath(Path.Combine(baseDir, "..", "..", "html-to-gum", "converter")),
-            Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Repos", "html-to-gum", "converter")),
-        ];
+        var candidates = GetConverterDirCandidates(AppDomain.CurrentDomain.BaseDirectory);
         foreach (string candidate in candidates)
         {
             if (File.Exists(Path.Combine(candidate, "convert.ts")) ||
@@ -589,12 +596,8 @@ internal static class ImportOptionsForm
             }
             if (radioUrl.Checked)
             {
-                if (!HtmlImportNaming.IsUrl(source))
-                {
-                    MessageBox.Show(form, "URL must start with http:// or https://.", "Import HTML",
-                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
+                source = HtmlImportNaming.NormalizeUrl(source);
+                txtSource.Text = source;
             }
             else if (!File.Exists(source))
             {

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -94,8 +94,7 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             _dialogService.ShowMessage(
                 "Converter not found.\n\n" +
                 $"Looked for:\n{convertTs}\n{convertMjs}\n\n" +
-                "Fix: run `cd Tool/HtmlToGum/converter && npm install`, or set the\n" +
-                "HTMLTOGUM_CONVERTER environment variable to the converter folder, then restart Gum.");
+                "Fix: set the HTMLTOGUM_CONVERTER environment variable to the converter folder, then restart Gum.");
             return;
         }
 
@@ -105,16 +104,6 @@ public class MainHtmlToGumPlugin : WpfPluginBase
                 "Node.js was not found on PATH.\n\n" +
                 "Install Node.js LTS and ensure `node` works in a terminal, then restart Gum.\n\n" +
                 nodeHint);
-            return;
-        }
-
-        var tsxCli = Path.Combine(converterDir, "node_modules", "tsx", "dist", "cli.mjs");
-        if (useTs && !File.Exists(tsxCli))
-        {
-            _dialogService.ShowMessage(
-                "tsx is required to run convert.ts but was not found.\n\n" +
-                $"Looked for:\n{tsxCli}\n\n" +
-                "Fix: cd Tool/HtmlToGum/converter && npm install, then restart Gum.");
             return;
         }
 
@@ -142,6 +131,23 @@ public class MainHtmlToGumPlugin : WpfPluginBase
 
         try
         {
+            var tsxCli = Path.Combine(converterDir, "node_modules", "tsx", "dist", "cli.mjs");
+            if (useTs && !File.Exists(tsxCli))
+            {
+                progress.SetStatus("Installing converter dependencies (first run only)…");
+                var (installExitCode, installStdout, installStderr) = await RunProcessAsync(
+                        "cmd.exe", "/c npm install", converterDir, progress)
+                    .ConfigureAwait(true);
+
+                if (installExitCode != 0 || !File.Exists(tsxCli))
+                {
+                    progress.Hide();
+                    _dialogService.ShowMessage(
+                        FormatNpmInstallFailure(installExitCode, installStdout, installStderr, converterDir));
+                    return;
+                }
+            }
+
             var flagArgs = opts.NoResponsive ? " --no-responsive" : "";
             var scriptArgs =
                 $"\"{opts.HtmlPath}\" \"{opts.Selector}\" {screenName} " +
@@ -222,19 +228,36 @@ public class MainHtmlToGumPlugin : WpfPluginBase
     }
 
     private static string FormatConverterFailure(
-        int exitCode, string stdout, string stderr, string nodePath, string converterDir)
+        int exitCode, string stdout, string stderr, string nodePath, string converterDir) =>
+        FormatProcessFailure(
+            "Converter failed", exitCode, stdout, stderr,
+            [$"node: {nodePath}", $"cwd:  {converterDir}"],
+            "(no stdout/stderr — is Playwright Chromium installed?\n" +
+            "Run: cd Tool/HtmlToGum/converter && npx playwright-core install chromium)");
+
+    private static string FormatNpmInstallFailure(int exitCode, string stdout, string stderr, string converterDir) =>
+        FormatProcessFailure(
+            "Automatic npm install failed", exitCode, stdout, stderr,
+            [$"cwd: {converterDir}"],
+            "(no output — is npm on PATH? It ships with Node.js; run `npm -v` in a terminal to check.)") +
+        "\nFix: run `cd Tool/HtmlToGum/converter && npm install` manually, then retry.";
+
+    /// <summary>Formats a failed child-process run for display: exit code, context lines, then the last ~40 lines of its stderr/stdout.</summary>
+    private static string FormatProcessFailure(
+        string title, int exitCode, string stdout, string stderr, string[] contextLines, string noOutputHint)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"Converter failed (exit {exitCode}).");
+        sb.AppendLine($"{title} (exit {exitCode}).");
         sb.AppendLine();
-        sb.AppendLine($"node: {nodePath}");
-        sb.AppendLine($"cwd:  {converterDir}");
+        foreach (var line in contextLines)
+        {
+            sb.AppendLine(line);
+        }
         sb.AppendLine();
         var err = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
         if (string.IsNullOrWhiteSpace(err))
         {
-            sb.AppendLine("(no stdout/stderr — is Playwright Chromium installed?");
-            sb.AppendLine("Run: cd Tool/HtmlToGum/converter && npx playwright-core install chromium");
+            sb.AppendLine(noOutputHint);
         }
         else
         {

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -22,7 +22,7 @@ using Gum.ToolStates;
 namespace HtmlToGumPlugin;
 
 /// <summary>
-/// Content → Import HTML… — runs converter/convert.ts (via tsx) into a staging folder, copies
+/// Content → Import → HTML… — runs converter/convert.ts (via tsx) into a staging folder, copies
 /// Images/Fonts/FontCache into the open Gum project, then IImportLogic.ImportScreen.
 /// </summary>
 [Export(typeof(PluginBase))]
@@ -35,7 +35,8 @@ public class MainHtmlToGumPlugin : WpfPluginBase
 
     public override void StartUp()
     {
-        AddMenuItemTo("Import HTML…", HandleImportHtml, "Content");
+        var menuItem = AddMenuItem(new[] { "Content", "Import", "HTML…" });
+        menuItem.Click += HandleImportHtml;
     }
 
     private async void HandleImportHtml(object? sender, System.Windows.RoutedEventArgs e)

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -213,8 +213,9 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             }
 
             progress.Hide();
-            _dialogService.ShowMessage(
-                $"Imported and selected screen \"{qualifiedScreenName}\".\n\n{SummarizeConverterLog(stdout)}");
+            ImportResultForm.Show(
+                $"Imported and selected screen \"{qualifiedScreenName}\".",
+                SummarizeConverterLog(stdout, maxLines: 300));
         }
         catch (Exception ex)
         {
@@ -351,13 +352,13 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         });
     }
 
-    private static string SummarizeConverterLog(string stdout)
+    private static string SummarizeConverterLog(string stdout, int maxLines = 12)
     {
         var lines = stdout.Split('\n')
             .Select(l => l.TrimEnd())
             .Where(l => l.Length > 0)
             .Where(l => !l.StartsWith('>'))
-            .TakeLast(12);
+            .TakeLast(maxLines);
         return string.Join("\n", lines);
     }
 
@@ -527,6 +528,65 @@ internal sealed class ImportProgressForm : Form
             return;
         }
         _status.Text = text;
+    }
+}
+
+/// <summary>Success dialog with a terse summary and a collapsed "Show details" panel for the full converter log.</summary>
+internal static class ImportResultForm
+{
+    private const int CollapsedHeight = 104;
+    private const int DetailsHeight = 220;
+
+    public static void Show(string summary, string details)
+    {
+        using var form = new Form
+        {
+            Text = "Import HTML",
+            FormBorderStyle = FormBorderStyle.FixedDialog,
+            StartPosition = FormStartPosition.CenterParent,
+            MinimizeBox = false,
+            MaximizeBox = false,
+            ClientSize = new Size(420, CollapsedHeight),
+            Font = new Font("Segoe UI", 9f),
+        };
+
+        var lblSummary = new Label { Text = summary, Left = 16, Top = 16, Width = 388, Height = 40 };
+        var btnDetails = new Button
+        {
+            Text = "Show details ▾",
+            Left = 16,
+            Top = 60,
+            Width = 130,
+            Visible = !string.IsNullOrWhiteSpace(details),
+        };
+        var btnOk = new Button { Text = "OK", DialogResult = DialogResult.OK, Left = 324, Top = 60, Width = 80 };
+        var txtDetails = new TextBox
+        {
+            Left = 16,
+            Top = 96,
+            Width = 388,
+            Height = DetailsHeight,
+            Multiline = true,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Vertical,
+            Font = new Font("Consolas", 8.5f),
+            Text = details,
+            Visible = false,
+        };
+
+        btnDetails.Click += (_, _) =>
+        {
+            bool expanding = !txtDetails.Visible;
+            txtDetails.Visible = expanding;
+            btnDetails.Text = expanding ? "Hide details ▴" : "Show details ▾";
+            form.ClientSize = expanding
+                ? new Size(420, CollapsedHeight + DetailsHeight)
+                : new Size(420, CollapsedHeight);
+        };
+
+        form.AcceptButton = btnOk;
+        form.Controls.AddRange([lblSummary, btnDetails, btnOk, txtDetails]);
+        form.ShowDialog();
     }
 }
 

--- a/Tool/HtmlToGum/README.md
+++ b/Tool/HtmlToGum/README.md
@@ -1,6 +1,6 @@
 # HtmlToGum
 
-Gum Tool plugin: **Content → Import HTML…** converts a page into a Gum screen via Chromium’s computed box tree (Playwright), then imports the resulting `.gusx` and assets into the open project.
+Gum Tool plugin: **Content → Import → HTML…** converts a page into a Gum screen via Chromium’s computed box tree (Playwright), then imports the resulting `.gusx` and assets into the open project.
 
 Chromium is **not** bundled with Gum. It is downloaded locally when you `npm install` the converter.
 
@@ -37,7 +37,7 @@ cd Tool/HtmlToGum/converter
 npm install
 ```
 
-3. Launch Gum → open a saved `.gumx` → **Content → Import HTML…**. Choose a local file or a remote `http(s)://` URL, and optionally set a destination subfolder to import under `Screens/<subfolder>/` and avoid name conflicts with existing screens.
+3. Launch Gum → open a saved `.gumx` → **Content → Import → HTML…**. Choose a local file or a remote `http(s)://` URL, and optionally set a destination subfolder to import under `Screens/<subfolder>/` and avoid name conflicts with existing screens.
 
 ### Converter discovery
 

--- a/Tool/HtmlToGum/README.md
+++ b/Tool/HtmlToGum/README.md
@@ -2,7 +2,7 @@
 
 Gum Tool plugin: **Content → Import → HTML…** converts a page into a Gum screen via Chromium’s computed box tree (Playwright), then imports the resulting `.gusx` and assets into the open project.
 
-Chromium is **not** bundled with Gum. It is downloaded locally when you `npm install` the converter.
+Chromium is **not** bundled with Gum. The plugin runs `npm install` (downloading Playwright's Chromium) automatically the first time you import, if it hasn't been run yet.
 
 ## Layout
 
@@ -30,7 +30,7 @@ dotnet build Tool/HtmlToGum/HtmlToGumPlugin.csproj -c Release
 
 Post-build copies `HtmlToGumPlugin.dll` to `Gum/bin/{Config}/Plugins/HtmlToGumPlugin/`.
 
-2. Install Node.js LTS, then converter deps (downloads Playwright Chromium):
+2. Install Node.js LTS. Converter dependencies (`npm install`, including Playwright's Chromium download) run automatically on first import — or run them yourself ahead of time:
 
 ```powershell
 cd Tool/HtmlToGum/converter
@@ -71,6 +71,6 @@ See [`samples/README.md`](samples/README.md). Open any sample via Import HTML, o
 | Need | For |
 |------|-----|
 | .NET 8 / Gum Tool build | Plugin |
-| Node.js LTS + `npm install` in `converter/` | Import HTML / CLI |
+| Node.js LTS | Import HTML / CLI (`npm install` runs automatically on first Import HTML; run it manually for CLI use) |
 | Playwright Chromium (via postinstall) | Box tree + screenshots |
 | Python + fonttools (optional) | Variable-font → static TTF (`requirements-fonts.txt`) |

--- a/Tool/HtmlToGum/README.md
+++ b/Tool/HtmlToGum/README.md
@@ -37,7 +37,7 @@ cd Tool/HtmlToGum/converter
 npm install
 ```
 
-3. Launch Gum → open a saved `.gumx` → **Content → Import HTML…**.
+3. Launch Gum → open a saved `.gumx` → **Content → Import HTML…**. Choose a local file or a remote `http(s)://` URL, and optionally set a destination subfolder to import under `Screens/<subfolder>/` and avoid name conflicts with existing screens.
 
 ### Converter discovery
 

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\..\..\Gum\EventOutputPlugin\EventOutputPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\Gum.csproj" />
     <ProjectReference Include="..\..\..\Gum\GumFormsPlugin\GumFormsPlugin.csproj" />
+    <ProjectReference Include="..\..\HtmlToGum\HtmlToGumPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\ImportFromGumxPlugin\ImportFromGumxPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\PerformanceMeasurementPlugin\PerformanceMeasurementPlugin.csproj" />
     <ProjectReference Include="..\..\..\Gum\StateAnimationPlugin\StateAnimationPlugin.csproj" />

--- a/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportNamingTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportNamingTests.cs
@@ -32,6 +32,29 @@ public class HtmlImportNamingTests
     }
 
     [Fact]
+    public void NormalizeUrl_LeavesUrlUnchanged_WhenSchemeAlreadyPresent()
+    {
+        HtmlImportNaming.NormalizeUrl("http://example.com").ShouldBe("http://example.com");
+        HtmlImportNaming.NormalizeUrl("https://example.com").ShouldBe("https://example.com");
+    }
+
+    [Fact]
+    public void NormalizeUrl_PrependsHttps_WhenSchemeIsMissing()
+    {
+        string result = HtmlImportNaming.NormalizeUrl("example.com");
+
+        result.ShouldBe("https://example.com");
+    }
+
+    [Fact]
+    public void NormalizeUrl_TrimsWhitespace_BeforeChecking()
+    {
+        string result = HtmlImportNaming.NormalizeUrl("  example.com  ");
+
+        result.ShouldBe("https://example.com");
+    }
+
+    [Fact]
     public void QualifyScreenName_PrefixesWithSubfolder_WhenSubfolderProvided()
     {
         string result = HtmlImportNaming.QualifyScreenName("MyScreen", "Imported");

--- a/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportNamingTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportNamingTests.cs
@@ -1,0 +1,98 @@
+using HtmlToGumPlugin;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.HtmlToGumPlugin;
+
+public class HtmlImportNamingTests
+{
+    [Fact]
+    public void IsUrl_ReturnsFalse_ForLocalPath()
+    {
+        bool result = HtmlImportNaming.IsUrl(@"C:\pages\index.html");
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsUrl_ReturnsTrue_ForHttpUrl()
+    {
+        bool result = HtmlImportNaming.IsUrl("http://example.com/page.html");
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUrl_ReturnsTrue_ForHttpsUrl()
+    {
+        bool result = HtmlImportNaming.IsUrl("https://example.com/page.html");
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void QualifyScreenName_PrefixesWithSubfolder_WhenSubfolderProvided()
+    {
+        string result = HtmlImportNaming.QualifyScreenName("MyScreen", "Imported");
+
+        result.ShouldBe("Imported/MyScreen");
+    }
+
+    [Fact]
+    public void QualifyScreenName_ReturnsScreenNameUnchanged_WhenSubfolderIsNullOrWhitespace()
+    {
+        HtmlImportNaming.QualifyScreenName("MyScreen", null).ShouldBe("MyScreen");
+        HtmlImportNaming.QualifyScreenName("MyScreen", "   ").ShouldBe("MyScreen");
+    }
+
+    [Fact]
+    public void QualifyScreenName_TrimsTrailingSlash_FromSubfolder()
+    {
+        string result = HtmlImportNaming.QualifyScreenName("MyScreen", "Imported/");
+
+        result.ShouldBe("Imported/MyScreen");
+    }
+
+    [Fact]
+    public void ResolveUniqueScreenName_AppendsSuffix_WhenQualifiedNameConflicts()
+    {
+        HashSet<string> existing = new() { "MyScreen" };
+
+        string result = HtmlImportNaming.ResolveUniqueScreenName("MyScreen", null, existing.Contains);
+
+        result.ShouldBe("MyScreen_2");
+    }
+
+    [Fact]
+    public void ResolveUniqueScreenName_IncrementsSuffix_UntilNameIsFree()
+    {
+        HashSet<string> existing = new() { "MyScreen", "MyScreen_2", "MyScreen_3" };
+
+        string result = HtmlImportNaming.ResolveUniqueScreenName("MyScreen", null, existing.Contains);
+
+        result.ShouldBe("MyScreen_4");
+    }
+
+    [Fact]
+    public void ResolveUniqueScreenName_ReturnsDesiredName_WhenNoConflict()
+    {
+        HashSet<string> existing = new();
+
+        string result = HtmlImportNaming.ResolveUniqueScreenName("MyScreen", null, existing.Contains);
+
+        result.ShouldBe("MyScreen");
+    }
+
+    [Fact]
+    public void ResolveUniqueScreenName_ScopesConflictCheck_ToQualifiedName()
+    {
+        // "MyScreen" is taken at the project root, but "Imported/MyScreen" is free —
+        // the subfolder should avoid the conflict entirely.
+        HashSet<string> existing = new() { "MyScreen" };
+
+        string result = HtmlImportNaming.ResolveUniqueScreenName("MyScreen", "Imported", existing.Contains);
+
+        result.ShouldBe("MyScreen");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/MainHtmlToGumPluginConverterDirTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/MainHtmlToGumPluginConverterDirTests.cs
@@ -1,0 +1,37 @@
+using HtmlToGumPlugin;
+using Shouldly;
+using System.IO;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.HtmlToGumPlugin;
+
+public class MainHtmlToGumPluginConverterDirTests
+{
+    [Fact]
+    public void GetConverterDirCandidates_FirstCandidate_ResolvesToRepoConverterFolder()
+    {
+        // Gum.csproj sets AppendTargetFrameworkToOutputPath=false, so the plugin DLL's base
+        // directory is <root>/Gum/bin/<Config>/ with no TFM subfolder — three levels up is <root>.
+        string baseDir = Path.Combine(@"C:\", "repo", "Gum", "bin", "Debug") + Path.DirectorySeparatorChar;
+
+        string[] candidates = MainHtmlToGumPlugin.GetConverterDirCandidates(baseDir);
+
+        string expected = Path.GetFullPath(Path.Combine(@"C:\", "repo", "Tool", "HtmlToGum", "converter"));
+        candidates[0].ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GetConverterDirCandidates_FirstCandidate_ResolvesUnderGitWorktree()
+    {
+        // A git worktree nests the checkout under .claude/worktrees/<branch>/ — the plugin DLL's
+        // base directory still sits three levels under that worktree's own root.
+        string baseDir = Path.Combine(
+            @"C:\", "repo", ".claude", "worktrees", "some-branch", "Gum", "bin", "Debug") + Path.DirectorySeparatorChar;
+
+        string[] candidates = MainHtmlToGumPlugin.GetConverterDirCandidates(baseDir);
+
+        string expected = Path.GetFullPath(
+            Path.Combine(@"C:\", "repo", ".claude", "worktrees", "some-branch", "Tool", "HtmlToGum", "converter"));
+        candidates[0].ShouldBe(expected);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
@@ -199,7 +199,7 @@ public class MenuStripManagerTests : BaseTestClass
         // Register in one order
         _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
         _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
-        _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Import" });
         _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
         _menuStripManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
         _menuStripManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
@@ -220,7 +220,7 @@ public class MenuStripManagerTests : BaseTestClass
         // Register in a different order
         secondManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
         secondManager.AddMenuItem(new[] { "Content", "Re-create missing font files" });
-        secondManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        secondManager.AddMenuItem(new[] { "Content", "Import" });
         secondManager.AddMenuItem(new[] { "Content", "Force re-create all font files" });
         secondManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
         secondManager.AddMenuItem(new[] { "Content", "View Font Cache" });
@@ -234,7 +234,7 @@ public class MenuStripManagerTests : BaseTestClass
             "Find file references...",
             "<separator>",
             "Add Forms Components",
-            "Import from .gumx...",
+            "Import",
             "<separator>",
             "Clear Font Cache",
             "Re-create missing font files",
@@ -251,7 +251,7 @@ public class MenuStripManagerTests : BaseTestClass
         _menuStripManager.PopulateMenu(menu);
 
         _menuStripManager.AddMenuItem(new[] { "Content", "Add Forms Components" });
-        _menuStripManager.AddMenuItem(new[] { "Content", "Import from .gumx..." });
+        _menuStripManager.AddMenuItem(new[] { "Content", "Import" });
         _menuStripManager.AddMenuItem(new[] { "Content", "Clear Font Cache" });
         _menuStripManager.AddMenuItem(new[] { "Content", "View Font Cache" });
 
@@ -275,7 +275,7 @@ public class MenuStripManagerTests : BaseTestClass
 
         // The re-added item must land back in its forms group, not at the end.
         int formsIndex = Array.IndexOf(headers, (object)"Add Forms Components");
-        int importIndex = Array.IndexOf(headers, (object)"Import from .gumx...");
+        int importIndex = Array.IndexOf(headers, (object)"Import");
         int clearFontIndex = Array.IndexOf(headers, (object)"Clear Font Cache");
 
         formsIndex.ShouldBeLessThan(importIndex);

--- a/docs/gum-tool/importing-elements.md
+++ b/docs/gum-tool/importing-elements.md
@@ -31,7 +31,7 @@ This option is useful if you would like to import a set of components, such as a
 
 To import from a project:
 
-1. Click the Content -> Import from .gumx... menu item
+1. Click the Content -> Import -> .gumx... menu item
 2. Select either Local File or URL depending on the location of the .gumx
 3. Browser or enter the location of the project
 4. Select the desired objects to import. You can click entire folders to select all contained objects. Note that dependencies (such as behaviors) are automatically checked.


### PR DESCRIPTION
## Summary
- The Import HTML dialog now has a Local file / URL toggle — convert.ts already handled `http(s)://` (auto-detects and does `page.goto(url)`), but the plugin's `OpenFileDialog`-only entry point never let you type one.
- Added an optional "Destination subfolder" field. When set, the imported screen lands at `Screens/<subfolder>/<name>` instead of relying only on the `_2`/`_3` numeric-suffix fallback on conflict — mirrors `GumxImportService`'s subfolder convention from the `.gumx` importer.
- Conflict detection is scoped to the qualified name, so `Sub/Foo` doesn't collide with an existing top-level `Foo`.
- Switched `ImportScreen` from the `FilePath` overload to the `ScreenSave` overload (deserialize, optionally rename, then import) — the old path always tripped `DetermineIfShouldAdd`'s "must be in Gum project's Screens folder, copy it?" prompt since the staged `.gusx` always lived in a temp dir, not the project's `Screens/` folder.
- Extracted the naming/conflict logic into `HtmlImportNaming` (pure, unit-tested) since the rest of the plugin is WinForms UI.

Closes #4006

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` — 1108 passed, 0 failed (includes 10 new `HtmlImportNamingTests`)
- [ ] Manual: Content → Import HTML… — try a local file, a URL, and a destination subfolder
