### PR TITLE
Add drag-to-scrub to individual corner radius fields

### DIFF
--- a/Gum/Controls/CornerRadiusDisplay.xaml
+++ b/Gum/Controls/CornerRadiusDisplay.xaml
@@ -17,7 +17,13 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <Label x:Name="Label" MinWidth="100">Property Label:</Label>
+            <Label
+                x:Name="Label"
+                MinWidth="100"
+                Cursor="ScrollWE"
+                MouseDown="Label_MouseDown"
+                MouseMove="Label_MouseMove"
+                MouseUp="Label_MouseUp">Property Label:</Label>
 
             <!--  Linked state: a single uniform-radius field, matching the plain CornerRadius row.  -->
             <TextBox
@@ -45,11 +51,16 @@
                 </Grid.RowDefinitions>
 
                 <TextBlock
+                    x:Name="TopLeftLabel"
                     Grid.Row="0"
                     Grid.Column="0"
                     Margin="0,0,2,0"
                     VerticalAlignment="Center"
+                    Cursor="ScrollWE"
                     FontSize="10"
+                    MouseDown="Label_MouseDown"
+                    MouseMove="Label_MouseMove"
+                    MouseUp="Label_MouseUp"
                     Text="TL"
                     ToolTip="Top-left corner radius" />
                 <TextBox
@@ -61,11 +72,16 @@
                     LostFocus="CornerTextBox_LostFocus" />
 
                 <TextBlock
+                    x:Name="TopRightLabel"
                     Grid.Row="0"
                     Grid.Column="2"
                     Margin="0,0,2,0"
                     VerticalAlignment="Center"
+                    Cursor="ScrollWE"
                     FontSize="10"
+                    MouseDown="Label_MouseDown"
+                    MouseMove="Label_MouseMove"
+                    MouseUp="Label_MouseUp"
                     Text="TR"
                     ToolTip="Top-right corner radius" />
                 <TextBox
@@ -77,11 +93,16 @@
                     LostFocus="CornerTextBox_LostFocus" />
 
                 <TextBlock
+                    x:Name="BottomLeftLabel"
                     Grid.Row="1"
                     Grid.Column="0"
                     Margin="0,0,2,0"
                     VerticalAlignment="Center"
+                    Cursor="ScrollWE"
                     FontSize="10"
+                    MouseDown="Label_MouseDown"
+                    MouseMove="Label_MouseMove"
+                    MouseUp="Label_MouseUp"
                     Text="BL"
                     ToolTip="Bottom-left corner radius" />
                 <TextBox
@@ -93,11 +114,16 @@
                     LostFocus="CornerTextBox_LostFocus" />
 
                 <TextBlock
+                    x:Name="BottomRightLabel"
                     Grid.Row="1"
                     Grid.Column="2"
                     Margin="0,0,2,0"
                     VerticalAlignment="Center"
+                    Cursor="ScrollWE"
                     FontSize="10"
+                    MouseDown="Label_MouseDown"
+                    MouseMove="Label_MouseMove"
+                    MouseUp="Label_MouseUp"
                     Text="BR"
                     ToolTip="Bottom-right corner radius" />
                 <TextBox

