### PR TITLE
Gum.SilkNet: implement gamepad input for Forms navigation via Silk.NET.Input

### DIFF
--- a/MonoGameGum.Tests/Forms/MenuItemTests.cs
+++ b/MonoGameGum.Tests/Forms/MenuItemTests.cs
@@ -66,4 +66,19 @@ public class MenuItemTests : BaseTestClass
         childMenuItem.ParentMenuItem.ShouldNotBeNull();
         childMenuItem.GetVisual("SubmenuIndicatorInstance")!.Visible.ShouldBeTrue();
     }
+
+    [Fact]
+    public void DoItemsHaveFocus_SetTrue_OnMenuItem_ShouldNotThrow()
+    {
+        // MenuItem inherits ScrollViewer.DoItemsHaveFocus (via ItemsControl), but MenuItemVisual --
+        // unlike ScrollViewerVisual -- has no InnerPanelInstance, since menu items don't scroll.
+        // Gamepad/keyboard nav sets this to true when A/Enter is pressed while a MenuItem has focus
+        // (ScrollViewer.DoTopLevelFocusUpdate), which must not NRE on the null InnerPanel (#3668).
+        MenuItem menuItem = new();
+        menuItem.InnerPanel.ShouldBeNull();
+
+        menuItem.IsFocused = true;
+
+        Should.NotThrow(() => menuItem.DoItemsHaveFocus = true);
+    }
 }

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -282,7 +282,7 @@ public class ScrollViewer :
                         this.IsFocused = true;
                     }
                 }
-                else
+                else if (InnerPanel != null)
                 {
                     // find first InputReceiver and give it focus:
                     for (int i = 0; i < this.InnerPanel.Children.Count; i++)
@@ -302,6 +302,10 @@ public class ScrollViewer :
                         }
                     }
                 }
+                // else: subclasses like MenuItem (via ItemsControl) have no InnerPanelInstance in
+                // their default Visual since they don't scroll -- DoItemsHaveFocus still flips (e.g.
+                // from gamepad/keyboard A/Enter while a MenuItem has top-level focus, #3668), it just
+                // has no items to hand focus to.
             }
             // todo - give the first item focus:
             //if (SelectedIndex > -1 && SelectedIndex < ListBoxItemsInternal.Count)

--- a/Runtimes/SilkNetGum/GumService.Silk.cs
+++ b/Runtimes/SilkNetGum/GumService.Silk.cs
@@ -87,8 +87,19 @@ public partial class GumService
         return new Keyboard(_inputContext.Keyboards[0]);
     }
 
-    // ApplyGamePadState is intentionally NOT overridden -- gamepad support is out of scope (#3564),
-    // so the IGumService default no-op is inherited.
+    /// <inheritdoc/>
+    void IGumService.ApplyGamePadState(Gum.Input.GamePad gamepad, int index, double time)
+    {
+        if (_inputContext != null && index < _inputContext.Gamepads.Count)
+        {
+            Gum.Input.GamePadDriver.Apply(gamepad, _inputContext.Gamepads[index], time);
+        }
+        else
+        {
+            gamepad.SetConnected(false);
+            gamepad.Activity(time);
+        }
+    }
 
     // AssignClipboard is implemented below via Silk.NET.Input's IKeyboard.ClipboardText (#3651).
     // The AssignNativeTextInput / UninitializePlatform / ApplyTextureFilterPlatform /

