### PR TITLE
HtmlToGum: invoke prebuilt gumcli.dll instead of dotnet run (~4x faster import)

### DIFF
--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -503,7 +503,7 @@ internal sealed class ImportProgressForm : Form
         ControlBox = false;
         MinimizeBox = false;
         MaximizeBox = false;
-        ClientSize = new Size(420, 72);
+        ClientSize = new Size(420, 92);
         Font = new Font("Segoe UI", 9f);
         TopMost = true;
 
@@ -511,12 +511,26 @@ internal sealed class ImportProgressForm : Form
         {
             Text = "Starting…",
             Left = 16,
-            Top = 24,
+            Top = 16,
             Width = 388,
             Height = 28,
             AutoEllipsis = true,
         };
         Controls.Add(_status);
+
+        // convert.ts prints its progress lines in one burst near the end, not as it goes —
+        // without this, the status label can sit unchanged for the whole run and reads as
+        // hung rather than working. Marquee needs no real progress signal to stay honest.
+        var spinner = new ProgressBar
+        {
+            Style = ProgressBarStyle.Marquee,
+            MarqueeAnimationSpeed = 30,
+            Left = 16,
+            Top = 48,
+            Width = 388,
+            Height = 16,
+        };
+        Controls.Add(spinner);
     }
 
     public void SetStatus(string text)

