### PR TITLE
Converge Container Alpha/IsRenderTarget dispatch onto ContainerRuntime

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -273,28 +273,56 @@ public partial class CustomSetPropertyOnRenderable
 
     private static bool TrySetPropertyOnContainer(InvisibleRenderable invisibleRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
+#if FRB
+        // FRB doesn't have a ContainerRuntime, so we have to do this:
+        var containerRuntime = graphicalUiElement;
+#else
+        var containerRuntime = graphicalUiElement as Gum.GueDeriving.ContainerRuntime;
+#endif
+
         switch (propertyName)
         {
             case "IsRenderTarget":
-                invisibleRenderable.IsRenderTarget = value as bool? ?? false;
-                return true;
+                {
+                    bool valueAsBool = value as bool? ?? false;
+#if FRB
+                    invisibleRenderable.IsRenderTarget = valueAsBool;
+#else
+                    if (containerRuntime != null)
+                    {
+                        containerRuntime.IsRenderTarget = valueAsBool;
+                    }
+#endif
+                    return true;
+                }
             case "SourceShaderFile":
                 AssignSourceShaderFileOnContainer(invisibleRenderable, graphicalUiElement, value as string);
                 return true;
             case "Alpha":
-                if (value is int asInt)
                 {
-                    invisibleRenderable.Alpha = asInt;
+                    int valueAsInt;
+                    if (value is int asInt)
+                    {
+                        valueAsInt = asInt;
+                    }
+                    else if (value is float asFloat)
+                    {
+                        valueAsInt = (int)asFloat;
+                    }
+                    else
+                    {
+                        valueAsInt = 255;
+                    }
+#if FRB
+                    invisibleRenderable.Alpha = valueAsInt;
+#else
+                    if (containerRuntime != null)
+                    {
+                        containerRuntime.Alpha = valueAsInt;
+                    }
+#endif
+                    return true;
                 }
-                else if (value is float asFloat)
-                {
-                    invisibleRenderable.Alpha = (int)asFloat;
-                }
-                else
-                {
-                    invisibleRenderable.Alpha = 255;
-                }
-                return true;
         }
 
         return false;

--- a/MonoGameGum.Tests/Runtimes/ContainerSetPropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ContainerSetPropertyTests.cs
@@ -1,0 +1,34 @@
+using Gum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnContainer) for Container, mirroring
+// Tests/RaylibGum.Tests/Runtimes/ContainerSetPropertyTests.cs. These properties are set at runtime
+// by the state/variable system (StateSave/VariableSave applied via GraphicalUiElement.SetProperty),
+// not by direct C# property assignment, so this pins that the string-path dispatch produces the
+// same result as direct C# usage (e.g. ContainerRuntime.Alpha = 128).
+public class ContainerSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_Alpha_ShouldForwardToContainerRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty(nameof(ContainerRuntime.Alpha), 128);
+
+        sut.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void SetProperty_IsRenderTarget_ShouldForwardToContainerRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty(nameof(ContainerRuntime.IsRenderTarget), true);
+
+        sut.IsRenderTarget.ShouldBeTrue();
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/ContainerSetPropertyTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/ContainerSetPropertyTests.cs
@@ -1,0 +1,33 @@
+using Gum.GueDeriving;
+using Shouldly;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnContainer) for Container, mirroring
+// MonoGameGum.Tests/Runtimes/ContainerSetPropertyTests.cs. These properties are set at runtime by
+// the state/variable system (StateSave/VariableSave applied via GraphicalUiElement.SetProperty),
+// not by direct C# property assignment, so this pins that the string-path dispatch produces the
+// same result as direct C# usage (e.g. ContainerRuntime.Alpha = 128).
+public class ContainerSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_Alpha_ShouldForwardToContainerRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty(nameof(ContainerRuntime.Alpha), 128);
+
+        sut.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void SetProperty_IsRenderTarget_ShouldForwardToContainerRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty(nameof(ContainerRuntime.IsRenderTarget), true);
+
+        sut.IsRenderTarget.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Part of #3727 (phase 3 of 4): converges `TrySetPropertyOnContainer` in `Gum/Wireframe/CustomSetPropertyOnRenderable.cs` onto `ContainerRuntime` for `Alpha` and `IsRenderTarget`, following the Sprite/NineSlice pattern from `Direction/decisions/0010-converge-sprite-nineslice-container-polygon-dispatch.md`.
- `#if FRB`/`#else` split preserves the raw `InvisibleRenderable` write for FRB1 (no `ContainerRuntime` type exists there); non-FRB dispatches through `graphicalUiElement as Gum.GueDeriving.ContainerRuntime` with a null guard.
- `SourceShaderFile` stays renderable-direct, unchanged, per the ADR (real work, not a mechanical redirect).

## Test plan
- [x] New pinning tests: `MonoGameGum.Tests/Runtimes/ContainerSetPropertyTests.cs`, `Tests/RaylibGum.Tests/Runtimes/ContainerSetPropertyTests.cs` (both green)
- [x] `SkiaGum.csproj` builds clean (file isn't linked into it, confirmed)
- [x] FRB canary: pass — built `GumCore.DesktopGlNet6.csproj` from the primary checkout with the changed file copied in, 0 new errors vs baseline
- [x] Manual test: not needed — dispatch-only redirection covered by unit tests + FRB canary
