### PR TITLE
Fix Rectangle/Circle fill/stroke variables not applying from saved projects

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -3098,6 +3098,44 @@ public partial class CustomSetPropertyOnRenderable
             case "Radius":
                 circleRuntime.Radius = (float)value;
                 return true;
+            // Issue #2768 v3 shape surface (fill/stroke as independent channels) — these
+            // properties only exist on the runtime, not on either renderable slot, so without
+            // an explicit case they fell through to SetPropertyThroughReflection, which
+            // reflects on the contained renderable slot and silently drops them (a Circle
+            // saved with IsFilled=true loaded back unfilled).
+            case "IsFilled":
+                circleRuntime.IsFilled = (bool)value;
+                return true;
+            case "FillRed":
+                circleRuntime.FillRed = (int)value;
+                return true;
+            case "FillGreen":
+                circleRuntime.FillGreen = (int)value;
+                return true;
+            case "FillBlue":
+                circleRuntime.FillBlue = (int)value;
+                return true;
+            case "FillAlpha":
+                circleRuntime.FillAlpha = (int)value;
+                return true;
+            case "StrokeRed":
+                circleRuntime.StrokeRed = (int)value;
+                return true;
+            case "StrokeGreen":
+                circleRuntime.StrokeGreen = (int)value;
+                return true;
+            case "StrokeBlue":
+                circleRuntime.StrokeBlue = (int)value;
+                return true;
+            case "StrokeAlpha":
+                circleRuntime.StrokeAlpha = (int)value;
+                return true;
+            case "StrokeWidth":
+                circleRuntime.StrokeWidth = (float)value;
+                return true;
+            case "Blend":
+                circleRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
+                return true;
         }
         return false;
 #pragma warning restore CS0618
@@ -3149,6 +3187,44 @@ public partial class CustomSetPropertyOnRenderable
                 return true;
             case "CustomRadiusBottomRight":
                 rectangleRuntime.CustomRadiusBottomRight = (float?)value;
+                return true;
+            // Issue #2768 v3 shape surface (fill/stroke as independent channels) — these
+            // properties only exist on the runtime, not on either renderable slot, so without
+            // an explicit case they fell through to SetPropertyThroughReflection, which
+            // reflects on the contained renderable slot and silently drops them (a Rectangle
+            // saved with IsFilled=true loaded back unfilled).
+            case "IsFilled":
+                rectangleRuntime.IsFilled = (bool)value;
+                return true;
+            case "FillRed":
+                rectangleRuntime.FillRed = (int)value;
+                return true;
+            case "FillGreen":
+                rectangleRuntime.FillGreen = (int)value;
+                return true;
+            case "FillBlue":
+                rectangleRuntime.FillBlue = (int)value;
+                return true;
+            case "FillAlpha":
+                rectangleRuntime.FillAlpha = (int)value;
+                return true;
+            case "StrokeRed":
+                rectangleRuntime.StrokeRed = (int)value;
+                return true;
+            case "StrokeGreen":
+                rectangleRuntime.StrokeGreen = (int)value;
+                return true;
+            case "StrokeBlue":
+                rectangleRuntime.StrokeBlue = (int)value;
+                return true;
+            case "StrokeAlpha":
+                rectangleRuntime.StrokeAlpha = (int)value;
+                return true;
+            case "StrokeWidth":
+                rectangleRuntime.StrokeWidth = (float)value;
+                return true;
+            case "Blend":
+                rectangleRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
                 return true;
         }
         return false;

