### PR TITLE
Use Apos.Shapes' native DashStyle API for dashed shape strokes

### DIFF
--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -142,6 +142,19 @@ internal class Arc : RenderableShapeBase
 
         var endpointRadius = lineThickness / 2;
 
+        // Issue #3972 — Apos.Shapes 0.7.5 added a native DashStyle parameter to both DrawArc and
+        // DrawRing, so dashing flows through the same draw calls as a solid stroke instead of a
+        // hand-rolled perimeter walk. This also lifts the old butt-cap-only restriction (#2892) —
+        // rounded-end dashed arcs are now supported for free. DashSnap.Off preserves Gum's
+        // historical look (see Circle.RenderInternal for the rationale). The shadow pass
+        // (forcedColor != null) stays un-dashed on purpose: it renders as one continuous arc
+        // behind the dashes, matching Skia.
+        DashStyle dash = default;
+        if (forcedColor == null && StrokeDashLength > 0 && StrokeGapLength > 0 && lineThickness > 0 && radius > 0)
+        {
+            dash = new DashStyle(StrokeDashLength, StrokeGapLength, cap: DashCap.Butt, snap: DashSnap.Off);
+        }
+
         if(_isEndRounded)
         {
             if (ShouldPaintGradient(forcedColor))
@@ -155,7 +168,8 @@ internal class Arc : RenderableShapeBase
                     gradient,
                     gradient,
                     1,
-                    aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
             else
             {
@@ -168,7 +182,8 @@ internal class Arc : RenderableShapeBase
                     color,
                     color,
                     1,
-                    aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
         }
         else
@@ -182,18 +197,6 @@ internal class Arc : RenderableShapeBase
             // thin background-color ring around the outside of the Arc.
             var compensatedRadius = radius + 1f;
 
-            // Dashed strokes only flow through the butt-cap path. The rounded-cap branch above
-            // uses DrawArc which has no dash analog in Apos.Shapes 0.6.x; if dashed rendering is
-            // ever wanted for rounded caps it has to be synthesized by emitting per-dash arcs
-            // (issue #2892). When forcedColor is set we're rendering the dropshadow pass — the
-            // shadow renders as one continuous arc behind the dashes (Skia / SkiaSharp do the
-            // same), so skip the dash decomposition there.
-            if (forcedColor == null && StrokeDashLength > 0 && StrokeGapLength > 0 && lineThickness > 0 && radius > 0)
-            {
-                RenderDashed(sb, absoluteLeft, absoluteTop, center, radius, compensatedRadius, startAngleRadians, endAngleRadians, antiAliasSize, lineThickness);
-                return;
-            }
-
             if (ShouldPaintGradient(forcedColor))
             {
                 var gradient = base.GetGradient(absoluteLeft, absoluteTop);
@@ -205,7 +208,8 @@ internal class Arc : RenderableShapeBase
                     gradient,
                     gradient,
                     1,
-                    aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
             else
             {
@@ -218,57 +222,10 @@ internal class Arc : RenderableShapeBase
                     color,
                     color,
                     1,
-                    aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
         }
 
-    }
-
-    // Mirrors Circle.RenderDashed, bounded by the arc's sweep. Walks dash starts along the
-    // arc from startAngleRadians to endAngleRadians and emits a partial DrawRing per dash.
-    // See Circle.RenderDashed for the full rationale on the AA-compensation math and the
-    // (centerline, totalThickness) abuse of DrawRing's (radius1, radius2) parameters.
-    private void RenderDashed(Apos.Shapes.ShapeBatch sb,
-        float absoluteLeft,
-        float absoluteTop,
-        Vector2 center,
-        float radius,
-        float compensatedRadius,
-        float startAngleRadians,
-        float endAngleRadians,
-        int antiAliasSize,
-        float lineThickness)
-    {
-        var sweepRadians = endAngleRadians - startAngleRadians;
-        var arcLength = sweepRadians * radius;
-
-        // Same AA compensation as Circle.RenderDashed: nudge into the gap, trim off each dash,
-        // floor the dash length so a tight 1-px-dash pattern doesn't push 0 (Apos won't render
-        // a zero-length dash).
-        var effectiveGapLen = StrokeGapLength + 1.5f * antiAliasSize;
-        var dashLen = MathHelper.Max(0.01f, StrokeDashLength - 0.5f * antiAliasSize);
-        var period = dashLen + effectiveGapLen;
-        if (period <= 0) return;
-
-        Gradient? gradient = UseGradient
-            ? base.GetGradient(absoluteLeft, absoluteTop)
-            : null;
-        var color = this.Color;
-
-        for (float t = 0; t < arcLength; t += period)
-        {
-            var dashEnd = MathHelper.Min(t + dashLen, arcLength);
-            var a1 = startAngleRadians + t / radius;
-            var a2 = startAngleRadians + dashEnd / radius;
-
-            if (gradient is Gradient g)
-            {
-                sb.DrawRing(center, a1, a2, compensatedRadius, lineThickness, g, g, 1, aaSize: antiAliasSize);
-            }
-            else
-            {
-                sb.DrawRing(center, a1, a2, compensatedRadius, lineThickness, color, color, 1, aaSize: antiAliasSize);
-            }
-        }
     }
 }

