### PR TITLE
Variable references: resolve AbsoluteX/Y/Left/Top/Right/Bottom/Width/Height

### DIFF
--- a/.claude/skills/gum-runtime-variable-references/SKILL.md
+++ b/.claude/skills/gum-runtime-variable-references/SKILL.md
@@ -38,7 +38,7 @@ Gum.Expressions (adds Roslyn) — optional NuGet
 Gum Tool    Game (opt-in)
 ```
 
-The decoupling mechanism is `ElementSaveExtensions.CustomEvaluateExpression` — a static `Func<StateSave, string, string, object>` delegate. When null, falls back to `RecursiveVariableFinder` (simple lookups only). When set by `GumExpressionService.Initialize()`, uses Roslyn for full expression support.
+The decoupling mechanism is `ElementSaveExtensions.CustomEvaluateExpression` — a static `Func<StateSave, string, string, GraphicalUiElement?, object>` delegate. When null, falls back to `RecursiveVariableFinder` (simple lookups only). When set by `GumExpressionService.Initialize()`, uses Roslyn for full expression support. The 4th argument is the live, already-laid-out `GraphicalUiElement` being applied against (when one exists) — it lets a reference resolve the runtime-computed Absolute* properties, which don't exist on authored `StateSave` data at all (see `gum-tool-variable-references` for the resolution mechanism). `ApplyVariableReferences(GraphicalUiElement, StateSave)` supplies its own top-level element automatically; `ApplyVariableReferences(ElementSave, StateSave)` only resolves Absolute* references when called with its optional `liveRoot` argument.
 
 After applying variable references, call `GraphicalUiElement.RefreshStyles()` or
 `GumService.Default.RefreshStyles()` to push the updated values to live visuals. For a deep

--- a/.claude/skills/gum-tool-variable-references/SKILL.md
+++ b/.claude/skills/gum-tool-variable-references/SKILL.md
@@ -51,10 +51,10 @@ SetVariableLogic (variable change entry point)
 
 | Class | Location | Role |
 |-------|----------|------|
-| `VariableReferenceLogic` | `Gum/Plugins/InternalPlugins/VariableGrid/` | Tool-side orchestration: validation, reaction to changes, line expansion |
-| `EvaluatedSyntax` | Same directory | Roslyn-based expression parser/evaluator; resolves right-side values via `RecursiveVariableFinder` |
+| `VariableReferenceLogic` | `Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/` | Tool-side orchestration: validation, reaction to changes, line expansion |
+| `EvaluatedSyntax` | `Runtimes/GumExpressions/` | Roslyn-based expression parser/evaluator (shared `Gum.Expressions` package); resolves right-side values via `RecursiveVariableFinder`, or via a live `GraphicalUiElement` for Absolute* identifiers (see below) |
 | `ElementSaveExtensions` (partial) | `GumRuntime/ElementSaveExtensions.GumRuntime.cs` | `ApplyVariableReferences` — two overloads: one for `ElementSave` (save-class, tool-time), one for `GraphicalUiElement` (runtime) |
-| `MainVariableGridPlugin` | Same directory as logic | Wires `CustomEvaluateExpression` delegate so the runtime can use Roslyn evaluation |
+| `MainVariableGridPlugin` | `Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/` | Calls `GumExpressionService.Initialize()` so the tool uses Roslyn evaluation |
 
 ### Two Apply Paths
 
@@ -69,6 +69,12 @@ SetVariableLogic (variable change entry point)
 `GetRightSideValue` resolves the right side of an assignment:
 - In the tool: `CustomEvaluateExpression` is set by `MainVariableGridPlugin` to use `EvaluatedSyntax` (Roslyn parsing with full expression support).
 - At runtime (no tool): Falls back to `RecursiveVariableFinder` with simple dot-path lookup — no expression support, just direct variable resolution.
+
+### Resolving Absolute* Identifiers (AbsoluteX/Y/Left/Top/Right/Bottom/Width/Height)
+
+These exist only as computed properties on an already-laid-out `GraphicalUiElement` — never as authored `StateSave` data — so `RecursiveVariableFinder` can never resolve them. `EvaluatedSyntax` takes an optional `liveRoot` (a `GraphicalUiElement`) threaded all the way from the top of the apply chain; when the right side's final identifier is one of these names, it resolves against `liveRoot.GetGraphicalUiElementByName(...)` instead of falling through to state lookup. `liveRoot` is scoped to one element (mirrors how instance names are scoped), so a cross-element (`Components/Foo...`) reference never attempts this resolution.
+
+Both apply paths supply `liveRoot` when a live tree is available: the tool passes `IWireframeObjectManager.GetRepresentation(parentElement)` (null when nothing is currently rendered for that element); the runtime passes the top-level `GraphicalUiElement` already being applied against. Validation (`AddFailureForLine`) needs the same `liveRoot` as the apply call, or a valid Absolute* reference gets auto-commented out before it's ever applied.
 
 ### Left-Side Type Coercion
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -11,8 +11,6 @@ using Gum.Wireframe;
 using GumRuntime;
 using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -31,17 +29,6 @@ public class MainVariableGridPlugin : PriorityPlugin
         _propertyGridManager = propertyGridManager;
         _variableReferenceLogic = variableReferenceLogic;
         GumExpressionService.Initialize();
-
-        // TEMP DIAGNOSTIC - remove before merge
-        GraphicalUiElement.DiagnosticPropertySetHook = (gue, propertyName, oldValue, newValue) =>
-        {
-            if (string.IsNullOrEmpty(gue.Name)) return;
-            var frames = new StackTrace(2, false).GetFrames()
-                ?.Take(20)
-                .Select(f => f.GetMethod()?.DeclaringType?.Name + "." + f.GetMethod()?.Name);
-            var callChain = frames != null ? string.Join(" <- ", frames) : "?";
-            _guiCommands.PrintOutput($"[{propertyName} SET] {gue.Name} ({gue.GetHashCode()}): {oldValue} -> {newValue} | {callChain}");
-        };
     }
 
     public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -33,14 +33,14 @@ public class MainVariableGridPlugin : PriorityPlugin
         GumExpressionService.Initialize();
 
         // TEMP DIAGNOSTIC - remove before merge
-        GraphicalUiElement.DiagnosticXSetHook = (gue, oldX, newX) =>
+        GraphicalUiElement.DiagnosticPropertySetHook = (gue, propertyName, oldValue, newValue) =>
         {
             if (string.IsNullOrEmpty(gue.Name)) return;
             var frames = new StackTrace(2, false).GetFrames()
-                ?.Take(8)
+                ?.Take(20)
                 .Select(f => f.GetMethod()?.DeclaringType?.Name + "." + f.GetMethod()?.Name);
             var callChain = frames != null ? string.Join(" <- ", frames) : "?";
-            _guiCommands.PrintOutput($"[X SET] {gue.Name} ({gue.GetHashCode()}): {oldX} -> {newX} | {callChain}");
+            _guiCommands.PrintOutput($"[{propertyName} SET] {gue.Name} ({gue.GetHashCode()}): {oldValue} -> {newValue} | {callChain}");
         };
     }
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -7,9 +7,12 @@ using Gum.Managers;
 
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
+using Gum.Wireframe;
 using GumRuntime;
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -28,6 +31,17 @@ public class MainVariableGridPlugin : PriorityPlugin
         _propertyGridManager = propertyGridManager;
         _variableReferenceLogic = variableReferenceLogic;
         GumExpressionService.Initialize();
+
+        // TEMP DIAGNOSTIC - remove before merge
+        GraphicalUiElement.DiagnosticXSetHook = (gue, oldX, newX) =>
+        {
+            if (string.IsNullOrEmpty(gue.Name)) return;
+            var frames = new StackTrace(2, false).GetFrames()
+                ?.Take(8)
+                .Select(f => f.GetMethod()?.DeclaringType?.Name + "." + f.GetMethod()?.Name);
+            var callChain = frames != null ? string.Join(" <- ", frames) : "?";
+            _guiCommands.PrintOutput($"[X SET] {gue.Name} ({gue.GetHashCode()}): {oldX} -> {newX} | {callChain}");
+        };
     }
 
     public override void StartUp()

--- a/GumRuntime/ElementSaveExtensions.GumRuntime.cs
+++ b/GumRuntime/ElementSaveExtensions.GumRuntime.cs
@@ -25,7 +25,14 @@ namespace GumRuntime
         static Dictionary<string, Func<GraphicalUiElement>> mElementToGueTypeFuncs = new Dictionary<string, Func<GraphicalUiElement>>();
         static Func<GraphicalUiElement>? TemplateFunc;
 
-        public static Func<StateSave, string, string, object>? CustomEvaluateExpression;
+        /// <summary>
+        /// Evaluates a variable reference's right side. The 4th argument is the live,
+        /// already-laid-out <see cref="GraphicalUiElement"/> that owns the reference (null when
+        /// applying against pure <see cref="StateSave"/> data with no live tree, e.g. the tool's
+        /// design-time apply path with no wireframe rendered) - it lets the evaluator resolve
+        /// runtime-computed identifiers like <c>AbsoluteWidth</c> that don't exist on authored data.
+        /// </summary>
+        public static Func<StateSave, string, string, GraphicalUiElement?, object>? CustomEvaluateExpression;
 
         public static void RegisterGueInstantiationType(string elementName, Type gueInheritingType, bool overwriteIfAlreadyExists = true)
         {
@@ -719,7 +726,11 @@ namespace GumRuntime
             }
         }
 
-        public static void ApplyVariableReferences(this ElementSave element, StateSave stateSave)
+        // liveRoot: the live, already-laid-out GraphicalUiElement representing element, when one is
+        // currently rendered (e.g. the tool's wireframe for the element being edited). Lets right-side
+        // references resolve runtime-computed identifiers such as AbsoluteWidth; null (the default)
+        // leaves those identifiers unresolved, same as before this parameter existed.
+        public static void ApplyVariableReferences(this ElementSave element, StateSave stateSave, GraphicalUiElement? liveRoot = null)
         {
             foreach (var variableList in stateSave.VariableLists)
             {
@@ -735,7 +746,7 @@ namespace GumRuntime
                     foreach (string referenceString in variableList.ValueAsIList)
                     {
                         // this applies the variable and returns info about the application:
-                        var result = ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave);
+                        var result = ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave, liveRoot);
                         // In the gum tool, we need to check if the applicatoin actually changed the value
                         // If so, we notify plugins that the variable was changed in case any additional changes
                         // need to happen
@@ -773,7 +784,7 @@ namespace GumRuntime
                     {
                         foreach (string referenceString in variableList.ValueAsIList)
                         {
-                            ApplyVariableReferencesOnSpecificOwner(graphicalElement, referenceString, stateSave);
+                            ApplyVariableReferencesOnSpecificOwner(graphicalElement, referenceString, stateSave, graphicalElement);
                         }
                     }
                     else
@@ -787,7 +798,7 @@ namespace GumRuntime
                         else
                         {
                             // Give preferential treatment to the children of graphicalElement. If none are found, then go to the managers
-                            // 
+                            //
                             instance = graphicalElement.GetGraphicalUiElementByName(variableList.SourceObject);
                         }
 
@@ -795,7 +806,7 @@ namespace GumRuntime
                         {
                             foreach (string referenceString in variableList.ValueAsIList)
                             {
-                                ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave);
+                                ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave, graphicalElement);
                             }
                         }
                     }
@@ -811,7 +822,12 @@ namespace GumRuntime
         /// <param name="referenceOwner">The owner that owns the variable reference, such as the instance.</param>
         /// <param name="referenceString">The string such as "X = SomeItem.X"</param>
         /// <param name="stateSave">The state save which owns the variable reference.</param>
-        public static void ApplyVariableReferencesOnSpecificOwner(GraphicalUiElement referenceOwner, string referenceString, StateSave stateSave)
+        /// <param name="liveRootForRightSide">The top-level live <see cref="GraphicalUiElement"/> to
+        /// search within for a right-side runtime-computed identifier such as <c>AbsoluteWidth</c>
+        /// (e.g. "Source.AbsoluteWidth"). Defaults to <paramref name="referenceOwner"/> when not
+        /// given, since instance names are scoped to the owning element, not to the instance that
+        /// happens to own the reference.</param>
+        public static void ApplyVariableReferencesOnSpecificOwner(GraphicalUiElement referenceOwner, string referenceString, StateSave stateSave, GraphicalUiElement? liveRootForRightSide = null)
         {
             //////////////////////////////Early Out/////////////////////////////////
             if(referenceString?.StartsWith("//") == true)
@@ -849,7 +865,7 @@ namespace GumRuntime
 
 
             var right = split[1];
-            var value = GetRightSideValue(stateSave, right, leftSideType);
+            var value = GetRightSideValue(stateSave, right, leftSideType, liveRootForRightSide ?? referenceOwner);
 
 
             if (value != null)
@@ -872,9 +888,13 @@ namespace GumRuntime
         /// back into the state. Used by both state-level <c>VariableReferences</c>
         /// application and (tool-only) behavior <c>ToolOnlyVariableReferences</c>
         /// application. Returns the resulting variable name + old/new values so callers
-        /// can fire change notifications.
+        /// can fire change notifications. <paramref name="liveRoot"/> is the live <see
+        /// cref="GraphicalUiElement"/> to search within for a right-side runtime-computed identifier
+        /// such as <c>AbsoluteWidth</c>, when one is available (e.g. the tool's currently-rendered
+        /// wireframe for this element); null when applying against pure save data with nothing
+        /// rendered, in which case such identifiers are simply unresolvable.
         /// </summary>
-        public static VariableReferenceAssignmentResult ApplyVariableReferencesOnSpecificOwner(InstanceSave instanceLeft, string referenceString, StateSave stateSave)
+        public static VariableReferenceAssignmentResult ApplyVariableReferencesOnSpecificOwner(InstanceSave instanceLeft, string referenceString, StateSave stateSave, GraphicalUiElement? liveRoot = null)
         {
 
             //////////////////////////////Early Out/////////////////////////////////
@@ -909,7 +929,7 @@ namespace GumRuntime
             }
 
             var right = split[1];
-            object value = GetRightSideValue(stateSave, right, leftSideType);
+            object value = GetRightSideValue(stateSave, right, leftSideType, liveRoot);
 
             object valueBefore = null;
             string effectiveLeft = null;
@@ -935,19 +955,19 @@ namespace GumRuntime
             };
         }
 
-        private static object GetRightSideValue(StateSave stateSave, string right, string leftSideType)
+        private static object GetRightSideValue(StateSave stateSave, string right, string leftSideType, GraphicalUiElement? liveRoot = null)
         {
             if (right.TrimStart().StartsWith("!"))
             {
                 var withoutNot = right.TrimStart().Substring(1).Trim();
-                var originalValue = GetRightSideValue(stateSave, withoutNot, leftSideType);
+                var originalValue = GetRightSideValue(stateSave, withoutNot, leftSideType, liveRoot);
                 if (originalValue is bool boolValue) return !boolValue;
                 return null;
             }
 
             if(CustomEvaluateExpression != null)
             {
-                return CustomEvaluateExpression(stateSave, right, leftSideType);
+                return CustomEvaluateExpression(stateSave, right, leftSideType, liveRoot);
             }
             else
             {

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -859,6 +859,9 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
+    // TEMP DIAGNOSTIC - remove before merge
+    public static Action<GraphicalUiElement, float, float>? DiagnosticXSetHook;
+
     public float X
     {
         get
@@ -869,6 +872,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         {
             if (mX != value && mContainedObjectAsIpso != null)
             {
+                // TEMP DIAGNOSTIC - remove before merge
+                DiagnosticXSetHook?.Invoke(this, mX, value);
 #if FULL_DIAGNOSTICS
                 if (float.IsNaN(value))
                 {

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -859,9 +859,6 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
-    // TEMP DIAGNOSTIC - remove before merge
-    public static Action<GraphicalUiElement, string, float, float>? DiagnosticPropertySetHook;
-
     public float X
     {
         get
@@ -872,8 +869,6 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         {
             if (mX != value && mContainedObjectAsIpso != null)
             {
-                // TEMP DIAGNOSTIC - remove before merge
-                DiagnosticPropertySetHook?.Invoke(this, "X", mX, value);
 #if FULL_DIAGNOSTICS
                 if (float.IsNaN(value))
                 {
@@ -1001,8 +996,6 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         {
             if (mWidth != value)
             {
-                // TEMP DIAGNOSTIC - remove before merge
-                DiagnosticPropertySetHook?.Invoke(this, "Width", mWidth, value);
 #if FULL_DIAGNOSTICS
                 if (float.IsPositiveInfinity(value) ||
                     float.IsNegativeInfinity(value) ||

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -860,7 +860,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     }
 
     // TEMP DIAGNOSTIC - remove before merge
-    public static Action<GraphicalUiElement, float, float>? DiagnosticXSetHook;
+    public static Action<GraphicalUiElement, string, float, float>? DiagnosticPropertySetHook;
 
     public float X
     {
@@ -873,7 +873,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
             if (mX != value && mContainedObjectAsIpso != null)
             {
                 // TEMP DIAGNOSTIC - remove before merge
-                DiagnosticXSetHook?.Invoke(this, mX, value);
+                DiagnosticPropertySetHook?.Invoke(this, "X", mX, value);
 #if FULL_DIAGNOSTICS
                 if (float.IsNaN(value))
                 {
@@ -1001,6 +1001,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         {
             if (mWidth != value)
             {
+                // TEMP DIAGNOSTIC - remove before merge
+                DiagnosticPropertySetHook?.Invoke(this, "Width", mWidth, value);
 #if FULL_DIAGNOSTICS
                 if (float.IsPositiveInfinity(value) ||
                     float.IsNegativeInfinity(value) ||

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -256,4 +256,53 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
     }
 
     #endregion
+
+    #region AbsoluteValues
+
+    [Fact]
+    public void ApplyVariableReferences_RightSideReferencesAbsoluteWidthOfSibling_ResolvesLiveLayoutValue()
+    {
+        // AbsoluteWidth only exists on a live, already-laid-out GraphicalUiElement - it can't be
+        // derived from authored StateSave data - so this locks in that the runtime apply path
+        // threads the top-level element through to EvaluatedSyntax so it can resolve it.
+        GumExpressionService.Initialize();
+
+        ContainerRuntime parent = new ContainerRuntime();
+        parent.Width = 0;
+
+        ContainerRuntime source = new ContainerRuntime();
+        source.Name = "Source";
+        source.Width = 120f;
+        source.Parent = parent;
+
+        StateSave state = BuildStateWithVariableReference(
+            "Width = Source.AbsoluteWidth",
+            null,
+            ("Width", 0f, "float"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.Width.ShouldBe(120f);
+    }
+
+    [Fact]
+    public void ApplyVariableReferences_RightSideReferencesOwnAbsoluteX_ResolvesLiveLayoutValue()
+    {
+        GumExpressionService.Initialize();
+
+        ContainerRuntime parent = new ContainerRuntime();
+        parent.X = 15f;
+        parent.Height = 0;
+
+        StateSave state = BuildStateWithVariableReference(
+            "Height = AbsoluteX",
+            null,
+            ("Height", 0f, "float"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.Height.ShouldBe(15f);
+    }
+
+    #endregion
 }

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -1,6 +1,7 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Wireframe;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CSharp.RuntimeBinder;
@@ -57,9 +58,19 @@ public class EvaluatedSyntax
     /// returns null. The Forms-property-promotion apply pipeline uses this to fall
     /// back to a linked behavior's <c>FormsProperty.Value</c> declarations when no
     /// state authors a value (mirrors WPF DependencyProperty default values).</param>
-    public static EvaluatedSyntax FromSyntaxNode(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)
+    /// <param name="liveRoot">Optional live, already-laid-out <see cref="GraphicalUiElement"/>
+    /// used to resolve the runtime-computed <c>AbsoluteX</c>/<c>AbsoluteY</c>/<c>AbsoluteLeft</c>/
+    /// <c>AbsoluteTop</c>/<c>AbsoluteRight</c>/<c>AbsoluteBottom</c>/<c>AbsoluteWidth</c>/
+    /// <c>AbsoluteHeight</c> identifiers. These only exist on a live object post-layout, not on
+    /// authored <see cref="StateSave"/> data, so <see cref="RecursiveVariableFinder"/> can never
+    /// resolve them; when null (the default), those identifiers are simply unresolvable, same as
+    /// any other unknown identifier. The instance path is resolved against <paramref
+    /// name="liveRoot"/> via <see cref="GraphicalUiElement.GetGraphicalUiElementByName(string)"/>,
+    /// so it is scoped to <paramref name="liveRoot"/>'s own element (does not cross into a
+    /// different element for a cross-element reference).</param>
+    public static EvaluatedSyntax FromSyntaxNode(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null, GraphicalUiElement? liveRoot = null)
     {
-        return Evaluate(syntaxNode, stateForUnqualifiedRightSide, fallback);
+        return Evaluate(syntaxNode, stateForUnqualifiedRightSide, fallback, liveRoot);
     }
 
     /// <summary>
@@ -92,15 +103,15 @@ public class EvaluatedSyntax
         return Evaluate(syntaxNode, restingState, fallback);
     }
 
-    private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null)
+    private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null, GraphicalUiElement? liveRoot = null)
     {
         if (syntaxNode is BinaryExpressionSyntax binaryExpressionSytax)
         {
             var leftSyntax = binaryExpressionSytax.Left;
             var rightSyntax = binaryExpressionSytax.Right;
 
-            var leftEvaluated = Evaluate(leftSyntax, stateForUnqualifiedRightSide, fallback);
-            var rightEvaluated = Evaluate(rightSyntax, stateForUnqualifiedRightSide, fallback);
+            var leftEvaluated = Evaluate(leftSyntax, stateForUnqualifiedRightSide, fallback, liveRoot);
+            var rightEvaluated = Evaluate(rightSyntax, stateForUnqualifiedRightSide, fallback, liveRoot);
 
             var value = Combine(leftEvaluated, rightEvaluated, binaryExpressionSytax.OperatorToken);
 
@@ -117,7 +128,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback, liveRoot);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;
@@ -127,6 +138,11 @@ public class EvaluatedSyntax
         }
         else if (syntaxNode is IdentifierNameSyntax or VariableDeclarationSyntax)
         {
+            if (TryResolveAbsoluteValue(liveRoot, syntaxNode.ToString(), out var absoluteValue))
+            {
+                return FromSyntaxAndValue(syntaxNode, absoluteValue);
+            }
+
             var rfv = new RecursiveVariableFinder(stateForUnqualifiedRightSide) { Fallback = fallback };
 
             var value = rfv.GetValue(syntaxNode.ToString());
@@ -142,8 +158,9 @@ public class EvaluatedSyntax
             RecursiveVariableFinder rfv = null;
 
             var stateForRfv = stateForUnqualifiedRightSide;
+            var isCrossElement = rightSideToEvaluate.StartsWith("global::");
 
-            if (rightSideToEvaluate.StartsWith("global::"))
+            if (isCrossElement)
             {
                 string elementName, elementType;
                 ConvertGlobalToElementNameWithSlashes(rightSideToEvaluate, out elementName, out elementType);
@@ -154,6 +171,14 @@ public class EvaluatedSyntax
                     stateForRfv = element?.DefaultState;
                     rightSideToEvaluate = rightSideToEvaluate.Substring(($"global::{elementType}." + elementName).Length + 1);
                 }
+            }
+
+            // liveRoot is scoped to stateForUnqualifiedRightSide's own element; a cross-element
+            // reference (global::) targets a different element's live tree, which liveRoot doesn't
+            // represent, so Absolute* resolution only applies to same-element references.
+            if (!isCrossElement && TryResolveAbsoluteValue(liveRoot, rightSideToEvaluate, out var absoluteValue))
+            {
+                return FromSyntaxAndValue(syntaxNode, absoluteValue);
             }
 
             if (stateForRfv == null)
@@ -172,11 +197,11 @@ public class EvaluatedSyntax
         }
         else if (syntaxNode is ConditionalExpressionSyntax conditional)
         {
-            var conditionEvaluated = Evaluate(conditional.Condition, stateForUnqualifiedRightSide, fallback);
+            var conditionEvaluated = Evaluate(conditional.Condition, stateForUnqualifiedRightSide, fallback, liveRoot);
             if (conditionEvaluated?.Value is bool conditionValue)
             {
                 var branch = conditionValue ? conditional.WhenTrue : conditional.WhenFalse;
-                var branchEvaluated = Evaluate(branch, stateForUnqualifiedRightSide, fallback);
+                var branchEvaluated = Evaluate(branch, stateForUnqualifiedRightSide, fallback, liveRoot);
                 if (branchEvaluated != null)
                 {
                     return FromSyntaxAndValue(syntaxNode, branchEvaluated.Value);
@@ -188,7 +213,7 @@ public class EvaluatedSyntax
         {
             if (prefixUnary.OperatorToken.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExclamationToken))
             {
-                var operand = Evaluate(prefixUnary.Operand, stateForUnqualifiedRightSide, fallback);
+                var operand = Evaluate(prefixUnary.Operand, stateForUnqualifiedRightSide, fallback, liveRoot);
                 if (operand?.Value is bool b)
                 {
                     return FromSyntaxAndValue(syntaxNode, !b);
@@ -215,7 +240,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback, liveRoot);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;
@@ -233,7 +258,7 @@ public class EvaluatedSyntax
 
             foreach (var item in childNodes)
             {
-                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback);
+                var evaluatedSyntax = Evaluate(item, stateForUnqualifiedRightSide, fallback, liveRoot);
                 if (evaluatedSyntax != null)
                 {
                     return evaluatedSyntax;
@@ -241,6 +266,57 @@ public class EvaluatedSyntax
             }
         }
         return null;
+    }
+
+    private static readonly Dictionary<string, Func<GraphicalUiElement, float>> AbsoluteValueSelectors = new()
+    {
+        ["AbsoluteX"] = gue => gue.AbsoluteX,
+        ["AbsoluteY"] = gue => gue.AbsoluteY,
+        ["AbsoluteLeft"] = gue => gue.AbsoluteLeft,
+        ["AbsoluteTop"] = gue => gue.AbsoluteTop,
+        ["AbsoluteRight"] = gue => gue.AbsoluteRight,
+        ["AbsoluteBottom"] = gue => gue.AbsoluteBottom,
+        ["AbsoluteWidth"] = gue => gue.AbsoluteWidth,
+        ["AbsoluteHeight"] = gue => gue.AbsoluteHeight,
+    };
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> (e.g. <c>"AbsoluteWidth"</c> or <c>"Source.AbsoluteWidth"</c>)
+    /// against <paramref name="liveRoot"/> when its final segment names one of the runtime-computed
+    /// Absolute* properties. These exist only on an already-laid-out <see cref="GraphicalUiElement"/>,
+    /// never on authored <see cref="StateSave"/> data, so they must be resolved here rather than via
+    /// <see cref="RecursiveVariableFinder"/>. Everything before the last dot (if any) is the
+    /// unqualified instance name, looked up within <paramref name="liveRoot"/>'s own element via
+    /// <see cref="GraphicalUiElement.GetGraphicalUiElementByName(string)"/>; no dot means "liveRoot
+    /// itself". Returns false (path not an Absolute* reference, or unresolvable) rather than throwing,
+    /// so callers can fall through to the normal resolution path.
+    /// </summary>
+    private static bool TryResolveAbsoluteValue(GraphicalUiElement? liveRoot, string path, out object? value)
+    {
+        value = null;
+
+        if (liveRoot == null)
+        {
+            return false;
+        }
+
+        var lastDot = path.LastIndexOf('.');
+        var instanceName = lastDot < 0 ? null : path.Substring(0, lastDot);
+        var propertyName = lastDot < 0 ? path : path.Substring(lastDot + 1);
+
+        if (!AbsoluteValueSelectors.TryGetValue(propertyName, out var selector))
+        {
+            return false;
+        }
+
+        var target = instanceName == null ? liveRoot : liveRoot.GetGraphicalUiElementByName(instanceName);
+        if (target == null)
+        {
+            return false;
+        }
+
+        value = selector(target);
+        return true;
     }
 
     // FixEnumerationsWithReflection promotes int-on-disk enum values to boxed enums in

--- a/Runtimes/GumExpressions/GumExpressionService.cs
+++ b/Runtimes/GumExpressions/GumExpressionService.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes.Variables;
+using Gum.Wireframe;
 using GumRuntime;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -20,7 +21,7 @@ public static class GumExpressionService
         ElementSaveExtensions.CustomEvaluateExpression = EvaluateExpression;
     }
 
-    private static object EvaluateExpression(StateSave stateSave, string expression, string desiredType)
+    private static object EvaluateExpression(StateSave stateSave, string expression, string desiredType, GraphicalUiElement? liveRoot)
     {
         expression = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
 
@@ -31,7 +32,7 @@ public static class GumExpressionService
 
         if (syntax != null)
         {
-            var evaluatedSyntax = EvaluatedSyntax.FromSyntaxNode(syntax, stateSave);
+            var evaluatedSyntax = EvaluatedSyntax.FromSyntaxNode(syntax, stateSave, liveRoot: liveRoot);
 
             if (evaluatedSyntax?.CastTo(desiredType) == true)
             {

--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -2,6 +2,7 @@ using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.Expressions;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.PropertyGridHelpers;
@@ -10,6 +11,7 @@ using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using Moq;
+using RenderingLibrary.Graphics;
 using Shouldly;
 
 namespace Gum.Presentation.Tests;
@@ -136,6 +138,69 @@ public class ElementCommandsTests : BaseTestClass
         // assert
         name.ShouldBe("TextInstance1");
     }
+
+    #region ModifyVariable
+
+    [Fact]
+    public void ModifyVariable_ReferenceReadsAbsoluteRightOfDraggedInstance_MaterializesLiveResolvedValueIntoStateSave()
+    {
+        // Repro for a live-drag bug: while dragging Source, a sibling's "X = Source.AbsoluteRight"
+        // reference must track Source's live position - not the position from before this drag
+        // tick started. ModifyVariable is called on every drag tick (ElementCommands.MoveSelectedObjectsBy),
+        // so its ElementSave-overload ApplyVariableReferences call must resolve against a live root
+        // that already reflects Source's just-applied position, or the materialized value goes stale
+        // and later gets overwritten back to the pre-drag value when the wireframe next refreshes
+        // from the (never-updated) StateSave scalar.
+        GumExpressionService.Initialize();
+
+        ComponentSave component = new ComponentSave { Name = "TestComponent" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+
+        InstanceSave sourceInstance = new InstanceSave { Name = "Source", BaseType = "Container", ParentContainer = component };
+        InstanceSave targetInstance = new InstanceSave { Name = "Target", BaseType = "Container", ParentContainer = component };
+        component.Instances.Add(sourceInstance);
+        component.Instances.Add(targetInstance);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Components.Add(component);
+        ObjectFinder.GumProjectSave = project;
+
+        defaultState.Variables.Add(new VariableSave { Name = "Source.X", Value = 0f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.XUnits", Value = PositionUnitType.PixelsFromLeft, Type = "PositionUnitType", SetsValue = true });
+        // The existing scalar the reference will overwrite - also what gives ApplyVariableReferencesOnSpecificOwner
+        // the left-side type ("float") it needs to cast the resolved AbsoluteRight value to.
+        defaultState.Variables.Add(new VariableSave { Name = "Target.X", Value = 0f, Type = "float", SetsValue = true });
+
+        VariableListSave<string> targetRefs = new VariableListSave<string> { Type = "string", Name = "Target.VariableReferences" };
+        targetRefs.Value.Add("X = Source.AbsoluteRight");
+        defaultState.VariableLists.Add(targetRefs);
+
+        GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+        GraphicalUiElement sourceGue = new GraphicalUiElement(new InvisibleRenderable()) { Name = "Source", Width = 40f };
+        sourceGue.Parent = rootGue;
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns(component);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+        _selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+
+        _wireframeObjectManager.Setup(x => x.GetRepresentation(sourceInstance, null)).Returns(sourceGue);
+        _wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+        // Drag Source 100px to the right.
+        _sut.ModifyVariable("X", 100f, sourceInstance);
+
+        // AbsoluteRight = AbsoluteX (100, the just-applied drag position) + Width (40) = 140.
+        // A stale/unresolved reference would leave Target.X unset (null) or resolved against
+        // Source's pre-drag X (0 + 40 = 40).
+        defaultState.GetValue("Target.X").ShouldBe(140f);
+    }
+
+    #endregion
 
     [Fact]
     public void GetUniqueNameForNewInstance_WithBehaviorSave_ShouldReturnDefaultName()

--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -212,10 +212,10 @@ public class ElementCommandsTests : BaseTestClass
         // commit loop (iterate stateSave.Variables in file order, SetVariableLogic.PropertyValueChanged
         // -> VariableReferenceLogic.DoVariableReferenceReaction for each variable that changed since
         // the drag started). Asserts every step tracks correctly and release never reverts the value -
-        // pins the ElementCommands.ModifyVariable fix at the data/logic layer. (A live-app flicker the
-        // user still saw after this fix did not reproduce here, so it lives in WPF-canvas refresh
-        // timing outside what this headless test can drive - see PrintOutput diagnostics in
-        // ElementCommands.ModifyVariable / VariableReferenceLogic.DoVariableReferenceReaction.)
+        // pins the ElementCommands.ModifyVariable fix at the data/logic layer. (The on-load flicker
+        // the user still saw after this fix was a separate root cause - Absolute* references resolving
+        // against stale, pre-layout geometry during suspended wireframe construction - fixed in
+        // WireframeObjectManager.RefreshAll and pinned by WireframeObjectManagerVariableReferenceTests.)
         GumExpressionService.Initialize();
 
         ScreenSave screen = new ScreenSave { Name = "RectScreen" };

--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -5,8 +5,11 @@ using Gum.DataTypes.Variables;
 using Gum.Expressions;
 using Gum.Managers;
 using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.PropertyGridHelpers;
 using Gum.PropertyGridHelpers.Converters;
+using Gum.Services;
+using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
@@ -198,6 +201,116 @@ public class ElementCommandsTests : BaseTestClass
         // A stale/unresolved reference would leave Target.X unset (null) or resolved against
         // Source's pre-drag X (0 + 40 = 40).
         defaultState.GetValue("Target.X").ShouldBe(140f);
+    }
+
+    [Fact]
+    public void ModifyVariable_DragThenReleaseOnRectScreenScenario_TracksCorrectlyThroughoutWithNoReversion()
+    {
+        // Reproduces the real RectScreen.gusx repro reported by the user: RectangleInstance1 has
+        // "X = RectangleInstance.AbsoluteRight". Drags RectangleInstance across several ticks (like
+        // real mouse-move deltas), then replicates EditorContext.DoEndOfSettingValuesLogic's release
+        // commit loop (iterate stateSave.Variables in file order, SetVariableLogic.PropertyValueChanged
+        // -> VariableReferenceLogic.DoVariableReferenceReaction for each variable that changed since
+        // the drag started). Asserts every step tracks correctly and release never reverts the value -
+        // pins the ElementCommands.ModifyVariable fix at the data/logic layer. (A live-app flicker the
+        // user still saw after this fix did not reproduce here, so it lives in WPF-canvas refresh
+        // timing outside what this headless test can drive - see PrintOutput diagnostics in
+        // ElementCommands.ModifyVariable / VariableReferenceLogic.DoVariableReferenceReaction.)
+        GumExpressionService.Initialize();
+
+        ScreenSave screen = new ScreenSave { Name = "RectScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave rectInstance = new InstanceSave { Name = "RectangleInstance", BaseType = "Rectangle", ParentContainer = screen };
+        InstanceSave rectInstance1 = new InstanceSave { Name = "RectangleInstance1", BaseType = "Rectangle", ParentContainer = screen };
+        screen.Instances.Add(rectInstance);
+        screen.Instances.Add(rectInstance1);
+
+        StandardElementSave rectangleStandard = new StandardElementSave { Name = "Rectangle" };
+        rectangleStandard.States.Add(new StateSave { Name = "Default", ParentContainer = rectangleStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(rectangleStandard);
+        project.Screens.Add(screen);
+        ObjectFinder.GumProjectSave = project;
+
+        // Matches RectScreen.gusx exactly (file order: RectangleInstance's vars, then RectangleInstance1's).
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Height", Value = 154f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Value = 225f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.X", Value = 394f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Y", Value = 139f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.Height", Value = 154f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.Width", Value = 225f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.X", Value = 619f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.Y", Value = 314f, Type = "float", SetsValue = true });
+
+        VariableListSave<string> refs = new VariableListSave<string> { Type = "string", Name = "RectangleInstance1.VariableReferences" };
+        refs.Value.Add("X=RectangleInstance.AbsoluteRight");
+        defaultState.VariableLists.Add(refs);
+
+        GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+        GraphicalUiElement rectGue = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RectangleInstance", X = 394f, Width = 225f, Tag = rectInstance };
+        GraphicalUiElement rectGue1 = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RectangleInstance1", X = 619f, Width = 225f, Tag = rectInstance1 };
+        rectGue.Parent = rootGue;
+        rectGue1.Parent = rootGue;
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+        _selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+
+        _wireframeObjectManager.Setup(x => x.GetRepresentation(rectInstance, null)).Returns(rectGue);
+        _wireframeObjectManager.Setup(x => x.GetRepresentation(screen)).Returns(rootGue);
+        _wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+        defaultState.GetValue("RectangleInstance1.X").ShouldBe(619f, "before drag");
+
+        // Pre-drag snapshot, matching what EditorContext.GrabbedState.StateSave would hold.
+        float preDragRectX = 394f;
+        float preDragRect1X = 619f;
+
+        // Simulate 3 mouse-move ticks of +10px each (real drags fire ModifyVariable every tick).
+        // AbsoluteRight = X + Width(225), so it must track 619 -> 629 -> 639 -> 649 exactly.
+        float[] expectedAfterEachTick = { 629f, 639f, 649f };
+        for (int tick = 1; tick <= 3; tick++)
+        {
+            _sut.ModifyVariable("X", 10f, rectInstance);
+
+            defaultState.GetValue("RectangleInstance1.X").ShouldBe(expectedAfterEachTick[tick - 1], $"state after drag tick {tick}");
+            rectGue1.X.ShouldBe(expectedAfterEachTick[tick - 1], $"live GUE after drag tick {tick}");
+        }
+
+        // Simulate EditorContext.DoEndOfSettingValuesLogic's release commit loop: iterate
+        // stateSave.Variables in order, and for each one that changed since the drag started,
+        // fire the same reaction SetVariableLogic.PropertyValueChanged would (DoVariableReferenceReaction).
+        var wireframeCommandsMock = new Mock<IWireframeCommands>();
+        var dialogServiceMock = new Mock<IDialogService>();
+        var fileCommandsMock = new Mock<IFileCommands>();
+        var dispatcherMock = new Mock<IDispatcher>();
+        var registryMock = new Mock<ICompositeMemberRegistry>();
+        registryMock.Setup(x => x.Descriptors).Returns(new List<CompositeMemberDescriptor>());
+        var variableReferenceLogic = new VariableReferenceLogic(
+            _guiCommands.Object, wireframeCommandsMock.Object, dialogServiceMock.Object,
+            fileCommandsMock.Object, registryMock.Object, dispatcherMock.Object, _wireframeObjectManager.Object);
+
+        foreach (var possiblyChangedVariable in defaultState.Variables.ToList())
+        {
+            object oldValue = possiblyChangedVariable.Name switch
+            {
+                "RectangleInstance.X" => preDragRectX,
+                "RectangleInstance1.X" => preDragRect1X,
+                _ => defaultState.GetValue(possiblyChangedVariable.Name)
+            };
+            var newValue = defaultState.GetValue(possiblyChangedVariable.Name);
+            if (Equals(oldValue, newValue)) continue;
+
+            var instance = screen.GetInstance(possiblyChangedVariable.SourceObject);
+            variableReferenceLogic.DoVariableReferenceReaction(screen, instance,
+                possiblyChangedVariable.GetRootName(), defaultState, possiblyChangedVariable.Name, trySave: false);
+
+            // Release must never revert the drag's resolved value.
+            defaultState.GetValue("RectangleInstance1.X").ShouldBe(649f, $"after release commit of {possiblyChangedVariable.Name}");
+        }
     }
 
     #endregion

--- a/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
@@ -1,10 +1,12 @@
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Expressions;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.VariableGrid;
 using Gum.Services;
 using Gum.Services.Dialogs;
+using Gum.Wireframe;
 using Moq;
 using Shouldly;
 using System;
@@ -17,6 +19,7 @@ public class VariableReferenceLogicTests : BaseTestClass
     private readonly Mock<IGuiCommands> _guiCommandsMock;
     private readonly Mock<IDialogService> _dialogServiceMock;
     private readonly Mock<IDispatcher> _dispatcherMock;
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManagerMock;
     private readonly VariableReferenceLogic _sut;
 
     public VariableReferenceLogicTests()
@@ -24,13 +27,15 @@ public class VariableReferenceLogicTests : BaseTestClass
         _guiCommandsMock = new Mock<IGuiCommands>();
         _dialogServiceMock = new Mock<IDialogService>();
         _dispatcherMock = new Mock<IDispatcher>();
+        _wireframeObjectManagerMock = new Mock<IWireframeObjectManager>();
         _sut = new VariableReferenceLogic(
             _guiCommandsMock.Object,
             new Mock<IWireframeCommands>().Object,
             _dialogServiceMock.Object,
             new Mock<IFileCommands>().Object,
             BuildCompositeMemberRegistry(),
-            _dispatcherMock.Object);
+            _dispatcherMock.Object,
+            _wireframeObjectManagerMock.Object);
     }
 
     /// <summary>
@@ -417,6 +422,42 @@ public class VariableReferenceLogicTests : BaseTestClass
 
         varList.Value[0].ShouldBe("Visible = !OtherInstance.Visible"); // not commented out
         defaultState.GetValue("Visible").ShouldBe(false);
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_RightSideReferencesOwnAbsoluteWidth_ResolvesFromWireframeRepresentation()
+    {
+        // AbsoluteWidth only exists on a live, already-laid-out GraphicalUiElement - it can't be
+        // derived from authored StateSave data - so this locks in that the tool's apply path looks
+        // up the currently-rendered wireframe representation and threads it through so the
+        // evaluator can resolve it, rather than leaving it unresolved.
+        GumExpressionService.Initialize();
+        GraphicalUiElement.CanvasWidth = 800f;
+
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "Width = AbsoluteWidth",
+            out StateSave defaultState,
+            out _);
+        defaultState.Variables.Add(new VariableSave { Name = "Width", SetsValue = true, Value = 0f, Type = "float" });
+        project.Screens.Add(screen);
+
+        // A bare GraphicalUiElement has no ContainedObject, so its IPSO Width getter falls back to
+        // the static CanvasWidth - that's a real (if minimal) live layout value, not authored data,
+        // which is exactly what distinguishes this from a normal state lookup.
+        _wireframeObjectManagerMock.Setup(w => w.GetRepresentation(screen)).Returns(new GraphicalUiElement());
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        defaultState.GetValue("Width").ShouldBe(800f);
     }
 
     #endregion

--- a/Tests/Gum.Presentation.Tests/WireframeObjectManagerVariableReferenceTests.cs
+++ b/Tests/Gum.Presentation.Tests/WireframeObjectManagerVariableReferenceTests.cs
@@ -1,0 +1,102 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Expressions;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using GumRuntime;
+using Moq;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class WireframeObjectManagerVariableReferenceTests : BaseTestClass
+{
+    /// <summary>
+    /// Root-cause pin for #4015: a variable reference that reads an Absolute* property
+    /// ("RectangleInstance1.X = RectangleInstance.AbsoluteRight") is resolved during wireframe
+    /// construction, while WireframeObjectManager.RefreshAll has IsAllLayoutSuspended = true. Under
+    /// suspension a Width/X setter updates the GUE's cached field but its UpdateLayout no-ops, so the
+    /// underlying renderable geometry that AbsoluteRight reads stays stale (0). RefreshAll resumes
+    /// layout and calls UpdateLayout afterward, but nothing re-resolved the reference against the
+    /// now-correct geometry - so the sibling was left at the pre-layout value. This drives the real
+    /// RefreshAll end-to-end and asserts the live position is correct once layout has caught up.
+    /// </summary>
+    [Fact]
+    public void RefreshAll_AbsoluteReferenceResolvedDuringSuspendedConstruction_IsCorrectAfterLayoutResumes()
+    {
+        GumExpressionService.Initialize();
+
+        ScreenSave screen = new ScreenSave { Name = "RectScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave rectInstance = new InstanceSave { Name = "RectangleInstance", BaseType = "Container", ParentContainer = screen };
+        InstanceSave rectInstance1 = new InstanceSave { Name = "RectangleInstance1", BaseType = "Container", ParentContainer = screen };
+        screen.Instances.Add(rectInstance);
+        screen.Instances.Add(rectInstance1);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Value = 225f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.X", Value = 394f, Type = "float", SetsValue = true });
+        // Existing scalar the reference overwrites; also supplies the left-side type ("float") the cast needs.
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.X", Value = 0f, Type = "float", SetsValue = true });
+
+        VariableListSave<string> refs = new VariableListSave<string> { Type = "string", Name = "RectangleInstance1.VariableReferences" };
+        refs.Value.Add("X=RectangleInstance.AbsoluteRight");
+        defaultState.VariableLists.Add(refs);
+
+        GraphicalUiElement? rectGue1Live = null;
+
+        Mock<IPluginManager> pluginManager = new Mock<IPluginManager>();
+        // Runs inside RefreshAll, after it has set IsAllLayoutSuspended = true. Mirrors what real
+        // construction (SetVariablesRecursively) does under that suspension: set instance geometry
+        // (Width/X setters' UpdateLayout no-op while suspended, so the renderable AbsoluteRight reads
+        // stays 0) and resolve the variable references against that stale geometry.
+        pluginManager.Setup(x => x.CreateGraphicalUiElement(screen)).Returns(() =>
+        {
+            GraphicalUiElement root = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RectScreen" };
+            GraphicalUiElement rectGue = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RectangleInstance", Tag = rectInstance, Parent = root };
+            GraphicalUiElement rectGue1 = new GraphicalUiElement(new InvisibleRenderable()) { Name = "RectangleInstance1", Tag = rectInstance1, Parent = root };
+            rectGue.X = 394f;
+            rectGue.Width = 225f;
+            root.ApplyVariableReferences(defaultState);
+            rectGue1Live = rectGue1;
+            return root;
+        });
+
+        Mock<ISelectedState> selectedState = new Mock<ISelectedState>();
+        selectedState.SetupGet(x => x.SelectedElements).Returns(new[] { screen });
+        selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+        selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+
+        WireframeObjectManager wireframeObjectManager = new WireframeObjectManager(
+            Mock.Of<IFontManager>(),
+            selectedState.Object,
+            Mock.Of<IDialogService>(),
+            Mock.Of<IGuiCommands>(),
+            new LocalizationService(),
+            pluginManager.Object,
+            Mock.Of<IProjectState>());
+
+        wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        rectGue1Live.ShouldNotBeNull();
+        // RectangleInstance.AbsoluteRight = X(394) + Width(225) = 619. Before the fix the reference
+        // resolved against the pre-layout stale width (0), leaving RectangleInstance1 at 0.
+        rectGue1Live!.X.ShouldBe(619f);
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -556,7 +556,7 @@ public class HeadlessErrorCheckerTests : BaseTestClass
         // returns false). The check must pass the LHS type so the Roslyn-based
         // evaluator can resolve cross-element / literal RHSes.
         bool sawNonNullDesiredType = false;
-        ElementSaveExtensions.CustomEvaluateExpression = (state, expr, desiredType) =>
+        ElementSaveExtensions.CustomEvaluateExpression = (state, expr, desiredType, liveRoot) =>
         {
             if (desiredType == null)
             {

--- a/Tests/Gum.ProjectServices.Tests/UninitializeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/UninitializeTests.cs
@@ -40,7 +40,7 @@ public class UninitializeTests : IDisposable
     [Fact]
     public void ClearRegistrations_ClearsCustomEvaluateExpression()
     {
-        ElementSaveExtensions.CustomEvaluateExpression = (_, _, _) => null!;
+        ElementSaveExtensions.CustomEvaluateExpression = (_, _, _, _) => null!;
 
         ElementSaveExtensions.ClearRegistrations();
 

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -2,6 +2,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Expressions;
 using Gum.Managers;
+using Gum.Wireframe;
 using Microsoft.CodeAnalysis.CSharp;
 using Shouldly;
 
@@ -11,13 +12,13 @@ public class EvaluatedSyntaxTests : BaseTestClass
 {
     #region Helpers
 
-    private static EvaluatedSyntax Evaluate(string expression, StateSave state)
+    private static EvaluatedSyntax Evaluate(string expression, StateSave state, GraphicalUiElement? liveRoot = null)
     {
         string csharp = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
         // Parse as an expression (matches GumExpressionService) so top-level ternaries are not
         // mis-parsed as nullable variable declarations.
         Microsoft.CodeAnalysis.SyntaxNode syntax = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseExpression(csharp);
-        return EvaluatedSyntax.FromSyntaxNode(syntax, state);
+        return EvaluatedSyntax.FromSyntaxNode(syntax, state, liveRoot: liveRoot);
     }
 
     private static StateSave BuildState(params (string name, object value, string type)[] variables)
@@ -598,6 +599,39 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
         result.ShouldNotBeNull();
         result.Value.ShouldBe(42f);
+    }
+
+    #endregion
+
+    #region AbsoluteValues
+
+    // Positive resolution (an Absolute* identifier actually resolving to a live, laid-out pixel
+    // value) requires a real contained renderable - a bare GraphicalUiElement's IPSO X/Width
+    // getters just return 0/CanvasWidth with no ContainedObject, and Parent assignment throws
+    // without one ("did you create a proper Visual... such as ContainerRuntime?"). That case is
+    // covered end-to-end in MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs using
+    // ContainerRuntime. These tests cover the routing/null-safety paths that don't need real layout.
+
+    [Fact]
+    public void FromSyntaxNode_AbsoluteWidthWithNoLiveRoot_ReturnsNullValue()
+    {
+        StateSave state = BuildState();
+
+        EvaluatedSyntax result = Evaluate("Source.AbsoluteWidth", state, liveRoot: null);
+
+        (result?.Value).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromSyntaxNode_AbsoluteWidthOfUnknownInstance_ReturnsNullValue()
+    {
+        StateSave state = BuildState();
+
+        GraphicalUiElement root = new GraphicalUiElement();
+
+        EvaluatedSyntax result = Evaluate("Nonexistent.AbsoluteWidth", state, root);
+
+        (result?.Value).ShouldBeNull();
     }
 
     #endregion

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -488,11 +488,6 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         // apply references on this element first, then apply the values to the other references:
         ElementSaveExtensions.ApplyVariableReferences(parentElement, stateSave, liveRoot);
 
-        // TEMP DIAGNOSTIC - remove before merge
-        DiagnosticLogReferencedVariables("DoVariableReferenceReaction",
-            $"unqualifiedMember={unqualifiedMember} qualifiedName={qualifiedName} instance={leftSideInstance?.Name}",
-            stateSave, liveRoot);
-
         // Then evaluate any behavior-level ToolOnlyVariableReferences so design-time
         // wireframe preview reflects FormsProperty values (e.g. IsEnabled = false →
         // ButtonCategoryState = "Disabled"). Tool-only by design — never invoked at
@@ -646,30 +641,6 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         }
         return didAssignDeepReference;
     }
-
-    // TEMP DIAGNOSTIC - remove before merge
-    private void DiagnosticLogReferencedVariables(string callSite, string context, StateSave stateSave, GraphicalUiElement? liveRoot)
-    {
-        foreach (var variableList in stateSave.VariableLists)
-        {
-            if (variableList.GetRootName() != "VariableReferences" || variableList.ValueAsIList.Count == 0) continue;
-
-            var sourceObject = variableList.SourceObject;
-            foreach (var entryObj in variableList.ValueAsIList)
-            {
-                var entry = entryObj as string;
-                if (string.IsNullOrEmpty(entry) || entry.StartsWith("//")) continue;
-
-                var left = entry.Split('=')[0].Trim();
-                var qualifiedLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
-                var materialized = stateSave.GetValue(qualifiedLeft);
-
-                _guiCommands.PrintOutput($"[{callSite}] {context} | liveRoot={liveRoot?.GetHashCode()} | " +
-                    $"{qualifiedLeft} = {entry.Split('=', 2)[1].Trim()} -> materialized={materialized}");
-            }
-        }
-    }
-
 
     public void ReactIfChangedMemberIsVariableReference(InstanceSave? instance, StateSave stateSave, string changedMember, object? oldValue)
     {

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -488,6 +488,11 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         // apply references on this element first, then apply the values to the other references:
         ElementSaveExtensions.ApplyVariableReferences(parentElement, stateSave, liveRoot);
 
+        // TEMP DIAGNOSTIC - remove before merge
+        DiagnosticLogReferencedVariables("DoVariableReferenceReaction",
+            $"unqualifiedMember={unqualifiedMember} qualifiedName={qualifiedName} instance={leftSideInstance?.Name}",
+            stateSave, liveRoot);
+
         // Then evaluate any behavior-level ToolOnlyVariableReferences so design-time
         // wireframe preview reflects FormsProperty values (e.g. IsEnabled = false →
         // ButtonCategoryState = "Disabled"). Tool-only by design — never invoked at
@@ -640,6 +645,29 @@ public class VariableReferenceLogic : IVariableReferenceLogic
             }
         }
         return didAssignDeepReference;
+    }
+
+    // TEMP DIAGNOSTIC - remove before merge
+    private void DiagnosticLogReferencedVariables(string callSite, string context, StateSave stateSave, GraphicalUiElement? liveRoot)
+    {
+        foreach (var variableList in stateSave.VariableLists)
+        {
+            if (variableList.GetRootName() != "VariableReferences" || variableList.ValueAsIList.Count == 0) continue;
+
+            var sourceObject = variableList.SourceObject;
+            foreach (var entryObj in variableList.ValueAsIList)
+            {
+                var entry = entryObj as string;
+                if (string.IsNullOrEmpty(entry) || entry.StartsWith("//")) continue;
+
+                var left = entry.Split('=')[0].Trim();
+                var qualifiedLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
+                var materialized = stateSave.GetValue(qualifiedLeft);
+
+                _guiCommands.PrintOutput($"[{callSite}] {context} | liveRoot={liveRoot?.GetHashCode()} | " +
+                    $"{qualifiedLeft} = {entry.Split('=', 2)[1].Trim()} -> materialized={materialized}");
+            }
+        }
     }
 
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
+using Gum.Wireframe;
 using GumRuntime;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -29,6 +30,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     private readonly IFileCommands _fileCommands;
     private readonly ICompositeMemberRegistry _compositeMemberRegistry;
     private readonly IDispatcher _dispatcher;
+    private readonly IWireframeObjectManager _wireframeObjectManager;
 
     #endregion
 
@@ -37,7 +39,8 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         IDialogService dialogService,
         IFileCommands fileCommands,
         ICompositeMemberRegistry compositeMemberRegistry,
-        IDispatcher dispatcher)
+        IDispatcher dispatcher,
+        IWireframeObjectManager wireframeObjectManager)
     {
         _guiCommands = guiCommands;
         _wireframeCommands = wireframeCommands;
@@ -45,6 +48,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         _fileCommands = fileCommands;
         _compositeMemberRegistry = compositeMemberRegistry;
         _dispatcher = dispatcher;
+        _wireframeObjectManager = wireframeObjectManager;
     }
 
     public AssignmentExpressionSyntax? GetAssignmentSyntax(string item)
@@ -83,7 +87,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
     #region Validation (failures)
 
-    private List<(string, GeneralResponse)> GetIndividualFailures(ElementSave parentElement, InstanceSave? leftSideInstance, VariableListSave newDirectValue)
+    private List<(string, GeneralResponse)> GetIndividualFailures(ElementSave parentElement, InstanceSave? leftSideInstance, VariableListSave newDirectValue, GraphicalUiElement? liveRoot)
     {
         var values = newDirectValue.ValueAsIList;
 
@@ -91,13 +95,13 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
         foreach (string line in values)
         {
-            AddFailureForLine(parentElement, leftSideInstance, failures, line);
+            AddFailureForLine(parentElement, leftSideInstance, failures, line, liveRoot);
         }
 
         return failures;
     }
 
-    private void AddFailureForLine(ElementSave parentElement, InstanceSave? leftSideInstance, List<(string, GeneralResponse)> failures, string line)
+    private void AddFailureForLine(ElementSave parentElement, InstanceSave? leftSideInstance, List<(string, GeneralResponse)> failures, string line, GraphicalUiElement? liveRoot)
     {
         if (line.StartsWith("//") || string.IsNullOrEmpty(line))
         {
@@ -144,7 +148,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
 
         if (response.Succeeded)
         {
-            evaluatedSyntax = EvaluatedSyntax.FromSyntaxNode(assignmentSyntax.Right, parentElement.DefaultState);
+            evaluatedSyntax = EvaluatedSyntax.FromSyntaxNode(assignmentSyntax.Right, parentElement.DefaultState, liveRoot: liveRoot);
 
             if (evaluatedSyntax == null)
             {
@@ -444,13 +448,19 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     public void DoVariableReferenceReaction(ElementSave parentElement, InstanceSave? leftSideInstance, string unqualifiedMember,
         StateSave stateSave, string qualifiedName, bool trySave)
     {
+        // The currently-rendered wireframe representation of parentElement, if any. Lets a right
+        // side like "Root.AbsoluteWidth" resolve against the live, already-laid-out object - null
+        // when nothing is rendered for this element, in which case such identifiers stay
+        // unresolved, same as any other unresolvable identifier.
+        var liveRoot = _wireframeObjectManager.GetRepresentation(parentElement);
+
         if (unqualifiedMember == "VariableReferences")
         {
             var newDirectValue = stateSave.GetVariableListSave(qualifiedName);
 
             if (newDirectValue != null)
             {
-                var failures = GetIndividualFailures(parentElement, leftSideInstance, newDirectValue);
+                var failures = GetIndividualFailures(parentElement, leftSideInstance, newDirectValue, liveRoot);
 
                 if (failures.Count > 0)
                 {
@@ -476,7 +486,7 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         }
 
         // apply references on this element first, then apply the values to the other references:
-        ElementSaveExtensions.ApplyVariableReferences(parentElement, stateSave);
+        ElementSaveExtensions.ApplyVariableReferences(parentElement, stateSave, liveRoot);
 
         // Then evaluate any behavior-level ToolOnlyVariableReferences so design-time
         // wireframe preview reflects FormsProperty values (e.g. IsEnabled = false →
@@ -504,7 +514,8 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         {
             if (statesAlreadyApplied.Contains(reference.StateSave) == false)
             {
-                ElementSaveExtensions.ApplyVariableReferences(reference.OwnerOfReferencingObject, reference.StateSave);
+                ElementSaveExtensions.ApplyVariableReferences(reference.OwnerOfReferencingObject, reference.StateSave,
+                    _wireframeObjectManager.GetRepresentation(reference.OwnerOfReferencingObject));
                 statesAlreadyApplied.Add(reference.StateSave);
                 elementsToSave.Add(reference.OwnerOfReferencingObject);
             }

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -396,11 +396,17 @@ public class ElementCommands : IElementCommands
 
             float newValue = currentValue + modificationAmount;
             _selectedState.SelectedStateSave.SetValue(nameWithInstance, newValue, instanceSave, "float");
-            ElementSaveExtensions.ApplyVariableReferences(_selectedState.SelectedElement, _selectedState.SelectedStateSave);
 
+            // Push the dragged instance's own new value onto its live GUE *before* resolving
+            // references, so a sibling reference reading a runtime-computed identifier such as
+            // AbsoluteWidth (which only exists on a live, laid-out GraphicalUiElement) sees this
+            // tick's position rather than the previous one.
             graphicalUiElement.SetProperty(baseVariableName, newValue);
 
-            _wireframeObjectManager.RootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
+            var rootGue = _wireframeObjectManager.RootGue;
+            ElementSaveExtensions.ApplyVariableReferences(_selectedState.SelectedElement, _selectedState.SelectedStateSave, rootGue);
+
+            rootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
             _variableInCategoryPropagationLogic.PropagateVariablesInCategory(nameWithInstance,
                 _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -408,9 +408,6 @@ public class ElementCommands : IElementCommands
 
             rootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
-            // TEMP DIAGNOSTIC - remove before merge
-            DiagnosticLogReferencedVariables("ModifyVariable", $"{baseVariableName}={newValue} on {instanceSave.Name}", rootGue);
-
             _variableInCategoryPropagationLogic.PropagateVariablesInCategory(nameWithInstance,
                 _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
 
@@ -420,32 +417,6 @@ public class ElementCommands : IElementCommands
         else
         {
             return 0;
-        }
-    }
-
-    // TEMP DIAGNOSTIC - remove before merge
-    private void DiagnosticLogReferencedVariables(string callSite, string context, GraphicalUiElement? liveRoot)
-    {
-        var stateSave = _selectedState.SelectedStateSave;
-        if (stateSave == null) return;
-
-        foreach (var variableList in stateSave.VariableLists)
-        {
-            if (variableList.GetRootName() != "VariableReferences" || variableList.ValueAsIList.Count == 0) continue;
-
-            var sourceObject = variableList.SourceObject;
-            foreach (var entryObj in variableList.ValueAsIList)
-            {
-                var entry = entryObj as string;
-                if (string.IsNullOrEmpty(entry) || entry.StartsWith("//")) continue;
-
-                var left = entry.Split('=')[0].Trim();
-                var qualifiedLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
-                var materialized = stateSave.GetValue(qualifiedLeft);
-
-                _guiCommands.PrintOutput($"[{callSite}] {context} | liveRoot={liveRoot?.GetHashCode()} | " +
-                    $"{qualifiedLeft} = {entry.Split('=', 2)[1].Trim()} -> materialized={materialized}");
-            }
         }
     }
 

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -408,6 +408,9 @@ public class ElementCommands : IElementCommands
 
             rootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
+            // TEMP DIAGNOSTIC - remove before merge
+            DiagnosticLogReferencedVariables("ModifyVariable", $"{baseVariableName}={newValue} on {instanceSave.Name}", rootGue);
+
             _variableInCategoryPropagationLogic.PropagateVariablesInCategory(nameWithInstance,
                 _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
 
@@ -417,6 +420,32 @@ public class ElementCommands : IElementCommands
         else
         {
             return 0;
+        }
+    }
+
+    // TEMP DIAGNOSTIC - remove before merge
+    private void DiagnosticLogReferencedVariables(string callSite, string context, GraphicalUiElement? liveRoot)
+    {
+        var stateSave = _selectedState.SelectedStateSave;
+        if (stateSave == null) return;
+
+        foreach (var variableList in stateSave.VariableLists)
+        {
+            if (variableList.GetRootName() != "VariableReferences" || variableList.ValueAsIList.Count == 0) continue;
+
+            var sourceObject = variableList.SourceObject;
+            foreach (var entryObj in variableList.ValueAsIList)
+            {
+                var entry = entryObj as string;
+                if (string.IsNullOrEmpty(entry) || entry.StartsWith("//")) continue;
+
+                var left = entry.Split('=')[0].Trim();
+                var qualifiedLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
+                var materialized = stateSave.GetValue(qualifiedLeft);
+
+                _guiCommands.PrintOutput($"[{callSite}] {context} | liveRoot={liveRoot?.GetHashCode()} | " +
+                    $"{qualifiedLeft} = {entry.Split('=', 2)[1].Trim()} -> materialized={materialized}");
+            }
         }
     }
 

--- a/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
@@ -196,6 +196,18 @@ public partial class WireframeObjectManager : IWireframeObjectManager
                     RootGue.UpdateFontRecursive();
                     RootGue.UpdateLayout();
 
+                    // Variable references that read an Absolute* property (AbsoluteWidth, AbsoluteX,
+                    // AbsoluteRight, ...) were already resolved during construction above, while
+                    // IsAllLayoutSuspended was true. Those getters read the underlying renderable's
+                    // geometry, which only UpdateLayout syncs - so under suspension they saw stale
+                    // (pre-layout) values and baked the wrong result. Now that UpdateLayout has caught
+                    // up, re-resolve the references so Absolute* reads correct geometry (#4015).
+                    var stateForReferences = _selectedState.SelectedStateSave ?? elementSave.DefaultState;
+                    if (stateForReferences != null)
+                    {
+                        RootGue.ApplyVariableReferences(stateForReferences);
+                    }
+
                     gueManager.Add(RootGue);
                     //FontManager.Self.CreateAllMissingFontFiles(ObjectFinder.Self.GumProjectSave);
 

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -251,7 +251,9 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         {
             try
             {
-                return ElementSaveExtensions.CustomEvaluateExpression(ownerState, right, leftType);
+                // No live wireframe in a headless check, so runtime-computed identifiers like
+                // AbsoluteWidth are simply unresolvable here, same as any other unresolvable identifier.
+                return ElementSaveExtensions.CustomEvaluateExpression(ownerState, right, leftType, null);
             }
             catch
             {


### PR DESCRIPTION
Closes #4015.

Variable references can read Absolute* properties (e.g. `RectangleInstance1.X = RectangleInstance.AbsoluteRight`), resolved live against the wireframe. Two bugs prevented that from working:

**1. Live drag** (earlier commits): `ElementCommands.ModifyVariable` fires every drag tick but resolved references without a live root, so `AbsoluteRight` never materialized and reverted on refresh. Fixed by pushing the dragged value onto the live GUE before resolving and passing the live root through.

**2. On load** (this fix): `WireframeObjectManager.RefreshAll` builds the tree and resolves references while `IsAllLayoutSuspended = true`. Under suspension a `Width`/`X` setter updates the GUE's cached field but its `UpdateLayout` no-ops, so the renderable geometry `AbsoluteWidth`/`AbsoluteRight` read stays stale — `AbsoluteRight` came out as `X + 0` instead of `X + Width`. `RefreshAll` resumes layout and calls `UpdateLayout`, but nothing re-resolved the references. Fix: re-apply variable references after `UpdateLayout`, once geometry has synced.

Also adds the core feature: `EvaluatedSyntax` resolves `AbsoluteX/Y/Left/Top/Right/Bottom/Width/Height` against a live `GraphicalUiElement` root, threaded through the apply/validation paths.

**Tests**
- `WireframeObjectManagerVariableReferenceTests` — drives the real `RefreshAll`; red at 394 (X + stale 0), green at 619 (X + Width). Pins the on-load root cause.
- `ApplyVariableReferencesRuntimeTests` — runtime resolution of Absolute* references.
- `ElementCommandsTests.ModifyVariable_*` — drag/release materialization.

Temporary diagnostic hooks used to trace the root cause have been removed.
