### PR TITLE
Add AbsoluteWidth/AbsoluteHeight properties, obsolete GetAbsoluteWidt…

### DIFF
--- a/.claude/skills/gum-layout/SKILL.md
+++ b/.claude/skills/gum-layout/SKILL.md
@@ -66,7 +66,7 @@ system, dirty tracking, and performance considerations.
 | `UpdateLayout(updateParent, childrenUpdateDepth, xOrY)` | Granular control |
 | `SuspendLayout(recursive)` | Pause layout, queue as dirty |
 | `ResumeLayout(recursive)` | Resume and apply queued updates |
-| `GetAbsoluteWidth()` / `GetAbsoluteHeight()` | Final computed dimensions |
+| `AbsoluteWidth` / `AbsoluteHeight` | Final computed dimensions |
 | `MakeDirty(...)` | Queue deferred update when suspended |
 
 ### Key Properties

--- a/.claude/skills/gum-theming/SKILL.md
+++ b/.claude/skills/gum-theming/SKILL.md
@@ -67,7 +67,7 @@ Different controls have different state sets — Button has 7, TextBox has 4 (no
 
 Need a dotted / dashed outline (Win95 focus rectangle, marching-ants selection, etc.)? Don't spawn many small `RectangleRuntime` "dot" instances along the edges. `RectangleRuntime` / `CircleRuntime` (and the other Apos shape runtimes) expose `StrokeDashLength` and `StrokeGapLength`. Set `IsFilled = false`, `StrokeWidth = 1`, both dash properties to your desired pattern, and the shape renders as a properly-rasterized dashed stroke — one node in the render tree, sized via the usual `RelativeToParent` units, with no per-frame dot bookkeeping and no sensitivity to layout timing.
 
-The dotted-rectangle materialization approach (place N tiny rectangles at fixed offsets) looks superficially simpler, but ends up needing `GetAbsoluteWidth()` to compute N — and that returns stale values when the consumer sets `control.Width = X; control.IsFocused = true;` back-to-back: the state callback fires before the next layout pass, so the dot count is computed off the construction-time size. The visible artifact is a half-drawn focus rect that "self-heals" once a hover fires another state change after layout has run.
+The dotted-rectangle materialization approach (place N tiny rectangles at fixed offsets) looks superficially simpler, but ends up needing `AbsoluteWidth` to compute N — and that returns stale values when the consumer sets `control.Width = X; control.IsFocused = true;` back-to-back: the state callback fires before the next layout pass, so the dot count is computed off the construction-time size. The visible artifact is a half-drawn focus rect that "self-heals" once a hover fires another state change after layout has run.
 
 ## ContainerRuntime sub-wrappers eat clicks
 

--- a/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -715,8 +715,8 @@ public class TextureCoordinateDisplayController : ITextureCoordinateDisplayContr
                     var widthScale = rfv.GetValue<float>($"{instancePrefix}TextureWidthScale");
                     var heightScale = rfv.GetValue<float>($"{instancePrefix}TextureHeightScale");
 
-                    var absoluteWidth = graphicalUiElement.GetAbsoluteWidth();
-                    var absoluteHeight = graphicalUiElement.GetAbsoluteHeight();
+                    var absoluteWidth = graphicalUiElement.AbsoluteWidth;
+                    var absoluteHeight = graphicalUiElement.AbsoluteHeight;
 
                     selector.Width = absoluteWidth / widthScale;
                     selector.Height = absoluteHeight / heightScale;

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -536,13 +536,15 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     /// Returns the absolute width of the GraphicalUiElement in pixels (as opposed to using its WidthUnits)
     /// </summary>
     /// <returns>The absolute width in pixels.</returns>
-    public float GetAbsoluteWidth() => ((IPositionedSizedObject)this).Width;
+    [Obsolete("Use AbsoluteWidth instead.")]
+    public float GetAbsoluteWidth() => AbsoluteWidth;
 
     /// <summary>
     /// Returns the absolute height of the GraphicalUiElement in pixels (as opposed to using its HeightUnits)
     /// </summary>
     /// <returns>The absolute height in pixels.</returns>
-    public float GetAbsoluteHeight() => ((IPositionedSizedObject)this).Height;
+    [Obsolete("Use AbsoluteHeight instead.")]
+    public float GetAbsoluteHeight() => AbsoluteHeight;
 
     void IRenderableIpso.SetParentDirect(IRenderableIpso? parent)
     {
@@ -1405,14 +1407,24 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     public float AbsoluteTop => this.GetAbsoluteY();
 
     /// <summary>
+    /// Returns the absolute width of the GraphicalUiElement in pixels (as opposed to using its WidthUnits).
+    /// </summary>
+    public float AbsoluteWidth => ((IPositionedSizedObject)this).Width;
+
+    /// <summary>
+    /// Returns the absolute height of the GraphicalUiElement in pixels (as opposed to using its HeightUnits).
+    /// </summary>
+    public float AbsoluteHeight => ((IPositionedSizedObject)this).Height;
+
+    /// <summary>
     /// Returns the right side in absolute pixel coordinates
     /// </summary>
-    public float AbsoluteRight => AbsoluteLeft + this.GetAbsoluteWidth();
+    public float AbsoluteRight => AbsoluteLeft + this.AbsoluteWidth;
 
     /// <summary>
     /// Returns the bottom side in absolute pixel coordinates
     /// </summary>
-    public float AbsoluteBottom => AbsoluteTop + this.GetAbsoluteHeight();
+    public float AbsoluteBottom => AbsoluteTop + this.AbsoluteHeight;
 
     public IVisible ExplicitIVisibleParent
     {
@@ -2459,7 +2471,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                             var element = Children[0];
 
                             maxHeight = element.GetRequiredParentHeight();
-                            var elementHeight = element.GetAbsoluteHeight();
+                            var elementHeight = element.AbsoluteHeight;
                             maxHeight += (StackSpacing + elementHeight) * (Children.Count - 1);
                         }
                         else
@@ -2584,7 +2596,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                         //    throw new NotImplementedException();
                         //}
                         //else 
-                        pixelHeightToSet = GetAbsoluteWidth() * (mHeight / 100.0f) / aspectRatioObject.AspectRatio;
+                        pixelHeightToSet = AbsoluteWidth * (mHeight / 100.0f) / aspectRatioObject.AspectRatio;
                         wasSet = true;
 
                         if (wasSet && mContainedObjectAsIpso is ITextureCoordinate textureCoordinate)
@@ -2596,7 +2608,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                                 var scale = 1f;
                                 if (textureCoordinate.SourceRectangle.Value.Width != 0)
                                 {
-                                    scale = GetAbsoluteWidth() / textureCoordinate.SourceRectangle.Value.Width;
+                                    scale = AbsoluteWidth / textureCoordinate.SourceRectangle.Value.Width;
                                 }
                                 pixelHeightToSet = textureCoordinate.SourceRectangle.Value.Height * scale * mHeight / 100.0f;
                             }
@@ -2674,7 +2686,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                                         gue.HeightUnits == DimensionUnitType.ScreenPixel ||
                                         gue.HeightUnits == DimensionUnitType.RelativeToMaxParentOrChildren)
                                     {
-                                        var childAbsoluteWidth = gue.GetAbsoluteHeight();
+                                        var childAbsoluteWidth = gue.AbsoluteHeight;
                                         heightToSplit -= childAbsoluteWidth;
                                     }
                                     numberOfVisibleChildren++;
@@ -3013,7 +3025,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                     if (mContainedObjectAsIpso is IAspectRatio aspectRatioObject)
                     {
                         // mWidth is a percent where 100 means maintain aspect ratio
-                        pixelWidthToSet = GetAbsoluteHeight() * aspectRatioObject.AspectRatio * (mWidth / 100.0f);
+                        pixelWidthToSet = AbsoluteHeight * aspectRatioObject.AspectRatio * (mWidth / 100.0f);
                         wasSet = true;
 
                         if (wasSet && mContainedObjectAsIpso is ITextureCoordinate iTextureCoordinate)
@@ -3023,7 +3035,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                                 var scale = 1f;
                                 if (iTextureCoordinate.SourceRectangle.Value.Height != 0)
                                 {
-                                    scale = GetAbsoluteHeight() / iTextureCoordinate.SourceRectangle.Value.Height;
+                                    scale = AbsoluteHeight / iTextureCoordinate.SourceRectangle.Value.Height;
                                 }
                                 pixelWidthToSet = iTextureCoordinate.SourceRectangle.Value.Width * scale * mWidth / 100.0f;
                             }
@@ -3102,7 +3114,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                                         gue.WidthUnits == DimensionUnitType.ScreenPixel ||
                                         gue.WidthUnits == DimensionUnitType.RelativeToMaxParentOrChildren)
                                     {
-                                        var childAbsoluteWidth = gue.GetAbsoluteWidth();
+                                        var childAbsoluteWidth = gue.AbsoluteWidth;
                                         widthToSplit -= childAbsoluteWidth;
                                     }
                                     numberOfVisibleChildren++;
@@ -3434,14 +3446,14 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                     }
                 }
 
-                parentWidth = (Parent.GetAbsoluteWidth() - (effectiveHorizontalCells - 1) * Parent.StackSpacing) / effectiveHorizontalCells;
+                parentWidth = (Parent.AbsoluteWidth - (effectiveHorizontalCells - 1) * Parent.StackSpacing) / effectiveHorizontalCells;
 
-                parentHeight = ( Parent.GetAbsoluteHeight() - (effectiveVerticalCells - 1) * Parent.StackSpacing ) / effectiveVerticalCells;
+                parentHeight = ( Parent.AbsoluteHeight - (effectiveVerticalCells - 1) * Parent.StackSpacing ) / effectiveVerticalCells;
             }
             else
             {
-                parentWidth = Parent.GetAbsoluteWidth();
-                parentHeight = Parent.GetAbsoluteHeight();
+                parentWidth = Parent.AbsoluteWidth;
+                parentHeight = Parent.AbsoluteHeight;
             }
         }
         else if (this.ElementGueContainingThis != null && this.ElementGueContainingThis.mContainedObjectAsIpso != null)
@@ -4314,7 +4326,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                 var visibleIndex = this.GetIndexInVisibleSiblings();
                 if (visibleIndex > 0)
                 {
-                    var firstChildHeight = effectiveParent.Children[0].GetAbsoluteHeight();
+                    var firstChildHeight = effectiveParent.Children[0].AbsoluteHeight;
                     unitOffsetY += visibleIndex * (firstChildHeight + effectiveParent.StackSpacing);
                 }
                 this.StackedRowOrColumnIndex = 0;
@@ -4410,11 +4422,11 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             float myDimension;
             if (parentGue.ChildrenLayout == ChildrenLayout.LeftToRightStack)
             {
-                myDimension = this.Y + this.GetAbsoluteHeight();
+                myDimension = this.Y + this.AbsoluteHeight;
             }
             else
             {
-                myDimension = this.X + this.GetAbsoluteWidth();
+                myDimension = this.X + this.AbsoluteWidth;
             }
 
             float currentMax = parentGue.StackedRowOrColumnDimensions[indexToUpdate];
@@ -4444,13 +4456,13 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                             {
                                 parentGue.StackedRowOrColumnDimensions[indexToUpdate] =
                                     System.Math.Max(parentGue.StackedRowOrColumnDimensions[indexToUpdate],
-                                    child.Y + child.GetAbsoluteHeight());
+                                    child.Y + child.AbsoluteHeight);
                             }
                             else
                             {
                                 parentGue.StackedRowOrColumnDimensions[indexToUpdate] =
                                     System.Math.Max(parentGue.StackedRowOrColumnDimensions[indexToUpdate],
-                                    child.X + child.GetAbsoluteWidth());
+                                    child.X + child.AbsoluteWidth);
                             }
 
                             if (this == child)
@@ -4501,8 +4513,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             var requiredColumnCount = (int)Math.Ceiling((float)childCount / rowCount);
             columnCount = System.Math.Max(columnCount, requiredColumnCount);
         }
-        var parentWidth = effectiveParent.GetAbsoluteWidth() - (columnCount - 1) * effectiveParent.StackSpacing;
-        var parentHeight = effectiveParent.GetAbsoluteHeight() - (rowCount - 1) * effectiveParent.StackSpacing;
+        var parentWidth = effectiveParent.AbsoluteWidth - (columnCount - 1) * effectiveParent.StackSpacing;
+        var parentHeight = effectiveParent.AbsoluteHeight - (rowCount - 1) * effectiveParent.StackSpacing;
 
         cellWidth = (parentWidth / columnCount);
         cellHeight = (parentHeight / rowCount);

--- a/GumRuntime/LayoutExporter.cs
+++ b/GumRuntime/LayoutExporter.cs
@@ -55,8 +55,8 @@ public static class LayoutExporter
 
         writer.WriteNumber("x", element.AbsoluteX);
         writer.WriteNumber("y", element.AbsoluteY);
-        writer.WriteNumber("width", element.GetAbsoluteWidth());
-        writer.WriteNumber("height", element.GetAbsoluteHeight());
+        writer.WriteNumber("width", element.AbsoluteWidth);
+        writer.WriteNumber("height", element.AbsoluteHeight);
         writer.WriteBoolean("visible", element.AbsoluteVisible);
 
         if (element.RenderableComponent is IText text && text.RawText != null)

--- a/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementTests.cs
@@ -773,10 +773,10 @@ public class FrameworkElementTests : BaseTestClass
 
         frameworkElement.RepositionToKeepInScreen(boundsRoot);
 
-        (frameworkElement.Visual.AbsoluteX + frameworkElement.Visual.GetAbsoluteWidth())
-            .ShouldBeLessThanOrEqualTo(boundsRoot.X + boundsRoot.GetAbsoluteWidth());
-        (frameworkElement.Visual.AbsoluteY + frameworkElement.Visual.GetAbsoluteHeight())
-            .ShouldBeLessThanOrEqualTo(boundsRoot.Y + boundsRoot.GetAbsoluteHeight());
+        (frameworkElement.Visual.AbsoluteX + frameworkElement.Visual.AbsoluteWidth)
+            .ShouldBeLessThanOrEqualTo(boundsRoot.X + boundsRoot.AbsoluteWidth);
+        (frameworkElement.Visual.AbsoluteY + frameworkElement.Visual.AbsoluteHeight)
+            .ShouldBeLessThanOrEqualTo(boundsRoot.Y + boundsRoot.AbsoluteHeight);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/GridTests.cs
+++ b/MonoGameGum.Tests/Forms/GridTests.cs
@@ -897,7 +897,7 @@ public class GridTests : BaseTestClass
         GraphicalUiElement rowContainer = (GraphicalUiElement)grid.Visual.Children[0];
         rowContainer.UpdateLayout();
 
-        rowContainer.GetAbsoluteHeight().ShouldBe(60f);
+        rowContainer.AbsoluteHeight.ShouldBe(60f);
     }
 
     [Fact]
@@ -1592,7 +1592,7 @@ public class GridTests : BaseTestClass
         Panel child = new Panel();
         grid.AddChild(child, row: 0, column: 0);
 
-        // In unit test context, GetAbsoluteHeight() returns 0.
+        // In unit test context, AbsoluteHeight returns 0.
         // MinHeight (50) > computed (0), so clamping fires and sets Absolute height.
         GraphicalUiElement rowContainer = (GraphicalUiElement)grid.Visual.Children[0];
         rowContainer.HeightUnits.ShouldBe(DimensionUnitType.Absolute);

--- a/MonoGameGum.Tests/Forms/ListBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/ListBoxTests.cs
@@ -516,8 +516,8 @@ public class ListBoxTests : BaseTestClass
         listBox.SelectionChanged += (_, _) => fireCount++;
 
         Mock<ICursor> cursor = SetupForPush();
-        var cx = button.GetAbsoluteX() + button.GetAbsoluteWidth() / 2;
-        var cy = button.GetAbsoluteY() + button.GetAbsoluteHeight() / 2;
+        var cx = button.GetAbsoluteX() + button.AbsoluteWidth / 2;
+        var cy = button.GetAbsoluteY() + button.AbsoluteHeight / 2;
         cursor.Setup(c => c.XRespectingGumZoomAndBounds()).Returns(cx);
         cursor.Setup(c => c.YRespectingGumZoomAndBounds()).Returns(cy);
         cursor.Setup(c => c.X).Returns((int)cx);
@@ -1554,8 +1554,8 @@ public class ListBoxTests : BaseTestClass
         if (itemIndex >= 0 && itemIndex < listBox.ListBoxItems.Count)
         {
             var targetItemVisual = listBox.ListBoxItems[itemIndex]!.Visual;
-            var cursorX = targetItemVisual.GetAbsoluteX() + targetItemVisual.GetAbsoluteWidth() / 2;
-            var cursorY = targetItemVisual.GetAbsoluteY() + targetItemVisual.GetAbsoluteHeight() / 2;
+            var cursorX = targetItemVisual.GetAbsoluteX() + targetItemVisual.AbsoluteWidth / 2;
+            var cursorY = targetItemVisual.GetAbsoluteY() + targetItemVisual.AbsoluteHeight / 2;
 
             mockCursor.Setup(c => c.XRespectingGumZoomAndBounds()).Returns(cursorX);
             mockCursor.Setup(c => c.YRespectingGumZoomAndBounds()).Returns(cursorY);
@@ -1922,8 +1922,8 @@ public class ListBoxTests : BaseTestClass
         listBox.SelectionChanged += (_, _) => fireCount++;
 
         Mock<ICursor> cursor = SetupForPush();
-        float cx = separator.GetAbsoluteX() + separator.GetAbsoluteWidth() / 2;
-        float cy = separator.GetAbsoluteY() + separator.GetAbsoluteHeight() / 2;
+        float cx = separator.GetAbsoluteX() + separator.AbsoluteWidth / 2;
+        float cy = separator.GetAbsoluteY() + separator.AbsoluteHeight / 2;
         cursor.Setup(c => c.XRespectingGumZoomAndBounds()).Returns(cx);
         cursor.Setup(c => c.YRespectingGumZoomAndBounds()).Returns(cy);
         cursor.Setup(c => c.X).Returns((int)cx);
@@ -2407,10 +2407,10 @@ public class ListBoxTests : BaseTestClass
 
             ListBox.ShowPopupListBox(popup, listBoxParent);
 
-            (popup.Visual.AbsoluteX + popup.Visual.GetAbsoluteWidth())
-                .ShouldBeLessThanOrEqualTo(customPopupRoot.X + customPopupRoot.GetAbsoluteWidth());
-            (popup.Visual.AbsoluteY + popup.Visual.GetAbsoluteHeight())
-                .ShouldBeLessThanOrEqualTo(customPopupRoot.Y + customPopupRoot.GetAbsoluteHeight());
+            (popup.Visual.AbsoluteX + popup.Visual.AbsoluteWidth)
+                .ShouldBeLessThanOrEqualTo(customPopupRoot.X + customPopupRoot.AbsoluteWidth);
+            (popup.Visual.AbsoluteY + popup.Visual.AbsoluteHeight)
+                .ShouldBeLessThanOrEqualTo(customPopupRoot.Y + customPopupRoot.AbsoluteHeight);
         }
         finally
         {

--- a/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollBarThumbResizeTests.cs
@@ -9,7 +9,7 @@ namespace MonoGameGum.Tests.Forms;
 
 /// <summary>
 /// Regression coverage for issue #2781 — ScrollBar's thumb is sized in absolute pixels
-/// from a snapshot of <see cref="GraphicalUiElement.GetAbsoluteHeight"/>/<see cref="GraphicalUiElement.GetAbsoluteWidth"/>
+/// from a snapshot of <see cref="GraphicalUiElement.AbsoluteHeight"/>/<see cref="GraphicalUiElement.AbsoluteWidth"/>
 /// on Track. If Track resizes after construction (parent resize, sibling resize, layout reflow,
 /// or direct Track manipulation) and nothing re-runs UpdateThumbSize, the thumb keeps the old
 /// absolute size. The fix is to subscribe to Track.SizeChanged so any Track resize — from any
@@ -43,8 +43,8 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.Value = 50;
         visual.UpdateLayout();
 
-        float trackHeightBefore = scrollBar.Track!.GetAbsoluteHeight();
-        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float trackHeightBefore = scrollBar.Track!.AbsoluteHeight;
+        float thumbHeightBefore = GetThumbVisual(scrollBar).AbsoluteHeight;
         float rangeBefore = trackHeightBefore - thumbHeightBefore;
         GetThumbVisual(scrollBar).Y.ShouldBe(rangeBefore * 0.5f, 0.5f,
             "Sanity: thumb Y at Value=50 should sit at midpoint of (trackHeight - thumbHeight).");
@@ -52,8 +52,8 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         visual.Height = 256;
         visual.UpdateLayout();
 
-        float trackHeightAfter = scrollBar.Track.GetAbsoluteHeight();
-        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float trackHeightAfter = scrollBar.Track.AbsoluteHeight;
+        float thumbHeightAfter = GetThumbVisual(scrollBar).AbsoluteHeight;
         float rangeAfter = trackHeightAfter - thumbHeightAfter;
         GetThumbVisual(scrollBar).Y.ShouldBe(rangeAfter * 0.5f, 0.5f,
             "After Track resize, thumb Y must reflect the new (trackHeight - thumbHeight), not the cached old range.");
@@ -76,7 +76,7 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.Maximum = 10;
         scrollBar.ViewportSize = 10;          // ratio 0.5, initial thumb = 80 * 0.5 = 40
         visual.UpdateLayout();
-        GetThumbVisual(scrollBar).GetAbsoluteHeight().ShouldBe(40f, 0.5f,
+        GetThumbVisual(scrollBar).AbsoluteHeight.ShouldBe(40f, 0.5f,
             "Sanity precondition: initial thumb should be 40, well above the 16 floor.");
 
         // Shrink Track to a size where (trackSize * ratio) = 10, which is below MinimumThumbSize.
@@ -84,7 +84,7 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.Track.Height = 20;
         visual.UpdateLayout();
 
-        GetThumbVisual(scrollBar).GetAbsoluteHeight().ShouldBe(16f, 0.01f,
+        GetThumbVisual(scrollBar).AbsoluteHeight.ShouldBe(16f, 0.01f,
             "After Track shrink, thumb must be re-clamped to MinimumThumbSize (16), not left at the stale 40.");
     }
 
@@ -104,16 +104,16 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.ViewportSize = 40;
         visual.UpdateLayout();
 
-        float thumbWidthBefore = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        float thumbWidthBefore = GetThumbVisual(scrollBar).AbsoluteWidth;
 
         visual.Width = 256;
         visual.UpdateLayout();
 
-        float thumbWidthAfter = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        float thumbWidthAfter = GetThumbVisual(scrollBar).AbsoluteWidth;
         thumbWidthAfter.ShouldBeGreaterThan(thumbWidthBefore,
             "Thumb width must grow when the ScrollBar Visual (and therefore Track) widens.");
 
-        float trackWidthAfter = scrollBar.Track!.GetAbsoluteWidth();
+        float trackWidthAfter = scrollBar.Track!.AbsoluteWidth;
         double expectedRatio = 40.0 / (100.0 + 40.0);
         thumbWidthAfter.ShouldBe((float)(trackWidthAfter * expectedRatio), 0.5f,
             "Thumb width should equal trackWidth * (ViewportSize / valueRange) after Visual resize.");
@@ -133,16 +133,16 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.ViewportSize = 40;
         visual.UpdateLayout();
 
-        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float thumbHeightBefore = GetThumbVisual(scrollBar).AbsoluteHeight;
 
         visual.Height = 256;
         visual.UpdateLayout();
 
-        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float thumbHeightAfter = GetThumbVisual(scrollBar).AbsoluteHeight;
         thumbHeightAfter.ShouldBeGreaterThan(thumbHeightBefore,
             "Thumb height must grow when the ScrollBar Visual (and therefore Track) grows.");
 
-        float trackHeightAfter = scrollBar.Track!.GetAbsoluteHeight();
+        float trackHeightAfter = scrollBar.Track!.AbsoluteHeight;
         double expectedRatio = 40.0 / (100.0 + 40.0);
         thumbHeightAfter.ShouldBe((float)(trackHeightAfter * expectedRatio), 0.5f,
             "Thumb height should equal trackHeight * (ViewportSize / valueRange) after Visual resize.");
@@ -162,13 +162,13 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.ViewportSize = 40;
         visual.UpdateLayout();
 
-        float thumbWidthBefore = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        float thumbWidthBefore = GetThumbVisual(scrollBar).AbsoluteWidth;
 
         scrollBar.Track!.WidthUnits = DimensionUnitType.Absolute;
         scrollBar.Track.Width = 200;
         visual.UpdateLayout();
 
-        float thumbWidthAfter = GetThumbVisual(scrollBar).GetAbsoluteWidth();
+        float thumbWidthAfter = GetThumbVisual(scrollBar).AbsoluteWidth;
         thumbWidthAfter.ShouldNotBe(thumbWidthBefore,
             "Thumb width must change when Track is resized directly.");
 
@@ -194,7 +194,7 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.ViewportSize = 40;
         visual.UpdateLayout();
 
-        float thumbHeightBefore = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float thumbHeightBefore = GetThumbVisual(scrollBar).AbsoluteHeight;
 
         // Override Track sizing to be absolute so Visual size doesn't dictate it. Then resize
         // Track. This is the path the original Visual.SizeChanged hook fails to cover.
@@ -202,7 +202,7 @@ public class ScrollBarThumbResizeTests : BaseTestClass
         scrollBar.Track.Height = 200;
         visual.UpdateLayout();
 
-        float thumbHeightAfter = GetThumbVisual(scrollBar).GetAbsoluteHeight();
+        float thumbHeightAfter = GetThumbVisual(scrollBar).AbsoluteHeight;
         thumbHeightAfter.ShouldNotBe(thumbHeightBefore,
             "Thumb height must change when Track is resized directly (independent of Visual size).");
 

--- a/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderThumbResizeTests.cs
@@ -23,10 +23,10 @@ public class SliderThumbResizeTests : BaseTestClass
     // Default thumb has Center XOrigin so AbsoluteLeft is offset by half its width.
     // Compare centers, not left edges.
     private static float CenterX(GraphicalUiElement element) =>
-        element.AbsoluteLeft + element.GetAbsoluteWidth() * 0.5f;
+        element.AbsoluteLeft + element.AbsoluteWidth * 0.5f;
 
     private static float CenterX(InteractiveGue element) =>
-        element.AbsoluteLeft + element.GetAbsoluteWidth() * 0.5f;
+        element.AbsoluteLeft + element.AbsoluteWidth * 0.5f;
 
     [Fact]
     public void ThumbCenter_ShouldFollow_WhenSliderVisualResizes()

--- a/MonoGameGum.Tests/Forms/SplitterTests.cs
+++ b/MonoGameGum.Tests/Forms/SplitterTests.cs
@@ -52,13 +52,13 @@ public class SplitterTests : BaseTestClass
         _secondPanel!.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
         _secondPanel.Height = 100;
 
-        var originalAbsoluteHeightBefore = _firstPanel.Visual.GetAbsoluteHeight();
-        var originalAbsoluteHeightAfter = _secondPanel.Visual.GetAbsoluteHeight();
+        var originalAbsoluteHeightBefore = _firstPanel.Visual.AbsoluteHeight;
+        var originalAbsoluteHeightAfter = _secondPanel.Visual.AbsoluteHeight;
 
         _splitter!.ApplyResizeChangeInPixels(12);
 
-        _firstPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightBefore + 12);
-        _secondPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightAfter - 12);
+        _firstPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightBefore + 12);
+        _secondPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightAfter - 12);
     }
 
     [Fact]