--- a/Runtimes/GumShapes/Renderables/Circle.cs
+++ b/Runtimes/GumShapes/Renderables/Circle.cs
@@ -213,10 +213,15 @@ public class Circle : RenderableShapeBase,
         float cameraZoom,
         Color? forcedColor = null)
     {
+        // Issue #3972 — Apos.Shapes 0.7.5 added a native DashStyle parameter to DrawCircle, so
+        // dashing now flows through the same draw call as a solid stroke instead of a hand-rolled
+        // perimeter walk. DashSnap.Off preserves Gum's historical look (fixed period from a fixed
+        // start, last dash clipped wherever it lands) rather than upstream's new seamless-tiling
+        // default, so existing saved projects render unchanged.
+        DashStyle dash = default;
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0 && strokeWidth > 0 && radius > 0)
         {
-            RenderDashed(sb, absoluteLeft, absoluteTop, center, radius, antiAliasSize, strokeWidth, rotationRadians, forcedColor);
-            return;
+            dash = new DashStyle(StrokeDashLength, StrokeGapLength, cap: DashCap.Butt, snap: DashSnap.Off);
         }
 
         // See RoundedRectangle for more info. The offset is half a SCREEN pixel, so it is divided
@@ -283,7 +288,8 @@ public class Circle : RenderableShapeBase,
                     transparentGradient,
                     gradient,
                     strokeWidth,