--- a/Runtimes/SilkNetGum/Input/GamePadDriver.cs
+++ b/Runtimes/SilkNetGum/Input/GamePadDriver.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using Silk.NET.Input;
+using GumGamepadButton = Gum.Input.GamepadButton;
+
+namespace Gum.Input;
+
+/// <summary>
+/// Reads a Silk.NET.Input <see cref="IGamepad"/> and pushes it into the platform-neutral
+/// <see cref="GamePad"/> holder (defined in GumCommon). Every platform (MonoGame, Raylib, Sokol)
+/// exposes a same-named <c>GamePadDriver</c> class in its own namespace, so
+/// <c>FormsUtilities.UpdateGamepads</c> can dispatch through one unqualified call resolved by the
+/// file's per-platform <c>using</c> block, with no <c>#if</c> in the method body (issue #3559).
+/// Unlike Raylib (static query functions reading live hardware), Silk.NET.Input already hands out
+/// an <see cref="IGamepad"/> instance per connected controller, so that instance itself is the
+/// testing seam -- no delegate-injection overload is needed here.
+/// </summary>
+internal static class GamePadDriver
+{
+    // Silk has no digital trigger buttons -- ButtonName has no LeftTrigger/RightTrigger member --
+    // so triggers are only exposed as the analog Triggers[].Position (0..1). Threshold to the
+    // digital LeftTrigger/RightTrigger semantics Gum's GamePad models, matching the MonoGame
+    // driver's TriggerThreshold.
+    const float TriggerThreshold = 0.5f;
+
+    /// <summary>
+    /// Pushes the current state of <paramref name="silkGamepad"/> into <paramref name="gamepad"/>
+    /// via its driver-facing setters and commits the frame with <see cref="GamePad.Activity"/>.
+    /// </summary>
+    public static void Apply(GamePad gamepad, IGamepad silkGamepad, double time)
+    {
+        gamepad.SetConnected(silkGamepad.IsConnected);
+
+        gamepad.SetButtonState(GumGamepadButton.DPadUp, IsDown(silkGamepad, ButtonName.DPadUp));
+        gamepad.SetButtonState(GumGamepadButton.DPadDown, IsDown(silkGamepad, ButtonName.DPadDown));
+        gamepad.SetButtonState(GumGamepadButton.DPadLeft, IsDown(silkGamepad, ButtonName.DPadLeft));
+        gamepad.SetButtonState(GumGamepadButton.DPadRight, IsDown(silkGamepad, ButtonName.DPadRight));
+
+        gamepad.SetButtonState(GumGamepadButton.A, IsDown(silkGamepad, ButtonName.A));
+        gamepad.SetButtonState(GumGamepadButton.B, IsDown(silkGamepad, ButtonName.B));
+        gamepad.SetButtonState(GumGamepadButton.X, IsDown(silkGamepad, ButtonName.X));
+        gamepad.SetButtonState(GumGamepadButton.Y, IsDown(silkGamepad, ButtonName.Y));
+
+        gamepad.SetButtonState(GumGamepadButton.LeftShoulder, IsDown(silkGamepad, ButtonName.LeftBumper));
+        gamepad.SetButtonState(GumGamepadButton.RightShoulder, IsDown(silkGamepad, ButtonName.RightBumper));
+
+        gamepad.SetButtonState(GumGamepadButton.Start, IsDown(silkGamepad, ButtonName.Start));
+        gamepad.SetButtonState(GumGamepadButton.Back, IsDown(silkGamepad, ButtonName.Back));
+
+        gamepad.SetButtonState(GumGamepadButton.LeftStick, IsDown(silkGamepad, ButtonName.LeftStick));
+        gamepad.SetButtonState(GumGamepadButton.RightStick, IsDown(silkGamepad, ButtonName.RightStick));
+
+        // Silk.NET's SDL/GLFW backends both fix Triggers[0] = left, Triggers[1] = right.
+        gamepad.SetButtonState(GumGamepadButton.LeftTrigger, TriggerPosition(silkGamepad, 0) >= TriggerThreshold);
+        gamepad.SetButtonState(GumGamepadButton.RightTrigger, TriggerPosition(silkGamepad, 1) >= TriggerThreshold);
+
+        // Silk.NET's SDL/GLFW backends both fix Thumbsticks[0] = left, Thumbsticks[1] = right, and
+        // report Y as positive-down (SDL native convention); flip to the XNA/Gum convention
+        // (positive-up), matching the Raylib driver.
+        Thumbstick left = Stick(silkGamepad, 0);
+        gamepad.SetLeftStickPosition(left.X, -left.Y);
+
+        Thumbstick right = Stick(silkGamepad, 1);
+        gamepad.SetRightStickPosition(right.X, -right.Y);
+
+        gamepad.Activity(time);
+    }
+
+    static bool IsDown(IGamepad silkGamepad, ButtonName name) =>
+        silkGamepad.Buttons.FirstOrDefault(b => b.Name == name).Pressed;
+
+    static float TriggerPosition(IGamepad silkGamepad, int index) =>
+        index < silkGamepad.Triggers.Count ? silkGamepad.Triggers[index].Position : 0f;
+
+    static Thumbstick Stick(IGamepad silkGamepad, int index) =>
+        index < silkGamepad.Thumbsticks.Count ? silkGamepad.Thumbsticks[index] : default;
+}