@@ -74,13 +74,13 @@ public class SplitterTests : BaseTestClass
         _secondPanel!.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.PercentageOfParent;
         _secondPanel.Height = 30;
 
-        var originalAbsoluteHeightBefore = _firstPanel.Visual.GetAbsoluteHeight();
-        var originalAbsoluteHeightAfter = _secondPanel.Visual.GetAbsoluteHeight();
+        var originalAbsoluteHeightBefore = _firstPanel.Visual.AbsoluteHeight;
+        var originalAbsoluteHeightAfter = _secondPanel.Visual.AbsoluteHeight;
 
         _splitter!.ApplyResizeChangeInPixels(12);
 
-        _firstPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightBefore + 12);
-        _secondPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightAfter - 12);
+        _firstPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightBefore + 12);
+        _secondPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightAfter - 12);
     }
 
 
@@ -98,13 +98,13 @@ public class SplitterTests : BaseTestClass
         _parentPanel!.Height = 300;
         _parentPanel.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
-        var originalAbsoluteHeightBefore = _firstPanel.Visual.GetAbsoluteHeight();
-        var originalAbsoluteHeightAfter = _secondPanel.Visual.GetAbsoluteHeight();
+        var originalAbsoluteHeightBefore = _firstPanel.Visual.AbsoluteHeight;
+        var originalAbsoluteHeightAfter = _secondPanel.Visual.AbsoluteHeight;
 
         _splitter!.ApplyResizeChangeInPixels(12);
 
-        _firstPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightBefore + 12);
-        _secondPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightAfter - 12);
+        _firstPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightBefore + 12);
+        _secondPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightAfter - 12);
     }
 
     [Fact]
@@ -121,13 +121,13 @@ public class SplitterTests : BaseTestClass
         _parentPanel!.Height = 300;
         _parentPanel.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
-        var originalAbsoluteHeightBefore = _firstPanel.Visual.GetAbsoluteHeight();
-        var originalAbsoluteHeightAfter = _secondPanel.Visual.GetAbsoluteHeight();
+        var originalAbsoluteHeightBefore = _firstPanel.Visual.AbsoluteHeight;
+        var originalAbsoluteHeightAfter = _secondPanel.Visual.AbsoluteHeight;
 
         _splitter!.ApplyResizeChangeInPixels(12);
 
-        _firstPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightBefore + 12, .01f);
-        _secondPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightAfter - 12, .01f);
+        _firstPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightBefore + 12, .01f);
+        _secondPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightAfter - 12, .01f);
     }
 
     [Fact]
@@ -149,15 +149,15 @@ public class SplitterTests : BaseTestClass
         _parentPanel.Height = 300;
         _parentPanel.Visual.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
-        var originalAbsoluteHeightBefore = _firstPanel.Visual.GetAbsoluteHeight();
-        var originalAbsoluteHeightAfter = _secondPanel.Visual.GetAbsoluteHeight();
-        var additionalAbsoluteHeight = additionalSibling.Visual.GetAbsoluteHeight();
+        var originalAbsoluteHeightBefore = _firstPanel.Visual.AbsoluteHeight;
+        var originalAbsoluteHeightAfter = _secondPanel.Visual.AbsoluteHeight;
+        var additionalAbsoluteHeight = additionalSibling.Visual.AbsoluteHeight;
 
         _splitter!.ApplyResizeChangeInPixels(12);
 
-        _firstPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightBefore + 12, .01f);
-        _secondPanel.Visual.GetAbsoluteHeight().ShouldBe(originalAbsoluteHeightAfter - 12, .01f);
-        additionalSibling.Visual.GetAbsoluteHeight().ShouldBe(additionalAbsoluteHeight, .01f);
+        _firstPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightBefore + 12, .01f);
+        _secondPanel.Visual.AbsoluteHeight.ShouldBe(originalAbsoluteHeightAfter - 12, .01f);
+        additionalSibling.Visual.AbsoluteHeight.ShouldBe(additionalAbsoluteHeight, .01f);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -120,8 +120,8 @@ public class TextBoxTests : BaseTestClass
         // the bottom. Tolerance matches the convention used by the existing X-axis
         // scroll tests (font/layout geometry has small implementation-dependent
         // variance).
-        float caretAbsoluteCenter = visual.CaretInstance.AbsoluteTop + visual.CaretInstance.GetAbsoluteHeight() / 2f;
-        float visualBottom = visual.AbsoluteTop + visual.GetAbsoluteHeight();
+        float caretAbsoluteCenter = visual.CaretInstance.AbsoluteTop + visual.CaretInstance.AbsoluteHeight / 2f;
+        float visualBottom = visual.AbsoluteTop + visual.AbsoluteHeight;
         caretAbsoluteCenter.ShouldBeLessThanOrEqualTo(visualBottom,
             "because the caret center should remain inside the visible area after vertical scrolling");
     }

--- a/MonoGameGum.Tests/Forms/TooltipTests.cs
+++ b/MonoGameGum.Tests/Forms/TooltipTests.cs
@@ -139,7 +139,7 @@ public class TooltipTests : BaseTestClass
 
         tooltip.Show(cursorX: 790, cursorY: 10);
 
-        tooltip.Visual.X.ShouldBeLessThanOrEqualTo(800 - tooltip.Visual.GetAbsoluteWidth());
+        tooltip.Visual.X.ShouldBeLessThanOrEqualTo(800 - tooltip.Visual.AbsoluteWidth);
     }
 
     [Fact]
@@ -159,8 +159,8 @@ public class TooltipTests : BaseTestClass
 
         tooltip.Show(cursorX: 390, cursorY: 290);
 
-        var width = tooltip.Visual.GetAbsoluteWidth();
-        var height = tooltip.Visual.GetAbsoluteHeight();
+        var width = tooltip.Visual.AbsoluteWidth;
+        var height = tooltip.Visual.AbsoluteHeight;
         tooltip.Visual.X.ShouldBeLessThanOrEqualTo(400 - width);
         tooltip.Visual.Y.ShouldBeLessThanOrEqualTo(300 - height);
     }

--- a/MonoGameGum.Tests/Forms/WindowTests.cs
+++ b/MonoGameGum.Tests/Forms/WindowTests.cs
@@ -399,12 +399,12 @@ public class WindowTests : BaseTestClass
         top.TryCallDragging();
 
         sut.Y.ShouldBe(100);
-        sut.Visual.GetAbsoluteHeight().ShouldBe(256);
+        sut.Visual.AbsoluteHeight.ShouldBe(256);
 
         // A second drag at the same cursor position must not push further.
         top.TryCallDragging();
         sut.Y.ShouldBe(100);
-        sut.Visual.GetAbsoluteHeight().ShouldBe(256);
+        sut.Visual.AbsoluteHeight.ShouldBe(256);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -193,14 +193,14 @@ public class GraphicalUiElementTests : BaseTestClass
             child.Dock(Dock.Fill);
             parent.AddChild(child);
         }
-        parent.Children[0].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[0].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[1].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[1].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[2].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[2].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[3].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[3].GetAbsoluteHeight().ShouldBe(200);
+        parent.Children[0].AbsoluteWidth.ShouldBe(200);
+        parent.Children[0].AbsoluteHeight.ShouldBe(200);
+        parent.Children[1].AbsoluteWidth.ShouldBe(200);
+        parent.Children[1].AbsoluteHeight.ShouldBe(200);
+        parent.Children[2].AbsoluteWidth.ShouldBe(200);
+        parent.Children[2].AbsoluteHeight.ShouldBe(200);
+        parent.Children[3].AbsoluteWidth.ShouldBe(200);
+        parent.Children[3].AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -223,14 +223,14 @@ public class GraphicalUiElementTests : BaseTestClass
             child.Dock(Dock.Fill);
             parent.AddChild(child);
         }
-        parent.Children[0].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[0].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[1].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[1].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[2].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[2].GetAbsoluteHeight().ShouldBe(200);
-        parent.Children[3].GetAbsoluteWidth().ShouldBe(200);
-        parent.Children[3].GetAbsoluteHeight().ShouldBe(200);
+        parent.Children[0].AbsoluteWidth.ShouldBe(200);
+        parent.Children[0].AbsoluteHeight.ShouldBe(200);
+        parent.Children[1].AbsoluteWidth.ShouldBe(200);
+        parent.Children[1].AbsoluteHeight.ShouldBe(200);
+        parent.Children[2].AbsoluteWidth.ShouldBe(200);
+        parent.Children[2].AbsoluteHeight.ShouldBe(200);
+        parent.Children[3].AbsoluteWidth.ShouldBe(200);
+        parent.Children[3].AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -244,22 +244,22 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AutoGridHorizontalCells = 2;
         container.AutoGridVerticalCells = 2;
 
-        container.GetAbsoluteWidth().ShouldBe(0);
+        container.AbsoluteWidth.ShouldBe(0);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         void AddChild()
         {
@@ -281,26 +281,26 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AutoGridHorizontalCells = 2;
         container.AutoGridVerticalCells = 2;
 
-        container.GetAbsoluteHeight().ShouldBe(0);
+        container.AbsoluteHeight.ShouldBe(0);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(300);
+        container.AbsoluteHeight.ShouldBe(300);
 
         AddChild();
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(400);
+        container.AbsoluteHeight.ShouldBe(400);
 
         void AddChild()
         {
@@ -335,8 +335,8 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AddChild(fillContainer);
         fillContainer.Dock(Dock.Fill);
 
-        fillContainer.GetAbsoluteWidth().ShouldBe(100);
-        fillContainer.GetAbsoluteHeight().ShouldBe(100);
+        fillContainer.AbsoluteWidth.ShouldBe(100);
+        fillContainer.AbsoluteHeight.ShouldBe(100);
         fillContainer.AbsoluteLeft.ShouldBe(100);
 
         ContainerRuntime fillContainer2 = new();
@@ -344,8 +344,8 @@ public class GraphicalUiElementTests : BaseTestClass
         fillContainer2.Dock(Dock.Fill);
         container.AddChild(fillContainer2);
 
-        fillContainer2.GetAbsoluteWidth().ShouldBe(100);
-        fillContainer2.GetAbsoluteHeight().ShouldBe(100);
+        fillContainer2.AbsoluteWidth.ShouldBe(100);
+        fillContainer2.AbsoluteHeight.ShouldBe(100);
         fillContainer2.AbsoluteLeft.ShouldBe(0);
         fillContainer2.AbsoluteTop.ShouldBe(100);
     }
@@ -361,22 +361,22 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AutoGridHorizontalCells = 2;
         container.AutoGridVerticalCells = 2;
 
-        container.GetAbsoluteHeight().ShouldBe(0);
+        container.AbsoluteHeight.ShouldBe(0);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteHeight().ShouldBe(200);
+        container.AbsoluteHeight.ShouldBe(200);
 
         void AddChild()
         {
@@ -398,26 +398,26 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AutoGridHorizontalCells = 2;
         container.AutoGridVerticalCells = 2;
 
-        container.GetAbsoluteWidth().ShouldBe(0);
+        container.AbsoluteWidth.ShouldBe(0);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(200);
+        container.AbsoluteWidth.ShouldBe(200);
 
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(300);
+        container.AbsoluteWidth.ShouldBe(300);
 
         AddChild();
         AddChild();
-        container.GetAbsoluteWidth().ShouldBe(400);
+        container.AbsoluteWidth.ShouldBe(400);
 
         void AddChild()
         {
@@ -453,8 +453,8 @@ public class GraphicalUiElementTests : BaseTestClass
         container.AddChild(fillContainer);
         fillContainer.Dock(Dock.Fill);
 
-        fillContainer.GetAbsoluteWidth().ShouldBe(100);
-        fillContainer.GetAbsoluteHeight().ShouldBe(100);
+        fillContainer.AbsoluteWidth.ShouldBe(100);
+        fillContainer.AbsoluteHeight.ShouldBe(100);
         fillContainer.AbsoluteLeft.ShouldBe(0);
         fillContainer.AbsoluteTop.ShouldBe(100);
 
@@ -463,8 +463,8 @@ public class GraphicalUiElementTests : BaseTestClass
         fillContainer2.Dock(Dock.Fill);
         container.AddChild(fillContainer2);
 
-        fillContainer2.GetAbsoluteWidth().ShouldBe(100);
-        fillContainer2.GetAbsoluteHeight().ShouldBe(100);
+        fillContainer2.AbsoluteWidth.ShouldBe(100);
+        fillContainer2.AbsoluteHeight.ShouldBe(100);
         fillContainer2.AbsoluteLeft.ShouldBe(100);
         fillContainer2.AbsoluteTop.ShouldBe(0);
     }
@@ -501,7 +501,7 @@ public class GraphicalUiElementTests : BaseTestClass
 
         // 6 children in a 2-column grid => 3 rows (spilling past the 2 minimum rows),
         // each 100 tall.
-        container.GetAbsoluteHeight().ShouldBe(300);
+        container.AbsoluteHeight.ShouldBe(300);
 
         container.Children[0].AbsoluteX.ShouldBe(0);
         container.Children[0].AbsoluteY.ShouldBe(0);
@@ -551,7 +551,7 @@ public class GraphicalUiElementTests : BaseTestClass
 
         // 6 children in a 2-row grid => 3 columns (spilling past the 2 minimum columns),
         // each 100 wide.
-        container.GetAbsoluteWidth().ShouldBe(300);
+        container.AbsoluteWidth.ShouldBe(300);
 
         container.Children[0].AbsoluteX.ShouldBe(0);
         container.Children[0].AbsoluteY.ShouldBe(0);
@@ -1309,11 +1309,11 @@ public class GraphicalUiElementTests : BaseTestClass
             parent.AddChild(child);
         }
 
-        parent.GetAbsoluteHeight().ShouldBe(200);
+        parent.AbsoluteHeight.ShouldBe(200);
 
         parent.StackSpacing = 20;
 
-        parent.GetAbsoluteHeight().ShouldBe(220);
+        parent.AbsoluteHeight.ShouldBe(220);
     }
 
     [Fact]
@@ -1334,7 +1334,7 @@ public class GraphicalUiElementTests : BaseTestClass
             parent.AddChild(child);
         }
 
-        parent.GetAbsoluteHeight().ShouldBe(200);
+        parent.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -1357,7 +1357,7 @@ public class GraphicalUiElementTests : BaseTestClass
             parent.AddChild(child);
         }
 
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -1380,7 +1380,7 @@ public class GraphicalUiElementTests : BaseTestClass
             parent.AddChild(child);
         }
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -1402,11 +1402,11 @@ public class GraphicalUiElementTests : BaseTestClass
             parent.AddChild(child);
         }
 
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
 
         parent.StackSpacing = 20;
 
-        parent.GetAbsoluteWidth().ShouldBe(220);
+        parent.AbsoluteWidth.ShouldBe(220);
     }
 
     [Fact]
@@ -1420,28 +1420,28 @@ public class GraphicalUiElementTests : BaseTestClass
         sut.Width = 1;
         sut.WidthUnits = DimensionUnitType.Ratio;
 
-        sut.GetAbsoluteWidth().ShouldBe(1000);
+        sut.AbsoluteWidth.ShouldBe(1000);
 
         ContainerRuntime absoluteContainer = new();
         parent.AddChild(absoluteContainer);
         absoluteContainer.Width = 100;
         absoluteContainer.WidthUnits = DimensionUnitType.Absolute;
 
-        sut.GetAbsoluteWidth().ShouldBe(900);
+        sut.AbsoluteWidth.ShouldBe(900);
 
         ContainerRuntime percentContainer = new();
         parent.AddChild(percentContainer);
         percentContainer.Width = 5;
         percentContainer.WidthUnits = DimensionUnitType.PercentageOfParent;
 
-        sut.GetAbsoluteWidth().ShouldBe(850);
+        sut.AbsoluteWidth.ShouldBe(850);
 
         ContainerRuntime relativeToParentContainer = new();
         parent.AddChild(relativeToParentContainer);
         relativeToParentContainer.Width = -880; // 120 width
         relativeToParentContainer.WidthUnits = DimensionUnitType.RelativeToParent;
 
-        sut.GetAbsoluteWidth().ShouldBe(850 - 120); // 730
+        sut.AbsoluteWidth.ShouldBe(850 - 120); // 730
 
         var mockSprite = new Mock<IPositionedSizedObject>()
             .As<IRenderable>()
@@ -1476,7 +1476,7 @@ public class GraphicalUiElementTests : BaseTestClass
         parent.AddChild(percentOfSourceFile);
         percentOfSourceFile.WidthUnits = DimensionUnitType.PercentageOfSourceFile;
 
