### PR TITLE
KernSmith: use AutofitTexture instead of Gum's bmfont.exe-oriented size heuristic

### DIFF
--- a/.claude/skills/gum-kernsmith-integrations/SKILL.md
+++ b/.claude/skills/gum-kernsmith-integrations/SKILL.md
@@ -5,7 +5,7 @@ description: KernSmith runtime bitmap-font packages. Triggers: Integrations/Kern
 
 # KernSmith Integrations
 
-[KernSmith](https://github.com/kaltinril/KernSmith) is a third-party, cross-platform, in-memory BMFont rasterizer. `Integrations/KernSmith/*` are optional first-party Gum packages that bridge it into each runtime — this is unrelated to the tool's `bmfont.exe`-based generation pipeline (see `gum-tool-font-generation`).
+[KernSmith](https://github.com/kaltinril/KernSmith) is a third-party, cross-platform, in-memory BMFont rasterizer. `Integrations/KernSmith/*` are optional first-party Gum packages that bridge it into each runtime. The tool itself also uses KernSmith directly as an alternate offline generator backend — see `gum-tool-font-generation` for that (`KernSmithFileGenerator`, unrelated to the runtime packages below).
 
 ## Package map
 

--- a/.claude/skills/gum-tool-font-generation/SKILL.md
+++ b/.claude/skills/gum-tool-font-generation/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: gum-tool-font-generation
-description: Gum bitmap font generation — tool converts font properties into .fnt/.png via bmfont.exe. Triggers: BmfcSave, HeadlessFontGenerationService, FontManager, BmfcTemplate.bmfc, font cache naming, texture size estimation, GumProjectFontGenerator CLI.
+description: Gum bitmap font generation — tool converts font properties into .fnt/.png via bmfont.exe or KernSmith. Triggers: BmfcSave, HeadlessFontGenerationService, FontManager, FontFileGeneratorSelector, KernSmithFileGenerator, BmfcTemplate.bmfc, texture size estimation, dropshadow.
 ---
 
 # Font Generation Pipeline
 
-Gum generates BMFont-format bitmap fonts (`.fnt` + `.png` atlas) by shelling out to `bmfont.exe`. The pipeline is: **collect font properties → build BmfcSave → write .bmfc file → invoke bmfont.exe → produce .fnt + .png**.
+Gum generates BMFont-format bitmap fonts (`.fnt` + `.png` atlas). Pipeline: **collect font properties → build BmfcSave → pick a generator backend → produce .fnt + .png**. Two interchangeable `IFontFileGenerator` backends exist, chosen per-project via `GumProjectSave.FontGenerator` (`FontGeneratorType.BmFont`, the default for back-compat, or `.KernSmith`):
 
-> **Future direction:** The bmfont.exe dependency is being evaluated for replacement due to platform limitations (Windows-only) and other concerns. A leading candidate is [KernSmith](https://github.com/kaltinril/Kernsmith), a cross-platform .NET BMFont library/CLI that consumes the same `.bmfc` files Gum already produces — making it a near drop-in.
+- **`BmFontExeFileGenerator`** shells out to the embedded `bmfont.exe` (Windows-only). Legacy path; does **not** support dropshadow at all — `BmfcTemplate.bmfc` has no dropshadow placeholders, so `BmfcSave.HasDropshadow`/`Dropshadow*` fields are silently ignored on this backend.
+- **`KernSmithFileGenerator`** calls the [KernSmith](https://github.com/kaltinril/Kernsmith) library in-process (cross-platform, no external exe, supports dropshadow). This is the newer, recommended backend.
+
+`FontFileGeneratorSelector` picks between them at generation time (project isn't loaded yet when DI wires services up, so selection can't happen at construction).
 
 ## Architecture
 
@@ -15,17 +18,19 @@ Gum generates BMFont-format bitmap fonts (`.fnt` + `.png` atlas) by shelling out
 FontManager (tool facade)
   └─ HeadlessFontGenerationService (core logic, headless)
        ├─ BmfcSave (data model + .bmfc serialization)
-       │    └─ BmfcTemplate.bmfc (template file with placeholders)
-       └─ bmfont.exe (external process, one per font, run in parallel)
+       │    └─ BmfcTemplate.bmfc (template file with placeholders, bmfont.exe only)
+       └─ FontFileGeneratorSelector → BmFontExeFileGenerator | KernSmithFileGenerator
 ```
 
 **FontManager** is the tool-facing entry point. It wires `IFontGenerationCallbacks` (UI output, spinner, file-watch suppression) and delegates all real work to **HeadlessFontGenerationService** via `IHeadlessFontGenerationService`.
 
-**HeadlessFontGenerationService** is platform-checked (Windows-only, throws `PlatformNotSupportedException` otherwise). It owns:
+**HeadlessFontGenerationService** is platform-checked for the bmfont.exe backend only (throws `PlatformNotSupportedException` off-Windows when `FontGeneratorType.BmFont` is selected). It owns:
 - Collecting all unique fonts a project needs (`CollectRequiredFonts`)
 - Deciding whether a font file already exists or needs (re)generation
-- Launching bmfont.exe processes — one per font, all awaited via `Task.WhenAll` for parallelism
+- Invoking the selected `IFontFileGenerator` — one call per font, all awaited via `Task.WhenAll` for parallelism
 - Texture size estimation (heuristic) and optimization (binary search over `AvailableSizes`)
+
+**Texture-size estimation is bmfont.exe-specific and does not run for KernSmith.** `EstimateBlocksNeeded`'s heuristic (and the dropshadow blindness that falls out of it) only matters for `BmFontExeFileGenerator`. `IFontFileGenerator.RequiresSizeEstimation` (false on `KernSmithFileGenerator`, true on `BmFontExeFileGenerator`) gates the whole `AssignEstimatedNeededSizeOn` call in `HeadlessFontGenerationService` — KernSmith instead sizes its own atlas via `FontGeneratorOptions.AutofitTexture`.
 
 **BmfcSave** holds the six font properties (FontName, FontSize, OutlineThickness, UseSmoothing, IsItalic, IsBold) plus ranges, spacing, and output dimensions. Its `Save()` method loads `BmfcTemplate.bmfc` and does string replacement to produce the `.bmfc` file that bmfont.exe consumes. It also owns `FontCacheFileName` which determines the output path.
 

--- a/Tests/Gum.ProjectServices.Tests/FontFileGeneratorSelectorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/FontFileGeneratorSelectorTests.cs
@@ -63,6 +63,22 @@ public class FontFileGeneratorSelectorTests
         bmFont.WasCalled.ShouldBeFalse();
     }
 
+    [Fact]
+    public void RequiresSizeEstimation_ShouldDelegateToCurrentlySelectedGenerator()
+    {
+        RecordingFontFileGenerator bmFont = new RecordingFontFileGenerator { RequiresSizeEstimation = true };
+        RecordingFontFileGenerator kernSmith = new RecordingFontFileGenerator { RequiresSizeEstimation = false };
+        FontGeneratorType currentType = FontGeneratorType.BmFont;
+        FontFileGeneratorSelector selector = new FontFileGeneratorSelector(
+            bmFont, kernSmith, () => currentType);
+
+        selector.RequiresSizeEstimation.ShouldBeTrue();
+
+        currentType = FontGeneratorType.KernSmith;
+
+        selector.RequiresSizeEstimation.ShouldBeFalse();
+    }
+
     // -------------------------------------------------------------------------
     // Test doubles
     // -------------------------------------------------------------------------
@@ -73,6 +89,8 @@ public class FontFileGeneratorSelectorTests
     private sealed class RecordingFontFileGenerator : IFontFileGenerator
     {
         public bool WasCalled { get; private set; }
+
+        public bool RequiresSizeEstimation { get; init; } = true;
 
         public void Reset()
         {

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -828,6 +828,47 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
     #endregion
 
     // -------------------------------------------------------------------------
+    // Size estimation gating (IFontFileGenerator.RequiresSizeEstimation)
+    // -------------------------------------------------------------------------
+
+    #region Size estimation gating
+
+    [Fact]
+    public void CreateFontIfNecessary_ShouldEstimateSize_WhenGeneratorRequiresSizeEstimation()
+    {
+        HeadlessFontGenerationService service =
+            new HeadlessFontGenerationService(new NoOpFontFileGenerator { RequiresSizeEstimation = true });
+
+        BmfcSave bmfcSave = new BmfcSave();
+        bmfcSave.FontName = "Arial";
+        bmfcSave.FontSize = 48;
+
+        service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+
+        bmfcSave.OutputWidth.ShouldBe(1024);
+    }
+
+    [Fact]
+    public void CreateFontIfNecessary_ShouldNotEstimateSize_WhenGeneratorDoesNotRequireSizeEstimation()
+    {
+        HeadlessFontGenerationService service =
+            new HeadlessFontGenerationService(new NoOpFontFileGenerator { RequiresSizeEstimation = false });
+
+        BmfcSave bmfcSave = new BmfcSave();
+        bmfcSave.FontName = "Arial";
+        bmfcSave.FontSize = 48;
+        bmfcSave.OutputWidth = 999;
+        bmfcSave.OutputHeight = 999;
+
+        service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+
+        bmfcSave.OutputWidth.ShouldBe(999);
+        bmfcSave.OutputHeight.ShouldBe(999);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
     // Windows gate (BmFontExeFileGenerator)
     // -------------------------------------------------------------------------
 
@@ -861,6 +902,8 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
     /// </summary>
     private sealed class NoOpFontFileGenerator : IFontFileGenerator
     {
+        public bool RequiresSizeEstimation { get; init; } = true;
+
         public Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
         {
             GeneralResponse response = GeneralResponse.SuccessfulResponse;

--- a/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
@@ -1,5 +1,6 @@
 using Gum.ProjectServices.FontGeneration;
 using KernSmith;
+using KernSmith.Output;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using Xunit;
@@ -32,5 +33,30 @@ public class KernSmithFileGeneratorSizeTests
         options.AutofitTexture.ShouldBeTrue();
         options.MaxTextureWidth.ShouldBe(8192);
         options.MaxTextureHeight.ShouldBe(8192);
+    }
+
+    [Fact]
+    public void BuildOptions_ThenGenerate_WithLargeDropshadow_ProducesSinglePage()
+    {
+        // The issue's exact repro: Font48Arial_ds31_-13_6_0_0_0_255.bmfc.
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 48,
+            Ranges = "32-126,160-255",
+            HasDropshadow = true,
+            DropshadowOffsetX = 31f,
+            DropshadowOffsetY = -13f,
+            DropshadowBlur = 6f,
+            DropshadowAlpha = 255,
+            // The undersized heuristic guess that produced the multi-page split in the issue.
+            OutputWidth = 1024,
+            OutputHeight = 256,
+        };
+
+        FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
+        BmFontResult result = BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+
+        result.Pages.Count.ShouldBe(1);
     }
 }

--- a/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
@@ -1,0 +1,36 @@
+using Gum.ProjectServices.FontGeneration;
+using KernSmith;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Issue #4019 — Gum's size-estimation heuristic (built for bmfont.exe, which cannot autofit)
+/// doesn't account for dropshadow inflation and can undersize the atlas it hands to KernSmith,
+/// forcing a single font to spill across multiple atlas pages. KernSmith can size its own atlas
+/// via AutofitTexture, so BuildOptions should use that instead of trusting the heuristic's guess.
+/// </summary>
+public class KernSmithFileGeneratorSizeTests
+{
+    [Fact]
+    public void BuildOptions_ShouldEnableAutofitTexture_RegardlessOfBmfcOutputDimensions()
+    {
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 48,
+            Ranges = "32-126",
+            // Mirrors the issue's undersized heuristic guess for a 48px font with a large dropshadow.
+            OutputWidth = 1024,
+            OutputHeight = 256,
+        };
+
+        FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
+
+        options.AutofitTexture.ShouldBeTrue();
+        options.MaxTextureWidth.ShouldBe(8192);
+        options.MaxTextureHeight.ShouldBe(8192);
+    }
+}

--- a/Tools/Gum.ProjectServices/FontGeneration/BmFontExeFileGenerator.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/BmFontExeFileGenerator.cs
@@ -32,6 +32,9 @@ public class BmFontExeFileGenerator : IFontFileGenerator
     private string BmFontExeLocation => Path.Combine(AppContext.BaseDirectory, "Libraries", "bmfont.exe");
 
     /// <inheritdoc/>
+    public bool RequiresSizeEstimation => true;
+
+    /// <inheritdoc/>
     public async Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
     {
         ThrowIfNotWindows();

--- a/Tools/Gum.ProjectServices/FontGeneration/FontFileGeneratorSelector.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/FontFileGeneratorSelector.cs
@@ -42,12 +42,15 @@ public class FontFileGeneratorSelector : IFontFileGenerator
     /// <inheritdoc/>
     public Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
     {
-        IFontFileGenerator generator = _getGeneratorType() switch
-        {
-            FontGeneratorType.KernSmith => _kernSmithGenerator,
-            _ => _bmFontGenerator
-        };
-
-        return generator.GenerateFont(bmfcSave, outputFntPath, createTask);
+        return CurrentGenerator.GenerateFont(bmfcSave, outputFntPath, createTask);
     }
+
+    /// <inheritdoc/>
+    public bool RequiresSizeEstimation => CurrentGenerator.RequiresSizeEstimation;
+
+    private IFontFileGenerator CurrentGenerator => _getGeneratorType() switch
+    {
+        FontGeneratorType.KernSmith => _kernSmithGenerator,
+        _ => _bmFontGenerator
+    };
 }

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -351,7 +351,8 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
     private async Task<GeneralResponse> TryCreateFontFor(BmfcSave bmfcSave, bool force, bool showSpinner,
         bool createTask, string projectDirectory, bool iterativelyDetermineSize)
     {
-        if (force || GetFilePath(bmfcSave, destinationDirectory: null, projectDirectory).Exists() == false)
+        if ((force || GetFilePath(bmfcSave, destinationDirectory: null, projectDirectory).Exists() == false)
+            && _fontFileGenerator.RequiresSizeEstimation)
         {
             await AssignEstimatedNeededSizeOn(bmfcSave, iterativelyDetermineSize, _callbacks.OnOutput);
         }

--- a/Tools/Gum.ProjectServices/FontGeneration/IFontFileGenerator.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/IFontFileGenerator.cs
@@ -16,4 +16,11 @@ public interface IFontFileGenerator
     /// <param name="outputFntPath">Absolute path for the output .fnt file.</param>
     /// <param name="createTask">When true, runs asynchronously; when false, blocks until complete.</param>
     Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask);
+
+    /// <summary>
+    /// Whether this generator needs <see cref="BmfcSave.OutputWidth"/>/<see cref="BmfcSave.OutputHeight"/>
+    /// pre-populated by the caller before generation. Generators that can size their own atlas
+    /// (e.g. KernSmith's autofit) should return false so the caller skips that work entirely.
+    /// </summary>
+    bool RequiresSizeEstimation { get; }
 }

--- a/Tools/Gum.ProjectServices/FontGeneration/KernSmithFileGenerator.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/KernSmithFileGenerator.cs
@@ -33,6 +33,13 @@ public class KernSmithFileGenerator : IFontFileGenerator
         EnsureRasterizerRegistered();
     }
 
+    /// <summary>
+    /// KernSmith sizes its own atlas via <see cref="FontGeneratorOptions.AutofitTexture"/>, so the
+    /// caller's <c>OutputWidth</c>/<c>OutputHeight</c> heuristic (built for bmfont.exe, which can't
+    /// autofit) is unnecessary here.
+    /// </summary>
+    public bool RequiresSizeEstimation => false;
+
     private static void EnsureRasterizerRegistered()
     {
         if (_rasterizerRegistered)
@@ -99,6 +106,12 @@ public class KernSmithFileGenerator : IFontFileGenerator
         return response;
     }
 
+    /// <summary>
+    /// Largest atlas dimension KernSmith is allowed to grow to via <see cref="FontGeneratorOptions.AutofitTexture"/>,
+    /// matching the largest size in <see cref="HeadlessFontGenerationService"/>'s bmfont.exe binary-search table.
+    /// </summary>
+    private const int MaxAtlasDimension = 8192;
+
     internal static FontGeneratorOptions BuildOptions(BmfcSave bmfcSave)
     {
         FontGeneratorOptions options = new FontGeneratorOptions();
@@ -112,8 +125,12 @@ public class KernSmithFileGenerator : IFontFileGenerator
         options.AntiAlias = bmfcSave.UseSmoothing ? AntiAliasMode.Grayscale : AntiAliasMode.None;
         options.Outline = bmfcSave.OutlineThickness;
         options.Spacing = new Spacing(bmfcSave.SpacingHorizontal, bmfcSave.SpacingVertical);
-        options.MaxTextureWidth = bmfcSave.OutputWidth;
-        options.MaxTextureHeight = bmfcSave.OutputHeight;
+        // KernSmith picks the smallest atlas that fits everything on one page (capped by
+        // MaxTextureWidth/Height below) instead of relying on Gum's own bmfont.exe-oriented size
+        // guess, which doesn't account for dropshadow inflation and can undersize the atlas.
+        options.AutofitTexture = true;
+        options.MaxTextureWidth = MaxAtlasDimension;
+        options.MaxTextureHeight = MaxAtlasDimension;
 
         // Drop shadow (and outline/shadow combos) are composited to RGBA by KernSmith's effect
         // pipeline. A custom ChannelConfig routes through ChannelCompositor, which rebuilds RGB from


### PR DESCRIPTION
## Summary
Gum's texture-size heuristic (`AssignEstimatedNeededSizeOn` / `EstimateBlocksNeeded`) was built for `bmfont.exe`, which can't autofit and needs a size guessed up front. bmfont.exe also has no dropshadow support at all, so that heuristic never accounted for dropshadow inflation — and it never should have, since the KernSmith backend doesn't need Gum's guess either: it has its own `FontGeneratorOptions.AutofitTexture`.

- `KernSmithFileGenerator.BuildOptions` now sets `AutofitTexture = true` with a generous max (8192, matching Gum's own largest bmfont.exe size), ignoring Gum's heuristic-computed `OutputWidth/Height` entirely.
- New `IFontFileGenerator.RequiresSizeEstimation` (true for `BmFontExeFileGenerator`, false for `KernSmithFileGenerator`) gates `HeadlessFontGenerationService`'s size-estimation call, so it's skipped entirely for KernSmith rather than computing a value that gets thrown away.
- Updated the `gum-tool-font-generation` / `gum-kernsmith-integrations` skills, which were stale (described KernSmith as a future/runtime-only integration; it's already a selectable tool-side generator backend).

## Test plan
- [x] `KernSmithFileGeneratorSizeTests.BuildOptions_ThenGenerate_WithLargeDropshadow_ProducesSinglePage` reproduces the issue's exact repro (48px Arial, dropshadow offsetX=31/offsetY=-13/blur=6) via the real KernSmith library — 4 pages without the fix, 1 with it.
- [x] Full `Gum.ProjectServices.Tests` suite green (376 passed).

Manual test: not needed — the regression test above exercises the real KernSmith library end-to-end and reproduces the issue's exact scenario; there's no UI/rendering surface to this change.
FRB canary: not needed — change is confined to `Tools/Gum.ProjectServices/FontGeneration/`, not FRB1-shared source.

Closes #4019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
