### PR TITLE
Converge Polygon dispatch onto PolygonRuntime (final phase of #3727)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -180,7 +180,7 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if (renderableIpso is LinePolygon)
         {
-            handled = TrySetPropertyOnLinePolygon(renderableIpso, propertyName, value);
+            handled = TrySetPropertyOnLinePolygon(renderableIpso, graphicalUiElement, propertyName, value);
         }
         else if (renderableIpso is SolidRectangle)
         {
@@ -2706,20 +2706,33 @@ public partial class CustomSetPropertyOnRenderable
 #endif
 
 #if !RAYLIB
-    private static bool TrySetPropertyOnLinePolygon(IRenderableIpso mContainedObjectAsIpso, string propertyName, object value)
+    private static bool TrySetPropertyOnLinePolygon(IRenderableIpso mContainedObjectAsIpso, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
         bool handled = false;
 
+#if FRB
+        // FRB doesn't have a PolygonRuntime, so we have to do this:
+        var polygonRuntime = graphicalUiElement;
+#else
+        var polygonRuntime = graphicalUiElement as Gum.GueDeriving.PolygonRuntime;
+#endif
 
         if (propertyName == "Alpha")
         {
             int valueAsInt = (int)value;
 
+#if FRB
             var color =
                 ((LinePolygon)mContainedObjectAsIpso).Color;
             color = color.WithAlpha((byte)valueAsInt);
 
             ((LinePolygon)mContainedObjectAsIpso).Color = color;
+#else
+            if (polygonRuntime != null)
+            {
+                polygonRuntime.Alpha = valueAsInt;
+            }
+#endif
             handled = true;
         }
 
@@ -2727,11 +2740,18 @@ public partial class CustomSetPropertyOnRenderable
         {
             int valueAsInt = (int)value;
 
+#if FRB
             var color =
                 ((LinePolygon)mContainedObjectAsIpso).Color;
             color = color.WithRed((byte)valueAsInt);
 
             ((LinePolygon)mContainedObjectAsIpso).Color = color;
+#else
+            if (polygonRuntime != null)
+            {
+                polygonRuntime.Red = valueAsInt;
+            }
+#endif
             handled = true;
         }
 
@@ -2739,11 +2759,18 @@ public partial class CustomSetPropertyOnRenderable
         {
             int valueAsInt = (int)value;
 
+#if FRB
             var color =
                 ((LinePolygon)mContainedObjectAsIpso).Color;
             color = color.WithGreen((byte)valueAsInt);
 
             ((LinePolygon)mContainedObjectAsIpso).Color = color;
+#else
+            if (polygonRuntime != null)
+            {
+                polygonRuntime.Green = valueAsInt;
+            }
+#endif
             handled = true;
         }
 
@@ -2751,18 +2778,32 @@ public partial class CustomSetPropertyOnRenderable
         {
             int valueAsInt = (int)value;
 
+#if FRB
             var color =
                 ((LinePolygon)mContainedObjectAsIpso).Color;
             color = color.WithBlue((byte)valueAsInt);
 
             ((LinePolygon)mContainedObjectAsIpso).Color = color;
+#else
+            if (polygonRuntime != null)
+            {
+                polygonRuntime.Blue = valueAsInt;
+            }
+#endif
             handled = true;
         }
 
         else if (propertyName == "Color")
         {
             var valueAsColor = (Color)value;
+#if FRB
             ((LinePolygon)mContainedObjectAsIpso).Color = valueAsColor;
+#else
+            if (polygonRuntime != null)
+            {
+                polygonRuntime.Color = valueAsColor.ToUserColor();
+            }
+#endif
             handled = true;
         }
 

--- a/MonoGameGum.Tests/Runtimes/PolygonSetPropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/PolygonSetPropertyTests.cs
@@ -1,0 +1,44 @@
+using Gum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Covers the string-property-dispatch path (SetProperty -> CustomSetPropertyOnRenderable ->
+// TrySetPropertyOnLinePolygon) for Polygon. Unlike Sprite/NineSlice/Container this dispatch is
+// #if !RAYLIB only (raylib's LinePolygon dispatch, if any, is a separate concern), so there is no
+// Tests/RaylibGum.Tests counterpart. These properties are set at runtime by the state/variable
+// system (StateSave/VariableSave applied via GraphicalUiElement.SetProperty), not by direct C#
+// property assignment, so this pins that the string-path dispatch produces the same result as
+// direct C# usage (e.g. PolygonRuntime.Alpha = 128).
+public class PolygonSetPropertyTests : BaseTestClass
+{
+    [Fact]
+    public void SetProperty_AlphaRedGreenBlue_ShouldForwardToPolygonRuntime()
+    {
+        PolygonRuntime sut = new();
+
+        sut.SetProperty(nameof(PolygonRuntime.Alpha), 128);
+        sut.SetProperty(nameof(PolygonRuntime.Red), 10);
+        sut.SetProperty(nameof(PolygonRuntime.Green), 20);
+        sut.SetProperty(nameof(PolygonRuntime.Blue), 30);
+
+        sut.Alpha.ShouldBe(128);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void SetProperty_Color_ShouldForwardToPolygonRuntime()
+    {
+        PolygonRuntime sut = new();
+        var drawingColor = System.Drawing.Color.FromArgb(255, 10, 20, 30);
+
+        sut.SetProperty(nameof(PolygonRuntime.Color), drawingColor);
+
+        sut.Color.R.ShouldBe((byte)10);
+        sut.Color.G.ShouldBe((byte)20);
+        sut.Color.B.ShouldBe((byte)30);
+    }
+}


### PR DESCRIPTION
Closes #3727

Final phase of the Sprite/NineSlice/Container/Polygon dispatch-convergence workstream (ADR 0010). Converges `TrySetPropertyOnLinePolygon`'s `Alpha`/`Red`/`Green`/`Blue`/`Color` branches onto `PolygonRuntime` instead of writing `LinePolygon` directly, with the same `#if FRB`/`#else` split used by the Sprite/NineSlice/Container phases.

Scope notes:
- `PolygonRuntime`'s color properties are `#if !SKIA`, matching the ADR's callout that Skia's Polygon already routes through `SkiaShapeRuntime` (a separate file, out of scope here).
- This dispatch function is `#if !RAYLIB`-gated in the shared file, so there's no Raylib test counterpart (raylib's LinePolygon dispatch, if any, is separate).
- `Points` stays untouched (out of scope per the ADR).

## Test plan
- New `MonoGameGum.Tests/Runtimes/PolygonSetPropertyTests.cs` pins the string-path `SetProperty` -> `PolygonRuntime` result for Alpha/Red/Green/Blue/Color.
- `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 1911 passed, 0 failed.
- `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` and `Runtimes/RaylibGum/RaylibGum.csproj` — both build clean (this file isn't part of Skia's dispatch; raylib doesn't compile the changed function body).
- FRB canary: copied the diff into the primary checkout and built `GumCore.DesktopGlNet6.csproj` — baseline and post-change both 0 errors, no new warnings. Pass.