-        sut.GetAbsoluteWidth().ShouldBe(680);
+        sut.AbsoluteWidth.ShouldBe(680);
 
 
         ContainerRuntime percentOtherDimension = new();
@@ -1484,7 +1484,7 @@ public class GraphicalUiElementTests : BaseTestClass
         percentOtherDimension.Width = 50; // 50% of height
         percentOtherDimension.WidthUnits = DimensionUnitType.PercentageOfOtherDimension;
         percentOtherDimension.Height = 100; 
-        sut.GetAbsoluteWidth().ShouldBe(630); 
+        sut.AbsoluteWidth.ShouldBe(630); 
 
 
 
@@ -1508,7 +1508,7 @@ public class GraphicalUiElementTests : BaseTestClass
         absoluteMultipliedByFontScaleContainer.Width = 100;
         absoluteMultipliedByFontScaleContainer.WidthUnits = DimensionUnitType.AbsoluteMultipliedByFontScale;
 
-        sut.GetAbsoluteWidth().ShouldBe(800); // 1000 - (100 * 2)
+        sut.AbsoluteWidth.ShouldBe(800); // 1000 - (100 * 2)
     }
 
     [Fact]
@@ -1738,13 +1738,13 @@ public class GraphicalUiElementTests : BaseTestClass
         child.Height = 0;
         child.Parent = parent1;
 
-        child.GetAbsoluteWidth().ShouldBe(200);
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
 
         child.Parent = parent2;
 
-        child.GetAbsoluteWidth().ShouldBe(400);
-        child.GetAbsoluteHeight().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(400);
+        child.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -1892,13 +1892,13 @@ public class GraphicalUiElementTests : BaseTestClass
 
         leftChild.Visible = false;
 
-        rightChild.GetAbsoluteWidth().ShouldBe(200);
-        sut.GetAbsoluteWidth().ShouldBe(200);
+        rightChild.AbsoluteWidth.ShouldBe(200);
+        sut.AbsoluteWidth.ShouldBe(200);
 
         leftChild.Visible = true;
 
-        rightChild.GetAbsoluteWidth().ShouldBe(100);
-        sut.GetAbsoluteWidth().ShouldBe(100);
+        rightChild.AbsoluteWidth.ShouldBe(100);
+        sut.AbsoluteWidth.ShouldBe(100);
 
     }
 

--- a/MonoGameGum.Tests/Runtimes/LAYOUT_TEST_PLAN.md
+++ b/MonoGameGum.Tests/Runtimes/LAYOUT_TEST_PLAN.md
@@ -24,7 +24,7 @@ Tests for `DimensionUnitType.Absolute`, `PercentageOfParent`, `RelativeToParent`
 
 | # | Test Name | Priority | Notes |
 |---|-----------|----------|-------|
-| 1 | `WidthAbsolute_ShouldReturnExactPixels` | P0 | Width=150, assert GetAbsoluteWidth()=150 |
+| 1 | `WidthAbsolute_ShouldReturnExactPixels` | P0 | Width=150, assert AbsoluteWidth=150 |
 | 2 | `WidthAbsolute_ShouldReturnZero_WhenSetToZero` | P1 | Edge case: zero width |
 | 3 | `WidthAbsolute_ShouldAllowNegativeValues` | P2 | Verify negative width doesn't crash |
 | 4 | `WidthPercentageOfParent_ShouldReturnHalfParentWidth_WhenFiftyPercent` | P0 | Parent=400, Width=50 |

--- a/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
+++ b/MonoGameGum.Tests/Runtimes/LayoutUnitTests.cs
@@ -68,7 +68,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = -10;
         element.WidthUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteWidth().ShouldBe(-10);
+        element.AbsoluteWidth.ShouldBe(-10);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 150;
         element.WidthUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteWidth().ShouldBe(150);
+        element.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 0;
         element.WidthUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteWidth().ShouldBe(0);
+        element.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = 100;
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteWidth().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = 50;
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = 50;
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteWidth().ShouldBe(0);
+        child.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -148,7 +148,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = 20;
         child.WidthUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteWidth().ShouldBe(220);
+        child.AbsoluteWidth.ShouldBe(220);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = -20;
         child.WidthUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteWidth().ShouldBe(180);
+        child.AbsoluteWidth.ShouldBe(180);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Width = 0;
         child.WidthUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.ScreenPixel;
 
         // Should be the raw value, not scaled to parent
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -211,7 +211,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = -10;
         element.HeightUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteHeight().ShouldBe(-10);
+        element.AbsoluteHeight.ShouldBe(-10);
     }
 
     [Fact]
@@ -221,7 +221,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 150;
         element.HeightUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteHeight().ShouldBe(150);
+        element.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 0;
         element.HeightUnits = DimensionUnitType.Absolute;
 
-        element.GetAbsoluteHeight().ShouldBe(0);
+        element.AbsoluteHeight.ShouldBe(0);
     }
 
     [Fact]
@@ -246,7 +246,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 100;
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteHeight().ShouldBe(400);
+        child.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 50;
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 50;
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteHeight().ShouldBe(0);
+        child.AbsoluteHeight.ShouldBe(0);
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 20;
         child.HeightUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteHeight().ShouldBe(220);
+        child.AbsoluteHeight.ShouldBe(220);
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = -20;
         child.HeightUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteHeight().ShouldBe(180);
+        child.AbsoluteHeight.ShouldBe(180);
     }
 
     [Fact]
@@ -321,7 +321,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 0;
         child.HeightUnits = DimensionUnitType.RelativeToParent;
 
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -336,7 +336,7 @@ public class LayoutUnitTests : BaseTestClass
         child.Height = 200;
         child.HeightUnits = DimensionUnitType.ScreenPixel;
 
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
     }
 
     #endregion
@@ -355,7 +355,7 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(120);
+        parent.AbsoluteHeight.ShouldBe(120);
     }
 
     [Fact]
@@ -376,7 +376,7 @@ public class LayoutUnitTests : BaseTestClass
         invisibleChild.Visible = false;
         parent.AddChild(invisibleChild);
 
-        parent.GetAbsoluteHeight().ShouldBe(80);
+        parent.AbsoluteHeight.ShouldBe(80);
     }
 
     [Fact]
@@ -392,7 +392,7 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(150);
+        parent.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -412,7 +412,7 @@ public class LayoutUnitTests : BaseTestClass
         child2.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteHeight().ShouldBe(120);
+        parent.AbsoluteHeight.ShouldBe(120);
     }
 
     [Fact]
@@ -422,7 +422,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.Height = 10;
         parent.HeightUnits = DimensionUnitType.RelativeToChildren;
 
-        parent.GetAbsoluteHeight().ShouldBe(10);
+        parent.AbsoluteHeight.ShouldBe(10);
     }
 
     [Fact]
@@ -437,10 +437,10 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
 
         child.Height = 200;
-        parent.GetAbsoluteHeight().ShouldBe(200);
+        parent.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -464,18 +464,18 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Baseline: parent and grandparent should reflect the child's height
-        parent.GetAbsoluteHeight().ShouldBe(100);
-        grandparent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
+        grandparent.AbsoluteHeight.ShouldBe(100);
 
         // Hide the child — parent and grandparent should shrink to 0
         child.Visible = false;
-        parent.GetAbsoluteHeight().ShouldBe(0);
-        grandparent.GetAbsoluteHeight().ShouldBe(0);
+        parent.AbsoluteHeight.ShouldBe(0);
+        grandparent.AbsoluteHeight.ShouldBe(0);
 
         // Show the child again — parent and grandparent should restore to 100
         child.Visible = true;
-        parent.GetAbsoluteHeight().ShouldBe(100);
-        grandparent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
+        grandparent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -490,7 +490,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
     }
 
     [Fact]
@@ -511,7 +511,7 @@ public class LayoutUnitTests : BaseTestClass
         invisibleChild.Visible = false;
         parent.AddChild(invisibleChild);
 
-        parent.GetAbsoluteWidth().ShouldBe(80);
+        parent.AbsoluteWidth.ShouldBe(80);
     }
 
     [Fact]
@@ -527,7 +527,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -547,7 +547,7 @@ public class LayoutUnitTests : BaseTestClass
         child2.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
     }
 
     [Fact]
@@ -557,7 +557,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.Width = 10;
         parent.WidthUnits = DimensionUnitType.RelativeToChildren;
 
-        parent.GetAbsoluteWidth().ShouldBe(10);
+        parent.AbsoluteWidth.ShouldBe(10);
     }
 
     [Fact]
@@ -573,10 +573,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(110);
+        parent.AbsoluteWidth.ShouldBe(110);
 
         child.X = 50;
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -591,10 +591,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
 
         child.Width = 200;
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -610,7 +610,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 50;
         element.HeightUnits = DimensionUnitType.PercentageOfOtherDimension;
 
-        element.GetAbsoluteHeight().ShouldBe(100);
+        element.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -622,7 +622,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 100;
         element.HeightUnits = DimensionUnitType.PercentageOfOtherDimension;
 
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -634,7 +634,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 50;
         element.WidthUnits = DimensionUnitType.PercentageOfOtherDimension;
 
-        element.GetAbsoluteWidth().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -646,7 +646,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 100;
         element.WidthUnits = DimensionUnitType.PercentageOfOtherDimension;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -658,10 +658,10 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 100;
         element.WidthUnits = DimensionUnitType.PercentageOfOtherDimension;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
 
         element.Height = 300;
-        element.GetAbsoluteWidth().ShouldBe(300);
+        element.AbsoluteWidth.ShouldBe(300);
     }
 
     #endregion
@@ -677,7 +677,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 100;
         element.HeightUnits = DimensionUnitType.AbsoluteMultipliedByFontScale;
 
-        element.GetAbsoluteHeight().ShouldBe(150);
+        element.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -689,7 +689,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 100;
         element.HeightUnits = DimensionUnitType.AbsoluteMultipliedByFontScale;
 
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -701,7 +701,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 100;
         element.WidthUnits = DimensionUnitType.AbsoluteMultipliedByFontScale;
 
-        element.GetAbsoluteWidth().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -713,7 +713,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Width = 100;
         element.WidthUnits = DimensionUnitType.AbsoluteMultipliedByFontScale;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -738,8 +738,8 @@ public class LayoutUnitTests : BaseTestClass
         child2.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(child2);
 
-        child1.GetAbsoluteHeight().ShouldBe(100);
-        child2.GetAbsoluteHeight().ShouldBe(200);
+        child1.AbsoluteHeight.ShouldBe(100);
+        child2.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -760,7 +760,7 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteHeight().ShouldBe(200);
+        ratioChild.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -781,7 +781,7 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteHeight().ShouldBe(150);
+        ratioChild.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -806,9 +806,9 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child3);
 
-        child1.GetAbsoluteWidth().ShouldBe(100);
-        child2.GetAbsoluteWidth().ShouldBe(100);
-        child3.GetAbsoluteWidth().ShouldBe(100);
+        child1.AbsoluteWidth.ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(100);
+        child3.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -833,9 +833,9 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child3);
 
-        child1.GetAbsoluteWidth().ShouldBe(100);
-        child2.GetAbsoluteWidth().ShouldBe(200);
-        child3.GetAbsoluteWidth().ShouldBe(300);
+        child1.AbsoluteWidth.ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(200);
+        child3.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -861,8 +861,8 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child3);
 
-        child1.GetAbsoluteWidth().ShouldBe(150);
-        child3.GetAbsoluteWidth().ShouldBe(150);
+        child1.AbsoluteWidth.ShouldBe(150);
+        child3.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -882,7 +882,7 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteWidth().ShouldBe(0);
+        ratioChild.AbsoluteWidth.ShouldBe(0);
     }
 
     #endregion
@@ -1447,7 +1447,7 @@ public class LayoutUnitTests : BaseTestClass
 
         child1.AbsoluteTop.ShouldBe(0);
         child2.AbsoluteTop.ShouldBe(100);
-        child2.GetAbsoluteHeight().ShouldBe(200);
+        child2.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -1708,7 +1708,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // Parent height should be: 25 + (0 + 25) * 2 = 75
-        parent.GetAbsoluteHeight().ShouldBe(75);
+        parent.AbsoluteHeight.ShouldBe(75);
     }
 
     [Fact]
@@ -1766,7 +1766,7 @@ public class LayoutUnitTests : BaseTestClass
 
         child1.AbsoluteLeft.ShouldBe(0);
         child2.AbsoluteLeft.ShouldBe(100);
-        child2.GetAbsoluteWidth().ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -2129,7 +2129,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteHeight().ShouldBe(120);
+        parent.AbsoluteHeight.ShouldBe(120);
     }
 
     [Fact]
@@ -2157,7 +2157,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // 50 + 10 + 50 + 10 + 50 = 170
-        parent.GetAbsoluteHeight().ShouldBe(170);
+        parent.AbsoluteHeight.ShouldBe(170);
     }
 
     [Fact]
@@ -2183,7 +2183,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteHeight().ShouldBe(150);
+        parent.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -2211,7 +2211,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // 50 + 10 + 50 + 10 + 50 = 170
-        parent.GetAbsoluteWidth().ShouldBe(170);
+        parent.AbsoluteWidth.ShouldBe(170);
     }
 
     [Fact]
@@ -2237,7 +2237,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -2271,7 +2271,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteWidth().ShouldBe(450);
+        parent.AbsoluteWidth.ShouldBe(450);
     }
 
     [Fact]
@@ -2304,7 +2304,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteHeight().ShouldBe(450);
+        parent.AbsoluteHeight.ShouldBe(450);
     }
 
     [Fact]
@@ -2329,7 +2329,7 @@ public class LayoutUnitTests : BaseTestClass
         child.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(44);
+        parent.AbsoluteHeight.ShouldBe(44);
     }
 
     [Fact]
@@ -2398,7 +2398,7 @@ public class LayoutUnitTests : BaseTestClass
         child.XUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(44);
+        parent.AbsoluteWidth.ShouldBe(44);
     }
 
     [Fact]
@@ -2430,7 +2430,7 @@ public class LayoutUnitTests : BaseTestClass
         child3.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child3);
 
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
     }
 
     [Fact]
@@ -2452,14 +2452,14 @@ public class LayoutUnitTests : BaseTestClass
         child2.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteWidth().ShouldBe(57);
+        parent.AbsoluteWidth.ShouldBe(57);
 
         child2.Visible = false;
-        var widthWithLastHidden = parent.GetAbsoluteWidth();
+        var widthWithLastHidden = parent.AbsoluteWidth;
         child2.Visible = true;
 
         child1.Visible = false;
-        var widthWithFirstHidden = parent.GetAbsoluteWidth();
+        var widthWithFirstHidden = parent.AbsoluteWidth;
 
         widthWithFirstHidden.ShouldBe(widthWithLastHidden);
         widthWithFirstHidden.ShouldBe(21);
@@ -2485,16 +2485,16 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Both visible: 21 + 15 + 21 = 57
-        parent.GetAbsoluteHeight().ShouldBe(57);
+        parent.AbsoluteHeight.ShouldBe(57);
 
         // Hide last child -> only child1 contributes -> 21
         child2.Visible = false;
-        var heightWithLastHidden = parent.GetAbsoluteHeight();
+        var heightWithLastHidden = parent.AbsoluteHeight;
         child2.Visible = true;
 
         // Hide first child -> only child2 contributes -> should also be 21
         child1.Visible = false;
-        var heightWithFirstHidden = parent.GetAbsoluteHeight();
+        var heightWithFirstHidden = parent.AbsoluteHeight;
 
         heightWithFirstHidden.ShouldBe(heightWithLastHidden);
         heightWithFirstHidden.ShouldBe(21);
@@ -2649,10 +2649,10 @@ public class LayoutUnitTests : BaseTestClass
         child.X = 0;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
 
         child.X = 50;
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -2667,10 +2667,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
 
         child.Width = 200;
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -2690,10 +2690,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        grandparent.GetAbsoluteWidth().ShouldBe(100);
+        grandparent.AbsoluteWidth.ShouldBe(100);
 
         child.Width = 200;
-        grandparent.GetAbsoluteWidth().ShouldBe(200);
+        grandparent.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -2713,7 +2713,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(100);
+        child.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -2733,7 +2733,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(0);
+        child.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -2753,10 +2753,10 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        grandparent.GetAbsoluteHeight().ShouldBe(100);
+        grandparent.AbsoluteHeight.ShouldBe(100);
 
         child.Height = 150;
-        grandparent.GetAbsoluteHeight().ShouldBe(150);
+        grandparent.AbsoluteHeight.ShouldBe(150);
     }
 
     [Fact]
@@ -2777,7 +2777,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // parent = 400 - 50 = 350, child = 350 - 50 = 300
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -2792,10 +2792,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         parent.Width = 600;
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -2810,10 +2810,10 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.RelativeToParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
 
         parent.Width = 500;
-        child.GetAbsoluteWidth().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(400);
     }
 
     #endregion
@@ -2970,13 +2970,13 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         GraphicalUiElement.IsAllLayoutSuspended = true;
         parent.Width = 600;
 
         // Layout should NOT have updated
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -2997,7 +2997,7 @@ public class LayoutUnitTests : BaseTestClass
         GraphicalUiElement.IsAllLayoutSuspended = false;
         parent.UpdateLayout();
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -3016,11 +3016,11 @@ public class LayoutUnitTests : BaseTestClass
         parent.Width = 600;
 
         // Layout not yet updated during suspension
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         parent.ResumeLayout();
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -3033,7 +3033,7 @@ public class LayoutUnitTests : BaseTestClass
         // Should not throw
         element.ResumeLayout();
 
-        element.GetAbsoluteWidth().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -3048,13 +3048,13 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         parent.SuspendLayout();
         parent.Width = 800;
 
         // Layout should NOT have updated during suspension
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -3079,7 +3079,7 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteWidth().ShouldBe(300);
+        ratioChild.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -3100,8 +3100,8 @@ public class LayoutUnitTests : BaseTestClass
         child2.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child2);
 
-        child1.GetAbsoluteWidth().ShouldBe(100);
-        child2.GetAbsoluteWidth().ShouldBe(200);
+        child1.AbsoluteWidth.ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -3122,8 +3122,8 @@ public class LayoutUnitTests : BaseTestClass
         child2.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(child2);
 
-        child1.GetAbsoluteHeight().ShouldBe(100);
-        child2.GetAbsoluteHeight().ShouldBe(200);
+        child1.AbsoluteHeight.ShouldBe(100);
+        child2.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -3144,7 +3144,7 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteHeight().ShouldBe(300);
+        ratioChild.AbsoluteHeight.ShouldBe(300);
     }
 
     [Fact]
@@ -3165,10 +3165,10 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.HeightUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        ratioChild.GetAbsoluteHeight().ShouldBe(300);
+        ratioChild.AbsoluteHeight.ShouldBe(300);
 
         absoluteChild.Height = 200;
-        ratioChild.GetAbsoluteHeight().ShouldBe(200);
+        ratioChild.AbsoluteHeight.ShouldBe(200);
     }
 
     #endregion
@@ -3282,7 +3282,7 @@ public class LayoutUnitTests : BaseTestClass
         invisibleChild.Visible = false;
         parent.AddChild(invisibleChild);
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -3335,12 +3335,12 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child3);
 
-        child1.GetAbsoluteWidth().ShouldBe(100);
+        child1.AbsoluteWidth.ShouldBe(100);
 
         child3.Visible = false;
         // Space now split between two visible children
-        child1.GetAbsoluteWidth().ShouldBe(150);
-        child2.GetAbsoluteWidth().ShouldBe(150);
+        child1.AbsoluteWidth.ShouldBe(150);
+        child2.AbsoluteWidth.ShouldBe(150);
     }
 
     #endregion
@@ -3371,13 +3371,13 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(ratioChild);
 
         absoluteChild.AbsoluteTop.ShouldBe(0);
-        absoluteChild.GetAbsoluteHeight().ShouldBe(100);
+        absoluteChild.AbsoluteHeight.ShouldBe(100);
 
         percentChild.AbsoluteTop.ShouldBe(100);
-        percentChild.GetAbsoluteHeight().ShouldBe(100);
+        percentChild.AbsoluteHeight.ShouldBe(100);
 
         ratioChild.AbsoluteTop.ShouldBe(200);
-        ratioChild.GetAbsoluteHeight().ShouldBe(200);
+        ratioChild.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -3397,8 +3397,8 @@ public class LayoutUnitTests : BaseTestClass
         percentChild.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(percentChild);
 
-        absoluteChild.GetAbsoluteWidth().ShouldBe(150);
-        percentChild.GetAbsoluteWidth().ShouldBe(200);
+        absoluteChild.AbsoluteWidth.ShouldBe(150);
+        percentChild.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -3418,8 +3418,8 @@ public class LayoutUnitTests : BaseTestClass
         ratioChild.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(ratioChild);
 
-        absoluteChild.GetAbsoluteWidth().ShouldBe(100);
-        ratioChild.GetAbsoluteWidth().ShouldBe(300);
+        absoluteChild.AbsoluteWidth.ShouldBe(100);
+        ratioChild.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -3439,8 +3439,8 @@ public class LayoutUnitTests : BaseTestClass
         relativeChild.WidthUnits = DimensionUnitType.RelativeToParent;
         parent.AddChild(relativeChild);
 
-        percentChild.GetAbsoluteWidth().ShouldBe(200);
-        relativeChild.GetAbsoluteWidth().ShouldBe(300);
+        percentChild.AbsoluteWidth.ShouldBe(200);
+        relativeChild.AbsoluteWidth.ShouldBe(300);
     }
 
     #endregion
@@ -3459,8 +3459,8 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 50;
         element.HeightUnits = DimensionUnitType.PercentageOfParent;
 
-        element.GetAbsoluteWidth().ShouldBe(512);
-        element.GetAbsoluteHeight().ShouldBe(384);
+        element.AbsoluteWidth.ShouldBe(512);
+        element.AbsoluteHeight.ShouldBe(384);
     }
 
     [Fact]
@@ -3475,8 +3475,8 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = -100;
         element.HeightUnits = DimensionUnitType.RelativeToParent;
 
-        element.GetAbsoluteWidth().ShouldBe(924);
-        element.GetAbsoluteHeight().ShouldBe(668);
+        element.AbsoluteWidth.ShouldBe(924);
+        element.AbsoluteHeight.ShouldBe(668);
     }
 
     #endregion