-                    aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
             else
             {
@@ -297,75 +303,8 @@ public class Circle : RenderableShapeBase,
                     transparentColor,
                     color,
                     strokeWidth,
-                    aaSize: antiAliasSize);
-            }
-        }
-    }
-
-    // Ported from the upstream Apos.Shapes dashed-line PR
-    // (https://github.com/Apostolique/Apos.Shapes/pull/31, DrawDashedCircle).
-    // Walks dash starts around the circle perimeter and emits a partial ring per dash via
-    // ShapeBatch.DrawRing, which batches into the same draw call as the surrounding shapes.
-    // Adapted to Apos.Shapes 0.6.8's DrawRing(center, a1, a2, radius, thickness, ...) signature
-    // (the upstream PR is built against the unreleased master signature with radius1/radius2);
-    // the inner-fill pass and FitToPath logic are dropped because we only invoke this branch when
-    // IsFilled is false and we want Skia-style exact dashing.
-    private void RenderDashed(ShapeBatch sb,
-        float absoluteLeft,
-        float absoluteTop,
-        Microsoft.Xna.Framework.Vector2 center,
-        float radius,
-        int antiAliasSize,
-        float strokeWidth,
-        float rotationRadians,
-        Color? forcedColor)
-    {
-        // Apos.Shapes 0.6.x DrawRing parameter naming is misleading - despite being called
-        // (radius1, radius2), the shader's RingSDF treats them as (centerline, totalThickness):
-        //   abs(length(p) - r) - th * 0.5, meaning the band spans [r - th/2, r + th/2].
-        // The shader also does `radius1 -= 1f` internally before sampling, so we pass
-        // centerline + 1 to compensate so the outer edge of the band lines up with where a
-        // solid BorderCircle's outline sits.
-        var ringRadius = radius - strokeWidth / 2f;
-        var circumference = 2f * MathHelper.Pi * radius;
-
-        // Issue #2790: when AA is on, each dash's tangential end-cap halo leaks into the
-        // neighboring gap from each side, smearing dotted patterns into near-continuous
-        // rings. Shift 1.5 * aaSize into the gap and trim 0.5 * aaSize off each dash so the
-        // gap opens up noticeably while the dashes shrink slightly to compensate. Total
-        // period grows by aaSize so the perimeter still has one or two fewer dashes overall,
-        // but each one reads as a discrete dot. Dash length floored at a small epsilon so a
-        // tight 1-px-dash pattern doesn't push 0 (Apos won't render a zero-length dash).
-        var effectiveGapLen = StrokeGapLength + 1.5f * antiAliasSize;
-        var dashLen = MathHelper.Max(0.01f, StrokeDashLength - 0.5f * antiAliasSize);
-        var period = dashLen + effectiveGapLen;
-        if (period <= 0) return;
-
-        // Build the stroke "paint" once and pass the same Gradient/Color to every dash so the
-        // gradient looks continuous across the dashed border (each dash samples the same world-
-        // space gradient rather than restarting per-segment). GetGradient already returns world
-        // coords, mirroring how upstream's DrawDashedCircle calls GradientToWorld + IsLocal=false.
-        Gradient? gradient = ShouldPaintGradient(forcedColor)
-            ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
-            : null;
-        var color = forcedColor ?? Color;
-
-        for (float t = 0; t < circumference; t += period)
-        {
-            var dashEnd = MathHelper.Min(t + dashLen, circumference);
-            // Arc length / radius = swept angle. Apos.Shapes DrawRing expects start < end in math
-            // (CCW) radians; user-facing CW angles only enter via Arc.StartAngle, which is none of
-            // our concern here since we're walking the perimeter from angle 0.
-            var a1 = t / radius;
-            var a2 = dashEnd / radius;
-
-            if (gradient is Gradient g)
-            {
-                sb.DrawRing(center, a1, a2, ringRadius + 1f, strokeWidth, g, g, 1, aaSize: antiAliasSize);
-            }
-            else
-            {
-                sb.DrawRing(center, a1, a2, ringRadius + 1f, strokeWidth, color, color, 1, aaSize: antiAliasSize);
+                    aaSize: antiAliasSize,
+                    dash: dash);
             }
         }
     }

--- a/Runtimes/GumShapes/Renderables/Line.cs
+++ b/Runtimes/GumShapes/Renderables/Line.cs
@@ -1,3 +1,4 @@
+using Apos.Shapes;
 using Microsoft.Xna.Framework;
 using RenderingLibrary;
 using System;
@@ -55,55 +56,30 @@ internal class Line : RenderableShapeBase
         // Match Skia's semantics: dashing only kicks in when IsFilled is false. Skia lines also
         // require IsFilled = false to render as a stroke, so users authoring dashed strokes already
         // have to set this; keeping the trigger identical avoids cross-runtime surprises.
+        //
+        // Issue #3972 — Apos.Shapes 0.7.5 added a native DashStyle parameter to DrawLine, which
+        // dashes an open stroke along its centerline with independent per-dash cap control. This
+        // replaces the manual per-segment RenderRounded/RenderButt loop below. Only the round-cap
+        // path (RenderRounded's DrawLine call) can carry it — DrawRectangle's dash (RenderButt)
+        // dashes the shape's own outline perimeter, not a straight cut along a line's length, so
+        // it can't be reused for a butt-cap dashed line the same way. DashCap picks the per-dash
+        // end shape independently of IsRounded, and DashSnap.Off preserves Gum's historical look
+        // (see Circle.RenderInternal for the rationale).
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0)
         {
-            RenderDashed(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize, forcedColor);
+            var dash = new DashStyle(StrokeDashLength, StrokeGapLength,
+                cap: IsRounded ? DashCap.Round : DashCap.Butt, snap: DashSnap.Off);
+            RenderRounded(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize, forcedColor, dash);
             return;
         }
 
         if (IsRounded)
         {
-            RenderRounded(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize, forcedColor);
+            RenderRounded(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize, forcedColor, default);
         }
         else
         {
             RenderButt(sb, absoluteLeft, absoluteTop, a, b, antiAliasSize, forcedColor);
-        }
-    }
-
-    private void RenderDashed(Apos.Shapes.ShapeBatch sb,
-        float absoluteLeft,
-        float absoluteTop,
-        Vector2 a,
-        Vector2 b,
-        float antiAliasSize,
-        Color? forcedColor)
-    {
-        var delta = b - a;
-        var length = delta.Length();
-        if (length <= 0) return;
-
-        var direction = delta / length;
-        var period = StrokeDashLength + StrokeGapLength;
-
-        // Skia's default phase is 0: the first dash starts at t=0 and the last dash is clipped wherever
-        // it lands. We mirror that here rather than the "fit to path" mode from the upstream PR; the
-        // exact pattern is more predictable for short lines (where rescaling would visibly change dash
-        // sizes) and matches what users authoring against the Skia runtime already see.
-        for (float t = 0; t < length; t += period)
-        {
-            var dashEnd = MathHelper.Min(t + StrokeDashLength, length);
-            var segA = a + direction * t;
-            var segB = a + direction * dashEnd;
-
-            if (IsRounded)
-            {
-                RenderRounded(sb, absoluteLeft, absoluteTop, segA, segB, antiAliasSize, forcedColor);
-            }
-            else
-            {
-                RenderButt(sb, absoluteLeft, absoluteTop, segA, segB, antiAliasSize, forcedColor);
-            }
         }
     }
 
