### PR TITLE
Converge NineSlice dispatch onto NineSliceRuntime

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -396,6 +396,13 @@ public partial class CustomSetPropertyOnRenderable
     private static bool TrySetPropertyOnNineSlice(NineSlice nineSlice, GraphicalUiElement graphicalUiElement, string propertyName, object value, bool handled)
     {
 
+#if FRB
+        // FRB doesn't have a NineSliceRuntime, so we have to do this:
+        var nineSliceRuntime = graphicalUiElement;
+#else
+        var nineSliceRuntime = graphicalUiElement as Gum.GueDeriving.NineSliceRuntime;
+#endif
+
         if (propertyName == "SourceFile")
         {
             AssignSourceFileOnNineSlice(value as string, graphicalUiElement, nineSlice);
@@ -405,6 +412,7 @@ public partial class CustomSetPropertyOnRenderable
         {
             var valueAsGumBlend = (Gum.RenderingLibrary.Blend)value;
 
+#if FRB
 #if !RAYLIB
             var valueAsXnaBlend = valueAsGumBlend.ToBlendState();
 
@@ -415,6 +423,12 @@ public partial class CustomSetPropertyOnRenderable
             // needed here, unlike the XNA-family branch above.
             nineSlice.Blend = valueAsGumBlend;
 #endif
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.Blend = valueAsGumBlend;
+            }
+#endif
 
             handled = true;
         }
@@ -422,12 +436,20 @@ public partial class CustomSetPropertyOnRenderable
         {
             var asFloat = value as float?;
 
+#if FRB
             nineSlice.CustomFrameTextureCoordinateWidth = asFloat;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.CustomFrameTextureCoordinateWidth = asFloat;
+            }
+#endif
 
             handled = true;
         }
         else if (propertyName == "Color")
         {
+#if FRB
 #if !RAYLIB
             if (value is System.Drawing.Color drawingColor)
             {
@@ -446,20 +468,65 @@ public partial class CustomSetPropertyOnRenderable
                 handled = true;
             }
 #endif
+#else
+            if (nineSliceRuntime != null)
+            {
+                if (value is System.Drawing.Color drawingColor)
+                {
+#if RAYLIB
+                    nineSliceRuntime.Color = drawingColor.ToRaylib();
+#else
+                    // NineSliceRuntime.Color is XNA-typed on this backend (unlike the renderable's
+                    // System.Drawing-typed Color), so the incoming System.Drawing value needs the
+                    // same ToXNA conversion the runtime's own getter uses in reverse.
+                    nineSliceRuntime.Color = global::RenderingLibrary.Graphics.XNAExtensions.ToXNA(drawingColor);
+#endif
+                    handled = true;
+                }
+#if !RAYLIB
+                else if (value is Microsoft.Xna.Framework.Color xnaColor)
+                {
+                    nineSliceRuntime.Color = xnaColor;
+                    handled = true;
+                }
+#endif
+            }
+#endif
         }
         else if(propertyName == "Red")
         {
+#if FRB
             nineSlice.Red = (int)value;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.Red = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Green")
         {
+#if FRB
             nineSlice.Green = (int)value;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.Green = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Blue")
         {
+#if FRB
             nineSlice.Blue = (int)value;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.Blue = (int)value;
+            }
+#endif
             handled = true;
         }
         else if (propertyName == "Texture")
@@ -469,12 +536,26 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if(propertyName == nameof(NineSlice.BorderScale))
         {
+#if FRB
             nineSlice.BorderScale = (float)value;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.BorderScale = (float)value;
+            }
+#endif
             handled = true;
         }
         else if(propertyName == nameof(NineSlice.IsTilingMiddleSections))
         {
+#if FRB
             nineSlice.IsTilingMiddleSections = (bool)value;
+#else
+            if (nineSliceRuntime != null)
+            {
+                nineSliceRuntime.IsTilingMiddleSections = (bool)value;
+            }
+#endif
             handled = true;
         }
 