@@ -3493,8 +3493,8 @@ public class LayoutUnitTests : BaseTestClass
         orphan.HeightUnits = DimensionUnitType.Absolute;
 
         // Should not throw
-        orphan.GetAbsoluteWidth().ShouldBe(100);
-        orphan.GetAbsoluteHeight().ShouldBe(100);
+        orphan.AbsoluteWidth.ShouldBe(100);
+        orphan.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -3523,7 +3523,7 @@ public class LayoutUnitTests : BaseTestClass
             expectedWidth *= 0.5f;
         }
 
-        current.GetAbsoluteWidth().ShouldBe(expectedWidth);
+        current.AbsoluteWidth.ShouldBe(expectedWidth);
     }
 
     [Fact]
@@ -3542,8 +3542,8 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(0);
-        child.GetAbsoluteHeight().ShouldBe(0);
+        child.AbsoluteWidth.ShouldBe(0);
+        child.AbsoluteHeight.ShouldBe(0);
     }
 
     [Fact]
@@ -3562,8 +3562,8 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.RelativeToParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(-10);
-        child.GetAbsoluteHeight().ShouldBe(-10);
+        child.AbsoluteWidth.ShouldBe(-10);
+        child.AbsoluteHeight.ShouldBe(-10);
     }
 
     [Fact]
@@ -3579,7 +3579,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 50 + (-100) = -50
-        child.GetAbsoluteHeight().ShouldBe(-50);
+        child.AbsoluteHeight.ShouldBe(-50);
     }
 
     [Fact]
@@ -3595,7 +3595,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 50 + (-100) = -50
-        child.GetAbsoluteWidth().ShouldBe(-50);
+        child.AbsoluteWidth.ShouldBe(-50);
     }
 
     [Fact]
@@ -3611,14 +3611,14 @@ public class LayoutUnitTests : BaseTestClass
         child1.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child1);
 
-        parent.GetAbsoluteHeight().ShouldBe(50);
+        parent.AbsoluteHeight.ShouldBe(50);
 
         ContainerRuntime child2 = new();
         child2.Height = 50;
         child2.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -3677,7 +3677,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Only child1 contributes to parent height
-        parent.GetAbsoluteHeight().ShouldBe(80);
+        parent.AbsoluteHeight.ShouldBe(80);
     }
 
     [Fact]
@@ -3700,9 +3700,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Only child1 contributes to parent width
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
         // Child2 gets 50% of parent (100)
-        child2.GetAbsoluteWidth().ShouldBe(50);
+        child2.AbsoluteWidth.ShouldBe(50);
     }
 
     [Fact]
@@ -3725,9 +3725,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Only child1 contributes to parent width
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
         // Child2 gets parent(150) - 50 = 100
-        child2.GetAbsoluteWidth().ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -3750,7 +3750,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Only child1 contributes; ratio children are excluded
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -3773,7 +3773,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // No absolute children -> parent width is just the padding (0)
-        parent.GetAbsoluteWidth().ShouldBe(0);
+        parent.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -3790,7 +3790,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -3821,7 +3821,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child2 extends from 100 to 150, so parent should be 150
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -3843,7 +3843,7 @@ public class LayoutUnitTests : BaseTestClass
         // Child extends from -20 to 80. The engine computes parent width
         // based on the rightmost edge of children. With XOrigin=Left (default),
         // the child's right edge is at -20+100=80, so parent width = 80.
-        parent.GetAbsoluteWidth().ShouldBe(80);
+        parent.AbsoluteWidth.ShouldBe(80);
     }
 
     [Fact]
@@ -3866,7 +3866,7 @@ public class LayoutUnitTests : BaseTestClass
         // and starts at width=0, the child at X=0 from large edge sits at position 0.
         // The engine does not count PixelsFromLarge children toward parent sizing
         // because the position depends on the parent's width (circular).
-        parent.GetAbsoluteWidth().ShouldBe(0);
+        parent.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -3889,7 +3889,7 @@ public class LayoutUnitTests : BaseTestClass
         // PixelsFromMiddle uses 2*max(abs(smallEdge), abs(bigEdge)) formula
         // SmallEdge = 50, BigEdge = 50+100 = 150
         // Parent width = 2 * max(50, 150) = 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
     }
 
     #endregion
@@ -3906,8 +3906,8 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.PercentageOfOtherDimension;
 
         // Both depend on each other -> engine falls back to raw pixel values
-        element.GetAbsoluteWidth().ShouldBe(100);
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(100);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -3927,9 +3927,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child height = 50% of 200 = 100
-        child.GetAbsoluteHeight().ShouldBe(100);
+        child.AbsoluteHeight.ShouldBe(100);
         // Parent height should be 100 (RelativeToChildren)
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -3949,11 +3949,11 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child width = 50% of 400 = 200
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
         // Child height = 100% of child width = 200
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
         // Parent height = 200 (RelativeToChildren)
-        parent.GetAbsoluteHeight().ShouldBe(200);
+        parent.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -3966,11 +3966,11 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.PercentageOfOtherDimension;
 
         // Height = 100% of 200 = 200
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
 
         // Change width -> height should update
         element.Width = 300;
-        element.GetAbsoluteHeight().ShouldBe(300);
+        element.AbsoluteHeight.ShouldBe(300);
     }
 
     [Fact]
@@ -3998,9 +3998,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child2 width = ratio gets remaining 300
-        child2.GetAbsoluteWidth().ShouldBe(300);
+        child2.AbsoluteWidth.ShouldBe(300);
         // Child2 height = 50% of 300 = 150
-        child2.GetAbsoluteHeight().ShouldBe(150);
+        child2.AbsoluteHeight.ShouldBe(150);
     }
 
     #endregion
@@ -4031,7 +4031,7 @@ public class LayoutUnitTests : BaseTestClass
         // Document whatever the engine actually returns.
         // In a non-stacked parent, ratio children may get the full parent height
         // since there is no stacking to subtract absolute siblings from.
-        float child2Height = child2.GetAbsoluteHeight();
+        float child2Height = child2.AbsoluteHeight;
         child2Height.ShouldBeGreaterThanOrEqualTo(0);
     }
 
@@ -4058,9 +4058,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child1 width = 50% of height(100) = 50
-        child1.GetAbsoluteWidth().ShouldBe(50);
+        child1.AbsoluteWidth.ShouldBe(50);
         // Ratio child gets 1000 - 50 = 950
-        child2.GetAbsoluteWidth().ShouldBe(950);
+        child2.AbsoluteWidth.ShouldBe(950);
     }
 
     [Fact]
@@ -4084,9 +4084,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child1 = 10% of 1000 = 100
-        child1.GetAbsoluteWidth().ShouldBe(100);
+        child1.AbsoluteWidth.ShouldBe(100);
         // Ratio gets 1000 - 100 = 900
-        child2.GetAbsoluteWidth().ShouldBe(900);
+        child2.AbsoluteWidth.ShouldBe(900);
     }
 
     [Fact]
@@ -4110,9 +4110,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child1 = 1000 - 800 = 200
-        child1.GetAbsoluteWidth().ShouldBe(200);
+        child1.AbsoluteWidth.ShouldBe(200);
         // Ratio gets 1000 - 200 = 800
-        child2.GetAbsoluteWidth().ShouldBe(800);
+        child2.AbsoluteWidth.ShouldBe(800);
     }
 
     [Fact]
@@ -4140,9 +4140,9 @@ public class LayoutUnitTests : BaseTestClass
         child3.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child3);
 
-        child1.GetAbsoluteWidth().ShouldBe(100);
-        child2.GetAbsoluteWidth().ShouldBe(200);
-        child3.GetAbsoluteWidth().ShouldBe(300);
+        child1.AbsoluteWidth.ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(200);
+        child3.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -4172,9 +4172,9 @@ public class LayoutUnitTests : BaseTestClass
 
         // Each gets ~33.333...
         float expectedWidth = 100f / 3f;
-        child1.GetAbsoluteWidth().ShouldBe(expectedWidth, 0.01f);
-        child2.GetAbsoluteWidth().ShouldBe(expectedWidth, 0.01f);
-        child3.GetAbsoluteWidth().ShouldBe(expectedWidth, 0.01f);
+        child1.AbsoluteWidth.ShouldBe(expectedWidth, 0.01f);
+        child2.AbsoluteWidth.ShouldBe(expectedWidth, 0.01f);
+        child3.AbsoluteWidth.ShouldBe(expectedWidth, 0.01f);
     }
 
     [Fact]
@@ -4192,7 +4192,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Ratio;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(500);
+        child.AbsoluteWidth.ShouldBe(500);
     }
 
     [Fact]
@@ -4216,8 +4216,8 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Zero-ratio child gets 0, the other gets everything
-        child1.GetAbsoluteWidth().ShouldBe(0);
-        child2.GetAbsoluteWidth().ShouldBe(500);
+        child1.AbsoluteWidth.ShouldBe(0);
+        child2.AbsoluteWidth.ShouldBe(500);
     }
 
     #endregion
@@ -4281,8 +4281,8 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // 500 - 100 = 400 remaining, split between 2 ratio children
-        child2.GetAbsoluteWidth().ShouldBe(200);
-        child3.GetAbsoluteWidth().ShouldBe(200);
+        child2.AbsoluteWidth.ShouldBe(200);
+        child3.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -4303,7 +4303,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Width should be 50% of 400 = 200
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
         // Should be positioned normally in stack at Y=0
         child.AbsoluteTop.ShouldBe(0);
     }
@@ -4357,7 +4357,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Should not crash, parent should still be 400
-        parent.GetAbsoluteHeight().ShouldBe(400);
+        parent.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -4442,8 +4442,8 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // 300 - 100 = 200 remaining, split between 2 ratio children
-        child2.GetAbsoluteHeight().ShouldBe(100);
-        child3.GetAbsoluteHeight().ShouldBe(100);
+        child2.AbsoluteHeight.ShouldBe(100);
+        child3.AbsoluteHeight.ShouldBe(100);
     }
 
     #endregion
@@ -4485,7 +4485,7 @@ public class LayoutUnitTests : BaseTestClass
         // Row1: child1(80)+child2(80)=160 < 200, max height 60
         // Row2: child3(80), height 40
         // Parent height = 60 + 40 = 100
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -4522,7 +4522,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Row1: child1+child2 = 160 < 200, Row2: child3
         // Parent height = 50 + 50 = 100
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -4545,7 +4545,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Child wider than parent should not cause infinite loop.
         // Child stays on first row.
-        child.GetAbsoluteWidth().ShouldBe(150);
+        child.AbsoluteWidth.ShouldBe(150);
         child.AbsoluteTop.ShouldBe(0);
     }
 
@@ -4583,7 +4583,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Col1: child1+child2 = 160 < 200, Col2: child3
         // Parent width = 50 + 50 = 100
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     #endregion
@@ -4604,18 +4604,18 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         GraphicalUiElement.IsAllLayoutSuspended = true;
         parent.Width = 600;
 
         // Layout not updated while globally suspended
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         GraphicalUiElement.IsAllLayoutSuspended = false;
         parent.ResumeLayout(recursive: true);
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -4637,17 +4637,17 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         grandparent.SuspendLayout(recursive: true);
         grandparent.Width = 600;
 
         // Layout not updated during suspension
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         grandparent.ResumeLayout(recursive: true);
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -4666,8 +4666,8 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
 
         parent.SuspendLayout();
 
@@ -4676,14 +4676,14 @@ public class LayoutUnitTests : BaseTestClass
         parent.Height = 800;
 
         // Still old values
-        child.GetAbsoluteWidth().ShouldBe(200);
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
 
         parent.ResumeLayout();
 
         // All changes applied at once
-        child.GetAbsoluteWidth().ShouldBe(300);
-        child.GetAbsoluteHeight().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(300);
+        child.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -4742,9 +4742,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Child2 width = ratio gets 400
-        child2.GetAbsoluteWidth().ShouldBe(400);
+        child2.AbsoluteWidth.ShouldBe(400);
         // Child2 height = 50% of 400 = 200
-        child2.GetAbsoluteHeight().ShouldBe(200);
+        child2.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -4764,9 +4764,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child height = 50% of 400 = 200
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
         // Child width = 100% of height = 200
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -4786,9 +4786,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child height = 400 - 100 = 300
-        child.GetAbsoluteHeight().ShouldBe(300);
+        child.AbsoluteHeight.ShouldBe(300);
         // Child width = 50% of 300 = 150
-        child.GetAbsoluteWidth().ShouldBe(150);
+        child.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -4808,9 +4808,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent width = 200 (from child)
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
         // Child height = 50% of 200 = 100
-        child.GetAbsoluteHeight().ShouldBe(100);
+        child.AbsoluteHeight.ShouldBe(100);
     }
 
     #endregion
@@ -4849,9 +4849,9 @@ public class LayoutUnitTests : BaseTestClass
         outer.AddChild(inner2);
 
         // Inner1 should size to its child = 80
-        inner1.GetAbsoluteWidth().ShouldBe(80);
+        inner1.AbsoluteWidth.ShouldBe(80);
         // Inner2 gets remaining 500 - 80 = 420
-        inner2.GetAbsoluteWidth().ShouldBe(420);
+        inner2.AbsoluteWidth.ShouldBe(420);
     }
 
     [Fact]
@@ -4886,9 +4886,9 @@ public class LayoutUnitTests : BaseTestClass
         outer.AddChild(child2);
 
         // Child1 = grandchild(50) + padding(10) = 60
-        child1.GetAbsoluteWidth().ShouldBe(60);
+        child1.AbsoluteWidth.ShouldBe(60);
         // Child2 = 500 - 60 = 440
-        child2.GetAbsoluteWidth().ShouldBe(440);
+        child2.AbsoluteWidth.ShouldBe(440);
     }
 
     [Fact]
@@ -4917,7 +4917,7 @@ public class LayoutUnitTests : BaseTestClass
         // Grandparent has RelativeToChildren, but its only direct child (parent) uses
         // PercentageOfParent, which is ignored for sizing. So grandparent has
         // no absolute direct children contributing to its width -> width = 0.
-        grandparent.GetAbsoluteWidth().ShouldBe(0);
+        grandparent.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -4952,11 +4952,11 @@ public class LayoutUnitTests : BaseTestClass
         parent2.AddChild(grandchild);
 
         // Parent2 width = ratio gets 400
-        parent2.GetAbsoluteWidth().ShouldBe(400);
+        parent2.AbsoluteWidth.ShouldBe(400);
         // Grandchild width = parent2(400) + 0 = 400
-        grandchild.GetAbsoluteWidth().ShouldBe(400);
+        grandchild.AbsoluteWidth.ShouldBe(400);
         // Grandchild height = 50% of 400 = 200
-        grandchild.GetAbsoluteHeight().ShouldBe(200);
+        grandchild.AbsoluteHeight.ShouldBe(200);
     }
 
     #endregion
@@ -5008,15 +5008,15 @@ public class LayoutUnitTests : BaseTestClass
         child.Dock(Gum.Wireframe.Dock.Fill);
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(400);
-        child.GetAbsoluteHeight().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(400);
+        child.AbsoluteHeight.ShouldBe(300);
 
         // Resize parent
         parent.Width = 600;
         parent.Height = 400;
 
-        child.GetAbsoluteWidth().ShouldBe(600);
-        child.GetAbsoluteHeight().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(600);
+        child.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -5040,8 +5040,8 @@ public class LayoutUnitTests : BaseTestClass
         child.AddChild(grandchild);
 
         // SizeToChildren sets both Width and Height to RelativeToChildren
-        child.GetAbsoluteWidth().ShouldBe(100);
-        child.GetAbsoluteHeight().ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(100);
+        child.AbsoluteHeight.ShouldBe(50);
     }
 
     #endregion
@@ -5068,7 +5068,7 @@ public class LayoutUnitTests : BaseTestClass
         child2.IgnoredByParentSize = true;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -5091,7 +5091,7 @@ public class LayoutUnitTests : BaseTestClass
         child2.IgnoredByParentSize = true;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -5246,12 +5246,12 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        child.GetAbsoluteHeight().ShouldBe(50);
+        child.AbsoluteHeight.ShouldBe(50);
 
         // Change units to PercentageOfParent -> 50% of 400 = 200
         child.HeightUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteHeight().ShouldBe(200);
+        child.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -5313,12 +5313,12 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(50);
 
         // Change units to PercentageOfParent -> 50% of 400 = 200
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -5335,12 +5335,12 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
 
         // Change parent width to 600
         parent.Width = 600;
 
-        child.GetAbsoluteWidth().ShouldBe(300);
+        child.AbsoluteWidth.ShouldBe(300);
     }
 
     #endregion
@@ -5381,8 +5381,8 @@ public class LayoutUnitTests : BaseTestClass
 
         // Available = 400 - 100 (absolute) - 2*10 (2 spacing gaps between 3 children) = 280
         // Each ratio child gets 140
-        child2.GetAbsoluteWidth().ShouldBe(140);
-        child3.GetAbsoluteWidth().ShouldBe(140);
+        child2.AbsoluteWidth.ShouldBe(140);
+        child3.AbsoluteWidth.ShouldBe(140);
     }
 
     [Fact]
@@ -5419,8 +5419,8 @@ public class LayoutUnitTests : BaseTestClass
 
         // Available = 300 - 50 (absolute) - 2*10 (2 spacing gaps between 3 children) = 230
         // Each ratio child gets 115
-        child2.GetAbsoluteHeight().ShouldBe(115);
-        child3.GetAbsoluteHeight().ShouldBe(115);
+        child2.AbsoluteHeight.ShouldBe(115);
+        child3.AbsoluteHeight.ShouldBe(115);
     }
 
     [Fact]
@@ -5449,8 +5449,8 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Available = 100 - 100 (1 gap) = 0 -> each gets 0
-        child1.GetAbsoluteWidth().ShouldBe(0);
-        child2.GetAbsoluteWidth().ShouldBe(0);
+        child1.AbsoluteWidth.ShouldBe(0);
+        child2.AbsoluteWidth.ShouldBe(0);
     }
 
     #endregion
@@ -5473,7 +5473,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Height = 200;
 
         // 200% of source height 100 = 200
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -5492,7 +5492,7 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.PercentageOfSourceFile;
 
         // 100% of source height 100 = 100
-        element.GetAbsoluteHeight().ShouldBe(100);
+        element.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -5511,7 +5511,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.PercentageOfSourceFile;
 
         // 50% of source width 200 = 100
-        element.GetAbsoluteWidth().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -5530,7 +5530,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.PercentageOfSourceFile;
 
         // 100% of source width 200 = 200
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -5557,7 +5557,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Height = sourceHeight * (absoluteWidth / sourceWidth) * mHeight / 100
         // = 100 * (400 / 200) * 100 / 100 = 200
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -5580,7 +5580,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Height = sourceHeight * (absoluteWidth / sourceWidth) * mHeight / 100
         // = 200 * (200 / 100) * 100 / 100 = 400
-        element.GetAbsoluteHeight().ShouldBe(400);
+        element.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -5603,7 +5603,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Height = sourceHeight * (absoluteWidth / sourceWidth) * mHeight / 100
         // = 100 * (200 / 100) * 100 / 100 = 200
-        element.GetAbsoluteHeight().ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(200);
     }
 
     [Fact]
@@ -5626,7 +5626,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Width = sourceWidth * (absoluteHeight / sourceHeight) * mWidth / 100
         // = 200 * (200 / 100) * 100 / 100 = 400
-        element.GetAbsoluteWidth().ShouldBe(400);
+        element.AbsoluteWidth.ShouldBe(400);
     }
 
     #endregion
@@ -5660,7 +5660,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // child1 width = 50 * 2 = 100
-        child1.GetAbsoluteWidth().ShouldBe(100);
+        child1.AbsoluteWidth.ShouldBe(100);
         // child2 position after scaled child1
         child2.AbsoluteLeft.ShouldBe(100);
 
@@ -5694,7 +5694,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // child1 height = 50 * 2 = 100
-        child1.GetAbsoluteHeight().ShouldBe(100);
+        child1.AbsoluteHeight.ShouldBe(100);
         // child2 position after scaled child1
         child2.AbsoluteTop.ShouldBe(100);
 
@@ -5729,7 +5729,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // child1 width = 100 * 2 = 200
         // child2 gets remaining = 400 - 200 = 200
-        child2.GetAbsoluteWidth().ShouldBe(200);
+        child2.AbsoluteWidth.ShouldBe(200);
 
         GraphicalUiElement.GlobalFontScale = 1;
     }
@@ -5759,13 +5759,13 @@ public class LayoutUnitTests : BaseTestClass
         parent1.AddChild(child);
 
         // 50% of 200 = 100
-        child.GetAbsoluteWidth().ShouldBe(100);
+        child.AbsoluteWidth.ShouldBe(100);
 
         // Move child to parent2
         child.Parent = parent2;
 
         // 50% of 400 = 200
-        child.GetAbsoluteWidth().ShouldBe(200);
+        child.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -5788,14 +5788,14 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.Absolute;
         parent1.AddChild(child);
 
-        parent1.GetAbsoluteWidth().ShouldBe(100);
+        parent1.AbsoluteWidth.ShouldBe(100);
 
         // Move child to parent2
         child.Parent = parent2;
         parent1.UpdateLayout();
 
         // Parent1 has no children, so RelativeToChildren width = 0
-        parent1.GetAbsoluteWidth().ShouldBe(0);
+        parent1.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -5822,13 +5822,13 @@ public class LayoutUnitTests : BaseTestClass
         child2.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child2);
 
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
 
         // Remove child2
         child2.Parent = null;
         parent.UpdateLayout();
 
-        parent.GetAbsoluteHeight().ShouldBe(50);
+        parent.AbsoluteHeight.ShouldBe(50);
     }
 
     #endregion
@@ -5860,9 +5860,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Width = widest child = 120
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
         // Height = sum of stacked children = 100
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -5884,9 +5884,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent width = X + Width = 10 + 150 = 160
-        parent.GetAbsoluteWidth().ShouldBe(160);
+        parent.AbsoluteWidth.ShouldBe(160);
         // Parent height = Y + Height = 20 + 80 = 100