@@ -113,19 +89,20 @@ internal class Line : RenderableShapeBase
         Vector2 a,
         Vector2 b,
         float antiAliasSize,
-        Color? forcedColor)
+        Color? forcedColor,
+        DashStyle dash)
     {
         var lineRadius = StrokeWidth / 2.0f;
 
         if (UseGradient && forcedColor == null)
         {
             var gradient = base.GetGradient(absoluteLeft, absoluteTop);
-            sb.DrawLine(a, b, lineRadius, gradient, gradient, aaSize: antiAliasSize);
+            sb.DrawLine(a, b, lineRadius, gradient, gradient, aaSize: antiAliasSize, dash: dash);
         }
         else
         {
             var color = forcedColor ?? this.Color;
-            sb.DrawLine(a, b, lineRadius, color, color, aaSize: antiAliasSize);
+            sb.DrawLine(a, b, lineRadius, color, color, aaSize: antiAliasSize, dash: dash);
         }
     }
 

--- a/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
+++ b/Runtimes/GumShapes/Renderables/RoundedRectangle.cs
@@ -266,11 +266,18 @@ public class RoundedRectangle : RenderableShapeBase,
         float cameraZoom,
         Color? forcedColor = null)
     {
+        // Issue #3972 — Apos.Shapes 0.7.5 added a native DashStyle parameter to DrawRectangle,
+        // which dashes the full rounded perimeter (straight sides + corners) in-shader. Replaces
+        // the hand-rolled EmitStraightDash/EmitCornerDash perimeter walk below. DashSnap.Off
+        // preserves Gum's historical look (see Circle.RenderInternal for the rationale) — and,
+        // as a side effect of going through the same call as the solid path, custom per-corner
+        // radii (CustomRadiusTopLeft etc.) now dash correctly too; the old walk only ever used
+        // the uniform CornerRadius.
+        DashStyle dash = default;
         if (!IsFilled && StrokeDashLength > 0 && StrokeGapLength > 0 && strokeWidth > 0
             && size.X > 0 && size.Y > 0)
         {
-            RenderDashed(sb, absoluteLeft, absoluteTop, size, antiAliasSize, strokeWidth, rotationRadians, forcedColor);
-            return;
+            dash = new DashStyle(StrokeDashLength, StrokeGapLength, cap: DashCap.Butt, snap: DashSnap.Off);
         }
 
         var position = AdjustPositionForCenterRotation(
@@ -343,9 +350,9 @@ public class RoundedRectangle : RenderableShapeBase,
                 transparentGradient.BC = new Color((int)gradient.BC.R, gradient.BC.G, gradient.BC.B, 0);
 
                 if (hasCustomCorners)
-                    sb.DrawRectangle(position, size, transparentGradient, gradient, strokeWidth, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(position, size, transparentGradient, gradient, strokeWidth, corners, rotationRadians, antiAliasSize, dash);
                 else
-                    sb.DrawRectangle(position, size, transparentGradient, gradient, strokeWidth, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(position, size, transparentGradient, gradient, strokeWidth, CornerRadius, rotationRadians, antiAliasSize, dash);
             }
             else
             {
@@ -354,9 +361,9 @@ public class RoundedRectangle : RenderableShapeBase,
                 transparentColor.A = 0;
 
                 if (hasCustomCorners)
-                    sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, corners, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, corners, rotationRadians, antiAliasSize, dash);
                 else
-                    sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, CornerRadius, rotationRadians, antiAliasSize);
+                    sb.DrawRectangle(position, size, transparentColor, color, strokeWidth, CornerRadius, rotationRadians, antiAliasSize, dash);
 
             }
         }