--- a/Tool/HtmlToGum/converter/gumcli-resolve.test.ts
+++ b/Tool/HtmlToGum/converter/gumcli-resolve.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveGumCliEntrypoint } from './gumcli-resolve.js';
+
+function makeFakeCsprojDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'gumcli-resolve-test-'));
+  writeFileSync(join(dir, 'Gum.Cli.csproj'), '<Project />');
+  return dir;
+}
+
+function touchDll(projectDir, config, whenMs) {
+  const dir = join(projectDir, 'bin', config, 'net8.0');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'gumcli.dll');
+  writeFileSync(path, 'fake');
+  if (whenMs !== undefined) utimesSync(path, whenMs / 1000, whenMs / 1000);
+  return path;
+}
+
+test('resolveGumCliEntrypoint: falls back to dotnet run when nothing is built', () => {
+  const dir = makeFakeCsprojDir();
+  try {
+    const result = resolveGumCliEntrypoint(join(dir, 'Gum.Cli.csproj'));
+    assert.equal(result.mode, 'run');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveGumCliEntrypoint: uses the DLL when only one config is built', () => {
+  const dir = makeFakeCsprojDir();
+  try {
+    const dllPath = touchDll(dir, 'Debug');
+    const result = resolveGumCliEntrypoint(join(dir, 'Gum.Cli.csproj'));
+    assert.equal(result.mode, 'dll');
+    assert.equal(result.dllPath, dllPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveGumCliEntrypoint: prefers the more recently built config when both exist', () => {
+  const dir = makeFakeCsprojDir();
+  try {
+    const now = Date.now();
+    touchDll(dir, 'Release', now - 10_000); // older
+    const newerDebug = touchDll(dir, 'Debug', now); // newer
+    const result = resolveGumCliEntrypoint(join(dir, 'Gum.Cli.csproj'));
+    assert.equal(result.mode, 'dll');
+    assert.equal(result.dllPath, newerDebug);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/Tool/HtmlToGum/converter/gumcli-resolve.ts
+++ b/Tool/HtmlToGum/converter/gumcli-resolve.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { existsSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const CONFIGS = ['Release', 'Debug'];
+
+/**
+ * Gum.Cli is already a project in GumFull.sln, so building the Gum Tool (the ordinary dev
+ * workflow, and what CI/packaging already do) produces gumcli.dll as a side effect —
+ * there's no reason for the HtmlToGum converter to rebuild it itself on every call.
+ * `dotnet run --project ...` re-evaluates the whole MSBuild graph and does an up-to-date
+ * check on every single invocation — measured at 7-16s per call versus ~0.3s for invoking
+ * an already-built DLL directly (`dotnet <dll> ...`, which skips MSBuild entirely). Prefer
+ * whichever prebuilt config is newest; fall back to `dotnet run` (slow, but self-building)
+ * only when neither config has ever been built.
+ */
+export function resolveGumCliEntrypoint(gumCliCsprojPath) {
+  const projectDir = dirname(gumCliCsprojPath);
+  const candidates = CONFIGS
+    .map((config) => join(projectDir, 'bin', config, 'net8.0', 'gumcli.dll'))
+    .filter((path) => existsSync(path))
+    .map((path) => ({ path, mtimeMs: statSync(path).mtimeMs }));
+
+  if (candidates.length === 0) {
+    return { mode: 'run', csprojPath: gumCliCsprojPath };
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return { mode: 'dll', dllPath: candidates[0].path };
+}

--- a/Tool/HtmlToGum/converter/gumcli.ts
+++ b/Tool/HtmlToGum/converter/gumcli.ts
@@ -8,6 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
+import { resolveGumCliEntrypoint } from './gumcli-resolve.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const inRepoGumCliCsproj = resolve(__dirname, '..', '..', '..', 'Tools', 'Gum.Cli', 'Gum.Cli.csproj');
@@ -25,9 +26,14 @@ if (!cmd || !['fonts', 'check', 'new'].includes(cmd)) {
   process.exit(1);
 }
 
-const result = spawnSync(
-  'dotnet',
-  ['run', '--project', gumCliCsproj, '--', cmd, ...rest],
-  { stdio: 'inherit', shell: true },
-);
+const entrypoint = resolveGumCliEntrypoint(gumCliCsproj);
+const result = entrypoint.mode === 'dll'
+  ? spawnSync('dotnet', [entrypoint.dllPath, cmd, ...rest], { stdio: 'inherit', shell: true })
+  : (() => {
+    // Gum.Cli is part of GumFull.sln — building the Gum Tool normally already produces
+    // gumcli.dll. This path only runs before that's ever happened, and `dotnet run` pays
+    // a full MSBuild re-evaluation (several seconds) on every call as a result.
+    console.warn('gumcli.dll not found in Tools/Gum.Cli/bin — falling back to `dotnet run` (slow). Build GumFull.sln (or Tools/Gum.Cli/Gum.Cli.csproj) once to skip this.');
+    return spawnSync('dotnet', ['run', '--project', entrypoint.csprojPath, '--', cmd, ...rest], { stdio: 'inherit', shell: true });
+  })();
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
Every HtmlToGum conversion shells out to `gumcli` twice (`new`, `fonts`) via `dotnet run --project Gum.Cli.csproj`. `dotnet run` re-evaluates the whole MSBuild graph on every call — measured at **7-16s per call**, twice per conversion — dwarfing the actual page-processing time, which is well under a second even for a trivial page like `example.com`. This made the Import HTML dialog sit for 10-20+ seconds with only a static, non-animated status label, reading as hung.

Gum.Cli is already a project in `GumFull.sln`, so building the Gum Tool the normal way already produces `gumcli.dll` — there's no reason the converter should rebuild it itself on every call.

## Changes
- `gumcli.ts` now invokes the newest already-built `gumcli.dll` (Debug or Release, whichever is newer) directly via `dotnet <dll> ...`, skipping MSBuild entirely. Falls back to `dotnet run` (slow, self-building) only if neither config has ever been built, with a one-time warning suggesting a full build.
- Added a marquee `ProgressBar` to the import dialog — `convert.ts` prints its progress lines in one burst near the end rather than as it goes, so even at the improved ~5s, a static label alone can still look hung.

## Verification
- New `gumcli-resolve.test.ts` (3 tests, pure filesystem logic, no dotnet involved) — all pass.
- Full converter suite: 29/29 pass, typecheck clean.
- `dotnet build GumFull.sln` — 0 errors, no new warnings.
- End-to-end, measured: converting `https://example.com/` went from **~20s to ~5.2s**. The remaining ~5s is legitimate work (Chromium launch + 3 page loads for responsive-unit training, font generation, Node/tsx startup) — further optimization is possible but diminishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