-        parent.GetAbsoluteHeight().ShouldBe(100);
+        parent.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -5917,9 +5917,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Parent width = max(0+100, 30+80) = 110
-        parent.GetAbsoluteWidth().ShouldBe(110);
+        parent.AbsoluteWidth.ShouldBe(110);
         // Parent height = max(0+50, 10+120) = 130
-        parent.GetAbsoluteHeight().ShouldBe(130);
+        parent.AbsoluteHeight.ShouldBe(130);
     }
 
     [Fact]
@@ -5939,9 +5939,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent width = 100 + 20 = 120
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
         // Parent height = 50 + 10 = 60
-        parent.GetAbsoluteHeight().ShouldBe(60);
+        parent.AbsoluteHeight.ShouldBe(60);
     }
 
     #endregion
@@ -6128,7 +6128,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.WidthUnits = DimensionUnitType.RelativeToChildren;
         parent.Width = 0;
 
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     [Fact]
@@ -6147,7 +6147,7 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteWidth().ShouldBe(150);
+        parent.AbsoluteWidth.ShouldBe(150);
     }
 
     #endregion
@@ -6182,7 +6182,7 @@ public class LayoutUnitTests : BaseTestClass
         // child1 extends from middle+0 to middle+60, symmetric = 2*60 = 120
         // child2 extends from middle-50 to middle-10, symmetric = 2*50 = 100
         // Parent should use the larger symmetric bound = 120
-        parent.GetAbsoluteWidth().ShouldBe(120);
+        parent.AbsoluteWidth.ShouldBe(120);
     }
 
     [Fact]
@@ -6203,7 +6203,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Centered at middle: extends -50 to +50, symmetric = 2*50 = 100
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     #endregion
@@ -6227,9 +6227,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child height = 100% of width(300) = 300
-        child.GetAbsoluteHeight().ShouldBe(300);
+        child.AbsoluteHeight.ShouldBe(300);
         // Parent height = 300
-        parent.GetAbsoluteHeight().ShouldBe(300);
+        parent.AbsoluteHeight.ShouldBe(300);
     }
 
     [Fact]
@@ -6249,9 +6249,9 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child width = 50% of height(200) = 100
-        child.GetAbsoluteWidth().ShouldBe(100);
+        child.AbsoluteWidth.ShouldBe(100);
         // Parent width = 100
-        parent.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
     }
 
     #endregion
@@ -6283,7 +6283,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // child2 width = 25% of parent(400) = 100, not 25% of remaining space
-        child2.GetAbsoluteWidth().ShouldBe(100);
+        child2.AbsoluteWidth.ShouldBe(100);
         // child2 starts after child1
         child2.AbsoluteLeft.ShouldBe(100);
     }
@@ -6313,7 +6313,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // child2 height = 25% of parent(400) = 100, not 25% of remaining space
-        child2.GetAbsoluteHeight().ShouldBe(100);
+        child2.AbsoluteHeight.ShouldBe(100);
         // child2 starts after child1
         child2.AbsoluteTop.ShouldBe(100);
     }
@@ -6330,7 +6330,7 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.Absolute;
         element.MaxHeight = 300;
 
-        element.GetAbsoluteHeight().ShouldBe(300);
+        element.AbsoluteHeight.ShouldBe(300);
     }
 
     [Fact]
@@ -6349,7 +6349,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 80% of 1000 = 800, clamped to 400
-        child.GetAbsoluteHeight().ShouldBe(400);
+        child.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -6360,7 +6360,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
         element.MaxWidth = null;
 
-        element.GetAbsoluteWidth().ShouldBe(500);
+        element.AbsoluteWidth.ShouldBe(500);
     }
 
     [Fact]
@@ -6371,7 +6371,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
         element.MaxWidth = 300;
 
-        element.GetAbsoluteWidth().ShouldBe(300);
+        element.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -6390,7 +6390,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 80% of 1000 = 800, clamped to 400
-        child.GetAbsoluteWidth().ShouldBe(400);
+        child.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -6401,7 +6401,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
         element.MaxWidth = 500;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -6412,7 +6412,7 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.Absolute;
         element.MinHeight = 100;
 
-        element.GetAbsoluteHeight().ShouldBe(100);
+        element.AbsoluteHeight.ShouldBe(100);
     }
 
     [Fact]
@@ -6423,7 +6423,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
         element.MinWidth = 100;
 
-        element.GetAbsoluteWidth().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(100);
     }
 
     [Fact]
@@ -6434,7 +6434,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
         element.MinWidth = 100;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     [Fact]
@@ -6453,7 +6453,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // RelativeToParent: 200 + (-180) = 20, clamped to 50
-        child.GetAbsoluteWidth().ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(50);
     }
 
     #endregion
@@ -6475,7 +6475,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 200% of 400 = 800
-        child.GetAbsoluteWidth().ShouldBe(800);
+        child.AbsoluteWidth.ShouldBe(800);
     }
 
     [Fact]
@@ -6493,7 +6493,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // -50% of 400 = -200
-        child.GetAbsoluteWidth().ShouldBe(-200);
+        child.AbsoluteWidth.ShouldBe(-200);
     }
 
     [Fact]
@@ -6511,7 +6511,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // 0.1% of 1000 = 1
-        child.GetAbsoluteWidth().ShouldBe(1);
+        child.AbsoluteWidth.ShouldBe(1);
     }
 
     [Fact]
@@ -6528,7 +6528,7 @@ public class LayoutUnitTests : BaseTestClass
         child.WidthUnits = DimensionUnitType.PercentageOfParent;
         parent.AddChild(child);
 
-        child.GetAbsoluteWidth().ShouldBe(0);
+        child.AbsoluteWidth.ShouldBe(0);
     }
 
     #endregion
@@ -6627,9 +6627,9 @@ public class LayoutUnitTests : BaseTestClass
         inner.AddChild(child2);
 
         // Inner width = sum of children in LeftToRightStack = 80 + 60 = 140
-        inner.GetAbsoluteWidth().ShouldBe(140);
+        inner.AbsoluteWidth.ShouldBe(140);
         // Inner height = tallest child = 70
-        inner.GetAbsoluteHeight().ShouldBe(70);
+        inner.AbsoluteHeight.ShouldBe(70);
     }
 
     [Fact]
@@ -6666,7 +6666,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Inner width = 400 (RelativeToParent with 0 offset)
         // InnerChild1 = 100 absolute, InnerChild2 gets remaining = 300
-        innerChild2.GetAbsoluteWidth().ShouldBe(300);
+        innerChild2.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -6931,7 +6931,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent height = child height (100) + padding (-10) = 90
-        parent.GetAbsoluteHeight().ShouldBe(90);
+        parent.AbsoluteHeight.ShouldBe(90);
     }
 
     [Fact]
@@ -6951,7 +6951,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent width = child width (100) + padding (-10) = 90
-        parent.GetAbsoluteWidth().ShouldBe(90);
+        parent.AbsoluteWidth.ShouldBe(90);
     }
 
     #endregion
@@ -7079,7 +7079,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child2);
 
         // Invisible child1 is excluded, child2 gets full 400
-        child2.GetAbsoluteWidth().ShouldBe(400);
+        child2.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -7100,7 +7100,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Only child is invisible, parent width should be 0 (padding only)
-        parent.GetAbsoluteWidth().ShouldBe(0);
+        parent.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -7318,7 +7318,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Should not crash; the element has no renderable
         // Width may or may not be computed correctly, but it should not throw
-        Should.NotThrow(() => child.GetAbsoluteWidth());
+        Should.NotThrow(() => child.AbsoluteWidth);
     }
 
     [Fact]
@@ -7329,7 +7329,7 @@ public class LayoutUnitTests : BaseTestClass
         element.WidthUnits = DimensionUnitType.Absolute;
 
         // Should not crash even without a renderable
-        Should.NotThrow(() => element.GetAbsoluteWidth());
+        Should.NotThrow(() => element.AbsoluteWidth);
     }
 
     #endregion
@@ -7357,7 +7357,7 @@ public class LayoutUnitTests : BaseTestClass
     }
 
     [Fact]
-    public void Rotation_ShouldNotAffectGetAbsoluteWidth()
+    public void Rotation_ShouldNotAffectAbsoluteWidth()
     {
         ContainerRuntime element = new();
         element.Width = 200;
@@ -7367,7 +7367,7 @@ public class LayoutUnitTests : BaseTestClass
         element.Rotation = 45;
 
         // GetAbsoluteWidth returns the unrotated dimension
-        element.GetAbsoluteWidth().ShouldBe(200);
+        element.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -7384,8 +7384,8 @@ public class LayoutUnitTests : BaseTestClass
         element.HeightUnits = DimensionUnitType.Absolute;
         element.FlipHorizontal = true;
 
-        element.GetAbsoluteWidth().ShouldBe(200);
-        element.GetAbsoluteHeight().ShouldBe(100);
+        element.AbsoluteWidth.ShouldBe(200);
+        element.AbsoluteHeight.ShouldBe(100);
     }
 
     #endregion
@@ -7410,7 +7410,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Parent (400) > child (100), so element uses parent size
-        parent.GetAbsoluteWidth().ShouldBe(400);
+        parent.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -7431,7 +7431,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Child (500) > parent (200), so element uses children size
-        parent.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
     }
 
     [Fact]
@@ -7451,7 +7451,7 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(400);
+        parent.AbsoluteHeight.ShouldBe(400);
     }
 
     [Fact]
@@ -7471,7 +7471,7 @@ public class LayoutUnitTests : BaseTestClass
         child.HeightUnits = DimensionUnitType.Absolute;
         parent.AddChild(child);
 
-        parent.GetAbsoluteHeight().ShouldBe(500);
+        parent.AbsoluteHeight.ShouldBe(500);
     }
 
     #endregion
@@ -7499,7 +7499,7 @@ public class LayoutUnitTests : BaseTestClass
         // childrenBased: 300 + 20 = 320
         // parentBased: 200
         // max(200, 320) = 320
-        parent.GetAbsoluteWidth().ShouldBe(320);
+        parent.AbsoluteWidth.ShouldBe(320);
     }
 
     [Fact]
@@ -7522,7 +7522,7 @@ public class LayoutUnitTests : BaseTestClass
         // childrenBased: 100 + 20 = 120
         // parentBased: 400
         // max(400, 120) = 400
-        parent.GetAbsoluteWidth().ShouldBe(400);
+        parent.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -7545,14 +7545,14 @@ public class LayoutUnitTests : BaseTestClass
         // childrenBased: 380 + 50 = 430
         // parentBased: 400
         // max(400, 430) = 430 — children + padding wins
-        parent.GetAbsoluteWidth().ShouldBe(430);
+        parent.AbsoluteWidth.ShouldBe(430);
 
         // Now make child smaller so parent wins
         child.Width = 300;
         // childrenBased: 300 + 50 = 350
         // parentBased: 400
         // max(400, 350) = 400
-        parent.GetAbsoluteWidth().ShouldBe(400);
+        parent.AbsoluteWidth.ShouldBe(400);
     }
 
     #endregion
@@ -7572,7 +7572,7 @@ public class LayoutUnitTests : BaseTestClass
         grandparent.AddChild(parent);
 
         // No children, so max(400, 0) = 400
-        parent.GetAbsoluteWidth().ShouldBe(400);
+        parent.AbsoluteWidth.ShouldBe(400);
     }
 
     [Fact]
@@ -7587,7 +7587,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.HeightUnits = DimensionUnitType.RelativeToMaxParentOrChildren;
         grandparent.AddChild(parent);
 
-        parent.GetAbsoluteHeight().ShouldBe(300);
+        parent.AbsoluteHeight.ShouldBe(300);
     }
 
     #endregion
@@ -7613,7 +7613,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Invisible child excluded, falls back to parent size
-        parent.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
     }
 
     #endregion
@@ -7644,7 +7644,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // PercentageOfParent child excluded from children measurement (circular dep).
         // Only absoluteChild (100) contributes. max(300, 100) = 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -7671,7 +7671,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // RelativeToParent child excluded. Only absoluteChild (100) counts.
         // max(300, 100) = 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
     }
 
     #endregion
@@ -7704,7 +7704,7 @@ public class LayoutUnitTests : BaseTestClass
 
         // Ratio sibling should subtract maxChild's absolute width (600) from parent (600).
         // Remaining = 0
-        ratioChild.GetAbsoluteWidth().ShouldBe(0);
+        ratioChild.AbsoluteWidth.ShouldBe(0);
     }
 
     #endregion
@@ -7736,9 +7736,9 @@ public class LayoutUnitTests : BaseTestClass
         element.AddChild(wideChild);
 
         // Width: max(300, 500) = 500
-        element.GetAbsoluteWidth().ShouldBe(500);
+        element.AbsoluteWidth.ShouldBe(500);
         // Height is absolute 100
-        element.GetAbsoluteHeight().ShouldBe(100);
+        element.AbsoluteHeight.ShouldBe(100);
     }
 
     #endregion
@@ -7763,13 +7763,13 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Initially parent wins: max(300, 100) = 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
 
         // Now child grows larger than parent
         child.Width = 500;
 
         // Children win: max(300, 500) = 500
-        parent.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
     }
 
     [Fact]
@@ -7790,13 +7790,13 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child);
 
         // Initially children win: max(200, 300) = 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
 
         // Now grandparent grows
         grandparent.Width = 500;
 
         // Parent wins: max(500, 300) = 500
-        parent.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
     }
 
     #endregion
@@ -7831,7 +7831,7 @@ public class LayoutUnitTests : BaseTestClass
         parent.AddChild(child3);
 
         // Widest child is 350. max(200, 350) = 350
-        parent.GetAbsoluteWidth().ShouldBe(350);
+        parent.AbsoluteWidth.ShouldBe(350);
     }
 
     #endregion
@@ -7861,8 +7861,8 @@ public class LayoutUnitTests : BaseTestClass
         // Since inner depends on parent, it's excluded from outer's children measurement.
         // outer = max(400, 0) = 400
         // inner = max(400, 0) = 400
-        outer.GetAbsoluteWidth().ShouldBe(400);
-        inner.GetAbsoluteWidth().ShouldBe(400);
+        outer.AbsoluteWidth.ShouldBe(400);
+        inner.AbsoluteWidth.ShouldBe(400);
     }
 
     #endregion
@@ -7924,12 +7924,12 @@ public class LayoutUnitTests : BaseTestClass
         row3.AddChild(row3Child);
 
         // Parent should size to widest child's children-based size: 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
 
         // All rows should be max(parent=300, ownChild) = 300
-        row1.GetAbsoluteWidth().ShouldBe(300);
-        row2.GetAbsoluteWidth().ShouldBe(300);
-        row3.GetAbsoluteWidth().ShouldBe(300);
+        row1.AbsoluteWidth.ShouldBe(300);
+        row2.AbsoluteWidth.ShouldBe(300);
+        row3.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -7981,10 +7981,10 @@ public class LayoutUnitTests : BaseTestClass
         // Widest child is 600. With 30 padding: 600 + 30 = 630.
         // Parent sizes to widest row's children-based size: 630.
         // All rows: max(parent=630, ownChild+30) = 630.
-        parent.GetAbsoluteWidth().ShouldBe(630);
-        row1.GetAbsoluteWidth().ShouldBe(630);
-        row2.GetAbsoluteWidth().ShouldBe(630);
-        row3.GetAbsoluteWidth().ShouldBe(630);
+        parent.AbsoluteWidth.ShouldBe(630);
+        row1.AbsoluteWidth.ShouldBe(630);
+        row2.AbsoluteWidth.ShouldBe(630);
+        row3.AbsoluteWidth.ShouldBe(630);
     }
 
     [Fact]
@@ -8022,17 +8022,17 @@ public class LayoutUnitTests : BaseTestClass
         row2.AddChild(row2Child);
 
         // Both rows 200, parent 200, all rows 200
-        parent.GetAbsoluteWidth().ShouldBe(200);
-        row1.GetAbsoluteWidth().ShouldBe(200);
-        row2.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
+        row1.AbsoluteWidth.ShouldBe(200);
+        row2.AbsoluteWidth.ShouldBe(200);
 
         // Now row1's child grows
         row1Child.Width = 500;
 
         // Parent should expand to 500, both rows should follow
-        parent.GetAbsoluteWidth().ShouldBe(500);
-        row1.GetAbsoluteWidth().ShouldBe(500);
-        row2.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
+        row1.AbsoluteWidth.ShouldBe(500);
+        row2.AbsoluteWidth.ShouldBe(500);
     }
 
     [Fact]
@@ -8057,27 +8057,27 @@ public class LayoutUnitTests : BaseTestClass
         child.AddChild(grandchild);
 
         // Initial state: everything should be 50
-        parent.GetAbsoluteWidth().ShouldBe(50);
-        child.GetAbsoluteWidth().ShouldBe(50);
+        parent.AbsoluteWidth.ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(50);
 
         // Increase parent padding to 200: parent = 50 + 200 = 250, child matches parent
         parent.Width = 200;
-        parent.GetAbsoluteWidth().ShouldBe(250);
-        child.GetAbsoluteWidth().ShouldBe(250);
+        parent.AbsoluteWidth.ShouldBe(250);
+        child.AbsoluteWidth.ShouldBe(250);
 
         // Set parent padding back to 0: should return to 50, not stay at 250
         parent.Width = 0;
-        parent.GetAbsoluteWidth().ShouldBe(50);
-        child.GetAbsoluteWidth().ShouldBe(50);
+        parent.AbsoluteWidth.ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(50);
 
         // Another cycle to verify no ratcheting
         parent.Width = 200;
-        parent.GetAbsoluteWidth().ShouldBe(250);
-        child.GetAbsoluteWidth().ShouldBe(250);
+        parent.AbsoluteWidth.ShouldBe(250);
+        child.AbsoluteWidth.ShouldBe(250);
 
         parent.Width = 0;
-        parent.GetAbsoluteWidth().ShouldBe(50);
-        child.GetAbsoluteWidth().ShouldBe(50);
+        parent.AbsoluteWidth.ShouldBe(50);
+        child.AbsoluteWidth.ShouldBe(50);
     }
 
     [Fact]
@@ -8098,17 +8098,17 @@ public class LayoutUnitTests : BaseTestClass
         child.AddChild(grandchild);
 
         // Initial state
-        parent.GetAbsoluteHeight().ShouldBe(50);
-        child.GetAbsoluteHeight().ShouldBe(50);
+        parent.AbsoluteHeight.ShouldBe(50);
+        child.AbsoluteHeight.ShouldBe(50);
 
         // Increase then decrease parent padding
         parent.Height = 200;
-        parent.GetAbsoluteHeight().ShouldBe(250);
-        child.GetAbsoluteHeight().ShouldBe(250);
+        parent.AbsoluteHeight.ShouldBe(250);
+        child.AbsoluteHeight.ShouldBe(250);
 
         parent.Height = 0;
-        parent.GetAbsoluteHeight().ShouldBe(50);
-        child.GetAbsoluteHeight().ShouldBe(50);
+        parent.AbsoluteHeight.ShouldBe(50);
+        child.AbsoluteHeight.ShouldBe(50);
     }
 
     [Fact]
@@ -8144,22 +8144,22 @@ public class LayoutUnitTests : BaseTestClass
         row2.AddChild(row2Child);
 
         // row1 is widest at 500, all match
-        parent.GetAbsoluteWidth().ShouldBe(500);
-        row1.GetAbsoluteWidth().ShouldBe(500);
-        row2.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
+        row1.AbsoluteWidth.ShouldBe(500);
+        row2.AbsoluteWidth.ShouldBe(500);
 
         // Shrink row1's child — row2 is now widest at 200
         row1Child.Width = 100;
-        parent.GetAbsoluteWidth().ShouldBe(200);
-        row1.GetAbsoluteWidth().ShouldBe(200);
-        row2.GetAbsoluteWidth().ShouldBe(200);
+        parent.AbsoluteWidth.ShouldBe(200);
+        row1.AbsoluteWidth.ShouldBe(200);
+        row2.AbsoluteWidth.ShouldBe(200);
 
         // Shrink to zero
         row1Child.Width = 0;
         row2Child.Width = 0;
-        parent.GetAbsoluteWidth().ShouldBe(0);
-        row1.GetAbsoluteWidth().ShouldBe(0);
-        row2.GetAbsoluteWidth().ShouldBe(0);
+        parent.AbsoluteWidth.ShouldBe(0);
+        row1.AbsoluteWidth.ShouldBe(0);
+        row2.AbsoluteWidth.ShouldBe(0);
     }
 
     [Fact]
@@ -8192,20 +8192,20 @@ public class LayoutUnitTests : BaseTestClass
 
         // Absolute child (300) is wider than maxChild's content (100)
         // Parent sizes to 300, maxChild fills to 300
-        parent.GetAbsoluteWidth().ShouldBe(300);
-        absoluteChild.GetAbsoluteWidth().ShouldBe(300);
-        maxChild.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
+        absoluteChild.AbsoluteWidth.ShouldBe(300);
+        maxChild.AbsoluteWidth.ShouldBe(300);
 
         // Now make the maxChild's content wider
         maxChildInner.Width = 500;
-        parent.GetAbsoluteWidth().ShouldBe(500);
-        absoluteChild.GetAbsoluteWidth().ShouldBe(300);
-        maxChild.GetAbsoluteWidth().ShouldBe(500);
+        parent.AbsoluteWidth.ShouldBe(500);
+        absoluteChild.AbsoluteWidth.ShouldBe(300);
+        maxChild.AbsoluteWidth.ShouldBe(500);
 
         // Shrink it back — Absolute child dominates again
         maxChildInner.Width = 100;
-        parent.GetAbsoluteWidth().ShouldBe(300);
-        maxChild.GetAbsoluteWidth().ShouldBe(300);
+        parent.AbsoluteWidth.ShouldBe(300);
+        maxChild.AbsoluteWidth.ShouldBe(300);
     }
 
     [Fact]
@@ -8229,14 +8229,14 @@ public class LayoutUnitTests : BaseTestClass
         child.AddChild(grandchild);
 
         // At X=0: parent=100, child=100
