### PR TITLE
HtmlToGum: iterative visual-fidelity fixes (autonomous session)

### DIFF
--- a/Tool/HtmlToGum/converter/assets.ts
+++ b/Tool/HtmlToGum/converter/assets.ts
@@ -89,6 +89,14 @@ function sha1(buf) {
   return createHash('sha1').update(buf).digest('hex').slice(0, 12);
 }
 
+/** Width/height from a PNG's IHDR chunk (bytes 16-23, big-endian) — used to recover the
+ *  actual rasterized pixel size of an SVG->PNG conversion (SVG_UPSCALE / SVG_MAX_DIM in
+ *  rasterizeSvg mean it's not simply the SVG's own declared intrinsic size) without
+ *  duplicating that scale math here. */
+function pngDimensions(buf) {
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
 function sniffExt(buf) {
   if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') {
     return 'webp';
@@ -138,7 +146,14 @@ export async function downloadImages(
   })(root);
 
   const assetMap = new Map();
-  if (urls.size === 0) return assetMap;
+  // url -> actual rasterized pixel {width,height}, populated only for SVG sources (the
+  // only path where the on-disk asset's pixel size diverges from the box tree's captured
+  // naturalWidth/naturalHeight — see rasterizeSvg's SVG_UPSCALE/SVG_MAX_DIM). map.ts's
+  // TextureLeft/Top/Width/Height crop math (cover-fit and background-position sprites)
+  // scales by this against naturalWidth/Height so crop coordinates land on the right
+  // pixels in the actual (possibly upscaled) asset file.
+  const assetSizeMap = new Map();
+  if (urls.size === 0) return { assetMap, assetSizeMap };
 
   mkdirSync(outDir, { recursive: true });
   const hashToFile = new Map();
@@ -184,6 +199,7 @@ export async function downloadImages(
         try {
           outBuf = await rasterizeSvg(browser, buf);
           outExt = 'png';
+          assetSizeMap.set(url, pngDimensions(outBuf));
           console.log(`  image: rasterized svg → png`);
         } catch (e) {
           console.warn(`  ! svg rasterize failed: ${e.message} — skipped ${url}`);
@@ -214,5 +230,5 @@ export async function downloadImages(
       console.warn(`  ! image download error: ${url} (${e.message})`);
     }
   }
-  return assetMap;
+  return { assetMap, assetSizeMap };
 }

--- a/Tool/HtmlToGum/converter/convert.ts
+++ b/Tool/HtmlToGum/converter/convert.ts
@@ -163,6 +163,30 @@ async function renderTree(browser, width, height, { captureFonts = false } = {})
 }
 
 /**
+ * page.screenshot({ clip }) without fullPage only crops the currently visible viewport —
+ * it does not scroll to reach content below the fold, and clip regions entirely outside
+ * the viewport throw "Clipped area is either empty or outside the resulting image" (seen
+ * on tall pages like a full-page `body` root, where most raster nodes sit well past the
+ * requested viewport height). Scroll the clip's top-left into view, capture with clip
+ * coordinates adjusted for the resulting scroll offset, then restore scroll position so
+ * later page-relative captures (subsequent raster shots, the final reference screenshot)
+ * keep seeing document coordinates from a scroll-0 origin.
+ */
+async function screenshotClip(page, path, clip, screenshotOptions = {}) {
+  await page.evaluate(({ x, y }) => window.scrollTo(x, y), { x: clip.x, y: clip.y });
+  const scroll = await page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }));
+  try {
+    await page.screenshot({
+      path,
+      ...screenshotOptions,
+      clip: { ...clip, x: clip.x - scroll.x, y: clip.y - scroll.y },
+    });
+  } finally {
+    await page.evaluate(() => window.scrollTo(0, 0));
+  }
+}
+
+/**
  * Screenshot nodes flagged needsRaster (gradients / CSS filter / border-image) into Images/.
  * Backdrop-only parents: hide element children (and own text paint) so the sprite is
  * chrome-only; structured kids / Text labels are still emitted by map.mjs. Filter
@@ -270,11 +294,7 @@ async function rasterizeEffects(page, tree, imagesDir, assetMap, rootSelector) {
             return;
           }
         }
-        await page.screenshot({
-          path: join(imagesDir, filename),
-          clip,
-          omitBackground: false,
-        });
+        await screenshotClip(page, join(imagesDir, filename), clip, { omitBackground: false });
       };
       const backdropOnly = !node.style.rasterWholeSubtree
         && (node.children.length > 0 || !!(node.text && String(node.text).trim()));
@@ -374,7 +394,7 @@ async function main() {
 
   // Reuse the still-open browser for SVG rasterization inside downloadImages() instead
   // of paying a second Chromium launch — close only after it's done with it.
-  const downloaded = await downloadImages(tree, imagesDir, browser);
+  const { assetMap: downloaded, assetSizeMap } = await downloadImages(tree, imagesDir, browser);
   for (const [k, v] of downloaded) assetMap.set(k, v);
   await browser.close();
 
@@ -383,11 +403,11 @@ async function main() {
   });
   const nineSliceMap = generateNineSliceAssets(tree, imagesDir, assetMap);
 
-  const mapped = mapTreeToScreen(tree, assetMap, responsiveMap, fontMap, nineSliceMap);
+  const mapped = mapTreeToScreen(tree, assetMap, responsiveMap, fontMap, nineSliceMap, assetSizeMap);
   const screens = [{ name: screenName, mapped, gusx: toGusx(screenName, mapped) }];
 
   if (flags.responsive && flags.compareNaive) {
-    const naive = mapTreeToScreen(tree, assetMap, null, fontMap, nineSliceMap);
+    const naive = mapTreeToScreen(tree, assetMap, null, fontMap, nineSliceMap, assetSizeMap);
     const naiveName = `${screenName}Naive`;
     screens.push({ name: naiveName, mapped: naive, gusx: toGusx(naiveName, naive) });
   }

--- a/Tool/HtmlToGum/converter/diff_screenshots.py
+++ b/Tool/HtmlToGum/converter/diff_screenshots.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+"""Pixel-diff two PNGs and report the largest regions of visual difference.
+
+Usage:
+    python diff_screenshots.py <reference.png> <candidate.png> <outdir> [--cell=16] [--top=5]
+
+Writes <outdir>/diff-summary.json and, for each of the top-N differing regions,
+<outdir>/region-N-ref.png / region-N-candidate.png crops (with a margin) so a
+reviewer (human or agent) can see exactly what differs without opening the
+full-page screenshots.
+
+Prints a short human-readable summary to stdout: overall diff percentage and
+one line per top region (bbox + pixel count), ordered worst first.
+"""
+import sys
+import json
+import os
+import numpy as np
+from PIL import Image
+
+DIFF_THRESHOLD = 40  # summed abs RGB diff (0..765) above which a pixel counts as "differs"
+MARGIN = 24  # px of context around each cropped region
+
+
+def load_rgb(path):
+    im = Image.open(path).convert('RGB')
+    return im, np.asarray(im, dtype=np.int16)
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    if len(args) < 3:
+        print('Usage: diff_screenshots.py <reference.png> <candidate.png> <outdir> [--cell=16] [--top=5]')
+        sys.exit(2)
+    ref_path, cand_path, outdir = args[0], args[1], args[2]
+    cell = 16
+    top_n = 5
+    for a in sys.argv[1:]:
+        if a.startswith('--cell='):
+            cell = int(a.split('=', 1)[1])
+        if a.startswith('--top='):
+            top_n = int(a.split('=', 1)[1])
+
+    os.makedirs(outdir, exist_ok=True)
+
+    ref_im, ref = load_rgb(ref_path)
+    cand_im, cand = load_rgb(cand_path)
+
+    h = min(ref.shape[0], cand.shape[0])
+    w = min(ref.shape[1], cand.shape[1])
+    ref = ref[:h, :w]
+    cand = cand[:h, :w]
+
+    diff = np.abs(ref - cand).sum(axis=2)  # HxW, 0..765
+    differs = diff > DIFF_THRESHOLD
+
+    total = h * w
+    differing = int(differs.sum())
+    pct = 100.0 * differing / total
+
+    # Coarse grid: fraction of differing pixels per cell.
+    gh = (h + cell - 1) // cell
+    gw = (w + cell - 1) // cell
+    grid = np.zeros((gh, gw), dtype=np.float32)
+    for gy in range(gh):
+        for gx in range(gw):
+            y0, y1 = gy * cell, min((gy + 1) * cell, h)
+            x0, x1 = gx * cell, min((gx + 1) * cell, w)
+            block = differs[y0:y1, x0:x1]
+            grid[gy, gx] = block.mean() if block.size else 0.0
+
+    hot = grid > 0.15  # cell counts as "hot" if >15% of its pixels differ
+
+    # Flood-fill connected hot cells into regions (4-connectivity).
+    visited = np.zeros_like(hot, dtype=bool)
+    regions = []
+    for gy in range(gh):
+        for gx in range(gw):
+            if not hot[gy, gx] or visited[gy, gx]:
+                continue
+            stack = [(gy, gx)]
+            visited[gy, gx] = True
+            cells = []
+            while stack:
+                cy, cx = stack.pop()
+                cells.append((cy, cx))
+                for ny, nx in ((cy - 1, cx), (cy + 1, cx), (cy, cx - 1), (cy, cx + 1)):
+                    if 0 <= ny < gh and 0 <= nx < gw and hot[ny, nx] and not visited[ny, nx]:
+                        visited[ny, nx] = True
+                        stack.append((ny, nx))
+            ys = [c[0] for c in cells]
+            xs = [c[1] for c in cells]
+            y0px, y1px = min(ys) * cell, min(max(ys) + 1, gh) * cell
+            x0px, x1px = min(xs) * cell, min(max(xs) + 1, gw) * cell
+            y1px, x1px = min(y1px, h), min(x1px, w)
+            weight = int(differs[y0px:y1px, x0px:x1px].sum())
+            regions.append({
+                'bbox': [int(x0px), int(y0px), int(x1px), int(y1px)],
+                'differingPixels': weight,
+                'cellCount': len(cells),
+            })
+
+    regions.sort(key=lambda r: -r['differingPixels'])
+    regions = regions[:top_n]
+
+    for i, r in enumerate(regions, start=1):
+        x0, y0, x1, y1 = r['bbox']
+        x0m, y0m = max(0, x0 - MARGIN), max(0, y0 - MARGIN)
+        x1m, y1m = min(w, x1 + MARGIN), min(h, y1 + MARGIN)
+        ref_crop_path = os.path.join(outdir, f'region-{i}-ref.png')
+        cand_crop_path = os.path.join(outdir, f'region-{i}-candidate.png')
+        ref_im.crop((x0m, y0m, x1m, y1m)).save(ref_crop_path)
+        cand_im.crop((x0m, y0m, x1m, y1m)).save(cand_crop_path)
+        r['cropBbox'] = [x0m, y0m, x1m, y1m]
+        r['refCrop'] = ref_crop_path
+        r['candidateCrop'] = cand_crop_path
+
+    summary = {
+        'referenceImage': ref_path,
+        'candidateImage': cand_path,
+        'width': w,
+        'height': h,
+        'diffPixelPercent': round(pct, 3),
+        'diffThreshold': DIFF_THRESHOLD,
+        'regions': regions,
+    }
+    with open(os.path.join(outdir, 'diff-summary.json'), 'w') as f:
+        json.dump(summary, f, indent=2)
+
+    print(f'overall diff: {pct:.2f}% of pixels ({differing}/{total})')
+    if not regions:
+        print('no significant differing regions found (below hotness threshold)')
+    for i, r in enumerate(regions, start=1):
+        x0, y0, x1, y1 = r['bbox']
+        print(f'region {i}: bbox=({x0},{y0})-({x1},{y1}) differingPixels={r["differingPixels"]} '
+              f'ref={r["refCrop"]} candidate={r["candidateCrop"]}')
+
+
+if __name__ == '__main__':
+    main()

--- a/Tool/HtmlToGum/converter/extract.test.ts
+++ b/Tool/HtmlToGum/converter/extract.test.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright-core';
+import { extractBoxTree } from './extract.js';
+import { installTsxEvaluateShim } from './tsx-evaluate-shim.js';
+
+// Regression for the IANA "As described in RFC 2606 and RFC 6761, a number of..." bug:
+// a #text node that continues on the same line as a preceding <a>, then itself wraps
+// onto further lines, was collapsed into one leaf positioned at the union bounding box
+// of all its lines — which starts back at the block's left margin, overlapping the <a>
+// siblings that precede it on line 1.
+test('extractBoxTree: a #text run that wraps across lines is split per rendered line', async () => {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await installTsxEvaluateShim(page);
+    await page.setContent(`
+      <div style="width:320px;font:16px/22px Arial;">
+        <p>As described in <a href="#">RFC 2606</a> and <a href="#">RFC 6761</a>, a number of domains such as example.com and example.org are maintained for documentation purposes.</p>
+      </div>
+    `);
+    const tree = await page.evaluate(extractBoxTree, 'p');
+    await page.close();
+
+    const textLeaves = tree.children.filter((c) => c.tag === '#text');
+    // The trailing run must be split into more than one leaf (one per wrapped line).
+    assert.ok(textLeaves.length > 2, `expected multiple split #text leaves, got ${textLeaves.length}`);
+
+    // No leaf may start left of the paragraph's own left edge, and none may start at
+    // the same (x, y) as the first "As described in " leaf — that exact overlap was
+    // the visible bug.
+    const first = textLeaves[0];
+    for (const leaf of textLeaves.slice(1)) {
+      assert.ok(
+        !(leaf.rect.x === first.rect.x && leaf.rect.y === first.rect.y),
+        `leaf "${leaf.text}" overlaps the first leaf's origin (${first.rect.x},${first.rect.y})`,
+      );
+    }
+
+    // Reconstructing all children's text (in order) should reproduce the paragraph,
+    // modulo whitespace collapsing.
+    const rebuilt = tree.children.map((c) => c.text).join('').replace(/\s+/g, ' ').trim();
+    const expected = 'As described in RFC 2606 and RFC 6761, a number of domains such as example.com '
+      + 'and example.org are maintained for documentation purposes.';
+    assert.equal(rebuilt, expected);
+  } finally {
+    await browser.close();
+  }
+});

--- a/Tool/HtmlToGum/converter/extract.ts
+++ b/Tool/HtmlToGum/converter/extract.ts
@@ -176,20 +176,70 @@ export async function extractBoxTree(rootSelector: string): Promise<BoxNode> {
       applyTextTransform(lead + trimmed + trail, cs.textTransform),
     );
     if (!ownText.trim()) return null;
-    let lineCount = 1;
-    const rects = Array.from(range.getClientRects()).filter((r) => r.width > 0 && r.height > 0);
-    if (rects.length > 0) lineCount = Math.max(1, rects.length);
-    return {
-      id: null,
-      tag: '#text',
-      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
-      text: ownText,
-      lineCount,
-      imgSrc: null,
-      naturalWidth: 0,
-      naturalHeight: 0,
-      rasterSrc: null,
-      style: {
+    const lineRects = Array.from(range.getClientRects()).filter((r) => r.width > 0 && r.height > 0);
+
+    function makeLeaf(text, r) {
+      return {
+        id: null,
+        tag: '#text',
+        rect: { x: r.x, y: r.y, width: r.width, height: r.height },
+        text,
+        lineCount: 1,
+        imgSrc: null,
+        naturalWidth: 0,
+        naturalHeight: 0,
+        rasterSrc: null,
+        style: leafStyle(),
+        children: [],
+      };
+    }
+
+    // A run that itself wraps across multiple rendered lines (e.g. a long sentence
+    // that continues after a sibling <a> on line 1, then wraps under it) can't be
+    // represented by one Absolute leaf: Range.getBoundingClientRect() unions every
+    // line into a single box whose left edge is the *leftmost* line — wrapped lines
+    // restart at the block's margin — not the actual start of this run on line 1.
+    // Placing a leaf there overlaps whatever inline content precedes it. Split into
+    // one leaf per rendered line instead, using caretRangeFromPoint to find where
+    // Chromium actually broke the line.
+    if (lineRects.length > 1) {
+      const boundaries = [0];
+      let ok = true;
+      for (let i = 1; i < lineRects.length; i++) {
+        const r = lineRects[i];
+        const caret = document.caretRangeFromPoint(r.left + 1, r.top + r.height / 2);
+        if (caret && caret.startContainer === textNode && caret.startOffset > boundaries[i - 1]) {
+          boundaries.push(caret.startOffset);
+        } else {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) {
+        boundaries.push(textNode.textContent.length);
+        const leaves = [];
+        for (let i = 0; i < lineRects.length; i++) {
+          const raw = textNode.textContent.slice(boundaries[i], boundaries[i + 1]);
+          // Collapse runs of whitespace to one space, but only trim at the very start/end
+          // of the whole text node — a space at an internal line boundary is the wrap
+          // point itself and reconstructs the original word-joined text.
+          let lineText = raw.replace(/\s+/g, ' ');
+          if (i === 0) lineText = lineText.replace(/^ /, '');
+          if (i === lineRects.length - 1) lineText = lineText.replace(/ $/, '');
+          if (!lineText) continue;
+          if (i === 0 && lead) lineText = lead + lineText;
+          if (i === lineRects.length - 1 && trail) lineText += trail;
+          lineText = normalizeForBitmapFont(applyTextTransform(lineText, cs.textTransform));
+          if (lineText.trim()) leaves.push(makeLeaf(lineText, lineRects[i]));
+        }
+        if (leaves.length > 0) return leaves;
+      }
+    }
+
+    return [makeLeaf(ownText, rect)];
+
+    function leafStyle() {
+      return {
         display: 'inline',
         backgroundImage: 'none',
         backgroundSize: cs.backgroundSize,
@@ -258,9 +308,8 @@ export async function extractBoxTree(rootSelector: string): Promise<BoxNode> {
         borderImageSource: 'none',
         borderImageSlice: 0,
         borderImageRepeat: '',
-      },
-      children: [],
-    };
+      };
+    }
   }
 
   function walk(el) {
@@ -301,8 +350,8 @@ export async function extractBoxTree(rootSelector: string): Promise<BoxNode> {
       walkChildren = [];
       for (const child of el.childNodes) {
         if (child.nodeType === Node.TEXT_NODE) {
-          const leaf = walkTextNode(child, el);
-          if (leaf) walkChildren.push(leaf);
+          const leaves = walkTextNode(child, el);
+          if (leaves) walkChildren.push(...leaves);
         } else if (child.nodeType === Node.ELEMENT_NODE && isVisible(child)) {
           walkChildren.push(walk(child));
         }

--- a/Tool/HtmlToGum/converter/extract.ts
+++ b/Tool/HtmlToGum/converter/extract.ts
@@ -450,6 +450,10 @@ export async function extractBoxTree(rootSelector: string): Promise<BoxNode> {
         display: cs.display,
         backgroundImage: cs.backgroundImage,
         backgroundSize: cs.backgroundSize,
+        // CSS sprite-sheet icons (background-image + background-position offset, e.g.
+        // GeeksforGeeks' social icon strip) select one sub-region of a shared image —
+        // see computeBackgroundSpriteCrop() in map.ts.
+        backgroundPosition: cs.backgroundPosition,
         objectFit: cs.objectFit,
         objectPosition: cs.objectPosition,
         listStyleType: cs.listStyleType,

--- a/Tool/HtmlToGum/converter/map.test.ts
+++ b/Tool/HtmlToGum/converter/map.test.ts
@@ -178,3 +178,83 @@ test('mapTreeToScreen: flex row child margin-top offsets stretch cross-axis (IAN
   assert.equal(findVar(variables, 'Main.HeightUnits')?.value, 2); // RelativeToParent
   assert.equal(findVar(variables, 'Main.Height')?.value, -25);
 });
+
+// ---- inline-styled run merging (IANA "Public Technical Identifiers" bold spans) ------
+function ianaParagraphFixture(runOverrides = {}) {
+  const plainStyle = baseStyle({ fontSize: 12, color: 'rgb(10, 20, 30)' });
+  const boldStyle = baseStyle({ fontSize: 12, fontWeight: '700', color: 'rgb(10, 20, 30)', ...runOverrides });
+  const run1 = boxNode({
+    tag: '#text',
+    text: 'The IANA functions ... provided by ',
+    rect: { x: 90, y: 778, width: 522, height: 17 },
+    lineCount: 1,
+    style: plainStyle,
+  });
+  const run2 = boxNode({
+    tag: 'a',
+    text: 'Public Technical Identifiers',
+    rect: { x: 612, y: 778, width: 161, height: 17 },
+    lineCount: 1,
+    style: boldStyle,
+  });
+  const run3 = boxNode({
+    tag: '#text',
+    text: ', an affiliate of ',
+    rect: { x: 773, y: 778, width: 83, height: 17 },
+    lineCount: 1,
+    style: plainStyle,
+  });
+  const run4 = boxNode({
+    tag: 'a',
+    text: 'ICANN',
+    rect: { x: 856, y: 778, width: 40, height: 17 },
+    lineCount: 1,
+    style: boldStyle,
+  });
+  const p = boxNode({
+    id: 'P1',
+    tag: 'p',
+    rect: { x: 90, y: 778, width: 806, height: 17 },
+    style: plainStyle,
+    children: [run1, run2, run3, run4],
+  });
+  return boxNode({
+    id: 'root',
+    rect: { x: 0, y: 0, width: 1000, height: 900 },
+    children: [p],
+  });
+}
+
+test('mapTreeToScreen: merges same-line inline-styled runs into one Text with BBCode (IANA bold links)', () => {
+  // Reproduces iana.org/help/example-domains: a paragraph with plain text, a bold <a> run,
+  // more plain text, and another bold <a> run — all on one visual line. Previously each run
+  // became its own sibling Text (WidthUnits=RelativeToChildren) positioned at a fixed
+  // Absolute X lifted from Chromium; Gum's own bitmap font renders each run at a different
+  // pixel width than Chromium measured, so the next run's fixed X drifted from where the
+  // previous run actually ended, producing a visible gap/overlap. Merging same-line runs
+  // into one Text with BBCode markup lets Gum's own font engine lay out the whole line
+  // consistently, the same way a single Text already measures run-by-run styling (#3520).
+  const root = ianaParagraphFixture();
+
+  const { instances, variables } = mapTreeToScreen(root);
+
+  const textInstances = instances.filter((i) => i.baseType === 'Text');
+  assert.equal(textInstances.length, 1, 'four same-line inline runs should merge into a single Text');
+  const name = textInstances[0].name;
+  assert.equal(
+    findVar(variables, `${name}.Text`)?.value,
+    'The IANA functions ... provided by [IsBold=true]Public Technical Identifiers[/IsBold], an affiliate of [IsBold=true]ICANN[/IsBold]',
+  );
+});
+
+test('mapTreeToScreen: does not merge same-line runs when a run color differs from the base run', () => {
+  // Color-changing runs (BBCode Color support) are out of scope for the merge — bail out
+  // to the pre-existing per-run Absolute-position behavior rather than silently dropping
+  // the color difference.
+  const root = ianaParagraphFixture({ color: 'rgb(200, 0, 0)' });
+
+  const { instances } = mapTreeToScreen(root);
+
+  const textInstances = instances.filter((i) => i.baseType === 'Text');
+  assert.equal(textInstances.length, 4, 'runs with a differing color should stay as separate Text instances');
+});

--- a/Tool/HtmlToGum/converter/map.test.ts
+++ b/Tool/HtmlToGum/converter/map.test.ts
@@ -11,6 +11,7 @@ function baseStyle(overrides = {}) {
     display: 'block',
     backgroundImage: 'none',
     backgroundSize: 'auto',
+    backgroundPosition: '0% 0%',
     objectFit: 'fill',
     objectPosition: '50% 50%',
     listStyleType: 'none',
@@ -257,4 +258,123 @@ test('mapTreeToScreen: does not merge same-line runs when a run color differs fr
 
   const textInstances = instances.filter((i) => i.baseType === 'Text');
   assert.equal(textInstances.length, 4, 'runs with a differing color should stay as separate Text instances');
+});
+
+// ---- CSS sprite-sheet icon crop (GeeksforGeeks social-icon strip) -------------------
+test('mapTreeToScreen: background-position sprite offset crops the icon sub-region (GFG social icons)', () => {
+  // Ground truth from GeeksforGeeks' live social_sprites_icons.svg: a 38x532 vertical
+  // strip, one 38px-tall icon per multiple-of-38 offset. Each icon <div> is
+  // background-size:100% (== natural width, so 1:1 scale) + background-position:0 -76px
+  // for LinkedIn. Previously the missing crop stretched the *entire* 532px-tall strip into
+  // the 38x38 box (visibly garbled), instead of showing just the LinkedIn slice.
+  const url = 'https://media.geeksforgeeks.org/wp-content/cdn-uploads/social_sprites_icons.svg';
+  const assetMap = new Map([[url, 'Images/social.png']]);
+  const icon = boxNode({
+    id: 'linkedin',
+    rect: { x: 0, y: 0, width: 38, height: 38 },
+    naturalWidth: 38,
+    naturalHeight: 532,
+    style: baseStyle({
+      backgroundImage: `url("${url}")`,
+      backgroundSize: '100%',
+      backgroundPosition: '0px -76px',
+    }),
+  });
+  const root = boxNode({ id: 'root', rect: { x: 0, y: 0, width: 38, height: 38 }, children: [icon] });
+
+  const { variables } = mapTreeToScreen(root, assetMap);
+
+  assert.equal(findVar(variables, 'Linkedin.TextureAddress')?.value, 1); // Custom
+  assert.equal(findVar(variables, 'Linkedin.TextureLeft')?.value, 0);
+  assert.equal(findVar(variables, 'Linkedin.TextureTop')?.value, 76);
+  assert.equal(findVar(variables, 'Linkedin.TextureWidth')?.value, 38);
+  assert.equal(findVar(variables, 'Linkedin.TextureHeight')?.value, 38);
+});
+
+test('mapTreeToScreen: sprite crop scales to the actual rasterized SVG pixel size', () => {
+  // rasterizeSvg (assets.mjs) upscales an SVG source above its declared intrinsic size for
+  // a crisper downscale (SVG_UPSCALE/SVG_MAX_DIM) — GFG's 38x532 social-icon SVG actually
+  // gets rasterized to 73x1024 on disk (~1.9248x, clamped by SVG_MAX_DIM=1024). A crop
+  // computed in naturalWidth/Height (38x532) units without rescaling samples the wrong
+  // pixels once written as literal TextureLeft/Top into the 73x1024 file — this reproduces
+  // the youtube icon (bottom of the strip) rendering as a garbled diagonal mush.
+  const url = 'https://media.geeksforgeeks.org/wp-content/cdn-uploads/social_sprites_icons.svg';
+  const assetMap = new Map([[url, 'Images/social.png']]);
+  const assetSizeMap = new Map([[url, { width: 73, height: 1024 }]]);
+  const icon = boxNode({
+    id: 'youtube',
+    rect: { x: 0, y: 0, width: 38, height: 38 },
+    naturalWidth: 38,
+    naturalHeight: 532,
+    style: baseStyle({
+      backgroundImage: `url("${url}")`,
+      backgroundSize: '100%',
+      backgroundPosition: '0px -152px',
+    }),
+  });
+  const root = boxNode({ id: 'root', rect: { x: 0, y: 0, width: 38, height: 38 }, children: [icon] });
+
+  const { variables } = mapTreeToScreen(root, assetMap, null, null, null, assetSizeMap);
+
+  assert.equal(findVar(variables, 'Youtube.TextureLeft')?.value, 0);
+  assert.equal(findVar(variables, 'Youtube.TextureTop')?.value, Math.round(152 * (1024 / 532)));
+  assert.equal(findVar(variables, 'Youtube.TextureWidth')?.value, Math.round(38 * (73 / 38)));
+  assert.equal(findVar(variables, 'Youtube.TextureHeight')?.value, Math.round(38 * (1024 / 532)));
+});
+
+test('mapTreeToScreen: a sprite tile at the sheet\'s default (0,0) offset still crops', () => {
+  // GFG's facebook icon sits at the *top* of the strip (background-position: 0px 0px) — a
+  // deliberate sprite-tile selection that happens to coincide with the default position.
+  // Distinguishing signal: the same sprite URL is used elsewhere in the tree at a different
+  // position (instagram, -38px), so this really is a sprite sheet — a lone background-image
+  // at the default position (see the "plain background-image" test below) is left alone.
+  // Previously this bailed like a plain background image, stretching the whole 532px-tall
+  // strip into the 38x38 box instead of showing just the top (facebook) tile.
+  const url = 'https://media.geeksforgeeks.org/wp-content/cdn-uploads/social_sprites_icons.svg';
+  const assetMap = new Map([[url, 'Images/social.png']]);
+  const facebook = boxNode({
+    id: 'facebook',
+    rect: { x: 0, y: 0, width: 38, height: 38 },
+    naturalWidth: 38,
+    naturalHeight: 532,
+    style: baseStyle({ backgroundImage: `url("${url}")`, backgroundSize: '100%', backgroundPosition: '0px 0px' }),
+  });
+  const instagram = boxNode({
+    id: 'instagram',
+    rect: { x: 43, y: 0, width: 38, height: 38 },
+    naturalWidth: 38,
+    naturalHeight: 532,
+    style: baseStyle({ backgroundImage: `url("${url}")`, backgroundSize: '100%', backgroundPosition: '0px -38px' }),
+  });
+  const root = boxNode({
+    id: 'root', rect: { x: 0, y: 0, width: 81, height: 38 }, children: [facebook, instagram],
+  });
+
+  const { variables } = mapTreeToScreen(root, assetMap);
+
+  assert.equal(findVar(variables, 'Facebook.TextureAddress')?.value, 1); // Custom
+  assert.equal(findVar(variables, 'Facebook.TextureLeft')?.value, 0);
+  assert.equal(findVar(variables, 'Facebook.TextureTop')?.value, 0);
+  assert.equal(findVar(variables, 'Facebook.TextureWidth')?.value, 38);
+  assert.equal(findVar(variables, 'Facebook.TextureHeight')?.value, 38);
+});
+
+test('mapTreeToScreen: plain background-image at default position gets no sprite crop', () => {
+  // background-position:0% 0% (the default — no authored offset) is a plain full-image
+  // background, not a sprite selection. Must keep stretch-to-fill (no TextureAddress
+  // override) rather than emit a crop derived from a coincidental size mismatch.
+  const url = 'https://example.com/hero.png';
+  const assetMap = new Map([[url, 'Images/hero.png']]);
+  const node = boxNode({
+    id: 'hero',
+    rect: { x: 0, y: 0, width: 200, height: 100 },
+    naturalWidth: 400,
+    naturalHeight: 200,
+    style: baseStyle({ backgroundImage: `url("${url}")`, backgroundSize: 'auto' }),
+  });
+  const root = boxNode({ id: 'root', rect: { x: 0, y: 0, width: 200, height: 100 }, children: [node] });
+
+  const { variables } = mapTreeToScreen(root, assetMap);
+
+  assert.equal(findVar(variables, 'Hero.TextureAddress'), undefined);
 });

--- a/Tool/HtmlToGum/converter/map.test.ts
+++ b/Tool/HtmlToGum/converter/map.test.ts
@@ -1,7 +1,103 @@
 // @ts-nocheck
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseColor, parseBoxShadow, parseHardTextShadows } from './map.js';
+import {
+  parseColor, parseBoxShadow, parseHardTextShadows, mapTreeToScreen,
+} from './map.js';
+
+// ---- minimal BoxNode/BoxStyle fixtures for mapTreeToScreen ------------------
+function baseStyle(overrides = {}) {
+  return {
+    display: 'block',
+    backgroundImage: 'none',
+    backgroundSize: 'auto',
+    objectFit: 'fill',
+    objectPosition: '50% 50%',
+    listStyleType: 'none',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    rowGap: 0,
+    columnGap: 0,
+    flexGrow: 0,
+    order: 0,
+    alignItems: 'normal',
+    alignSelf: 'auto',
+    justifyContent: 'normal',
+    textAlign: 'left',
+    paddingTop: 0,
+    paddingRight: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    zIndex: 0,
+    gridTemplateColumns: 'none',
+    gridTemplateRows: 'none',
+    gridAutoFlow: 'row',
+    gridColumnStart: 'auto',
+    gridColumnEnd: 'auto',
+    gridRowStart: 'auto',
+    gridRowEnd: 'auto',
+    gridColumnStartSpecified: '',
+    gridColumnEndSpecified: '',
+    gridRowStartSpecified: '',
+    gridRowEndSpecified: '',
+    gridAreaSpecified: '',
+    gridColumnSpecified: '',
+    gridRowSpecified: '',
+    position: 'static',
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    borderTopLeftRadius: 0,
+    borderTopWidth: 0,
+    borderRightWidth: 0,
+    borderBottomWidth: 0,
+    borderLeftWidth: 0,
+    borderTopColor: 'rgb(0, 0, 0)',
+    borderRightColor: 'rgb(0, 0, 0)',
+    borderBottomColor: 'rgb(0, 0, 0)',
+    borderLeftColor: 'rgb(0, 0, 0)',
+    boxShadow: 'none',
+    textShadow: 'none',
+    webkitTextStrokeWidth: 0,
+    overflow: 'visible',
+    opacity: 1,
+    filter: 'none',
+    needsRaster: false,
+    rasterWholeSubtree: false,
+    color: 'rgb(0, 0, 0)',
+    fontSize: 16,
+    fontWeight: '400',
+    fontStyle: 'normal',
+    fontFamily: 'sans-serif',
+    widthSpecified: 'auto',
+    heightSpecified: 'auto',
+    borderImageSource: 'none',
+    borderImageSlice: 100,
+    borderImageRepeat: 'stretch',
+    ...overrides,
+  };
+}
+function boxNode(overrides = {}) {
+  return {
+    id: null,
+    tag: 'div',
+    rect: { x: 0, y: 0, width: 0, height: 0 },
+    text: '',
+    lineCount: 0,
+    imgSrc: null,
+    naturalWidth: 0,
+    naturalHeight: 0,
+    rasterSrc: null,
+    style: baseStyle(),
+    children: [],
+    ...overrides,
+  };
+}
+function findVar(variables, name) {
+  return variables.find((v) => v.name === name);
+}
 
 test('parseColor: rgb()', () => {
   assert.deepEqual(parseColor('rgb(255, 0, 128)'), { r: 255, g: 0, b: 128, a: 255 });
@@ -54,4 +150,31 @@ test('parseHardTextShadows: oklch() color', () => {
   const shadows = parseHardTextShadows({ textShadow: 'oklch(0.58 0.14 251) 1px 1px 0px' });
   assert.equal(shadows.length, 1);
   assert.deepEqual(shadows[0].color, { r: 46, g: 125, b: 202, a: 255 });
+});
+
+test('mapTreeToScreen: flex row child margin-top offsets stretch cross-axis (IANA article/main)', () => {
+  // Reproduces iana.org/help/example-domains: <article style="display:flex"> containing
+  // <main style="margin-top:25px"> under default align-items:stretch. Chromium's flex
+  // layout places main's border-box 25px below the container's cross-start (its margin
+  // box, not its border box, aligns to cross-start) and shrinks its stretched height by
+  // that margin. Previously the converter dropped the child's own cross-axis margin
+  // entirely, rendering every stretched row child flush at Y=0.
+  const child = boxNode({
+    id: 'main',
+    rect: { x: 0, y: 25, width: 80, height: 125 },
+    style: baseStyle({ marginTop: 25, heightSpecified: 'auto' }),
+  });
+  const root = boxNode({
+    id: 'root',
+    rect: { x: 0, y: 0, width: 200, height: 150 },
+    style: baseStyle({ display: 'flex', flexDirection: 'row' }),
+    children: [child],
+  });
+
+  const { variables } = mapTreeToScreen(root);
+
+  assert.equal(findVar(variables, 'Main.YUnits'), undefined); // default PixelsFromTop is fine once Y is set
+  assert.equal(findVar(variables, 'Main.Y')?.value, 25);
+  assert.equal(findVar(variables, 'Main.HeightUnits')?.value, 2); // RelativeToParent
+  assert.equal(findVar(variables, 'Main.Height')?.value, -25);
 });

--- a/Tool/HtmlToGum/converter/map.ts
+++ b/Tool/HtmlToGum/converter/map.ts
@@ -759,14 +759,27 @@ export function mapTreeToScreen(
    * Cross-axis sizing + alignment for a flex stack child.
    * stretch + indefinite → RelativeToParent 0; otherwise hug / % size and origin-align.
    * Child `align-self` overrides parent `align-items` when not `auto`.
+   *
+   * A literal (non-auto) margin on the cross-start/end edge still offsets the child even
+   * under flex-start/stretch alignment — CSS aligns the item's *margin* box to the line,
+   * not its border box (e.g. iana.org's <article style="display:flex"><main
+   * style="margin-top:25px">: main's border-box sits 25px below the container's
+   * cross-start, and its stretched height shrinks by that margin).
    */
   function emitStackCrossAxis(name, parentOrientation, alignItems, measuredCross, style) {
     const self = (style?.alignSelf || 'auto').toLowerCase();
     const align = (self !== 'auto' ? self : (alignItems || 'stretch')).toLowerCase();
     const stretch = isAlignStretch(align) && !hasDefiniteCrossSize(style, parentOrientation);
     const axisName = parentOrientation === 'column' ? 'Width' : 'Height';
+    const posName = parentOrientation === 'column' ? 'X' : 'Y';
+    const crossStart = (parentOrientation === 'column' ? style?.marginLeft : style?.marginTop) || 0;
+    const crossEnd = (parentOrientation === 'column' ? style?.marginRight : style?.marginBottom) || 0;
     if (stretch) {
-      variables.push(VDIM(`${name}.${axisName}Units`, DIM.RelativeToParent), VF(`${name}.${axisName}`, 0));
+      variables.push(
+        VDIM(`${name}.${axisName}Units`, DIM.RelativeToParent),
+        VF(`${name}.${axisName}`, -Math.round(crossStart + crossEnd)),
+      );
+      if (crossStart > 0) variables.push(VF(`${name}.${posName}`, Math.round(crossStart)));
       return;
     }
     const pct = specifiedPercent(style, axisName);
@@ -775,7 +788,11 @@ export function mapTreeToScreen(
     } else {
       variables.push(VDIM(`${name}.${axisName}Units`, DIM.Absolute), VF(`${name}.${axisName}`, Math.round(measuredCross)));
     }
-    if (isAlignStretch(align)) return; // definite size under stretch → cross-start (no origin shift)
+    if (isAlignStretch(align)) {
+      // Definite size under stretch → cross-start, offset only by the child's own margin.
+      if (crossStart > 0) variables.push(VF(`${name}.${posName}`, Math.round(crossStart)));
+      return;
+    }
     if (parentOrientation === 'column') {
       if (align === 'center') {
         variables.push(VPOS(`${name}.XUnits`, POS.PixelsFromCenterX), VOH(`${name}.XOrigin`, ORIGIN_H.Center), VF(`${name}.X`, 0));

--- a/Tool/HtmlToGum/converter/map.ts
+++ b/Tool/HtmlToGum/converter/map.ts
@@ -90,6 +90,11 @@ const isBold = (w) => w === 'bold' || w === 'bolder' || parseInt(w, 10) >= 600;
 const isItalic = (s) => s === 'italic' || s === 'oblique';
 const firstFont = (fam) => (fam || '').split(',')[0].replace(/["']/g, '').trim();
 
+// Tags whose only visual effect (once background/border/shadow/padding is ruled out) is a
+// font weight/style/color change — safe to fold into one Text via BBCode markup instead of
+// a sibling Text per run. #text nodes carry no style deviation of their own.
+const INLINE_PHRASING_TAGS = new Set(['#text', 'a', 'strong', 'b', 'em', 'i']);
+
 // Chromium serializes resolved grid tracks as "200px 200px 200px" (fr already computed).
 // Returns pixel lengths; empty for none/auto/unsupported keywords.
 function parseGridTracks(str) {
@@ -889,6 +894,27 @@ export function mapTreeToScreen(
     return false;
   }
 
+  // Web-font file path (B / gumcli fonts): style is baked into the instantiated TTF for
+  // this exact family+weight+style. No mapping (system/KernSmith fallback) → caller falls
+  // back to IsBold/IsItalic synthesis. Shared by emitVisual and the inline-run BBCode merge
+  // so both pick the same font file for the same style.
+  function resolveFontFile(s) {
+    const family = firstFont(s.fontFamily);
+    const weightNum = (() => {
+      const w = s.fontWeight;
+      if (w === 'bold' || w === 'bolder') return 700;
+      if (w === 'normal' || w === 'lighter') return 400;
+      const n = parseInt(w, 10);
+      return Number.isFinite(n) ? n : 400;
+    })();
+    const styleKey = isItalic(s.fontStyle) ? 'italic' : 'normal';
+    const famKey = (family || '').toLowerCase().replace(/\s+var\b/g, '').replace(/\s+/g, ' ').trim();
+    const filePath = fontMap && family
+      && (fontMap.get(`${famKey}|${weightNum}|${styleKey}`)
+        || fontMap.get(`${famKey}|${weightNum}|normal`));
+    return { family, filePath };
+  }
+
   function emitVisual(kind, name, node, alignOpts = null, { colorOverride = null, skipOutline = false } = {}) {
     const s = node.style;
     if (kind === 'rect') {
@@ -904,21 +930,7 @@ export function mapTreeToScreen(
         variables.push(VI(`${name}.Red`, col.r), VI(`${name}.Green`, col.g), VI(`${name}.Blue`, col.b));
         if (col.a != null && col.a !== 255) variables.push(VI(`${name}.Alpha`, col.a));
       }
-      // Web-font file path (B / gumcli fonts): style is baked into the instantiated TTF.
-      // Family name fallback: keep IsBold/IsItalic for system/KernSmith synthesis.
-      const family = firstFont(s.fontFamily);
-      const weightNum = (() => {
-        const w = s.fontWeight;
-        if (w === 'bold' || w === 'bolder') return 700;
-        if (w === 'normal' || w === 'lighter') return 400;
-        const n = parseInt(w, 10);
-        return Number.isFinite(n) ? n : 400;
-      })();
-      const styleKey = isItalic(s.fontStyle) ? 'italic' : 'normal';
-      const famKey = (family || '').toLowerCase().replace(/\s+var\b/g, '').replace(/\s+/g, ' ').trim();
-      const filePath = fontMap && family
-        && (fontMap.get(`${famKey}|${weightNum}|${styleKey}`)
-          || fontMap.get(`${famKey}|${weightNum}|normal`));
+      const { family, filePath } = resolveFontFile(s);
       if (filePath) {
         variables.push(VS(`${name}.Font`, filePath));
       } else {
@@ -941,6 +953,67 @@ export function mapTreeToScreen(
       emitSpriteSource(name, node);
     }
     applyOpacity(kind, name, s);
+  }
+
+  // Is this child a same-line inline-styled run that can fold into the parent's Text via
+  // BBCode instead of becoming its own sibling Text? Must differ from the base run only in
+  // weight/style (color support is a possible future extension — bail for now rather than
+  // guess a BBCode Color format), have no chrome/shadow/padding of its own, and contain no
+  // literal '[' or ']' (BBCode has no escape sequence for its own delimiters).
+  function isSimpleInlineStyleChild(child, baseStyle) {
+    if (!INLINE_PHRASING_TAGS.has(child.tag)) return false;
+    if (child.lineCount > 1) return false;
+    if (!child.text || /[[\]]/.test(child.text)) return false;
+    if (hasVisualStyling(child.style)) return false;
+    if (parseHardTextShadows(child.style).length > 0) return false;
+    if (hasPadding(paddingOf(child.style))) return false;
+    if (firstFont(child.style.fontFamily) !== firstFont(baseStyle.fontFamily)) return false;
+    if (Math.round(child.style.fontSize) !== Math.round(baseStyle.fontSize)) return false;
+    const baseColor = parseColor(baseStyle.color);
+    const childColor = parseColor(child.style.color);
+    return JSON.stringify(baseColor) === JSON.stringify(childColor);
+  }
+
+  // Folds a block-level text container's same-line inline runs (plain #text plus
+  // <strong>/<b>/<em>/<i>/<a> weight-or-style-only children — e.g. iana.org's "...provided
+  // by <a>Public Technical Identifiers</a>, an affiliate of <a>ICANN</a>.") into ONE Text
+  // leaf using BBCode markup, instead of one sibling Text per run.
+  //
+  // Previously every run got its own WidthUnits=RelativeToChildren Text at a fixed Absolute
+  // X lifted from Chromium. Gum's bitmap font renders each run at a slightly different pixel
+  // width than Chromium measured (worst for bold), so the next run's fixed X drifted from
+  // where the previous run actually ended — a visible gap before the run and an
+  // overlap/garbling right after it. One Text lets Gum's own font engine lay out the whole
+  // line itself, the same run-by-run measurement it already does for inline BBCode styling
+  // (#3520) — self-consistent regardless of how its bitmap font compares to Chromium's.
+  //
+  // Only applies when every run sits on the same rendered line (paragraphs that wrap are
+  // left alone — round 1 already handles per-line splitting for a single wrapping #text
+  // node; mixing that with cross-run BBCode wrapping is a separate, untested feature).
+  function mergeInlinePhrasingRun(node) {
+    if (!node.children || node.children.length < 2) return null;
+    if (!node.children.every((c) => isSimpleInlineStyleChild(c, node.style))) return null;
+    const y0 = node.children[0].rect.y;
+    if (!node.children.every((c) => Math.abs(c.rect.y - y0) < 1.5)) return null;
+
+    const base = resolveFontFile(node.style);
+    let text = '';
+    for (const c of node.children) {
+      let piece = c.text;
+      const cf = resolveFontFile(c.style);
+      if (cf.filePath && cf.filePath !== base.filePath) {
+        piece = `[Font=${cf.filePath}]${piece}[/Font]`;
+      } else if (!cf.filePath) {
+        if (isBold(c.style.fontWeight) !== isBold(node.style.fontWeight)) {
+          piece = `[IsBold=${isBold(c.style.fontWeight)}]${piece}[/IsBold]`;
+        }
+        if (isItalic(c.style.fontStyle) !== isItalic(node.style.fontStyle)) {
+          piece = `[IsItalic=${isItalic(c.style.fontStyle)}]${piece}[/IsItalic]`;
+        }
+      }
+      text += piece;
+    }
+    return { ...node, text, children: [], lineCount: 1 };
   }
 
   /** CSS hard text-shadow → black (or tinted) Text stamps behind the face label. */
@@ -1041,6 +1114,7 @@ export function mapTreeToScreen(
   // node's child-index chain from the root ("0.1.0"), the key responsiveMap is keyed by.
   // parentAlignItems is the parent's align-items (cross-axis) for flex stacks.
   function walk(node, parentName, parentOrientation, parentRect, path = [], parentAlignItems = 'stretch', opts = {}) {
+    node = mergeInlinePhrasingRun(node) || node;
     const kind = classify(node);
     const name = namer.forNode(node);
     // Image with a solid background-color/border (Cerberus broken-image affordance,

--- a/Tool/HtmlToGum/converter/map.ts
+++ b/Tool/HtmlToGum/converter/map.ts
@@ -403,6 +403,127 @@ function computeCoverCrop(srcW, srcH, dstW, dstH) {
   };
 }
 
+// CSS icon-sprite technique: one shared background-image, positioned with a
+// background-position offset per element so each element's fixed-size box acts as a
+// window onto one sub-region of the sheet (GeeksforGeeks' social-icon strip, common site
+// pattern). Gum's Sprite has no background-position concept — TextureAddress=EntireTexture
+// squashes the *whole* sheet into the box. Reproduces the visible sub-region as an explicit
+// TextureAddress=Custom source-rect crop, mirroring computeCoverCrop's approach.
+// Only background-size tokens resolvable without a layout pass are supported: 'auto' (natural
+// size) and <percentage> (relative to the box — the common case, matching how site sprites
+// are usually pinned to their native resolution). 'cover'/'contain' are cover-crop's territory
+// (see wantsCoverCrop) and never reach here; unrecognized tokens (bare lengths, keywords like
+// left/right/top/bottom) bail to null rather than emit a wrong crop.
+// allowZeroOffset: a sprite's *first* tile is legitimately at background-position:0 0 (no
+// offset needed to select it) — the caller sets this once it's established elsewhere that
+// the same URL is used at multiple distinct positions in the tree (see
+// collectBackgroundPositionsByUrl), i.e. this really is a sprite sheet, not a plain
+// single-use background image that happens to be positioned at the default top-left.
+function computeBackgroundSpriteCrop(style, naturalWidth, naturalHeight, boxWidth, boxHeight, allowZeroOffset = false) {
+  if (naturalWidth <= 0 || naturalHeight <= 0 || boxWidth <= 0 || boxHeight <= 0) return null;
+
+  function resolveSize(tok, basis) {
+    if (tok == null || tok === 'auto') return null;
+    if (tok.endsWith('%')) return (parseFloat(tok) / 100) * basis;
+    if (tok.endsWith('px')) return parseFloat(tok);
+    return undefined; // unrecognized (length in other units, etc.) — caller bails
+  }
+
+  const sizeToks = (style.backgroundSize || 'auto').trim().split(/\s+/);
+  const wTok = resolveSize(sizeToks[0], boxWidth);
+  const hTok = resolveSize(sizeToks[1], boxHeight);
+  if (wTok === undefined || hTok === undefined) return null;
+
+  let imgWidth;
+  let imgHeight;
+  if (wTok == null && hTok == null) {
+    imgWidth = naturalWidth;
+    imgHeight = naturalHeight;
+  } else if (hTok == null) {
+    imgWidth = wTok;
+    imgHeight = naturalHeight * (imgWidth / naturalWidth);
+  } else if (wTok == null) {
+    imgHeight = hTok;
+    imgWidth = naturalWidth * (imgHeight / naturalHeight);
+  } else {
+    imgWidth = wTok;
+    imgHeight = hTok;
+  }
+  if (imgWidth <= 0 || imgHeight <= 0) return null;
+
+  function resolvePos(tok, basis, imgSize) {
+    if (tok == null) return 0;
+    if (tok.endsWith('%')) return (basis - imgSize) * (parseFloat(tok) / 100);
+    if (tok.endsWith('px')) return parseFloat(tok);
+    return undefined;
+  }
+
+  const posToks = (style.backgroundPosition || '0% 0%').trim().split(/\s+/);
+  const posX = resolvePos(posToks[0], boxWidth, imgWidth);
+  const posY = resolvePos(posToks[1], boxHeight, imgHeight);
+  if (posX === undefined || posY === undefined) return null;
+
+  // Default top-left placement (posX===0 && posY===0) usually means "no sprite offset to
+  // reproduce" — leave it to the existing EntireTexture stretch-to-fill default rather than
+  // risk a crop rect that doesn't match Gum's current (correct-enough) behavior for plain
+  // backgrounds. Confirmed sprite sheets (allowZeroOffset) still crop even at (0,0) — that's
+  // just the sheet's first tile (e.g. GFG's facebook icon, offset 0 0).
+  if (posX === 0 && posY === 0 && !allowZeroOffset) return null;
+
+  const scaleX = imgWidth / naturalWidth;
+  const scaleY = imgHeight / naturalHeight;
+  const crop = {
+    left: Math.round(-posX / scaleX) || 0, // normalize -0
+    top: Math.round(-posY / scaleY) || 0,
+    width: Math.round(boxWidth / scaleX),
+    height: Math.round(boxHeight / scaleY),
+  };
+  // Bail if the resolved window falls outside the actual sheet — our px-only parsing
+  // (no repeat-tiling support) can't reproduce that correctly, so don't emit a bogus crop.
+  if (crop.left < 0 || crop.top < 0
+    || crop.left + crop.width > naturalWidth || crop.top + crop.height > naturalHeight) {
+    return null;
+  }
+  return crop;
+}
+
+// A URL used at 2+ distinct background-position values across the tree is definitionally
+// a sprite sheet in use (that's the whole point of the technique — one image, several
+// elements each dialing in a different offset). Lets computeBackgroundSpriteCrop tell a
+// sprite's first tile (offset 0 0, still a deliberate selection) apart from a plain
+// single-use background image that's simply left at its default top-left position.
+function collectBackgroundPositionsByUrl(node, acc = new Map()) {
+  const url = parseBackgroundImageUrl(node.style.backgroundImage);
+  if (url) {
+    const pos = (node.style.backgroundPosition || '0% 0%').trim();
+    if (!acc.has(url)) acc.set(url, new Set());
+    acc.get(url).add(pos);
+  }
+  for (const child of node.children) collectBackgroundPositionsByUrl(child, acc);
+  return acc;
+}
+
+// computeCoverCrop / computeBackgroundSpriteCrop both work in "natural" units — the box
+// tree's captured naturalWidth/naturalHeight (Chromium's intrinsic size for the source
+// image). That matches the on-disk asset pixel-for-pixel for ordinary raster images, but
+// not for a rasterized SVG: rasterizeSvg (assets.mjs) renders at up to 2x the SVG's
+// declared size for crisper downscaling (SVG_UPSCALE/SVG_MAX_DIM), so the PNG Gum actually
+// loads can be a different pixel size than naturalWidth/Height. Rescale the crop rect by
+// (actual asset size / natural size) so TextureLeft/Top/Width/Height index the real file.
+function scaleCropToAsset(crop, assetSizeMap, url, naturalWidth, naturalHeight) {
+  const actual = assetSizeMap && assetSizeMap.get(url);
+  if (!actual || naturalWidth <= 0 || naturalHeight <= 0) return crop;
+  const scaleX = actual.width / naturalWidth;
+  const scaleY = actual.height / naturalHeight;
+  if (scaleX === 1 && scaleY === 1) return crop;
+  return {
+    left: Math.round(crop.left * scaleX),
+    top: Math.round(crop.top * scaleY),
+    width: Math.round(crop.width * scaleX),
+    height: Math.round(crop.height * scaleY),
+  };
+}
+
 // List bullets are pseudo-content (::marker) — never part of textContent, so they were
 // silently absent from every emitted <li>. Gum has no marker/list concept, so this is a
 // text-prefix approximation covering the common unordered-list styles; `decimal` and
@@ -633,6 +754,11 @@ function wantsCoverCrop(style) {
  * @param {Map|null} fontMap fontFaceKey(family,weight,style) -> "Fonts/….ttf" from
  *   fonts.mjs. When present, Text.Font is the .ttf path (gumcli fonts / FontCache);
  *   weight/style are baked into the file so IsBold/IsItalic are omitted.
+ * @param {Map|null} assetSizeMap image URL -> actual rasterized pixel {width,height} from
+ *   assets.mjs's downloadImages, only populated for SVG sources (SVG_UPSCALE/SVG_MAX_DIM
+ *   mean the on-disk asset can be a different pixel size than the box tree's captured
+ *   naturalWidth/naturalHeight). Cover-fit and background-position-sprite crop math scales
+ *   against this so TextureLeft/Top/Width/Height land on the right pixels in that file.
  * @returns {{instances: {name,baseType}[], variables: {}[], warnings: string[]}}
  */
 export function mapTreeToScreen(
@@ -641,11 +767,13 @@ export function mapTreeToScreen(
   responsiveMap: ResponsiveMap | null = null,
   fontMap: Map<string, string> | null = null,
   nineSliceMap: Map<string, NineSliceInfo> | null = null,
+  assetSizeMap: Map<string, { width: number, height: number }> | null = null,
 ): MappedScreen {
   const namer = makeNamer();
   const instances = [];
   const variables = [];
   const warnings = [];
+  const backgroundPositionsByUrl = collectBackgroundPositionsByUrl(root);
 
   function orientationOf(node) {
     return layoutModeOf(node);
@@ -876,12 +1004,18 @@ export function mapTreeToScreen(
     const asset = url && assetMap.get(url);
     if (asset) {
       variables.push(VS(`${name}.SourceFile`, asset));
-      if (wantsCoverCrop(s) && node.naturalWidth > 0 && node.naturalHeight > 0) {
-        const crop = computeCoverCrop(node.naturalWidth, node.naturalHeight, node.rect.width, node.rect.height);
+      const isSpriteSheet = (backgroundPositionsByUrl.get(url)?.size || 0) > 1;
+      const crop = wantsCoverCrop(s) && node.naturalWidth > 0 && node.naturalHeight > 0
+        ? computeCoverCrop(node.naturalWidth, node.naturalHeight, node.rect.width, node.rect.height)
+        : computeBackgroundSpriteCrop(
+          s, node.naturalWidth, node.naturalHeight, node.rect.width, node.rect.height, isSpriteSheet,
+        );
+      if (crop) {
+        const scaled = scaleCropToAsset(crop, assetSizeMap, url, node.naturalWidth, node.naturalHeight);
         variables.push(
           v('TextureAddress', `${name}.TextureAddress`, 'xsd:int', 1), // Custom
-          VI(`${name}.TextureLeft`, crop.left), VI(`${name}.TextureTop`, crop.top),
-          VI(`${name}.TextureWidth`, crop.width), VI(`${name}.TextureHeight`, crop.height),
+          VI(`${name}.TextureLeft`, scaled.left), VI(`${name}.TextureTop`, scaled.top),
+          VI(`${name}.TextureWidth`, scaled.width), VI(`${name}.TextureHeight`, scaled.height),
         );
       }
       return true;

--- a/Tool/HtmlToGum/converter/types.ts
+++ b/Tool/HtmlToGum/converter/types.ts
@@ -12,6 +12,7 @@ export type BoxStyle = {
   display: string;
   backgroundImage: string;
   backgroundSize: string;
+  backgroundPosition: string;
   objectFit: string;
   objectPosition: string;
   listStyleType: string;


### PR DESCRIPTION
Autonomous visual-fidelity loop against two real-world pages, iterating on pixel diff against Chromium.

## Results

- **iana.org/help/example-domains**: 7.48% -> **5.80%**. Above the 3% bar but at its practical floor — remaining diff regions are confirmed font-antialiasing/kerning noise, not layout bugs.
- **geeksforgeeks.org home**: crash -> **4.18%**. Above the 3% bar. Remaining largest region is footer text-wrap/kerning drift, not a structural bug.

## Fixes landed (4 commits)

- Wrapped inline text runs no longer overlap preceding siblings (per-line leaf splitting).
- Flex-row/column stack children now respect their own cross-axis margin.
- Same-line mixed plain+bold inline runs merge into one BBCode-styled Text instead of garbling.
- GFG crashed outright on pages taller than the viewport (Playwright clip bug) — fixed, plus added `background-position` sprite-crop support (was rendering CSS icon sprites as noise).

## Not fixed / investigated dead ends

- IANA: reverted an attempt to fix bold-run spacing via a `LeftToRightStack` of Text instances — made rendering worse; superseded by the BBCode-merge fix above.
- GFG: one round saw a repeated-header rendering bug (~8x duplicate header down the page) that traced to neither the converter nor the generated XML. Could not reproduce on a fresh regeneration this session (GFG is a live site with changing content) — likely a live-content transient, not a persistent Gum rendering bug, but not confirmed either way.

## Verification this session

- `npm test` (26/26) and `npm run typecheck` clean in `Tool/HtmlToGum/converter`.
- No C# files touched — no dotnet build/test needed.
- Regenerated both pages fresh end-to-end (convert.ts -> gumcli screenshot -> pixel diff) to confirm current numbers above.

Neither page hit the 3% convergence bar, so leaving this **in draft** pending a decision on further rounds vs. accepting current state.