--- a/Gum/Controls/CornerRadiusDisplay.xaml.cs
+++ b/Gum/Controls/CornerRadiusDisplay.xaml.cs
@@ -126,6 +126,15 @@ namespace Gum.Controls.DataUi
 
         private static void ApplyBackground(TextBox textBox, InstanceMember member)
         {
+            // The DataUiGrid style sets this attached property so rows rely on the per-row
+            // "is edited" icon (Frb.Styles.Defaults.xaml's IsDefaultIcon) instead of a
+            // displayer-painted background - see TextBoxDisplayLogic.RefreshBackgroundColor
+            // for the reference check every other displayer already honors.
+            if (DataUiGrid.GetOverridesIsDefaultStyling(textBox))
+            {
+                return;
+            }
+
             if (member.IsDefault)
             {
                 textBox.Background = TextBoxDisplayLogic.DefaultValueBackground;
@@ -293,6 +302,11 @@ namespace Gum.Controls.DataUi
                 {
                     _dragUnroundedValue += difference;
                     double rounded = TextBoxDisplayLogic.SnapDraggedValue(_dragUnroundedValue, rounding: 1);
+
+                    // Stick visibly at the 0 floor while scrubbing (matching TextBoxDisplay's
+                    // min/max handling) instead of showing a negative value that only snaps back
+                    // to 0 once the commit round-trips through Decompose's clamp.
+                    rounded = (double)TextBoxDisplayLogic.ClampToRange(rounded, min: 0m, max: null);
 
                     _draggingTextBox.Text = FormatFloat((float)rounded);
                     CommitValue(SetPropertyCommitType.Intermediate);

--- a/Gum/Controls/CornerRadiusDisplay.xaml.cs
+++ b/Gum/Controls/CornerRadiusDisplay.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Windows;
@@ -25,6 +26,13 @@ namespace Gum.Controls.DataUi
         bool _isLinked = true;
         CornerRadiusComposite _current;
 
+        readonly Dictionary<FrameworkElement, TextBox> _labelDragTargets;
+        FrameworkElement? _draggingLabel;
+        TextBox? _draggingTextBox;
+        double? _dragCurrentX;
+        double? _dragPressedX;
+        double _dragUnroundedValue;
+
         public InstanceMember? InstanceMember
         {
             get => mInstanceMember;
@@ -51,6 +59,15 @@ namespace Gum.Controls.DataUi
         public CornerRadiusDisplay()
         {
             InitializeComponent();
+
+            _labelDragTargets = new Dictionary<FrameworkElement, TextBox>
+            {
+                [Label] = UniformTextBox,
+                [TopLeftLabel] = TopLeftTextBox,
+                [TopRightLabel] = TopRightTextBox,
+                [BottomLeftLabel] = BottomLeftTextBox,
+                [BottomRightLabel] = BottomRightTextBox,
+            };
         }
 
         public void Refresh(bool forceRefreshEvenIfFocused = false)
@@ -221,7 +238,7 @@ namespace Gum.Controls.DataUi
 
         private void CornerTextBox_LostFocus(object sender, RoutedEventArgs e) => CommitValue();
 
-        private void CommitValue()
+        private void CommitValue(SetPropertyCommitType commitType = SetPropertyCommitType.Full)
         {
             if (_isSyncingFromInstance)
             {
@@ -231,9 +248,77 @@ namespace Gum.Controls.DataUi
             ApplyValueResult result = TryGetValueOnUi(out object? value);
             if (result == ApplyValueResult.Success && value != null)
             {
-                this.TrySetValueOnInstance(value, SetPropertyCommitType.Full);
+                this.TrySetValueOnInstance(value, commitType);
             }
         }
+
+        #region Label Dragging
+
+        /// <summary>
+        /// Click-and-drag over a field's label to scrub its numeric value, mirroring
+        /// <see cref="TextBoxDisplay"/>'s label-drag gesture. Applies to the uniform field's shared
+        /// <see cref="Label"/> and each per-corner TL/TR/BL/BR label via <see cref="_labelDragTargets"/>.
+        /// </summary>
+        private void Label_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not FrameworkElement label || !_labelDragTargets.TryGetValue(label, out TextBox target))
+            {
+                return;
+            }
+
+            _draggingLabel = label;
+            _draggingTextBox = target;
+            _dragCurrentX = e.GetPosition(this).X;
+            _dragPressedX = _dragCurrentX;
+
+            Mouse.Capture(label);
+
+            _dragUnroundedValue = ParseFloat(target.Text) ?? _current.Uniform;
+        }
+
+        private void Label_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (_dragCurrentX == null || _draggingTextBox == null)
+            {
+                return;
+            }
+
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                double newX = e.GetPosition(this).X;
+                double difference = newX - _dragCurrentX.Value;
+                _dragCurrentX = newX;
+
+                if (difference != 0)
+                {
+                    _dragUnroundedValue += difference;
+                    double rounded = TextBoxDisplayLogic.SnapDraggedValue(_dragUnroundedValue, rounding: 1);
+
+                    _draggingTextBox.Text = FormatFloat((float)rounded);
+                    CommitValue(SetPropertyCommitType.Intermediate);
+                }
+            }
+            else if (Mouse.Captured == _draggingLabel)
+            {
+                Mouse.Capture(null);
+            }
+        }
+
+        private void Label_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (_draggingTextBox != null && _dragPressedX != e.GetPosition(this).X)
+            {
+                CommitValue(SetPropertyCommitType.Full);
+            }
+
+            _draggingLabel = null;
+            _draggingTextBox = null;
+            _dragCurrentX = null;
+            _dragPressedX = null;
+            Mouse.Capture(null);
+        }
+
+        #endregion
 
         private static string FormatFloat(float value) => value.ToString("0.####", CultureInfo.InvariantCulture);
 

--- a/Gum/Controls/CornerRadiusDisplay.xaml.cs
+++ b/Gum/Controls/CornerRadiusDisplay.xaml.cs
@@ -98,6 +98,10 @@ namespace Gum.Controls.DataUi
         /// field and would only confuse a single shared color. When InstanceMember isn't a plain
         /// CompositeInstanceMember (e.g. a multi-select wrapper), fall back to its own aggregate
         /// IsDefault/IsIndeterminate for every field - less precise, but still a signal.
+        /// Deferred via Dispatcher.BeginInvoke like TextBoxDisplayLogic.RefreshBackgroundColor:
+        /// DataUiGrid.OverridesIsDefaultStyling is an inherited attached property, and a pooled
+        /// control isn't necessarily re-parented into the grid's visual tree yet when Refresh runs,
+        /// so reading it synchronously here can see the pre-inheritance default (false).
         /// </summary>
         private void RefreshBackgrounds()
         {
@@ -106,22 +110,25 @@ namespace Gum.Controls.DataUi
                 return;
             }
 