--- a/MonoGameGum.Tests/Runtimes/NineSliceSetPropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/NineSliceSetPropertyTests.cs
@@ -1,0 +1,97 @@
+using Gum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnNineSlice) for NineSlice, mirroring SpriteSetPropertyTests.cs. These properties
+// are set at runtime by the state/variable system (StateSave/VariableSave applied via
+// GraphicalUiElement.SetProperty), not by direct C# property assignment, so this pins that the
+// string-path dispatch produces the same result as direct C# usage (e.g. NineSliceRuntime.Red = 10).
+public class NineSliceSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_BorderScale_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.BorderScale), 2f);
+
+        sut.BorderScale.ShouldBe(2f);
+    }
+
+    [Fact]
+    public void SetProperty_Blend_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+        var drawingColor = System.Drawing.Color.FromArgb(255, 10, 20, 30);
+
+        sut.SetProperty(nameof(NineSliceRuntime.Color), drawingColor);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+    }
+
+    [Fact]
+    public void SetProperty_Color_WithXnaColorValue_ShouldForwardToContainedNineSlice()
+    {
+        // The dispatcher accepts both System.Drawing.Color and Microsoft.Xna.Framework.Color as
+        // the incoming value (state/variable values are stored as System.Drawing.Color, but direct
+        // callers can pass XNA's Color) - this pins the XNA-typed branch, which needs no conversion
+        // since NineSliceRuntime.Color is itself XNA-typed on this backend.
+        NineSliceRuntime sut = new();
+        var xnaColor = new Microsoft.Xna.Framework.Color(10, 20, 30, 255);
+
+        sut.SetProperty(nameof(NineSliceRuntime.Color), xnaColor);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+    }
+
+    [Fact]
+    public void SetProperty_CustomFrameTextureCoordinateWidth_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.CustomFrameTextureCoordinateWidth), 4f);
+
+        sut.CustomFrameTextureCoordinateWidth.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void SetProperty_IsTilingMiddleSections_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.IsTilingMiddleSections), true);
+
+        sut.IsTilingMiddleSections.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_RedGreenBlue_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.Red), 10);
+        sut.SetProperty(nameof(NineSliceRuntime.Green), 20);
+        sut.SetProperty(nameof(NineSliceRuntime.Blue), 30);
+
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/NineSliceSetPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/NineSliceSetPropertyTests.cs
@@ -1,0 +1,79 @@
+using Gum.GueDeriving;
+using RaylibGum.Helpers;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnNineSlice) for NineSlice, mirroring SpriteSetPropertyTests.cs. These properties
+// are set at runtime by the state/variable system (StateSave/VariableSave applied via
+// GraphicalUiElement.SetProperty), not by direct C# property assignment, so this pins that the
+// string-path dispatch produces the same result as direct C# usage (e.g. NineSliceRuntime.Red = 10).
+public class NineSliceSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_BorderScale_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.BorderScale), 2f);
+
+        sut.BorderScale.ShouldBe(2f);
+    }
+
+    [Fact]
+    public void SetProperty_Blend_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+        var drawingColor = System.Drawing.Color.FromArgb(40, 10, 20, 30);
+
+        sut.SetProperty(nameof(NineSliceRuntime.Color), drawingColor);
+
+        ((Gum.Renderables.NineSlice)sut.RenderableComponent).Color.ShouldBe(drawingColor.ToRaylib());
+    }
+
+    [Fact]
+    public void SetProperty_CustomFrameTextureCoordinateWidth_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.CustomFrameTextureCoordinateWidth), 4f);
+
+        sut.CustomFrameTextureCoordinateWidth.ShouldBe(4f);
+    }
+
+    [Fact]
+    public void SetProperty_IsTilingMiddleSections_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.IsTilingMiddleSections), true);
+
+        sut.IsTilingMiddleSections.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_RedGreenBlue_ShouldForwardToContainedNineSlice()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty(nameof(NineSliceRuntime.Red), 10);
+        sut.SetProperty(nameof(NineSliceRuntime.Green), 20);
+        sut.SetProperty(nameof(NineSliceRuntime.Blue), 30);
+
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+}


### PR DESCRIPTION
Part of #3727.

Phase 2 of the ADR 0010 workstream (Sprite already merged as phase 1): converges `TrySetPropertyOnNineSlice` in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` onto `NineSliceRuntime`, mirroring the Sprite pattern.

## Changed

- Redispatched to `NineSliceRuntime`: `Blend`, `Color`, `Red`, `Green`, `Blue`, `BorderScale`, `IsTilingMiddleSections`, `CustomFrameTextureCoordinateWidth`.
- Each branch is `#if FRB` (unchanged, writes to `NineSlice` renderable) / `#else` (writes to `NineSliceRuntime`, null-guarded) — FRB1 has no `NineSliceRuntime`.
- `SourceFile`/`AssignSourceFileOnNineSlice` and `Texture` stay renderable-direct, per the ADR (real logic, own PR).

## Tests

- `MonoGameGum.Tests/Runtimes/NineSliceSetPropertyTests.cs` and `Tests/RaylibGum.Tests/Runtimes/NineSliceSetPropertyTests.cs` (new) — pin the string-path `SetProperty` dispatch for every converged property.
- MonoGame + Raylib NineSlice suites green post-change (23 + 51 passing).
- `RaylibGum`/`SkiaGum` build clean.

## FRB canary

Built `GumCore.DesktopGlNet6.csproj` from the primary checkout with this file's diff applied: 0 errors, same warning count as baseline. Pass.

## Manual test

Not needed — dispatch-only redirection, covered by unit tests + FRB canary.