--- a/Runtimes/SilkNetGum/Input/GamePadDriver.cs
+++ b/Runtimes/SilkNetGum/Input/GamePadDriver.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Silk.NET.Input;
 using GumGamepadButton = Gum.Input.GamepadButton;
@@ -22,12 +24,39 @@ internal static class GamePadDriver
     // driver's TriggerThreshold.
     const float TriggerThreshold = 0.5f;
 
+    // Works around a Silk.NET.Input.Sdl bug: SdlGamepad's DoEvent handler writes its internal
+    // _buttons/_triggers arrays as a side effect INSIDE the argument list of
+    // `ButtonDown?.Invoke(this, _buttons[i] = new Button(...))` (and the equivalent for
+    // ButtonUp/TriggerMoved). C#'s null-conditional operator short-circuits the ENTIRE call --
+    // including evaluating its arguments -- when the event has zero subscribers, so with nobody
+    // listening those arrays are never actually updated: every poll of Buttons/Triggers reads
+    // permanently stale (false/0) state, even though the controller is reporting real presses.
+    // Thumbsticks are unaffected (SdlGamepad assigns _thumbsticks unconditionally before invoking
+    // ThumbstickMoved), which is why analog-stick navigation always worked while D-pad/face
+    // buttons and analog triggers silently did nothing. Subscribing a no-op handler per gamepad
+    // instance forces Silk to keep the arrays live; a reference-equality set keyed by instance
+    // (not index) means a reconnect's new IGamepad gets re-subscribed automatically, and repeated
+    // per-frame Apply calls don't pile up duplicate handlers.
+    static readonly HashSet<IGamepad> _forceUpdatedGamepads = new(ReferenceEqualityComparer.Instance);
+
+    static void EnsureButtonAndTriggerEventsAreLive(IGamepad silkGamepad)
+    {
+        if (_forceUpdatedGamepads.Add(silkGamepad))
+        {
+            silkGamepad.ButtonDown += static (_, _) => { };
+            silkGamepad.ButtonUp += static (_, _) => { };
+            silkGamepad.TriggerMoved += static (_, _) => { };
+        }
+    }
+
     /// <summary>
     /// Pushes the current state of <paramref name="silkGamepad"/> into <paramref name="gamepad"/>
     /// via its driver-facing setters and commits the frame with <see cref="GamePad.Activity"/>.
     /// </summary>
     public static void Apply(GamePad gamepad, IGamepad silkGamepad, double time)
     {
+        EnsureButtonAndTriggerEventsAreLive(silkGamepad);
+
         gamepad.SetConnected(silkGamepad.IsConnected);
 
         gamepad.SetButtonState(GumGamepadButton.DPadUp, IsDown(silkGamepad, ButtonName.DPadUp));

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -452,14 +452,6 @@ unsafe class Program
                 };
             }
 
-            // TEMP diagnostic (#3668): isolate whether Silk.NET.Input.Sdl is delivering button
-            // events at all, independent of Gum's GamePadDriver polling. inputContext.Gamepads is
-            // empty right here -- SDL enumerates the controller as a device-connected event that
-            // only gets processed once window.DoEvents() starts pumping in the main loop below, so
-            // the subscribe attempt is deferred there (gamepadDiagSubscribed guards it to run once).
-            // Remove before merge.
-            bool gamepadDiagSubscribed = false;
-
             // Main loop
 
             sKPaint = new SKPaint()
@@ -508,17 +500,6 @@ unsafe class Program
                 // drives the input context -- mouse/keyboard state), then clears the list. This
                 // is what makes clicks/typing actually reach the Forms controls (#3652).
                 window.DoEvents();