-            if (InstanceMember is CompositeInstanceMember composite && composite.ChannelMembers.Count == 5)
+            Dispatcher.BeginInvoke(() =>
             {
-                ApplyBackground(UniformTextBox, composite.ChannelMembers[0]);
-                ApplyBackground(TopLeftTextBox, composite.ChannelMembers[1]);
-                ApplyBackground(TopRightTextBox, composite.ChannelMembers[2]);
-                ApplyBackground(BottomLeftTextBox, composite.ChannelMembers[3]);
-                ApplyBackground(BottomRightTextBox, composite.ChannelMembers[4]);
-            }
-            else
-            {
-                ApplyBackground(UniformTextBox, InstanceMember);
-                ApplyBackground(TopLeftTextBox, InstanceMember);
-                ApplyBackground(TopRightTextBox, InstanceMember);
-                ApplyBackground(BottomLeftTextBox, InstanceMember);
-                ApplyBackground(BottomRightTextBox, InstanceMember);
-            }
+                if (InstanceMember is CompositeInstanceMember composite && composite.ChannelMembers.Count == 5)
+                {
+                    ApplyBackground(UniformTextBox, composite.ChannelMembers[0]);
+                    ApplyBackground(TopLeftTextBox, composite.ChannelMembers[1]);
+                    ApplyBackground(TopRightTextBox, composite.ChannelMembers[2]);
+                    ApplyBackground(BottomLeftTextBox, composite.ChannelMembers[3]);
+                    ApplyBackground(BottomRightTextBox, composite.ChannelMembers[4]);
+                }
+                else if (InstanceMember != null)
+                {
+                    ApplyBackground(UniformTextBox, InstanceMember);
+                    ApplyBackground(TopLeftTextBox, InstanceMember);
+                    ApplyBackground(TopRightTextBox, InstanceMember);
+                    ApplyBackground(BottomLeftTextBox, InstanceMember);
+                    ApplyBackground(BottomRightTextBox, InstanceMember);
+                }
+            });
         }
 
         private static void ApplyBackground(TextBox textBox, InstanceMember member)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberRegistry.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberRegistry.cs
@@ -84,8 +84,19 @@ public class CompositeMemberRegistry : ICompositeMemberRegistry
     private object?[] DecomposeCornerRadius(object value)
     {
         CornerRadiusComposite composite = (CornerRadiusComposite)value;
-        return new object?[] { composite.Uniform, composite.TopLeft, composite.TopRight, composite.BottomLeft, composite.BottomRight };
+        return new object?[]
+        {
+            ClampToZeroMin(composite.Uniform),
+            ClampNullableToZeroMin(composite.TopLeft),
+            ClampNullableToZeroMin(composite.TopRight),
+            ClampNullableToZeroMin(composite.BottomLeft),
+            ClampNullableToZeroMin(composite.BottomRight)
+        };
     }
+
+    private static float ClampToZeroMin(float value) => Math.Max(0f, value);
+
+    private static float? ClampNullableToZeroMin(float? value) => value.HasValue ? Math.Max(0f, value.Value) : null;
 
     private float ToFloat(object? value) => value is float asFloat ? asFloat : 0f;
 

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberRegistryTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberRegistryTests.cs
@@ -90,6 +90,16 @@ public class CompositeMemberRegistryTests
     }
 
     [Fact]
+    public void CornerRadiusDescriptor_Decompose_ShouldClampNegativeUniformAndOverridesToZero()
+    {
+        CornerRadiusComposite composite = new(-8f, -1f, null, 3f, -0.5f);
+
+        object?[] channels = CornerRadiusDescriptor.Decompose(composite);
+
+        channels.ShouldBe(new object?[] { 0f, 0f, null, 3f, 0f });
+    }
+
+    [Fact]
     public void CornerRadiusDescriptor_ShouldUseCornerRadiusDisplayAndCompositeType()
     {
         CornerRadiusDescriptor.Displayer.ShouldBe(typeof(Gum.Controls.DataUi.CornerRadiusDisplay));


### PR DESCRIPTION
Closes #3970

Wires the label click-and-drag-to-scrub gesture (`TextBoxDisplay`'s `Label_MouseMove` pattern) onto `CornerRadiusDisplay`. Turns out none of its fields had it, including the uniform field — the issue's premise that the uniform field worked was slightly off, confirmed against the `gum-tool-variable-grid` skill doc which already flagged this as an opt-in-per-displayer gap. Fixed consistently: the shared Property Label now drags the uniform field, and each TL/TR/BL/BR label drags its own corner field.

Also, while testing:
- Corner radius (uniform and each per-corner override) is now clamped to a 0 floor. Enforced in `CompositeMemberRegistry.DecomposeCornerRadius`, the single point every write path (typed, dragged, undo/redo) funnels through — plus the drag now sticks visually at 0 instead of showing a negative value that snaps back.
- Removed `CornerRadiusDisplay`'s own green "is default" background tint. It was the one displayer that never checked `DataUiGrid.OverridesIsDefaultStyling` before painting a background, so it kept the legacy convention even though the grid's per-row edited icon already covers that signal.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] `GumToolUnitTests` full suite — 1099 passed
- [x] Manual: unlink Corner Radius, drag each label (uniform + TL/TR/BL/BR) below 0 — should stick at 0; type a negative value and tab away — should snap to 0; confirm no green background on default-valued corner radius fields