### PR TITLE
Fix Skia CircleRuntime fill/stroke seam on thick strokes

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1623,9 +1623,8 @@ public class CircleRuntime : GraphicalUiElement
     /// <summary>
     /// Pushes the issue #2834 fill radius inset after the base runs its stroke-width and
     /// W/H mirror. Inset equals the post-ScreenPixel-scaled stroke width (matching what the
-    /// base just pushed onto the stroke slot); zero when the stroke is hidden so fill-only
-    /// mode renders at full radius. Skia fits AA within the stroke thickness so no AA-bloom
-    /// adjustment is needed — the user's StrokeWidth IS the rendered thickness.
+    /// base just pushed onto the stroke slot), minus a small AA-seam overlap (issue #4028);
+    /// zero when the stroke is hidden so fill-only mode renders at full radius.
     /// </summary>
     public override void PreRender()
     {
@@ -1637,6 +1636,23 @@ public class CircleRuntime : GraphicalUiElement
             if (StrokeRenderable.Color.Alpha > 0)
             {
                 fillRadiusInset = StrokeRenderable.StrokeWidth;
+
+                // Issue #4028 — Skia's stroke AA fits within the nominal thickness (no bloom
+                // to compensate, unlike Apos), but fill and stroke are still two SEPARATE
+                // antialiased draw calls. Even though their nominal radii touch exactly, each
+                // draw blends its own AA fringe against the destination independently (alpha-
+                // over composition, not summed coverage), leaving a thin ring of background
+                // color visible at the seam — worse as StrokeWidth grows. Same root cause as
+                // the NineSlice abutting-section seam (see RenderableShapeBase.cs remarks).
+                // Overlapping the fill slightly into the stroke's opaque band guarantees full
+                // opacity at the boundary and hides the seam.
+                if (StrokeRenderable.IsAntialiased)
+                {
+                    var camera = this.EffectiveManagers?.Renderer?.Camera;
+                    float cameraZoom = camera?.Zoom ?? 1f;
+                    float aaSeamOverlap = 1f / cameraZoom;
+                    fillRadiusInset = Math.Max(0f, fillRadiusInset - aaSeamOverlap);
+                }
             }
             ContainedLineCircle.FillRadiusInset = fillRadiusInset;
         }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/CirclesScreen.cs
@@ -470,6 +470,19 @@ internal class CirclesScreen : FrameworkElement
         fillLast.IsFilled = true;
         row.Children.Add(fillLast);
 
+        // Same-color fill and stroke, thick and solid (not dashed) — issue #4028. Fill and
+        // stroke are two separately-antialiased draws that meet at the same nominal radius;
+        // with matching colors any seam between them shows up as a visible ring of the
+        // background color instead of blending away, which a dashed or differently-colored
+        // stroke would hide.
+        CircleRuntime blackOnBlack = new();
+        blackOnBlack.Radius = 28;
+        blackOnBlack.FillColor = new Color(0, 0, 0, 255);
+        blackOnBlack.IsFilled = true;
+        blackOnBlack.StrokeColor = new Color(0, 0, 0, 255);
+        blackOnBlack.StrokeWidth = 8;
+        row.Children.Add(blackOnBlack);
+
         // Dashed stroke over a fill, thin vs thick, so dash rendering is confirmed alongside the
         // two-slot fill+stroke composition rather than only on its own in BuildDashedStrokeRow.
         CircleRuntime dashedThin = new();

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -330,14 +330,18 @@ public class CircleRuntimeTests
     // is inscribed inside the runtime bounds (IsOffsetAppliedForStroke shifts the stroke
     // inward by StrokeWidth/2 so the ring spans R-sw to R). Without the inset, the stroke's
     // inner AA edge fades from opaque white to transparent atop the still-opaque fill at
-    // that radius, producing a visible pink halo on the inside of the stroke. Inset = full
-    // stroke width (Skia fits AA within the stroke thickness, so no AA-bloom adjustment).
+    // that radius, producing a visible pink halo on the inside of the stroke.
+    //
+    // Issue #4028 — inset is stroke width minus a 1px AA-seam overlap (not the full stroke
+    // width): two independently-antialiased draws touching at the exact same radius still
+    // leave a visible background seam (alpha-over composition, not summed coverage), so the
+    // fill is pushed slightly further in to guarantee full opacity at the boundary.
     //
     // Pushed via FillRadiusInset rather than mutating fill.Width because the fill is the
     // runtime's contained sizing object — mutating Width would feed back into layout and
     // accumulate frame-over-frame until the circle vanished (same trap caught on Apos).
     [Fact]