-
-                // TEMP diagnostic (#3668, see note above). Only run the subscribe attempt once
-                // the device has actually shown up post-DoEvents.
-                if (!gamepadDiagSubscribed && inputContext.Gamepads.Count > 0)
-                {
-                    gamepadDiagSubscribed = true;
-                    var pad = inputContext.Gamepads[0];
-                    Debug.WriteLine($"[GamepadDiag] Found gamepad: {pad.Name}, Buttons={pad.Buttons.Count}, Thumbsticks={pad.Thumbsticks.Count}, Triggers={pad.Triggers.Count}");
-                    pad.ButtonDown += (g, btn) => Debug.WriteLine($"[GamepadDiag] ButtonDown event: {btn.Name} (index {btn.Index})");
-                    pad.ButtonUp += (g, btn) => Debug.WriteLine($"[GamepadDiag] ButtonUp event: {btn.Name} (index {btn.Index})");
-                }
 
                 if (pendingResize.HasValue)
                 {

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -452,6 +452,14 @@ unsafe class Program
                 };
             }
 
+            // TEMP diagnostic (#3668): isolate whether Silk.NET.Input.Sdl is delivering button
+            // events at all, independent of Gum's GamePadDriver polling. inputContext.Gamepads is
+            // empty right here -- SDL enumerates the controller as a device-connected event that
+            // only gets processed once window.DoEvents() starts pumping in the main loop below, so
+            // the subscribe attempt is deferred there (gamepadDiagSubscribed guards it to run once).
+            // Remove before merge.
+            bool gamepadDiagSubscribed = false;
+
             // Main loop
 
             sKPaint = new SKPaint()
@@ -500,6 +508,17 @@ unsafe class Program
                 // drives the input context -- mouse/keyboard state), then clears the list. This
                 // is what makes clicks/typing actually reach the Forms controls (#3652).
                 window.DoEvents();
+
+                // TEMP diagnostic (#3668, see note above). Only run the subscribe attempt once
+                // the device has actually shown up post-DoEvents.
+                if (!gamepadDiagSubscribed && inputContext.Gamepads.Count > 0)
+                {
+                    gamepadDiagSubscribed = true;
+                    var pad = inputContext.Gamepads[0];
+                    Debug.WriteLine($"[GamepadDiag] Found gamepad: {pad.Name}, Buttons={pad.Buttons.Count}, Thumbsticks={pad.Thumbsticks.Count}, Triggers={pad.Triggers.Count}");
+                    pad.ButtonDown += (g, btn) => Debug.WriteLine($"[GamepadDiag] ButtonDown event: {btn.Name} (index {btn.Index})");
+                    pad.ButtonUp += (g, btn) => Debug.WriteLine($"[GamepadDiag] ButtonUp event: {btn.Name} (index {btn.Index})");
+                }
 
                 if (pendingResize.HasValue)
                 {

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -107,6 +107,13 @@ unsafe class Program
         // Registers GumUI.Keyboard for Tab / Shift+Tab focus traversal between Forms controls.
         GumUI.UseKeyboardDefaults();
 
+        // Enables gamepad navigation for Forms controls (#3668): GumUI.Update reads the connected
+        // controller into these gamepads each frame; the D-pad / left stick then move focus between
+        // controls and A activates the focused control. Mirrors the raylib sample's wiring. Visit the
+        // "Forms" screen and give a control focus (e.g. click it once) to see it take effect.
+        FrameworkElement.GamePadsForUiControl.Clear();
+        FrameworkElement.GamePadsForUiControl.AddRange(GumUI.Gamepads);
+
         GraphicalUiElement.CanvasWidth = windowWidth;
         GraphicalUiElement.CanvasHeight = windowHeight;
 

--- a/Tests/SilkNetGum.Tests/Input/GamePadDriverTests.cs
+++ b/Tests/SilkNetGum.Tests/Input/GamePadDriverTests.cs
@@ -2,6 +2,7 @@ using Gum.Input;
 using Moq;
 using Shouldly;
 using Silk.NET.Input;
+using System;
 using System.Collections.Generic;
 using GumGamepadButton = Gum.Input.GamepadButton;
 
@@ -86,5 +87,26 @@ public class GamePadDriverTests
         GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
 
         sut.IsConnected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Apply_SubscribesButtonAndTriggerEventsExactlyOnce_AcrossRepeatedCalls()
+    {
+        // Silk.NET.Input.Sdl's SdlGamepad writes its internal _buttons/_triggers arrays as a side
+        // effect INSIDE the argument list of `ButtonDown?.Invoke(...)` / `TriggerMoved?.Invoke(...)`.
+        // C#'s null-conditional operator short-circuits the WHOLE call -- including evaluating its
+        // arguments -- when the event has zero subscribers, so with nobody listening those arrays are
+        // never actually updated and polling Buttons/Triggers reads permanently stale state. Apply
+        // must force at least one subscriber so real hardware's button/trigger reads stay live. Called
+        // every frame, so it must not pile up a new subscription each call.
+        GamePad sut = new GamePad();
+        var silkGamepad = CreateGamepad();
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 2);
+
+        silkGamepad.VerifyAdd(g => g.ButtonDown += It.IsAny<Action<IGamepad, Button>>(), Times.Once());
+        silkGamepad.VerifyAdd(g => g.ButtonUp += It.IsAny<Action<IGamepad, Button>>(), Times.Once());
+        silkGamepad.VerifyAdd(g => g.TriggerMoved += It.IsAny<Action<IGamepad, Trigger>>(), Times.Once());
     }
 }