-        parent.GetAbsoluteWidth().ShouldBe(100);
-        child.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
+        child.AbsoluteWidth.ShouldBe(100);
 
         // Move child to X=100: parent stays at 100 (based on content only),
         // child stays at 100 (max of parent=100 and content=100)
         child.X = 100;
-        parent.GetAbsoluteWidth().ShouldBe(100);
-        child.GetAbsoluteWidth().ShouldBe(100);
+        parent.AbsoluteWidth.ShouldBe(100);
+        child.AbsoluteWidth.ShouldBe(100);
     }
 
     #endregion

--- a/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -184,7 +184,7 @@ public class SpriteRuntimeTests : BaseTestClass
         sut.TextureAddress = Gum.Managers.TextureAddress.EntireTexture;
         sut.TextureHeight = 150;
 
-        sut.GetAbsoluteHeight().ShouldBe(64);
+        sut.AbsoluteHeight.ShouldBe(64);
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class SpriteRuntimeTests : BaseTestClass
         sut.Width.ShouldBe(100);
         sut.WidthUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.PercentageOfSourceFile);
 
-        sut.GetAbsoluteWidth().ShouldBe(64);
+        sut.AbsoluteWidth.ShouldBe(64);
     }
 
     [Fact]
@@ -279,7 +279,7 @@ public class SpriteRuntimeTests : BaseTestClass
         sut.TextureAddress = Gum.Managers.TextureAddress.EntireTexture;
         sut.TextureWidth = 150;
 
-        sut.GetAbsoluteWidth().ShouldBe(64);
+        sut.AbsoluteWidth.ShouldBe(64);
     }
 
 }

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -44,10 +44,10 @@ $"chars count=223\r\n";
         sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
         sut.Width = 0;
         sut.Text = "Short";
-        float shortWidth = sut.GetAbsoluteWidth();
+        float shortWidth = sut.AbsoluteWidth;
 
         sut.Text = "This is much longer";
-        float longWidth = sut.GetAbsoluteWidth();
+        float longWidth = sut.AbsoluteWidth;
 
         longWidth.ShouldBeGreaterThan(shortWidth);
     }
@@ -62,11 +62,11 @@ $"chars count=223\r\n";
 
         textRuntime.Text = "Hello";
 
-        var widthBefore = textRuntime.GetAbsoluteWidth();
+        var widthBefore = textRuntime.AbsoluteWidth;
 
         textRuntime.Text = "Hello\na";
 
-        var widthAfter = textRuntime.GetAbsoluteWidth();
+        var widthAfter = textRuntime.AbsoluteWidth;
 
         widthBefore.ShouldBe(widthAfter, "Because a trailing newline should not affect the width of a text, regardless of its XAdavance");
     }
@@ -434,7 +434,7 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 
         float textContentWidth = ((Text)text.RenderableComponent).WrappedTextWidth;
         textContentWidth.ShouldBeGreaterThan(0);
-        box.GetAbsoluteWidth().ShouldBeGreaterThanOrEqualTo(textContentWidth,
+        box.AbsoluteWidth.ShouldBeGreaterThanOrEqualTo(textContentWidth,
             "because the RelativeToChildren box must be at least as wide as its text, even with a RelativeToParent background sibling");
         // #3645: containment alone isn't enough - a container that "correctly" grows to fit a wrapped
         // 2-line block still passes the containment assertion above even though the wrap itself is the
@@ -471,7 +471,7 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
             plainText.Text = "AA BB CC";
             plainContainer.Children.Add(plainText);
             plainContainer.AddToRoot();
-            float plainContainerWidth = plainContainer.GetAbsoluteWidth();
+            float plainContainerWidth = plainContainer.AbsoluteWidth;
             float baseBAdvance = plainText.BitmapFont.Characters['B'].XAdvance;
 
             ContainerRuntime swappedContainer = new();
@@ -485,14 +485,14 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
             swappedText.Text = "AA [FontSize=40]BB[/FontSize] CC";
             swappedContainer.Children.Add(swappedText);
             swappedContainer.AddToRoot();
-            float swappedContainerWidth = swappedContainer.GetAbsoluteWidth();
+            float swappedContainerWidth = swappedContainer.AbsoluteWidth;
 
             InlineVariable fontSwapVariable = ((Text)swappedText.RenderableComponent)
                 .InlineVariables.First(v => v.VariableName == "BitmapFont");
             float swappedBAdvance = ((BitmapFont)fontSwapVariable.Value).Characters['B'].XAdvance;
 
             // The container must wrap its child exactly — this is the "background contains the text" case.
-            swappedContainerWidth.ShouldBe(swappedText.GetAbsoluteWidth(),
+            swappedContainerWidth.ShouldBe(swappedText.AbsoluteWidth,
                 "because a RelativeToChildren container must size to its child's full measured width");
 
             // And that width must include the enlarged run: swapping the two 'B' glyphs to the size-40
@@ -674,13 +674,13 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         sut.Height = 0;
         sut.Text = "Hello";
 
-        var baseHeight = sut.GetAbsoluteHeight();
+        var baseHeight = sut.AbsoluteHeight;
         baseHeight.ShouldBeGreaterThan(0);
 
         GraphicalUiElement.GlobalFontScale = 2;
         sut.UpdateLayout();
 
-        sut.GetAbsoluteHeight().ShouldBe(baseHeight * 2);
+        sut.AbsoluteHeight.ShouldBe(baseHeight * 2);
     }
 
     [Fact]
@@ -691,13 +691,13 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         sut.Width = 0;
         sut.Text = "Hello";
 
-        var baseWidth = sut.GetAbsoluteWidth();
+        var baseWidth = sut.AbsoluteWidth;
         baseWidth.ShouldBeGreaterThan(0);
 
         GraphicalUiElement.GlobalFontScale = 2;
         sut.UpdateLayout();
 
-        sut.GetAbsoluteWidth().ShouldBe(baseWidth * 2);
+        sut.AbsoluteWidth.ShouldBe(baseWidth * 2);
     }
 
     [Fact]
@@ -782,12 +782,12 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         textRuntime.MaxWidth = 50; // Set a max width
         textRuntime.Text = "a a a a a a a a a a a a a a a a a";
 
-        textRuntime.GetAbsoluteWidth().ShouldBeLessThanOrEqualTo(50);
+        textRuntime.AbsoluteWidth.ShouldBeLessThanOrEqualTo(50);
         var innerText = (Text)textRuntime.RenderableComponent;
         innerText.WrappedText.Count.ShouldBeGreaterThan(1);
         var lineCount = innerText.WrappedText.Count;
 
-        var absoluteHeight = textRuntime.GetAbsoluteHeight();
+        var absoluteHeight = textRuntime.AbsoluteHeight;
         absoluteHeight.ShouldBe(lineCount * textRuntime.Typeface.LineHeightInPixels);
     }
 
@@ -1536,12 +1536,12 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         textRuntime.Width = 0;
         textRuntime.Text = "This is some sample text";
 
-        textRuntime.GetAbsoluteWidth().ShouldBeGreaterThan(0);
-        var absoluteWidth = textRuntime.GetAbsoluteWidth();
+        textRuntime.AbsoluteWidth.ShouldBeGreaterThan(0);
+        var absoluteWidth = textRuntime.AbsoluteWidth;
 
         textRuntime.MaxLettersToShow = 0;
 
-        textRuntime.GetAbsoluteWidth().ShouldBe(absoluteWidth);
+        textRuntime.AbsoluteWidth.ShouldBe(absoluteWidth);
 
 
     }
@@ -1754,10 +1754,10 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 
         float renderedHeight = renderable.WrappedTextHeight;
         renderedHeight.ShouldBeGreaterThan(0, "Because the single line must still be rendered");
-        sut.GetAbsoluteHeight().ShouldBe(renderedHeight + heightOffset,
+        sut.AbsoluteHeight.ShouldBe(renderedHeight + heightOffset,
             "Because the bounds are the full rendered height plus the (negative) offset");
-        sut.GetAbsoluteHeight().ShouldBeLessThan(renderedHeight);
-        sut.GetAbsoluteHeight().ShouldBeGreaterThan(0);
+        sut.AbsoluteHeight.ShouldBeLessThan(renderedHeight);
+        sut.AbsoluteHeight.ShouldBeGreaterThan(0);
     }
 
     // The exact issue #3372 repro: vertical truncation + RelativeToChildren height +

--- a/MonoGameGum/Forms/Controls/ComboBox.cs
+++ b/MonoGameGum/Forms/Controls/ComboBox.cs
@@ -396,8 +396,8 @@ public class ComboBox :
         // ... so grab the absolute values:
         var x = listBox.Visual.AbsoluteX;
         var y = listBox.Visual.AbsoluteY;
-        var width = listBox.Visual.GetAbsoluteWidth();
-        var height = listBox.Visual.GetAbsoluteHeight();
+        var width = listBox.Visual.AbsoluteWidth;
+        var height = listBox.Visual.AbsoluteHeight;
 
         listBoxWidthUnits = listBox.Visual.WidthUnits;
         listBoxHeightUnits = listBox.Visual.HeightUnits;

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -226,11 +226,11 @@ public class FrameworkElement : INotifyPropertyChanged
     /// <summary>
     /// The height in pixels. This is a calculated value considering HeightUnits and Height.
     /// </summary>
-    public float ActualHeight => Visual.GetAbsoluteHeight();
+    public float ActualHeight => Visual.AbsoluteHeight;
     /// <summary>
     /// The width in pixels. This is a calculated value considering WidthUnits and Width;
     /// </summary>
-    public float ActualWidth => Visual.GetAbsoluteWidth();
+    public float ActualWidth => Visual.AbsoluteWidth;
 
     /// <summary>
     /// Returns the left of this element in absolute (screen) coordinates
@@ -976,8 +976,8 @@ public class FrameworkElement : INotifyPropertyChanged
             canvasHeight = GraphicalUiElement.CanvasHeight;
         }
 
-        var width = Visual.GetAbsoluteWidth();
-        var height = Visual.GetAbsoluteHeight();
+        var width = Visual.AbsoluteWidth;
+        var height = Visual.AbsoluteHeight;
 
         // Use Absolute coords for the bounds check so this works even when Visual has
         // a non-zero-positioned parent. Mutate local X/Y by the same delta — the parent

--- a/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
@@ -112,8 +112,8 @@ public static class FrameworkElementExt
         
 
     //    var coloredRectangle = new ColoredRectangleRuntime();
-    //    coloredRectangle.Width = element.Visual.GetAbsoluteWidth();
-    //    coloredRectangle.Height = element.Visual.GetAbsoluteHeight();
+    //    coloredRectangle.Width = element.Visual.AbsoluteWidth;
+    //    coloredRectangle.Height = element.Visual.AbsoluteHeight;
     //    coloredRectangle.X = element.Visual.AbsoluteLeft;
     //    coloredRectangle.Y = element.Visual.AbsoluteTop;
     //    coloredRectangle.Color = color.Value;