--- a/MonoGameGum.Tests/Runtimes/DataDrivenShapePropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/DataDrivenShapePropertyTests.cs
@@ -1,0 +1,83 @@
+using Gum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+/// <summary>
+/// Reproduces the data-driven property-application path that loading a .gumx project uses
+/// (<c>ApplyState</c> → <c>SetProperty(string, object)</c>) for the v3 shape surface
+/// (<c>IsFilled</c>, <c>FillRed</c>/<c>Green</c>/<c>Blue</c>, <c>StrokeWidth</c>) on
+/// <see cref="RectangleRuntime"/> and <see cref="CircleRuntime"/>. Mirrors
+/// <c>DataDrivenContainerPropertyTests</c>.
+/// </summary>
+/// <remarks>
+/// <c>CustomSetPropertyOnRenderable.TrySetPropertyOnRectangleRuntime</c> /
+/// <c>TrySetPropertyOnCircleRuntime</c> only forwarded the pre-#2768 legacy single-color
+/// surface (<c>Color</c>/<c>Alpha</c>/<c>Red</c>/<c>Green</c>/<c>Blue</c>). Any project-file
+/// variable outside that set (<c>IsFilled</c>, <c>FillRed</c>, <c>StrokeWidth</c>, etc.) fell
+/// through to <c>SetPropertyThroughReflection</c>, which reflects on the contained renderable
+/// slot (e.g. <c>SolidRectangle</c>) — not the runtime — where these properties don't exist, so
+/// the value was silently dropped. A Rectangle with <c>IsFilled=true</c> saved to a .gumx and
+/// reloaded therefore rendered with no fill.
+/// </remarks>
+public class DataDrivenShapePropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_IsFilled_OnRectangleRuntime_AppliesValue()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("IsFilled", true);
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_FillRedGreenBlue_OnRectangleRuntime_AppliesValues()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("FillRed", 224);
+        sut.SetProperty("FillGreen", 165);
+        sut.SetProperty("FillBlue", 60);
+
+        sut.FillRed.ShouldBe(224);
+        sut.FillGreen.ShouldBe(165);
+        sut.FillBlue.ShouldBe(60);
+    }
+
+    [Fact]
+    public void SetProperty_StrokeWidth_OnRectangleRuntime_AppliesValue()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 0f);
+
+        sut.StrokeWidth.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void SetProperty_IsFilled_OnCircleRuntime_AppliesValue()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("IsFilled", true);
+
+        sut.IsFilled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_FillRedGreenBlue_OnCircleRuntime_AppliesValues()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("FillRed", 12);
+        sut.SetProperty("FillGreen", 34);
+        sut.SetProperty("FillBlue", 56);
+
+        sut.FillRed.ShouldBe(12);
+        sut.FillGreen.ShouldBe(34);
+        sut.FillBlue.ShouldBe(56);
+    }
+}


### PR DESCRIPTION
## Bug

Loading a Rectangle or Circle from a saved `.gumx`/`.gusx` project silently drops `IsFilled`, `FillRed`/`Green`/`Blue`/`Alpha`, `StrokeRed`/`Green`/`Blue`/`Alpha`, `StrokeWidth`, and `Blend`. Found via `gumcli screenshot`, whose PNG output came back ~98% transparent for a project with a filled background Rectangle (only the default 1px white stroke rendered).

## Root cause

`CustomSetPropertyOnRenderable.TrySetPropertyOnRectangleRuntime` / `TrySetPropertyOnCircleRuntime` dispatch data-driven `SetProperty(name, value)` calls (the path `ToGraphicalUiElement`/`ApplyState` uses when loading a project file) by runtime type. Both switches only forward the pre-#2768 legacy single-color surface (`Color`/`Alpha`/`Red`/`Green`/`Blue`). The v3 two-slot properties (`IsFilled`, `FillRed`/etc., `StrokeRed`/etc., `StrokeWidth`, `Blend`) have no case, so the switch returns `false` and the call falls through to `SetPropertyThroughReflection`, which reflects on the *contained renderable slot* (e.g. `SolidRectangle`) — not the runtime wrapper that actually declares these properties. Reflection finds nothing and silently no-ops.

This affects any MonoGame/KNI/FNA consumer loading a project file with v3 shape variables (Raylib and FRB have separate dispatch and are unaffected).

## Fix

Added the missing cases to both dispatchers, mirroring the pattern already used for `CornerRadius`/`CustomRadiusTopLeft` etc. Not covered: gradient and dropshadow variables — a separate, still-evolving surface per existing code comments, left for a follow-up.

## Testing

- `MonoGameGum.Tests/Runtimes/DataDrivenShapePropertyTests.cs` (new) — pins `SetProperty("IsFilled"/"FillRed"/.../"StrokeWidth", ...)` reaching `RectangleRuntime`/`CircleRuntime`. Red before the fix, green after.
- Full `MonoGameGum.Tests` (1904), `RaylibGum.Tests` (520), `MonoGameGum.IntegrationTests` (74) all green.
- `KniGum`, `RaylibGum`, `SkiaGum` build clean.
- Manual repro (HtmlToGum → `gumcli screenshot`): opaque-pixel coverage of a 300x400 PNG with a full-bleed filled panel went from 2.2% (675/30000 sampled pixels) to 78.2% (23471/30000), with sampled fill colors matching the source `.gusx` `FillRed`/`Green`/`Blue` exactly.

## Manual test verdict

Headless CLI rendering path — no GUI/manual verification needed. Verified via the repro above (build, `gumcli screenshot`, Python/Pillow pixel sampling), see testing section.