--- a/Tests/SilkNetGum.Tests/Input/GamePadDriverTests.cs
+++ b/Tests/SilkNetGum.Tests/Input/GamePadDriverTests.cs
@@ -1,0 +1,90 @@
+using Gum.Input;
+using Moq;
+using Shouldly;
+using Silk.NET.Input;
+using System.Collections.Generic;
+using GumGamepadButton = Gum.Input.GamepadButton;
+
+namespace SilkNetGum.Tests.Input;
+
+/// <summary>
+/// Pins the button/stick/trigger mapping of <see cref="GamePadDriver"/> (issue #3668). Unlike the
+/// Raylib driver (static functions reading live hardware, needing a delegate-injection seam), Silk
+/// hands out an <see cref="IGamepad"/> instance directly, so a mocked <see cref="IGamepad"/> is the
+/// seam here.
+/// </summary>
+public class GamePadDriverTests
+{
+    private static Mock<IGamepad> CreateGamepad(
+        bool connected = true,
+        IReadOnlyList<Button>? buttons = null,
+        IReadOnlyList<Thumbstick>? thumbsticks = null,
+        IReadOnlyList<Trigger>? triggers = null)
+    {
+        var gamepad = new Mock<IGamepad>();
+        gamepad.SetupGet(g => g.IsConnected).Returns(connected);
+        gamepad.SetupGet(g => g.Buttons).Returns(buttons ?? new List<Button>());
+        gamepad.SetupGet(g => g.Thumbsticks).Returns(thumbsticks ?? new List<Thumbstick>());
+        gamepad.SetupGet(g => g.Triggers).Returns(triggers ?? new List<Trigger>());
+        return gamepad;
+    }
+
+    [Fact]
+    public void Apply_MapsAButtonPressed_ToA()
+    {
+        GamePad sut = new GamePad();
+        var silkGamepad = CreateGamepad(buttons: new[] { new Button(ButtonName.A, 0, pressed: true) });
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+
+        sut.ButtonDown(GumGamepadButton.A).ShouldBeTrue();
+        sut.ButtonDown(GumGamepadButton.B).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Apply_MapsLeftBumper_ToLeftShoulder_NotRightShoulder()
+    {
+        GamePad sut = new GamePad();
+        var silkGamepad = CreateGamepad(buttons: new[] { new Button(ButtonName.LeftBumper, 0, pressed: true) });
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+
+        sut.ButtonDown(GumGamepadButton.LeftShoulder).ShouldBeTrue();
+        sut.ButtonDown(GumGamepadButton.RightShoulder).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Apply_ThresholdsLeftTriggerPosition_ToLeftTrigger()
+    {
+        GamePad sut = new GamePad();
+        var silkGamepad = CreateGamepad(triggers: new[] { new Trigger(0, position: 0.75f), new Trigger(1, position: 0f) });
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+
+        sut.ButtonDown(GumGamepadButton.LeftTrigger).ShouldBeTrue();
+        sut.ButtonDown(GumGamepadButton.RightTrigger).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Apply_FlipsLeftStickY_ToXnaGumConvention()
+    {
+        GamePad sut = new GamePad();
+        // Silk reports stick Y as positive-down (SDL native); Gum/XNA convention is positive-up.
+        var silkGamepad = CreateGamepad(thumbsticks: new[] { new Thumbstick(0, x: 0f, y: 1f) });
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+
+        sut.LeftStick.AsDPadDown(DPadDirection.Down).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Apply_MapsIsConnected()
+    {
+        GamePad sut = new GamePad();
+        var silkGamepad = CreateGamepad(connected: false);
+
+        GamePadDriver.Apply(sut, silkGamepad.Object, time: 1);
+
+        sut.IsConnected.ShouldBeFalse();
+    }
+}

--- a/Tests/SilkNetGum.Tests/TestAssemblyInitialize.cs
+++ b/Tests/SilkNetGum.Tests/TestAssemblyInitialize.cs
@@ -44,6 +44,7 @@ public class TestAssemblyInitialize : XunitTestFramework
         var inputContext = new Mock<IInputContext>();
         inputContext.SetupGet(x => x.Mice).Returns(new List<IMouse>());
         inputContext.SetupGet(x => x.Keyboards).Returns(new List<IKeyboard>());
+        inputContext.SetupGet(x => x.Gamepads).Returns(new List<IGamepad>());
 
         GumService.Default.Initialize(_surface.Canvas, inputContext.Object, 800, 600);
 


### PR DESCRIPTION
Closes #3668

Adds `Runtimes/SilkNetGum/Input/GamePadDriver.cs`, mirroring the Raylib driver: maps Silk.NET.Input's `IGamepad` (Buttons/Thumbsticks/Triggers) into the platform-neutral `Gum.Input.GamePad`, and overrides `ApplyGamePadState` in `GumService.Silk.cs` to call it.

**Upstream Silk.NET.Input.Sdl workaround:** `SdlGamepad.DoEvent` writes its internal `_buttons`/`_triggers` arrays as a side effect *inside* the argument list of `ButtonDown?.Invoke(...)` / `TriggerMoved?.Invoke(...)`. C#'s null-conditional operator short-circuits the whole call — including argument evaluation — when the event has zero subscribers, so with nobody listening, those arrays are never actually updated: polling `Buttons`/`Triggers` reads permanently stale state even with real button presses. Thumbsticks are unaffected (assigned unconditionally before their event fires), which is why the analog stick always worked while D-pad/face buttons/analog triggers silently did nothing. `GamePadDriver.Apply` now force-subscribes a no-op handler per `IGamepad` instance (once, tracked by reference so per-frame calls don't duplicate) to keep Silk's internal state live.

Also fixes a crash this surfaced: `ScrollViewer.DoItemsHaveFocus` NRE'd on `InnerPanel` for controls like `MenuItem` (via `ItemsControl : ScrollViewer`) that have no `InnerPanelInstance` in their default Visual. Gamepad/keyboard A/Enter flips `DoItemsHaveFocus` while a `MenuItem` has top-level focus, so pressing A on a focused menu item used to crash. Guarded the branch, added a regression test.

Notes:
- Silk has no digital trigger buttons (`ButtonName` has no Left/RightTrigger), so triggers are analog-only and thresholded at 0.5, matching the MonoGame driver.
- Silk reports stick Y as positive-down (SDL convention); flipped to XNA/Gum's positive-up, matching the Raylib driver.
- 6 unit tests in `Tests/SilkNetGum.Tests/Input/GamePadDriverTests.cs`, including one pinning the force-subscribe workaround via Moq's `VerifyAdd`.
- Wired `FrameworkElement.GamePadsForUiControl` into the SilkNetGum sample's `Program.cs` (mirrors the raylib sample). Manually verified against real Xbox controller hardware: D-pad, analog stick, A-button select/activate, Menu items, and hot-plug (launch with no controller, connect after) all confirmed working.