--- a/MonoGameGum/Forms/Controls/Grid.cs
+++ b/MonoGameGum/Forms/Controls/Grid.cs
@@ -360,7 +360,7 @@ public class Grid :
             {
                 InteractiveGue cell = (InteractiveGue)_rowContainers[r].Children[c];
                 cell.UpdateLayout();
-                float cellWidth = cell.GetAbsoluteWidth();
+                float cellWidth = cell.AbsoluteWidth;
                 if (cellWidth > maxContentWidth)
                 {
                     maxContentWidth = cellWidth;
@@ -394,7 +394,7 @@ public class Grid :
 
             InteractiveGue rowContainer = _rowContainers[r];
             rowContainer.UpdateLayout();
-            float computedHeight = rowContainer.GetAbsoluteHeight();
+            float computedHeight = rowContainer.AbsoluteHeight;
             float clamped = Math.Max(def.MinHeight, Math.Min(def.MaxHeight, computedHeight));
             if (clamped != computedHeight)
             {

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -1475,7 +1475,7 @@ public class ListBox : ItemsControl, IInputReceiver
             var visualBottom = visualAsIpso.Y + visualAsIpso.Height;
 
             var viewTop = -InnerPanel.Y;
-            var viewBottom = -InnerPanel.Y + clipContainer.GetAbsoluteHeight();
+            var viewBottom = -InnerPanel.Y + clipContainer.AbsoluteHeight;
             var isAboveView = visualTop < viewTop;
             var isBelowView = visualBottom > viewBottom;
 
@@ -1512,7 +1512,7 @@ public class ListBox : ItemsControl, IInputReceiver
 
                     var viewHeight = visualAsIpso.Height;
 
-                    var desiredViewTop = viewHeight / 2.0f + visualTop - clipContainer.GetAbsoluteHeight() / 2;
+                    var desiredViewTop = viewHeight / 2.0f + visualTop - clipContainer.AbsoluteHeight / 2;
 
                     amountToScroll = desiredViewTop - viewTop;
                     if (verticalScrollBar != null)
@@ -1860,8 +1860,8 @@ public class ListBox : ItemsControl, IInputReceiver
             var item = listBoxItem.Visual;
             if (item.Visible)
             {
-                var widthHalf = item.GetAbsoluteWidth() / 2.0f;
-                var heightHalf = item.GetAbsoluteHeight() / 2.0f;
+                var widthHalf = item.AbsoluteWidth / 2.0f;
+                var heightHalf = item.AbsoluteHeight / 2.0f;
 
                 var absoluteX = item.GetAbsoluteCenterX();
                 var absoluteY = item.GetAbsoluteCenterY();
@@ -1913,8 +1913,8 @@ public class ListBox : ItemsControl, IInputReceiver
 
                 var offsetToCheck = InnerPanel.StackSpacing + AdditionalOffsetToCheckForDPadNavigation;
 
-                float xCenter = currentSelection.GetAbsoluteX() + currentSelection.GetAbsoluteWidth() / 2.0f;
-                float yCenter = currentSelection.GetAbsoluteY() + currentSelection.GetAbsoluteHeight() / 2.0f;
+                float xCenter = currentSelection.GetAbsoluteX() + currentSelection.AbsoluteWidth / 2.0f;
+                float yCenter = currentSelection.GetAbsoluteY() + currentSelection.AbsoluteHeight / 2.0f;
 
                 float x = xCenter;
                 float y = yCenter;

--- a/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
@@ -456,7 +456,7 @@ public abstract class RangeBase :
         if (IsMoveToPointEnabled)
         {
             var left = Track.GetAbsoluteX();
-            var right = Track.GetAbsoluteX() + Track.GetAbsoluteWidth();
+            var right = Track.GetAbsoluteX() + Track.AbsoluteWidth;
 
             var screenX = MainCursor.XRespectingGumZoomAndBounds();
 
@@ -507,13 +507,13 @@ public abstract class RangeBase :
 
         if(Orientation == Orientation.Horizontal)
         {
-            var trackWidth = Track.GetAbsoluteWidth();
+            var trackWidth = Track.AbsoluteWidth;
             var cursorX = MainCursor.XRespectingGumZoomAndBounds();
             clickedPercentageOver = (cursorX - Track.AbsoluteLeft) / trackWidth;
         }
         else
         {
-            var trackHeight = Track.GetAbsoluteHeight();
+            var trackHeight = Track.AbsoluteHeight;
             var cursorY = MainCursor.YRespectingGumZoomAndBounds();
             clickedPercentageOver = (cursorY - Track.AbsoluteTop) / trackHeight;
         }

--- a/MonoGameGum/Forms/Controls/ScrollBar.cs
+++ b/MonoGameGum/Forms/Controls/ScrollBar.cs
@@ -62,8 +62,8 @@ public class ScrollBar : RangeBase
     float MinThumbPosition => 0;
     float MaxThumbPosition =>
         Orientation == Orientation.Vertical
-        ? Track.GetAbsoluteHeight() - thumb.ActualHeight
-        : Track.GetAbsoluteWidth() - thumb.ActualWidth;
+        ? Track.AbsoluteHeight - thumb.ActualHeight
+        : Track.AbsoluteWidth - thumb.ActualWidth;
 
 
     public override Orientation Orientation 
@@ -178,7 +178,7 @@ public class ScrollBar : RangeBase
 
 
         var visibleTrackSpace = upButton != null && downButton != null
-            ? Track.GetAbsoluteHeight() - upButton.ActualHeight - downButton.ActualHeight
+            ? Track.AbsoluteHeight - upButton.ActualHeight - downButton.ActualHeight
             : 0;
 
         if (visibleTrackSpace != 0)
@@ -480,7 +480,7 @@ public class ScrollBar : RangeBase
 
                 if(Orientation == Orientation.Vertical)
                 {
-                    float trackSize =  Track.GetAbsoluteHeight();
+                    float trackSize =  Track.AbsoluteHeight;
                     thumb.Visual.YUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
                     thumb.Visual.HeightUnits = global::Gum.DataTypes.DimensionUnitType.Absolute;
 
@@ -488,7 +488,7 @@ public class ScrollBar : RangeBase
                 }
                 else
                 {
-                    float trackSize =  Track.GetAbsoluteWidth();
+                    float trackSize =  Track.AbsoluteWidth;
                     thumb.Visual.XUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
                     thumb.Visual.WidthUnits = global::Gum.DataTypes.DimensionUnitType.Absolute;
 

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -795,7 +795,7 @@ public class ScrollViewer :
 
         // Capture the header's height before we move it; reparenting can
         // re-trigger layout and we want the size as the user sees it now.
-        float headerHeight = header.GetAbsoluteHeight();
+        float headerHeight = header.AbsoluteHeight;
 
         // Build the placeholder, then swap header → placeholder at the same
         // index in the inner panel's stack so nothing visually shifts.
@@ -818,7 +818,7 @@ public class ScrollViewer :
         };
         entry.HeaderSizeChangedHandler = (_, _) =>
         {
-            entry.Placeholder.Height = entry.Header.GetAbsoluteHeight();
+            entry.Placeholder.Height = entry.Header.AbsoluteHeight;
             RecomputeStickyHeaders();
         };
         header.SizeChanged += entry.HeaderSizeChangedHandler;
@@ -1015,7 +1015,7 @@ public class ScrollViewer :
             if (i + 1 < _stickyHeaders.Count)
             {
                 float nextRelY = _stickyHeaders[i + 1].Placeholder.AbsoluteTop - overlayTop;
-                float maxY = nextRelY - entry.Header!.GetAbsoluteHeight();
+                float maxY = nextRelY - entry.Header!.AbsoluteHeight;
                 if (headerY > maxY)
                 {
                     headerY = maxY;
@@ -1230,7 +1230,7 @@ public class ScrollViewer :
 
         // Record the inner panel height before (possibly) changing the
         // scroll bar height...
-        var innerPanelHeight = innerPanel.GetAbsoluteHeight();
+        var innerPanelHeight = innerPanel.AbsoluteHeight;
 
         switch (verticalScrollBarVisibility)
         {
@@ -1242,7 +1242,7 @@ public class ScrollViewer :
                 break;
             case ScrollBarVisibility.Auto:
                 {
-                    var clipContainerHeight = clipContainer.GetAbsoluteHeight();
+                    var clipContainerHeight = clipContainer.AbsoluteHeight;
                     verticalScrollBar.IsVisible = innerPanelHeight > clipContainerHeight;
                 }
                 break;
@@ -1251,7 +1251,7 @@ public class ScrollViewer :
 
 
         // now that we've set the visibility state, let's see if the height has changed
-        var didHeightChange = innerPanel.GetAbsoluteHeight() != innerPanelHeight;
+        var didHeightChange = innerPanel.AbsoluteHeight != innerPanelHeight;
         if (didHeightChange)
         {
             // It changed, which can adjust the scroll bar height so let's adjust it again
@@ -1261,10 +1261,10 @@ public class ScrollViewer :
         void SetVerticalScrollBarValuesFromVisuals()
         {
             verticalScrollBar.Minimum = 0;
-            verticalScrollBar.ViewportSize = clipContainer.GetAbsoluteHeight();
+            verticalScrollBar.ViewportSize = clipContainer.AbsoluteHeight;
 
-            var innerPanelHeight = innerPanel.GetAbsoluteHeight();
-            var clipContainerHeight = clipContainer.GetAbsoluteHeight();
+            var innerPanelHeight = innerPanel.AbsoluteHeight;
+            var clipContainerHeight = clipContainer.AbsoluteHeight;
             var maxValue = innerPanelHeight - clipContainerHeight;
 
             maxValue = System.Math.Max(0, maxValue);
@@ -1305,7 +1305,7 @@ public class ScrollViewer :
         SetHorizontalSrollBarValuesFromVisuals();
         // Record the inner panel width before (possibly) changing the
         // scroll bar width...
-        var innerPanelWidth = innerPanel.GetAbsoluteWidth();
+        var innerPanelWidth = innerPanel.AbsoluteWidth;
 
         switch (horizontalScrollBarVisibility)
         {
@@ -1317,7 +1317,7 @@ public class ScrollViewer :
                 break;
             case ScrollBarVisibility.Auto:
                 {
-                    var clipContainerWidth = clipContainer.GetAbsoluteWidth();
+                    var clipContainerWidth = clipContainer.AbsoluteWidth;
                     horizontalScrollBar.IsVisible = innerPanelWidth > clipContainerWidth;
                 }
                 break;
@@ -1327,7 +1327,7 @@ public class ScrollViewer :
 
 
         // now that we've set the visibility state, let's see if the width has changed
-        var didWidthChange = innerPanel.GetAbsoluteWidth() != innerPanelWidth;
+        var didWidthChange = innerPanel.AbsoluteWidth != innerPanelWidth;
         if (didWidthChange)
         {
             // It changed, which can adjust the scroll bar width so let's adjust it again
@@ -1337,10 +1337,10 @@ public class ScrollViewer :
         void SetHorizontalSrollBarValuesFromVisuals()
         {
             horizontalScrollBar.Minimum = 0;
-            horizontalScrollBar.ViewportSize = clipContainer.GetAbsoluteWidth();
+            horizontalScrollBar.ViewportSize = clipContainer.AbsoluteWidth;
 
-            var innerPanelWidth = innerPanel.GetAbsoluteWidth();
-            var clipContainerWidth = clipContainer.GetAbsoluteWidth();
+            var innerPanelWidth = innerPanel.AbsoluteWidth;
+            var clipContainerWidth = clipContainer.AbsoluteWidth;
             var maxValue = innerPanelWidth - clipContainerWidth;
 
             maxValue = System.Math.Max(0, maxValue);

--- a/MonoGameGum/Forms/Controls/Slider.cs
+++ b/MonoGameGum/Forms/Controls/Slider.cs
@@ -208,7 +208,7 @@ public class Slider : RangeBase, IInputReceiver
         if (IsMoveToPointEnabled)
         {
             var left = Track.GetAbsoluteX();
-            var right = Track.GetAbsoluteX() + Track.GetAbsoluteWidth();
+            var right = Track.GetAbsoluteX() + Track.AbsoluteWidth;
 
             var screenX = MainCursor.XRespectingGumZoomAndBounds();
 
@@ -342,7 +342,7 @@ public class Slider : RangeBase, IInputReceiver
         // problems:
 
         //thumb.Visual.XUnits = global::Gum.Converters.GeneralUnitType.PixelsFromSmall;
-        //thumb.X = Microsoft.Xna.Framework.MathHelper.Lerp(0, Track.GetAbsoluteWidth(),
+        //thumb.X = Microsoft.Xna.Framework.MathHelper.Lerp(0, Track.AbsoluteWidth,
         //    (float)ratioOver);
 
         if(thumb != null)
@@ -372,7 +372,7 @@ public class Slider : RangeBase, IInputReceiver
         thumb.Visual.XUnits = global::Gum.Converters.GeneralUnitType.Percentage;
 
         var pixelOffset = cursorXRelativeToTrack - cursorGrabOffsetRelativeToThumb;
-        var width = Track.GetAbsoluteWidth();
+        var width = Track.AbsoluteWidth;
         if (width == 0)
         {
             // prevent divide by 0's
@@ -381,7 +381,7 @@ public class Slider : RangeBase, IInputReceiver
 
         thumb.X = 100 * pixelOffset / width;
 
-        float range = Track.GetAbsoluteWidth();
+        float range = Track.AbsoluteWidth;
 
 
         if (range != 0)

--- a/MonoGameGum/Forms/Controls/Splitter.cs
+++ b/MonoGameGum/Forms/Controls/Splitter.cs
@@ -178,7 +178,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
         {
             if(resizeBehavior == Controls.ResizeBehavior.Rows)
             {
-                var absoluteHeight = firstVisual.GetAbsoluteHeight();
+                var absoluteHeight = firstVisual.AbsoluteHeight;
                 if(firstVisual.MinHeight != null)
                 {
                     absoluteHeight -= firstVisual.MinHeight.Value;
@@ -187,7 +187,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else
             {
-                var absoluteWidth = firstVisual.GetAbsoluteWidth();
+                var absoluteWidth = firstVisual.AbsoluteWidth;
                 if(firstVisual.MinWidth != null)
                 {
                     absoluteWidth -= firstVisual.MinWidth.Value;
@@ -199,7 +199,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
         {
             if(resizeBehavior == Controls.ResizeBehavior.Rows)
             {
-                var absoluteHeight = secondVisual.GetAbsoluteHeight();
+                var absoluteHeight = secondVisual.AbsoluteHeight;
                 if(secondVisual.MinHeight != null)
                 {
                     absoluteHeight -= secondVisual.MinHeight.Value;
@@ -208,7 +208,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else
             {
-                var absoluteWidth = secondVisual.GetAbsoluteWidth();
+                var absoluteWidth = secondVisual.AbsoluteWidth;
                 if(secondVisual.MinWidth != null)
                 {
                     absoluteWidth -= secondVisual.MinWidth.Value;
@@ -263,7 +263,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
         {
             if (resizeBehavior == Controls.ResizeBehavior.Rows)
             {
-                var firstHeightInPixels = firstVisual.GetAbsoluteHeight();
+                var firstHeightInPixels = firstVisual.AbsoluteHeight;
 
                 var ratioToAdd = (changeInPixels / firstHeightInPixels) * firstVisual.Height;
                 firstVisual.Height += ratioToAdd;
@@ -271,7 +271,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else
             {
-                var firstWidthInPixels = firstVisual.GetAbsoluteWidth();
+                var firstWidthInPixels = firstVisual.AbsoluteWidth;
 
                 var ratioToAdd = (changeInPixels / firstWidthInPixels) * firstVisual.Width;
                 firstVisual.Width += ratioToAdd;
@@ -284,22 +284,22 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             {
                 if (resizeBehavior == Controls.ResizeBehavior.Rows)
                 {
-                    var heightInPixels = firstVisual.GetAbsoluteHeight();
+                    var heightInPixels = firstVisual.AbsoluteHeight;
                     var newAbsoluteHeight = heightInPixels + changeInPixels;
 
                     // convert considering the parent's absolute height
                     firstVisual.Height =
-                        (newAbsoluteHeight / parent.GetAbsoluteHeight()) * 100.0f;
+                        (newAbsoluteHeight / parent.AbsoluteHeight) * 100.0f;
 
                 }
                 else // columns
                 {
-                    var widthInPixels = firstVisual.GetAbsoluteWidth();
+                    var widthInPixels = firstVisual.AbsoluteWidth;
                     var newAbsoluteWidth = widthInPixels + changeInPixels;
 
                     // convert considering the parent's absolute width
                     firstVisual.Width =
-                        (newAbsoluteWidth / parent.GetAbsoluteWidth()) * 100.0f;
+                        (newAbsoluteWidth / parent.AbsoluteWidth) * 100.0f;
                 }
             }
             else if (isFirstAbsolute)
@@ -315,7 +315,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else if(firstUnits == DimensionUnitType.Ratio)
             {
-                var firstHeightInPixels = firstVisual.GetAbsoluteHeight();
+                var firstHeightInPixels = firstVisual.AbsoluteHeight;
 
                 var ratioToAdd = (changeInPixels / firstHeightInPixels) * firstVisual.Height;
                 firstVisual.Height += ratioToAdd;
@@ -326,19 +326,19 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             {
                 if (resizeBehavior == Controls.ResizeBehavior.Rows)
                 {
-                    var heightInPixels = secondVisual.GetAbsoluteHeight();
+                    var heightInPixels = secondVisual.AbsoluteHeight;
                     var newAbsoluteHeight = heightInPixels - changeInPixels;
                     // convert considering the parent's absolute height
                     secondVisual.Height =
-                        (newAbsoluteHeight / parent.GetAbsoluteHeight()) * 100.0f;
+                        (newAbsoluteHeight / parent.AbsoluteHeight) * 100.0f;
                 }
                 else // columns
                 {
-                    var widthInPixels = secondVisual.GetAbsoluteWidth();
+                    var widthInPixels = secondVisual.AbsoluteWidth;
                     var newAbsoluteWidth = widthInPixels - changeInPixels;
                     // convert considering the parent's absolute width
                     secondVisual.Width =
-                        (newAbsoluteWidth / parent.GetAbsoluteWidth()) * 100.0f;
+                        (newAbsoluteWidth / parent.AbsoluteWidth) * 100.0f;
                 }
             }
             else if (isSecondAbsolute)
@@ -354,7 +354,7 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else if(secondUnits == DimensionUnitType.Ratio)
             {
-                var secondHeightInPixels = secondVisual.GetAbsoluteHeight();
+                var secondHeightInPixels = secondVisual.AbsoluteHeight;
 
                 var ratioToAdd = (changeInPixels / secondHeightInPixels) * secondVisual.Height;
                 secondVisual.Height -= ratioToAdd;

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1804,13 +1804,13 @@ public abstract class TextBoxBase :
             return;
         }
 
-        // textComponent.GetAbsoluteHeight() reflects layout-computed size, which
+        // textComponent.AbsoluteHeight reflects layout-computed size, which
         // in Multi state is bounded by the parent (HeightUnits=RelativeToParent).
         // For the clamp we want the actual content height — line count × line
         // height — so we don't over-clamp and undo a legitimate scroll.
         var lineCount = coreTextObject.WrappedText?.Count ?? 0;
         float contentHeight = lineCount * EffectiveLineHeightInPixels;
-        float containerHeight = caretComponent.EffectiveParentGue.GetAbsoluteHeight();
+        float containerHeight = caretComponent.EffectiveParentGue.AbsoluteHeight;
         float maxScrollUp = System.Math.Max(0f, contentHeight - containerHeight);
         float clamped = System.Math.Max(this.textComponent.Y, -maxScrollUp);
         float delta = clamped - this.textComponent.Y;
@@ -1844,14 +1844,14 @@ public abstract class TextBoxBase :
             // the text by hundreds of pixels and the asymmetric branches
             // below would never undo it once the parent reached a sane size.
             // See issue #2680.
-            float parentWidth = caretComponent.EffectiveParentGue.GetAbsoluteWidth();
+            float parentWidth = caretComponent.EffectiveParentGue.AbsoluteWidth;
             if (parentWidth <= 0)
             {
                 return;
             }
 
             float nearOfCaret = caretComponent.GetAbsoluteLeft();
-            float farOfCaret = nearOfCaret + caretComponent.GetAbsoluteWidth();
+            float farOfCaret = nearOfCaret + caretComponent.AbsoluteWidth;
             float nearOfParent = caretComponent.EffectiveParentGue.GetAbsoluteLeft();
             float farOfParent = nearOfParent + parentWidth;
 
@@ -1895,14 +1895,14 @@ public abstract class TextBoxBase :
             // meaning of the existing Y value.
 
             // Same invalid-geometry guard as the horizontal branch (see #2680).
-            float parentHeight = caretComponent.EffectiveParentGue.GetAbsoluteHeight();
+            float parentHeight = caretComponent.EffectiveParentGue.AbsoluteHeight;
             if (parentHeight <= 0)
             {
                 return;
             }
 
             float nearOfCaret = caretComponent.GetAbsoluteTop();
-            float farOfCaret = nearOfCaret + caretComponent.GetAbsoluteHeight();
+            float farOfCaret = nearOfCaret + caretComponent.AbsoluteHeight;
             float nearOfParent = caretComponent.EffectiveParentGue.GetAbsoluteTop();
             float farOfParent = nearOfParent + parentHeight;
 
@@ -2000,7 +2000,7 @@ public abstract class TextBoxBase :
             return 0;
 
         float measuredLineWidth = MeasureStringScaled(stringToMeasure);
-        float textComponentWidth = textComponent.GetAbsoluteWidth();
+        float textComponentWidth = textComponent.AbsoluteWidth;
         float gapBetweenTextAndEdge = textComponentWidth - measuredLineWidth;
         if (coreTextObject.HorizontalAlignment == global::RenderingLibrary.Graphics.HorizontalAlignment.Center)
             gapBetweenTextAndEdge /= 2.0f;
@@ -2030,7 +2030,7 @@ public abstract class TextBoxBase :
         }
         if (target.YUnits == global::Gum.Converters.GeneralUnitType.PixelsFromMiddle)
         {
-            adjusted -= textComponent.GetAbsoluteHeight() / 2.0f;
+            adjusted -= textComponent.AbsoluteHeight / 2.0f;
         }
         return adjusted;
     }

--- a/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/ScrollViewerVisual.cs
@@ -309,7 +309,7 @@ public class ScrollViewerVisual : InteractiveGue
             // Check the parent to verify that the user hasn't removed the ScrollBar
             if (VerticalScrollBarInstance.Visible)
             {
-                margin = VerticalScrollBarInstance.GetAbsoluteWidth();
+                margin = VerticalScrollBarInstance.AbsoluteWidth;
             }
             ClipContainerContainer.Width = -margin;
             if(HorizontalScrollBarInstance != null)
@@ -323,7 +323,7 @@ public class ScrollViewerVisual : InteractiveGue
             float margin = 0;
             if (HorizontalScrollBarInstance.Visible)
             {
-                margin = HorizontalScrollBarInstance.GetAbsoluteHeight();
+                margin = HorizontalScrollBarInstance.AbsoluteHeight;
             }
             ClipContainerContainer.Height = -margin;
             if(VerticalScrollBarInstance != null)

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ComboBoxVisual.cs
@@ -341,7 +341,7 @@ public class ComboBoxVisual : InteractiveGue
     private void PositionAndAttachListBox(GraphicalUiElement listBoxVisual)
     {
         listBoxVisual.Name = "ListBoxInstance";
-        listBoxVisual.Y = this.GetAbsoluteHeight();
+        listBoxVisual.Y = this.AbsoluteHeight;
         listBoxVisual.Width = 0f;
         listBoxVisual.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
         listBoxVisual.Height = 128f;

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ScrollViewerVisual.cs
@@ -409,7 +409,7 @@ public class ScrollViewerVisual : InteractiveGue
         {
             // Check the parent to verify that the user hasn't removed the ScrollBar
             float margin = VerticalScrollBarInstance.Visible
-                ? VerticalScrollBarInstance.GetAbsoluteWidth()
+                ? VerticalScrollBarInstance.AbsoluteWidth
                 : 0;
             ClipContainerContainer.Width = -margin;
         }
@@ -417,7 +417,7 @@ public class ScrollViewerVisual : InteractiveGue
         if (HorizontalScrollBarInstance.Parent == ScrollAndClipContainer)
         {
             float margin = HorizontalScrollBarInstance.Visible
-                ? HorizontalScrollBarInstance.GetAbsoluteHeight()
+                ? HorizontalScrollBarInstance.AbsoluteHeight
                 : 0;
             ClipContainerContainer.Height = -margin;
         }
@@ -436,7 +436,7 @@ public class ScrollViewerVisual : InteractiveGue
             && HorizontalScrollBarInstance != null)
         {
             float margin = VerticalScrollBarInstance.Visible
-                ? VerticalScrollBarInstance.GetAbsoluteWidth()
+                ? VerticalScrollBarInstance.AbsoluteWidth
                 : 0;
             HorizontalScrollBarInstance.Width = -margin;
         }
@@ -445,7 +445,7 @@ public class ScrollViewerVisual : InteractiveGue
             && VerticalScrollBarInstance != null)
         {
             float margin = HorizontalScrollBarInstance.Visible
-                ? HorizontalScrollBarInstance.GetAbsoluteHeight()
+                ? HorizontalScrollBarInstance.AbsoluteHeight
                 : 0;
             VerticalScrollBarInstance.Height = -margin;
         }

--- a/MonoGameGum/Forms/Window.cs
+++ b/MonoGameGum/Forms/Window.cs
@@ -264,23 +264,23 @@ public class Window : Gum.Forms.Controls.FrameworkElement
             // MinWidth clamp below restore the absolute width to at least
             // MinWidth without overshooting for non-absolute units.
             var widthUnitBefore = Visual.Width;
-            var absoluteWidthBefore = Visual.GetAbsoluteWidth();
+            var absoluteWidthBefore = Visual.AbsoluteWidth;
 
             switch (Visual.XOrigin)
             {
                 case global::RenderingLibrary.Graphics.HorizontalAlignment.Left:
                     {
-                        var widthBefore = Visual.GetAbsoluteWidth();
+                        var widthBefore = Visual.AbsoluteWidth;
                         Visual.Width -= difference;
-                        var addedWidth = Visual.GetAbsoluteWidth() - widthBefore;
+                        var addedWidth = Visual.AbsoluteWidth - widthBefore;
                         Visual.X -= addedWidth;
                     }
                     break;
                 case global::RenderingLibrary.Graphics.HorizontalAlignment.Center:
                     {
-                        var widthBefore = Visual.GetAbsoluteWidth();
+                        var widthBefore = Visual.AbsoluteWidth;
                         Visual.Width -= difference;
-                        var addedWidth = Visual.GetAbsoluteWidth() - widthBefore;
+                        var addedWidth = Visual.AbsoluteWidth - widthBefore;
                         Visual.X -= addedWidth / 2f;
                     }
                     break;
@@ -296,23 +296,23 @@ public class Window : Gum.Forms.Controls.FrameworkElement
             var difference = desiredTop - Visual.AbsoluteTop;
 
             var heightUnitBefore = Visual.Height;
-            var absoluteHeightBefore = Visual.GetAbsoluteHeight();
+            var absoluteHeightBefore = Visual.AbsoluteHeight;
 
             switch (Visual.YOrigin)
             {
                 case global::RenderingLibrary.Graphics.VerticalAlignment.Top:
                     {
-                        var heightBefore = Visual.GetAbsoluteHeight();
+                        var heightBefore = Visual.AbsoluteHeight;
                         Visual.Height -= difference;
-                        var addedHeight = Visual.GetAbsoluteHeight() - heightBefore;
+                        var addedHeight = Visual.AbsoluteHeight - heightBefore;
                         Visual.Y -= addedHeight;
                     }
                     break;
                 case global::RenderingLibrary.Graphics.VerticalAlignment.Center:
                     {
-                        var heightBefore = Visual.GetAbsoluteHeight();
+                        var heightBefore = Visual.AbsoluteHeight;
                         Visual.Height -= difference;
-                        var addedHeight = Visual.GetAbsoluteHeight() - heightBefore;
+                        var addedHeight = Visual.AbsoluteHeight - heightBefore;
                         Visual.Y -= addedHeight / 2f;
                     }
                     break;
@@ -329,7 +329,7 @@ public class Window : Gum.Forms.Controls.FrameworkElement
             var difference = desiredRight - Visual.AbsoluteRight;
 
             var widthUnitBefore = Visual.Width;
-            var absoluteWidthBefore = Visual.GetAbsoluteWidth();
+            var absoluteWidthBefore = Visual.AbsoluteWidth;
 
             switch (Visual.XOrigin)
             {
@@ -338,18 +338,18 @@ public class Window : Gum.Forms.Controls.FrameworkElement
                     break;
                 case global::RenderingLibrary.Graphics.HorizontalAlignment.Center:
                     {
-                        var widthBefore = Visual.GetAbsoluteWidth();
+                        var widthBefore = Visual.AbsoluteWidth;
                         Visual.Width += difference;
-                        var addedWidth = Visual.GetAbsoluteWidth() - widthBefore;
+                        var addedWidth = Visual.AbsoluteWidth - widthBefore;
                         Visual.X += addedWidth / 2f;
                     }
 
                     break;
                 case global::RenderingLibrary.Graphics.HorizontalAlignment.Right:
                     {
-                        var widthBefore = Visual.GetAbsoluteWidth();
+                        var widthBefore = Visual.AbsoluteWidth;
                         Visual.Width += difference;
-                        var addedWidth = Visual.GetAbsoluteWidth() - widthBefore;
+                        var addedWidth = Visual.AbsoluteWidth - widthBefore;
                         Visual.X += addedWidth;
                     }
                     break;
@@ -363,7 +363,7 @@ public class Window : Gum.Forms.Controls.FrameworkElement
             var difference = desiredBottom - Visual.AbsoluteBottom;
 
             var heightUnitBefore = Visual.Height;
-            var absoluteHeightBefore = Visual.GetAbsoluteHeight();
+            var absoluteHeightBefore = Visual.AbsoluteHeight;
 
             switch (Visual.YOrigin)
             {
@@ -372,18 +372,18 @@ public class Window : Gum.Forms.Controls.FrameworkElement
                     break;
                 case global::RenderingLibrary.Graphics.VerticalAlignment.Center:
                     {
-                        var heightBefore = Visual.GetAbsoluteHeight();
+                        var heightBefore = Visual.AbsoluteHeight;
                         Visual.Height += difference;
-                        var addedHeight = Visual.GetAbsoluteHeight() - heightBefore;
+                        var addedHeight = Visual.AbsoluteHeight - heightBefore;
                         Visual.Y += addedHeight / 2f;
 
                     }
                     break;
                 case global::RenderingLibrary.Graphics.VerticalAlignment.Bottom:
                     {
-                        var heightBefore = Visual.GetAbsoluteHeight();
+                        var heightBefore = Visual.AbsoluteHeight;
                         Visual.Height += difference;
-                        var addedHeight = Visual.GetAbsoluteHeight() - heightBefore;
+                        var addedHeight = Visual.AbsoluteHeight - heightBefore;
                         Visual.Y += addedHeight;
                     }
                     break;
@@ -406,7 +406,7 @@ public class Window : Gum.Forms.Controls.FrameworkElement
     }
 
     /// <summary>
-    /// Ensures Visual.GetAbsoluteWidth() is at least Visual.MinWidth by adjusting Visual.Width
+    /// Ensures Visual.AbsoluteWidth is at least Visual.MinWidth by adjusting Visual.Width
     /// by the deficit only. Using Math.Max(MinWidth, Visual.Width) directly is only correct
     /// for WidthUnits=Absolute; for RelativeToChildren the unit value is an offset added to
     /// children's size, so clamping it to MinWidth overshoots and inflates the absolute width,

--- a/MonoGameGum/Input/CursorExtensions.cs
+++ b/MonoGameGum/Input/CursorExtensions.cs
@@ -119,7 +119,7 @@ public static class CursorExtensions
             return $"The parent {NameOrType(notExposingParent)} does not raise its children's events, preventing {NameOrType(interactiveGue)} from raising events\n" +
                 GetAncestorTree(interactiveGue, notExposingParent);
         }
-        if (interactiveGue.GetAbsoluteWidth() == 0)
+        if (interactiveGue.AbsoluteWidth == 0)
         {
             return "The argument InteractiveGue has an AbsoluteWidth of 0";
         }
@@ -129,11 +129,11 @@ public static class CursorExtensions
         }
         if(Get0WidthOrHeightParent(interactiveGue) is GraphicalUiElement parentWith0WidthOrHeight)
         {
-            if(parentWith0WidthOrHeight.GetAbsoluteHeight() == 0)
+            if(parentWith0WidthOrHeight.AbsoluteHeight == 0)
             {
                 return $"The parent {parentWith0WidthOrHeight} has an AbsoluteHeight of 0";
             }
-            else if(parentWith0WidthOrHeight.GetAbsoluteWidth() == 0)
+            else if(parentWith0WidthOrHeight.AbsoluteWidth == 0)
             {
                 return $"The parent {parentWith0WidthOrHeight} has an AbsoluteWidth of 0";
             }
@@ -197,8 +197,8 @@ public static class CursorExtensions
             {
                 var absoluteX = gue.GetAbsoluteX();
                 var absoluteY = gue.GetAbsoluteY();
-                var absoluteWidth = gue.GetAbsoluteWidth();
-                var absoluteHeight = gue.GetAbsoluteHeight();
+                var absoluteWidth = gue.AbsoluteWidth;
+                var absoluteHeight = gue.AbsoluteHeight;
                 if(cursor.XRespectingGumZoomAndBounds() < absoluteX)
                 {
                     return $"The cursor X={cursor.XRespectingGumZoomAndBounds()} is to the left of the element which starts at X={absoluteX}";
@@ -379,8 +379,8 @@ public static class CursorExtensions
     {
         var x = gue.GetAbsoluteX();
         var y = gue.GetAbsoluteY();
-        var width = gue.GetAbsoluteWidth();
-        var height = gue.GetAbsoluteHeight();
+        var width = gue.AbsoluteWidth;
+        var height = gue.AbsoluteHeight;
 
         var info = $"abs=({x:0.#},{y:0.#} {width:0.#}x{height:0.#})";
 
@@ -462,7 +462,7 @@ public static class CursorExtensions
             return null;
         }
         else if(visual.Parent is GraphicalUiElement parentGue && 
-            (parentGue.GetAbsoluteWidth() == 0 || parentGue.GetAbsoluteHeight() == 0))
+            (parentGue.AbsoluteWidth == 0 || parentGue.AbsoluteHeight == 0))
         {
             return visual.Parent as GraphicalUiElement;
         }

--- a/Runtimes/SkiaGum/RenderingLibrary/IRenderableIpsoExtensions.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/IRenderableIpsoExtensions.cs
@@ -27,8 +27,8 @@ namespace RenderingLibrary.Graphics
             {
                 var left = renderableIpso.GetAbsoluteX();
                 var top = renderableIpso.GetAbsoluteY();
-                var right = left + gue.GetAbsoluteWidth();
-                var bottom = top + gue.GetAbsoluteHeight(); ;
+                var right = left + gue.AbsoluteWidth;
+                var bottom = top + gue.AbsoluteHeight; ;
 
                 return new SKRect(left, top, right, bottom);
             }

--- a/Samples/GameUiSamples/Screens/FrbClicker/FrbClickerCodeOnly.cs
+++ b/Samples/GameUiSamples/Screens/FrbClicker/FrbClickerCodeOnly.cs
@@ -209,7 +209,7 @@ public class FrbClickerCodeOnly : Panel, IUpdateScreen
 
             if(toolTip.AbsoluteRight > GraphicalUiElement.CanvasWidth)
             {
-                toolTip.X = GraphicalUiElement.CanvasWidth - toolTip.GetAbsoluteWidth();
+                toolTip.X = GraphicalUiElement.CanvasWidth - toolTip.AbsoluteWidth;
             }
         }
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -141,8 +141,8 @@ namespace MonoGameGumInCode
             // by the nav strip's footprint so the two never overlap.
             _currentScreen.Visual.YOrigin = RenderingLibrary.Graphics.VerticalAlignment.Top;
             _currentScreen.Visual.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
-            _currentScreen.Visual.Y = _navStrip.Visual.GetAbsoluteHeight();
-            _currentScreen.Visual.Height = -_navStrip.Visual.GetAbsoluteHeight();
+            _currentScreen.Visual.Y = _navStrip.Visual.AbsoluteHeight;
+            _currentScreen.Visual.Height = -_navStrip.Visual.AbsoluteHeight;
             _currentScreen.AddToRoot();
         }
 

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -206,8 +206,8 @@ unsafe class Program
             currentCodeScreen = codeScreenFactories[currentScreenIndex - gumxScreens.Count]();
             currentCodeScreen.Visual.YOrigin = VerticalAlignment.Top;
             currentCodeScreen.Visual.YUnits = Gum.Converters.GeneralUnitType.PixelsFromSmall;
-            currentCodeScreen.Visual.Y = navStrip.Visual.GetAbsoluteHeight();
-            currentCodeScreen.Visual.Height = -navStrip.Visual.GetAbsoluteHeight();
+            currentCodeScreen.Visual.Y = navStrip.Visual.AbsoluteHeight;
+            currentCodeScreen.Visual.Height = -navStrip.Visual.AbsoluteHeight;
             currentCodeScreen.AddToRoot();
         }
     }
@@ -222,7 +222,7 @@ unsafe class Program
     {
         if (currentGumxScreen == null) return;
 
-        float navStripHeight = navStrip.Visual.GetAbsoluteHeight();
+        float navStripHeight = navStrip.Visual.AbsoluteHeight;
         currentGumxScreen.Width = GraphicalUiElement.CanvasWidth;
         currentGumxScreen.Height = GraphicalUiElement.CanvasHeight - navStripHeight;
         currentGumxScreen.Y = navStripHeight;

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -243,7 +243,7 @@ public class BasicShapes
         // Offset the screen so it doesn't sit underneath the nav strip — same trick as
         // MonoGameGumInCode/Game1.ShowScreen. Use the nav strip's actual laid-out height so a
         // wrapped (multi-row) button strip still clears the screen content below it.
-        float navStripHeight = navStrip!.Visual.GetAbsoluteHeight();
+        float navStripHeight = navStrip!.Visual.AbsoluteHeight;
         activeScreen.Visual.YOrigin = VerticalAlignment.Top;
         activeScreen.Visual.YUnits = GeneralUnitType.PixelsFromSmall;
         activeScreen.Visual.Y = navStripHeight;

--- a/Tests/MonoGameGum.Tests.V2/Forms/MenuTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/MenuTests.cs
@@ -28,6 +28,6 @@ public class MenuTests
     public void AbsoluteHeight_ShouldNotBe0_IfNoItemsAreAdded()
     {
         Menu menu = new();
-        menu.Visual.GetAbsoluteHeight().ShouldBeGreaterThan(0);
+        menu.Visual.AbsoluteHeight.ShouldBeGreaterThan(0);
     }
 }

--- a/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Forms/ScrollBarTests.cs
@@ -62,8 +62,8 @@ public class ScrollBarTests
         ScrollBar scrollBar = new();
         ScrollBarVisual scrollBarVisual = (ScrollBarVisual)scrollBar.Visual;
 
-        scrollBarVisual.ThumbInstance.GetAbsoluteWidth().ShouldBe(
-            scrollBarVisual.GetAbsoluteWidth());
+        scrollBarVisual.ThumbInstance.AbsoluteWidth.ShouldBe(
+            scrollBarVisual.AbsoluteWidth);
     }
 
 }

--- a/Tests/MonoGameGum.Tests.V3/WindowVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/WindowVisualTests.cs
@@ -37,8 +37,8 @@ public class WindowVisualTests
         child.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
         child.HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute;
 
-        window.Visual.GetAbsoluteWidth().ShouldBe(100 + 1 + 3);
-        window.Visual.GetAbsoluteHeight().ShouldBe(150 + 2 + 4);
+        window.Visual.AbsoluteWidth.ShouldBe(100 + 1 + 3);
+        window.Visual.AbsoluteHeight.ShouldBe(150 + 2 + 4);
     }
 
     [Fact]

--- a/Tests/RaylibGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -97,7 +97,7 @@ public class SpriteRuntimeTests : BaseTestClass
 
         // Raylib implementation uses 64 as default width in InvisibleRenderable/GraphicalUiElement 
         // if texture is null and using PercentageOfSourceFile.
-        sut.GetAbsoluteWidth().ShouldBe(64);
+        sut.AbsoluteWidth.ShouldBe(64);
     }
 
     [Fact]
@@ -124,11 +124,11 @@ public class SpriteRuntimeTests : BaseTestClass
         
         sut.Texture = texture;
         
-        sut.GetAbsoluteWidth().ShouldBe(100);
+        sut.AbsoluteWidth.ShouldBe(100);
         
         var biggerTexture = new Texture2D { Width = 200, Height = 200 };
         sut.Texture = biggerTexture;
         
-        sut.GetAbsoluteWidth().ShouldBe(200);
+        sut.AbsoluteWidth.ShouldBe(200);
     }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
@@ -53,7 +53,7 @@ public class TextRuntimeFontCachingRegressionTests : BaseTestClass
                 Gum.Renderables.Text renderable = (Gum.Renderables.Text)textRuntime.RenderableComponent;
                 renderable.Font.BaseSize.ShouldBeGreaterThan(0,
                     "every text must resolve a usable fallback font, not the empty (BaseSize 0) font cached after the .fnt load failed");
-                textRuntime.GetAbsoluteHeight().ShouldBeGreaterThan(0,
+                textRuntime.AbsoluteHeight.ShouldBeGreaterThan(0,
                     "a text with a usable font and Height=RelativeToChildren must measure to a non-zero line height");
             }
         });
@@ -68,10 +68,10 @@ public class TextRuntimeFontCachingRegressionTests : BaseTestClass
         WithFont18ArialCached(() =>
         {
             TextRuntime first = NewArial18Text("List item 1");
-            first.GetAbsoluteHeight().ShouldBe(21);
+            first.AbsoluteHeight.ShouldBe(21);
 
             TextRuntime second = NewArial18Text("List item 2");
-            second.GetAbsoluteHeight().ShouldBe(21);
+            second.AbsoluteHeight.ShouldBe(21);
         });
     }
 
@@ -159,9 +159,9 @@ public class TextRuntimeFontCachingRegressionTests : BaseTestClass
 
             stack.UpdateLayout();
 
-            first.GetAbsoluteHeight().ShouldBe(21);
-            second.GetAbsoluteHeight().ShouldBe(21);
-            stack.GetAbsoluteHeight().ShouldBe(42);
+            first.AbsoluteHeight.ShouldBe(21);
+            second.AbsoluteHeight.ShouldBe(21);
+            stack.AbsoluteHeight.ShouldBe(42);
             second.AbsoluteTop.ShouldBe(first.AbsoluteTop + 21);
         });
     }

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -36,10 +36,10 @@ public class TextRuntimeTests : BaseTestClass
         sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
         sut.Width = 0;
         sut.Text = "Short";
-        float shortWidth = sut.GetAbsoluteWidth();
+        float shortWidth = sut.AbsoluteWidth;
 
         sut.Text = "This is much longer";
-        float longWidth = sut.GetAbsoluteWidth();
+        float longWidth = sut.AbsoluteWidth;
 
         longWidth.ShouldBeGreaterThan(shortWidth);
     }
@@ -51,11 +51,11 @@ public class TextRuntimeTests : BaseTestClass
 
         textRuntime.Text = "Hello";
 
-        var widthBefore = textRuntime.GetAbsoluteWidth();
+        var widthBefore = textRuntime.AbsoluteWidth;
 
         textRuntime.Text = "Hello\na";
 
-        var widthAfter = textRuntime.GetAbsoluteWidth();
+        var widthAfter = textRuntime.AbsoluteWidth;
 
         widthBefore.ShouldBe(widthAfter, "Because a trailing newline should not affect the width of a text");
     }
@@ -216,7 +216,7 @@ public class TextRuntimeTests : BaseTestClass
             setterFont.Texture.Width.ShouldBe(stateFont.Texture.Width);
             setterFont.Texture.Height.ShouldBe(stateFont.Texture.Height);
             // ... and on measured size (catches a wrong font size, which atlas size alone would not).
-            viaSetter.GetAbsoluteWidth().ShouldBe(viaState.GetAbsoluteWidth());
+            viaSetter.AbsoluteWidth.ShouldBe(viaState.AbsoluteWidth);
         }
         finally
         {
@@ -651,7 +651,7 @@ public class TextRuntimeTests : BaseTestClass
             text.SetProperty("FontSize", 18);
             text.Text = "List item 1";
 
-            text.GetAbsoluteHeight().ShouldBe(21);
+            text.AbsoluteHeight.ShouldBe(21);
         });
     }
 

--- a/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
@@ -295,19 +295,19 @@ public class SpriteRuntimeTests
         sut.HeightUnits = Gum.DataTypes.DimensionUnitType.PercentageOfSourceFile;
 
         // Initial 100% of nothing is probably 0 or default
-        var initialWidth = sut.GetAbsoluteWidth();
+        var initialWidth = sut.AbsoluteWidth;
 
         var bitmap = new SKBitmap(100, 50);
         sut.Texture = bitmap;
 
         // 100% of 100 should be 100
-        sut.GetAbsoluteWidth().ShouldBe(100);
-        sut.GetAbsoluteHeight().ShouldBe(50);
+        sut.AbsoluteWidth.ShouldBe(100);
+        sut.AbsoluteHeight.ShouldBe(50);
 
         var biggerBitmap = new SKBitmap(200, 300);
         sut.Texture = biggerBitmap;
 
-        sut.GetAbsoluteWidth().ShouldBe(200);
-        sut.GetAbsoluteHeight().ShouldBe(300);
+        sut.AbsoluteWidth.ShouldBe(200);
+        sut.AbsoluteHeight.ShouldBe(300);
     }
 }

--- a/Tests/SokolGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/SokolGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -314,7 +314,7 @@ public class TextRuntimeTests : BaseTestClass
                 Text = "aaa bbb ccc ddd",
             };
             sut.UpdateLayout();
-            sut.GetAbsoluteHeight().ShouldBe(48f);
+            sut.AbsoluteHeight.ShouldBe(48f);
         }
         finally { Text.DefaultMeasurer = previous; }
     }
@@ -334,7 +334,7 @@ public class TextRuntimeTests : BaseTestClass
                 Text = "Hello",
             };
             sut.UpdateLayout();
-            sut.GetAbsoluteHeight().ShouldBe(24f);
+            sut.AbsoluteHeight.ShouldBe(24f);
         }
         finally { Text.DefaultMeasurer = previousMeasurer; }
     }

--- a/Tool/EditorTabPlugin_XNA/Editors/Visuals/RotationHandleVisual.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Visuals/RotationHandleVisual.cs
@@ -86,11 +86,11 @@ public class RotationHandleVisual : EditorVisualBase, IRotationHandleVisual
 
         if (singleSelectedObject.XOrigin == HorizontalAlignment.Left)
         {
-            xOffset = singleSelectedObject.GetAbsoluteWidth() + minimumOffset;
+            xOffset = singleSelectedObject.AbsoluteWidth + minimumOffset;
         }
         else if (singleSelectedObject.XOrigin == HorizontalAlignment.Center)
         {
-            xOffset = singleSelectedObject.GetAbsoluteWidth() / 2.0f + minimumOffset;
+            xOffset = singleSelectedObject.AbsoluteWidth / 2.0f + minimumOffset;
         }
         else if (singleSelectedObject.XOrigin == HorizontalAlignment.Right)
         {

--- a/Tool/EditorTabPlugin_XNA/Views/OriginDisplay.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/OriginDisplay.cs
@@ -128,7 +128,7 @@ namespace Gum.Wireframe
                 //if (parentFlips)
                 //{
                 //    var rotationMatrix = parent.GetAbsoluteRotationMatrix();
-                //    Vector3 offset = new Vector3(parent.GetAbsoluteWidth(), 0, 0);
+                //    Vector3 offset = new Vector3(parent.AbsoluteWidth, 0, 0);
                 //    offset = Vector3.Transform(offset, rotationMatrix);
                 //    parentOriginOffsetX += offset.X;
                 //    parentOriginOffsetY += offset.Y;
@@ -221,7 +221,7 @@ namespace Gum.Wireframe
             if (parentFlips)
             {
                 var rotationMatrix = asGue.GetAbsoluteRotationMatrix();
-                Vector3 offset = new Vector3(asGue.GetAbsoluteWidth(), 0, 0);
+                Vector3 offset = new Vector3(asGue.AbsoluteWidth, 0, 0);
                 offset = Vector3.Transform(offset, rotationMatrix);
                 selectedObjectX += offset.X;
                 selectedObjectY += offset.Y;

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs
@@ -157,8 +157,8 @@ public class EditorContext
             SelectedState.SelectedIpso != null)
         {
             var ipso = (GraphicalUiElement)SelectedState.SelectedIpso;
-            float width = ipso.GetAbsoluteWidth();
-            float height = ipso.GetAbsoluteHeight();
+            float width = ipso.AbsoluteWidth;
+            float height = ipso.AbsoluteHeight;
 
             if (height != 0)
             {

--- a/docs/code/controls/scrollviewer/bottom-to-top-stacking.md
+++ b/docs/code/controls/scrollviewer/bottom-to-top-stacking.md
@@ -65,7 +65,7 @@ void FillAndExpandVertically(GraphicalUiElement visual)
     visual.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
 
     // then measure:
-    if(visual.GetAbsoluteHeight() > visual.Parent.GetAbsoluteHeight())
+    if(visual.AbsoluteHeight > visual.Parent.AbsoluteHeight)
     {
         visual.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
     }

--- a/docs/code/gum-code-reference/graphicaluielement/absolute-values.md
+++ b/docs/code/gum-code-reference/graphicaluielement/absolute-values.md
@@ -12,6 +12,8 @@ The following absolute values are available:
 * AbsoluteBottom - Returns the absolute bottom edge of the GraphicalUiElement
 * AbsoluteX - Returns the absolute X of the GraphicalUiElement considering its XOrigin
 * AbsoluteY - Returns the absolute Y of the GraphicalUiElement considering its YOrigin
+* AbsoluteWidth - Returns the absolute width of the GraphicalUiElement in pixels
+* AbsoluteHeight - Returns the absolute height of the GraphicalUiElement in pixels
 
 ## Code Example - Drawing a Sprite at the Absolute Position
 

--- a/docs/code/gum-code-reference/graphicaluielement/getabsoluteheight.md
+++ b/docs/code/gum-code-reference/graphicaluielement/getabsoluteheight.md
@@ -1,5 +1,9 @@
 # GetAbsoluteHeight
 
+{% hint style="warning" %}
+`GetAbsoluteHeight()` is obsolete. Use the [AbsoluteHeight](absolute-values.md) property instead.
+{% endhint %}
+
 ### Introduction
 
 Returns the height of the calling GraphicalUiElement in pixels. This can be used to get the actual height of instance even if it is using a Height Units that is not pixels.

--- a/docs/code/gum-code-reference/graphicaluielement/getabsolutewidth.md
+++ b/docs/code/gum-code-reference/graphicaluielement/getabsolutewidth.md
@@ -1,5 +1,9 @@
 # GetAbsoluteWidth
 
+{% hint style="warning" %}
+`GetAbsoluteWidth()` is obsolete. Use the [AbsoluteWidth](absolute-values.md) property instead.
+{% endhint %}
+
 ### Introduction
 
 Returns the width of the calling GraphicalUiElement in pixels. This can be used to get the actual width of instance even if it is using a Width Units that is not pixels.

--- a/docs/code/performance-and-optimization/measuring-layout-calls.md
+++ b/docs/code/performance-and-optimization/measuring-layout-calls.md
@@ -31,12 +31,12 @@ stackPanel.Anchor(Anchor.Center);
 
 for(int i = 0; i < 10; i++)
 {
-    float heightBefore = stackPanel.Visual.GetAbsoluteHeight();
+    float heightBefore = stackPanel.Visual.AbsoluteHeight;
 
     Label label = new();
     stackPanel.AddChild(label);
 
-    float heightAfter = stackPanel.Visual.GetAbsoluteHeight();
+    float heightAfter = stackPanel.Visual.AbsoluteHeight;
 
     label.Text = 
         $"Label {i + 1} (StackPanel Height: {heightBefore} -> {heightAfter})";
@@ -45,7 +45,7 @@ for(int i = 0; i < 10; i++)
 
 <figure><img src="../../.gitbook/assets/02_07 57 16.png" alt=""><figcaption><p>StackPanel displaying its size</p></figcaption></figure>
 
-This code shows that a `StackPanel's` absolute height is calculated after every `AddChild` call. Note that the absolute height is calculated whether we call `GetAbsoluteHeight` or not - this method simply retrieves the already-calculated value.
+This code shows that a `StackPanel's` absolute height is calculated after every `AddChild` call. Note that the absolute height is calculated whether we access `AbsoluteHeight` or not - this property simply retrieves the already-calculated value.
 
 This behavior has the benefit of an object always updating its most up-to-date position and size, but it has the downside of performing potentially unnecessary layout calls.
 
@@ -64,12 +64,12 @@ stackPanel.Anchor(Anchor.Center);
 
 <strong>for(int i = 0; i &#x3C; 20; i++)
 </strong>{
-    float heightBefore = stackPanel.Visual.GetAbsoluteHeight();
+    float heightBefore = stackPanel.Visual.AbsoluteHeight;
 
     Label label = new();
     stackPanel.AddChild(label);
 
-    float heightAfter = stackPanel.Visual.GetAbsoluteHeight();
+    float heightAfter = stackPanel.Visual.AbsoluteHeight;
 
 <strong>    label.Text =
 </strong><strong>        $"Label {i + 1}, layout calls: {GraphicalUiElement.UpdateLayoutCallCount}";
@@ -134,12 +134,12 @@ stackPanel.Anchor(Anchor.Center);
 
 for(int i = 0; i &#x3C; 20; i++)
 {
-    float heightBefore = stackPanel.Visual.GetAbsoluteHeight();
+    float heightBefore = stackPanel.Visual.AbsoluteHeight;
 
     Label label = new();
     stackPanel.AddChild(label);
 
-    float heightAfter = stackPanel.Visual.GetAbsoluteHeight();
+    float heightAfter = stackPanel.Visual.AbsoluteHeight;
 
     label.Text = 
         $"Label {i + 1}, layout calls: {GraphicalUiElement.UpdateLayoutCallCount}";

--- a/docs/code/styling/runtime-variable-references.md
+++ b/docs/code/styling/runtime-variable-references.md
@@ -119,7 +119,7 @@ For computed or transformed values, use the lambda overload:
 ```csharp
 // In CustomInitialize
 this.RegisterRuntimeProperty(
-    () => ContentPanel.GetAbsoluteWidth(),
+    () => ContentPanel.AbsoluteWidth,
     v => ContentPanel.Width = v);
 ```
 


### PR DESCRIPTION
…h/GetAbsoluteHeight

Mirrors the existing AbsoluteLeft/Top/Right/Bottom property pattern. Migrates all internal call sites across runtime/tool/tests/samples to the new properties.

Closes #4014