-    public void FillRadiusInset_WhenStrokeVisible_PushedStrokeWidthInPreRender()
+    public void FillRadiusInset_WhenStrokeVisible_PushedStrokeWidthMinusAaSeamOverlapInPreRender()
     {
         CircleRuntime sut = new();
         sut.Width = 56;
@@ -350,7 +354,7 @@ public class CircleRuntimeTests
         sut.PreRender();
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
-        fillSlot.FillRadiusInset.ShouldBe(4f);
+        fillSlot.FillRadiusInset.ShouldBe(3f);
     }
 
     // Issue #2938 — stroke is hidden via StrokeWidth = 0 (StrokeColor is non-nullable now).
@@ -369,6 +373,69 @@ public class CircleRuntimeTests
 
         Circle fillSlot = (Circle)sut.RenderableComponent;
         fillSlot.FillRadiusInset.ShouldBe(0f);
+    }
+
+    // Issue #4028 — a thick stroke with fill and stroke the same color shows a visible ring of
+    // background color at the seam. Fill and stroke are two SEPARATE antialiased draw calls;
+    // even though their nominal radii touch exactly (FillRadiusInset = StrokeWidth), each draw's
+    // AA fringe blends against the destination independently (alpha-over composition, not summed
+    // coverage), leaving a thin gap of background visible at the boundary -- more visible as
+    // StrokeWidth grows. Renders a black-filled, black-stroked circle over a white background and
+    // samples the seam pixel directly; a correct render is solid black there.
+    [Fact]
+    public void ThickStroke_SameColorFillAndStroke_NoBackgroundSeamAtBoundary()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(120, 120));
+        Gum.GumService.Default.Initialize(surface.Canvas, 120, 120);
+
+        RectangleRuntime background = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 120,
+            Height = 120,
+            IsFilled = true,
+            FillColor = SKColors.White,
+        };
+        Gum.GumService.Default.Root.Children.Add(background);
+
+        CircleRuntime circle = new()
+        {
+            X = 10,
+            Y = 10,
+            Width = 100,
+            Height = 100,
+            IsFilled = true,
+            FillColor = SKColors.Black,
+            StrokeColor = SKColors.Black,
+            StrokeWidth = 8,
+        };
+        Gum.GumService.Default.Root.Children.Add(circle);
+
+        Gum.GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+
+        // Circle center is at (60, 60), radius 50; the fill/stroke seam sits at radius
+        // 50 - 8 = 42 from center. Scan an annulus around that radius (well inside the
+        // circle's own outer AA edge) for the worst-case white bleed-through.
+        byte maxRed = 0;
+        for (int yy = 0; yy < 120; yy++)
+        {
+            for (int xx = 0; xx < 120; xx++)
+            {
+                double dx = xx - 60;
+                double dy = yy - 60;
+                double dist = System.Math.Sqrt(dx * dx + dy * dy);
+                if (dist >= 38 && dist <= 46)
+                {
+                    maxRed = System.Math.Max(maxRed, bitmap.GetPixel(xx, yy).Red);
+                }
+            }
+        }
+
+        maxRed.ShouldBeLessThan((byte)50);
     }
 
     // Regression guard matching the Apos-side test — repeated PreRender calls must not


### PR DESCRIPTION
## Problem
Black-filled/black-stroked circles on Skia (SilkNetGum) show a visible ring of background color between fill and stroke, worse at thick `StrokeWidth`. Fill and stroke touch at exactly the same nominal radius, but they're two independently-antialiased draw calls — each blends its own AA fringe against the destination separately (alpha-over composition, not summed coverage), leaving a seam. Same root cause as the NineSlice abutting-section seam.

## Fix
`CircleRuntime.PreRender` (Skia branch) now insets the fill by `StrokeWidth - 1px` (camera-zoom-scaled) instead of the full `StrokeWidth`, overlapping the fill slightly into the stroke's opaque band so there's no gap of partial coverage at the boundary.

## Testing
- New pixel-based regression test (`ThickStroke_SameColorFillAndStroke_NoBackgroundSeamAtBoundary`) renders a black-filled/black-stroked circle over white and scans the seam radius for background bleed-through; fails on old code (max red 94/255), passes after the fix.
- Updated the existing `FillRadiusInset` pin to the new inset value.
- Full `SkiaGum.Tests` suite green (389/389).

Closes #4028