@@ -378,206 +385,4 @@ public class RoundedRectangle : RenderableShapeBase,
         return true;
     }
 
-    // Ported from the upstream Apos.Shapes dashed-line PR
-    // (https://github.com/Apostolique/Apos.Shapes/pull/31, DrawDashedRectangle + EmitStripDash + EmitArcDash).
-    // Walks the perimeter (4 straight sides + 4 corner arcs) parameterized by t, clipping each
-    // dash to whichever segment it lands on. We follow Skia's "exact" dashing (last dash clipped
-    // wherever it lands) rather than the upstream PR's optional FitToPath rescaling, to keep the
-    // pattern visually identical to the Skia runtime.
-    private void RenderDashed(Apos.Shapes.ShapeBatch sb,
-        float absoluteLeft,
-        float absoluteTop,
-        Vector2 size,
-        int antiAliasSize,
-        float strokeWidth,
-        float rotationRadians,
-        Color? forcedColor)
-    {
-        // Build paint once, world-space. Pass the same Gradient to every dash so the gradient looks
-        // continuous across the dashed border (each dash samples the same global gradient rather
-        // than restarting per-segment). Falls back to a solid Color when no gradient is configured.
-        // Apos.Shapes overloads accept either, so we forward whichever fits.
-        var fallbackColor = forcedColor ?? Color;
-        Gradient strokeGradient = ShouldPaintGradient(forcedColor)
-            ? base.GetGradient(absoluteLeft, absoluteTop, rotationRadians)
-            : new Gradient(Vector2.Zero, fallbackColor, Vector2.Zero, fallbackColor, Gradient.Shape.None);
-
-        var halfT = strokeWidth / 2f;
-        var rounded = MathHelper.Min(MathHelper.Min(CornerRadius, size.X / 2f), size.Y / 2f);
-        // Apos.Shapes 0.6.x DrawRing's (radius1, radius2) params are really (centerline, totalThickness)
-        // per the shader's RingSDF (abs(length(p) - r) - th * 0.5). +1f cancels the internal
-        // radius1 -= 1f so the outer edge of each corner arc lines up with the rect's outer edge.
-        var ringRadius = MathHelper.Max(rounded - halfT, 0f);
-
-        var straightX = size.X - 2f * rounded;
-        var straightY = size.Y - 2f * rounded;
-        var cornerArc = rounded * MathHelper.PiOver2;
-        var perimeter = 2f * (straightX + straightY) + 4f * cornerArc;
-        if (perimeter <= 0) return;
-
-        // Issue #2818 (mirror of Circle.RenderDashed #2790): when AA is on, each dash's
-        // tangential end-cap halo leaks into the neighboring gap and smears dotted patterns
-        // into near-continuous borders. Shift 1.5 * aaSize into the gap and trim 0.5 * aaSize
-        // off each dash so the gap opens up noticeably while dashes shrink slightly to
-        // compensate. Dash length floored at a small epsilon so a tight 1-px-dash pattern
-        // doesn't push 0 (Apos won't render a zero-length dash).
-        var effectiveGapLen = StrokeGapLength + 1.5f * antiAliasSize;
-        var dashLen = MathHelper.Max(0.01f, StrokeDashLength - 0.5f * antiAliasSize);
-        var period = dashLen + effectiveGapLen;
-        if (period <= 0) return;
-
-        var topY = absoluteTop;
-        var bottomY = absoluteTop + size.Y;
-        var leftX = absoluteLeft;
-        var rightX = absoluteLeft + size.X;
-
-        var cornerTL = new Vector2(leftX + rounded, topY + rounded);
-        var cornerTR = new Vector2(rightX - rounded, topY + rounded);
-        var cornerBR = new Vector2(rightX - rounded, bottomY - rounded);
-        var cornerBL = new Vector2(leftX + rounded, bottomY - rounded);
-
-        // Rotation pivot matches the solid render: AdjustPositionForCenterRotation in the
-        // non-dashed path treats absolute(top, left) as the pivot the user "rotates around".
-        // We rotate every emitted dash's center around the same pivot, then pass rotationRadians
-        // to DrawRectangle/DrawRing so each primitive is also oriented to match.
-        var pivot = new Vector2(absoluteLeft, absoluteTop);
-        var cos = MathF.Cos(rotationRadians);
-        var sin = MathF.Sin(rotationRadians);
-
-        for (float t = 0; t < perimeter; t += period)
-        {
-            var dashStart = t;
-            var dashEnd = MathHelper.Min(t + dashLen, perimeter);
-            if (dashEnd <= dashStart) continue;
-
-            float segOff = 0f;
-
-            // Top edge (LtR), inward normal +y.
-            EmitStraightDash(sb, dashStart, dashEnd, segOff, straightX,
-                edgeStart: new Vector2(leftX + rounded, topY), edgeDir: new Vector2(1, 0), inwardNormal: new Vector2(0, 1),
-                strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            segOff += straightX;
-
-            // TR corner: from -π/2 (top tangent) to 0 (right tangent), CCW.
-            if (rounded > 0)
-            {
-                EmitCornerDash(sb, dashStart, dashEnd, segOff, cornerArc,
-                    cornerTR, startAngle: -MathHelper.PiOver2, endAngle: 0f,
-                    ringRadius, strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            }
-            segOff += cornerArc;
-
-            // Right edge (TtB), inward normal -x.
-            EmitStraightDash(sb, dashStart, dashEnd, segOff, straightY,
-                edgeStart: new Vector2(rightX, topY + rounded), edgeDir: new Vector2(0, 1), inwardNormal: new Vector2(-1, 0),
-                strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            segOff += straightY;
-
-            // BR corner: 0 to π/2.
-            if (rounded > 0)
-            {
-                EmitCornerDash(sb, dashStart, dashEnd, segOff, cornerArc,
-                    cornerBR, startAngle: 0f, endAngle: MathHelper.PiOver2,
-                    ringRadius, strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            }
-            segOff += cornerArc;
-
-            // Bottom edge (RtL), inward normal -y.
-            EmitStraightDash(sb, dashStart, dashEnd, segOff, straightX,
-                edgeStart: new Vector2(rightX - rounded, bottomY), edgeDir: new Vector2(-1, 0), inwardNormal: new Vector2(0, -1),
-                strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            segOff += straightX;
-
-            // BL corner: π/2 to π.
-            if (rounded > 0)
-            {
-                EmitCornerDash(sb, dashStart, dashEnd, segOff, cornerArc,
-                    cornerBL, startAngle: MathHelper.PiOver2, endAngle: MathHelper.Pi,
-                    ringRadius, strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            }
-            segOff += cornerArc;
-
-            // Left edge (BtT), inward normal +x.
-            EmitStraightDash(sb, dashStart, dashEnd, segOff, straightY,
-                edgeStart: new Vector2(leftX, bottomY - rounded), edgeDir: new Vector2(0, -1), inwardNormal: new Vector2(1, 0),
-                strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            segOff += straightY;
-
-            // TL corner: π to 3π/2.
-            if (rounded > 0)
-            {
-                EmitCornerDash(sb, dashStart, dashEnd, segOff, cornerArc,
-                    cornerTL, startAngle: MathHelper.Pi, endAngle: 1.5f * MathHelper.Pi,
-                    ringRadius, strokeWidth, strokeGradient, antiAliasSize, pivot, cos, sin, rotationRadians);
-            }
-        }
-    }
-
-    private static Vector2 RotateAround(Vector2 point, Vector2 pivot, float cos, float sin)
-    {
-        var dx = point.X - pivot.X;
-        var dy = point.Y - pivot.Y;
-        return new Vector2(
-            pivot.X + dx * cos - dy * sin,
-            pivot.Y + dx * sin + dy * cos);
-    }
-
-    private static void EmitStraightDash(Apos.Shapes.ShapeBatch sb,
-        float dashStart, float dashEnd, float segStart, float segLen,
-        Vector2 edgeStart, Vector2 edgeDir, Vector2 inwardNormal,
-        float strokeWidth, Gradient gradient, int aaSize,
-        Vector2 pivot, float cos, float sin, float rotationRadians)
-    {
-        if (segLen <= 0) return;
-        var overlapStart = MathHelper.Max(dashStart, segStart);
-        var overlapEnd = MathHelper.Min(dashEnd, segStart + segLen);
-        if (overlapEnd <= overlapStart) return;
-
-        var localStart = overlapStart - segStart;
-        var localEnd = overlapEnd - segStart;
-        var subDashLen = localEnd - localStart;
-
-        var p1 = edgeStart + edgeDir * localStart;
-        var p2 = edgeStart + edgeDir * localEnd;
-        var midpoint = (p1 + p2) * 0.5f;
-        var center = midpoint + inwardNormal * (strokeWidth * 0.5f);
-
-        // Axis-aligned: dashes on top/bottom are size (subDashLen, strokeWidth), on left/right
-        // are (strokeWidth, subDashLen). MathF.Abs distinguishes the two via edgeDir.
-        Vector2 dashSize = MathF.Abs(edgeDir.X) > 0.5f
-            ? new Vector2(subDashLen, strokeWidth)
-            : new Vector2(strokeWidth, subDashLen);
-
-        // Rotate the dash's visual center around the rect pivot, then back out the unrotated xy
-        // that Apos needs (Apos rotates each primitive around xy + size/2; if we want the visual
-        // center at rotatedCenter, set xy = rotatedCenter - size/2).
-        var rotatedCenter = RotateAround(center, pivot, cos, sin);
-        var xy = rotatedCenter - dashSize * 0.5f;
-        sb.DrawRectangle(xy, dashSize, gradient, gradient, thickness: 1f, cornerRadii: 0f, rotation: rotationRadians, aaSize: aaSize);
-    }
-
-    private static void EmitCornerDash(Apos.Shapes.ShapeBatch sb,
-        float dashStart, float dashEnd, float segStart, float segLen,
-        Vector2 cornerCenter, float startAngle, float endAngle,
-        float ringRadius, float strokeWidth, Gradient gradient, int aaSize,
-        Vector2 pivot, float cos, float sin, float rotationRadians)
-    {
-        if (segLen <= 0) return;
-        var overlapStart = MathHelper.Max(dashStart, segStart);
-        var overlapEnd = MathHelper.Min(dashEnd, segStart + segLen);
-        if (overlapEnd <= overlapStart) return;
-
-        var t1 = (overlapStart - segStart) / segLen;
-        var t2 = (overlapEnd - segStart) / segLen;
-        // Add rotationRadians to both angles so the arc segment is positioned around the (rotated)
-        // corner center the same way as in the unrotated case. The corner center itself is also
-        // rotated around the rect pivot.
-        var a1 = MathHelper.Lerp(startAngle, endAngle, t1) + rotationRadians;
-        var a2 = MathHelper.Lerp(startAngle, endAngle, t2) + rotationRadians;
-        var rotatedCornerCenter = RotateAround(cornerCenter, pivot, cos, sin);
-
-        // +1f cancels Apos.Shapes' internal radius1 -= 1f in DrawRing so the corner arc's outer
-        // edge lines up with the rect's outer bounding edge (where EmitStraightDash sits).
-        sb.DrawRing(rotatedCornerCenter, a1, a2, ringRadius + 1f, strokeWidth, gradient, gradient, 1, aaSize: aaSize);
-    }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ArcsScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ArcsScreen.cs
@@ -16,8 +16,6 @@ namespace MonoGameGumInCode.Screens;
 //   - Arcs are stroke-only on both backends (the chord-fill seal in #2891 is Skia-only; Apos's
 //     Arc.Render has always ignored IsFilled). The Skia "filled" cell in the AA row becomes a
 //     thick-band cell here so the row keeps its shape without inventing a fill mode.
-//   - Apos's Arc.RenderInternal only honors dashing on the butt-cap path (IsEndRounded = false).
-//     The dashed-stroke row pins butt caps so a regression that breaks one branch surfaces.
 //   - Apos's edge AA is signed-distance-field (1 px bloom on, crisp at aaSize = 0). Skia uses
 //     path AA. Subtle visual differences between the two are expected, not bugs.
 internal class ArcsScreen : FrameworkElement
@@ -233,11 +231,9 @@ internal class ArcsScreen : FrameworkElement
         return row;
     }
 
-    // Mirrors the dashed-stroke row from the Skia gallery. Caps pinned to butt (IsEndRounded
-    // = false, which is the default) because Apos's Arc.RenderInternal only routes through
-    // DrawRing — and therefore honors dashing — on the butt path. The rounded path goes
-    // through DrawArc which has no dash support, so flipping any cell to rounded here would
-    // silently swallow the dash pattern.
+    // Mirrors the dashed-stroke row from the Skia gallery. Issue #3972 — Apos.Shapes 0.7.5 added
+    // native dashing to both DrawRing (butt path) and DrawArc (rounded path, IsEndRounded = true),
+    // so the trailing cell pins IsEndRounded = true to cover the previously-unsupported case.
     static ContainerRuntime BuildDashedStrokeRow()
     {
         ContainerRuntime row = BuildHorizontalRow();
@@ -275,6 +271,16 @@ internal class ArcsScreen : FrameworkElement
         longDash.StrokeDashLength = 12;
         longDash.StrokeGapLength = 6;
         row.AddChild(longDash);
+
+        ArcRuntime roundedDash = new();
+        roundedDash.Width = 60; roundedDash.Height = 60;
+        roundedDash.SweepAngle = 270;
+        roundedDash.Thickness = 6;
+        roundedDash.Color = Color.Orange;
+        roundedDash.IsEndRounded = true;
+        roundedDash.StrokeDashLength = 12;
+        roundedDash.StrokeGapLength = 6;
+        row.AddChild(roundedDash);
 
         return row;
     }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/MixedScreen.cs
@@ -120,6 +120,33 @@ internal class MixedScreen : FrameworkElement
         polygon.Width = 30;
         polygon.Height = 8;
         container.Children.Add(polygon);
+
+        AddText(container, "These are dashed lines (round cap, butt cap):");
+        var dashedLineRounded = new LineRuntime();
+        dashedLineRounded.IsFilled = false;
+        dashedLineRounded.IsRounded = true;
+        dashedLineRounded.Color = Color.Yellow;
+        dashedLineRounded.StrokeWidth = 6;
+        dashedLineRounded.StrokeDashLength = 12;
+        dashedLineRounded.StrokeGapLength = 6;
+        dashedLineRounded.X = 10;
+        dashedLineRounded.Y = 10;
+        dashedLineRounded.Width = 150;
+        dashedLineRounded.Height = 0;
+        container.Children.Add(dashedLineRounded);
+
+        var dashedLineButt = new LineRuntime();
+        dashedLineButt.IsFilled = false;
+        dashedLineButt.IsRounded = false;
+        dashedLineButt.Color = Color.Cyan;
+        dashedLineButt.StrokeWidth = 6;
+        dashedLineButt.StrokeDashLength = 12;
+        dashedLineButt.StrokeGapLength = 6;
+        dashedLineButt.X = 10;
+        dashedLineButt.Y = 20;
+        dashedLineButt.Width = 150;
+        dashedLineButt.Height = 40;
+        container.Children.Add(dashedLineButt);
     }
 
     internal static void AddText(ContainerRuntime container, string text)


### PR DESCRIPTION
## Summary
Circle/RoundedRectangle/Arc/Line now dash via Apos.Shapes 0.7.5's native `DashStyle` parameter (shipped after the original hand-rolled port was written), instead of a hand-rolled perimeter-walk. Deletes `RenderDashed`/`EmitStraightDash`/`EmitCornerDash` (~280 lines) across the three files. `DashSnap.Off` preserves the existing pixel-exact look.

Two fixes fall out for free:
- RoundedRectangle dashing now respects per-corner custom radii (previously silently ignored — only used the uniform `CornerRadius`).
- `Arc.IsEndRounded` arcs can now dash (previously impossible — no upstream API existed).

Also updates the `MonoGameGumInCode` sample: a rounded-cap dashed-arc cell in `ArcsScreen.cs` (demonstrating the new capability), and a dashed-line demo (round + butt cap) in `MixedScreen.cs`.

Closes #3972

## Test plan
- [x] `dotnet build` on `MonoGameGumShapes.csproj` and `KniGumShapes.csproj` — 0 errors
- [x] `dotnet test Tests/MonoGameGum.Shapes.Tests` — 222/222 passed (property-plumbing coverage; this render path has no pixel-level unit harness in the repo — none existed before this change either)
- [x] `dotnet test MonoGameGum.Tests --filter CircleRuntimeTests` — 19/19 passed
- [x] Manual visual check in `MonoGameGumInCode` and raylib sample galleries, side by side — confirmed by repo owner
