### PR TITLE
Fix raylib LineCircle fill/stroke seam on solid strokes

### DIFF
--- a/Runtimes/RaylibGum/Renderables/LineCircle.cs
+++ b/Runtimes/RaylibGum/Renderables/LineCircle.cs
@@ -277,15 +277,29 @@ public class LineCircle : InvisibleRenderable
     }
 
     /// <summary>
+    /// Issue #4027 follow-up — a small overlap added back onto the stroke-width inset so the
+    /// fill's outer edge reaches slightly INTO the stroke ring's footprint rather than touching
+    /// it exactly flush. raylib's <c>DrawCircle</c> (fill) tessellates the disk with its own
+    /// internal segment count, independent of <c>DrawRing</c>'s explicit segment count for the
+    /// ring's inner edge — two separate polygon approximations of the same nominal radius don't
+    /// share vertices, so an exact flush touch leaves a thin background seam at some angles
+    /// around the circumference. The ring is drawn AFTER the fill and is opaque, so the overlap
+    /// is simply painted over and never visible itself.
+    /// </summary>
+    const float SeamOverlap = 1f;
+
+    /// <summary>
     /// Radius the fill pass draws at. Issue #4027 — when the stroke ring will render, the fill
-    /// is inset by <see cref="StrokeWidth"/> so it sits entirely inside the ring's inner edge
-    /// rather than sharing the ring's outer radius. Without this, a dashed/gapped stroke lets a
-    /// full-radius fill show through the gaps. Mirrors Apos.Shapes/SkiaGum's FillRadiusInset
-    /// contract (#2834). Applies equally whether the fill is solid or a gradient — a gradient
-    /// fill needs to stay clear of the stroke ring exactly like a solid one does.
+    /// is inset by <see cref="StrokeWidth"/> (minus <see cref="SeamOverlap"/>, clamped to never
+    /// exceed <see cref="Radius"/>) so it sits just inside the ring's inner edge, overlapping the
+    /// ring's footprint rather than sharing the ring's outer radius. Without the StrokeWidth
+    /// inset, a dashed/gapped stroke lets a full-radius fill show through the gaps. Mirrors
+    /// Apos.Shapes/SkiaGum's FillRadiusInset contract (#2834). Applies equally whether the fill
+    /// is solid or a gradient — a gradient fill needs to stay clear of the stroke ring exactly
+    /// like a solid one does.
     /// </summary>
     public float EffectiveFillRadius => WillRenderStroke
-        ? System.Math.Max(0f, Radius - StrokeWidth)
+        ? System.Math.Clamp(Radius - StrokeWidth + SeamOverlap, 0f, Radius)
         : Radius;
 
     /// <summary>

--- a/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/LineCircleTests.cs
@@ -325,8 +325,16 @@ public class LineCircleTests
     // gallery row's dashed cells). MonoGame/Skia already inset the fill by StrokeWidth
     // (FillRadiusInset) so the fill never reaches the ring's footprint at all.
 
+    // Issue #4027 follow-up — a solid (non-dashed) stroke still showed a thin background seam
+    // even though EffectiveFillRadius already inset the fill flush against the ring's inner
+    // edge. raylib's DrawCircle (fill) tessellates the disk with its own internal segment
+    // count, independent of DrawRing's explicit `segments` for the ring's inner edge -- two
+    // separate polygon approximations of the same nominal radius don't share vertices, so the
+    // "flush" touch leaves a sliver of background at some angles around the circumference.
+    // Overlapping the fill 1px further into the ring's opaque footprint (which is drawn AFTER
+    // the fill and covers the overlap) closes the gap regardless of the tessellation mismatch.
     [Fact]
-    public void EffectiveFillRadius_FillAndStrokeVisible_InsetByStrokeWidth()
+    public void EffectiveFillRadius_FillAndStrokeVisible_InsetByStrokeWidthMinusSeamOverlap()
     {
         LineCircle circle = new()
         {
@@ -337,7 +345,25 @@ public class LineCircleTests
             StrokeWidth = 8f,
         };
 
-        circle.EffectiveFillRadius.ShouldBe(24f);
+        circle.EffectiveFillRadius.ShouldBe(25f);
+    }
+
+    // The overlap must never push the fill radius past the ring's OUTER edge (Radius) -- a
+    // StrokeWidth thinner than the overlap constant would otherwise let the fill stick out
+    // past the ring entirely.
+    [Fact]
+    public void EffectiveFillRadius_StrokeThinnerThanSeamOverlap_ClampsToRadius()
+    {
+        LineCircle circle = new()
+        {
+            Width = 64,
+            Height = 64,
+            IsFilled = true,
+            StrokeColor = new Color(255, 255, 255, 255),
+            StrokeWidth = 0.5f,
+        };
+
+        circle.EffectiveFillRadius.ShouldBe(32f);
     }
 
     [Fact]
@@ -390,7 +416,7 @@ public class LineCircleTests
             StrokeWidth = 8f,
         };
 
-        circle.EffectiveFillRadius.ShouldBe(24f);
+        circle.EffectiveFillRadius.ShouldBe(25f);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
Black-filled/black-stroked circles on raylib show a thin ring of background color between fill and stroke even with a solid (non-dashed) stroke, though `EffectiveFillRadius` already insets the fill flush against the ring's inner edge (#4026 fixed the dashed-gap case). `DrawCircle` (fill) and `DrawRing` (stroke) tessellate the disk with different, independent segment counts, so the two polygon approximations don't share vertices at the boundary even when their nominal radii match exactly — same underlying class of bug as #4028 on Skia.

## Fix
`LineCircle.EffectiveFillRadius` now insets the fill by `StrokeWidth - 1px` (clamped to never exceed `Radius`) instead of the full `StrokeWidth`, so the fill overlaps slightly into the ring's footprint. The ring draws after the fill and is opaque, so the overlap is simply painted over.

## Testing
- Updated/added `EffectiveFillRadius` unit tests in `LineCircleTests` (pure computed-property tests, the established pattern for this contract — raylib pixel readback is avoided elsewhere in this suite as flaky).
- Full `RaylibGum.Tests` suite green (532/532).

Closes #4027