### PR TITLE
Pregenerate every branch of a conditional Font-affecting VariableReferences expression

### DIFF
--- a/GumCommon/Bundle/FontReferenceCollector.cs
+++ b/GumCommon/Bundle/FontReferenceCollector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Wireframe;
@@ -26,9 +27,25 @@ namespace Gum.Bundle;
 /// the resolved font for the referencing TextInstance). That's a deeper runtime-resolution
 /// gap that affects both gumcli fonts and gumcli pack equally; tracking separately.
 /// </para>
+/// <para>
+/// Known limitation: a conditional (ternary) <c>VariableReferences</c> row on the element
+/// itself or a direct instance has every branch pregenerated (see #4042), but a conditional
+/// reference reached only through a nested component instance's inner Text instances
+/// (<see cref="CollectFontsFromNestedTextInstances"/>) still resolves a single value via
+/// <see cref="RecursiveVariableFinder"/> - only the currently-active branch is collected there.
+/// </para>
 /// </remarks>
 public class FontReferenceCollector
 {
+    /// <summary>
+    /// Font-affecting properties whose <c>VariableReferences</c> row is branch-enumerated
+    /// (all ternary branches collected, not just the one active now). See #4042.
+    /// </summary>
+    private static readonly string[] FontAffectingVariableNames =
+    {
+        "Font", "FontSize", "OutlineThickness", "UseFontSmoothing", "IsItalic", "IsBold"
+    };
+
     private readonly Func<InstanceSave, ElementSave?> _resolveInstanceElement;
 
     /// <summary>
@@ -64,16 +81,14 @@ public class FontReferenceCollector
                 // paths the references may not have been applied yet.
                 element.ApplyVariableReferences(state);
 
-                BmfcSave? bmfcSave = TryGetBmfcSaveFor(instance: null, state, fontRanges, spacingHorizontal, spacingVertical);
-                if (bmfcSave != null)
+                foreach (BmfcSave bmfcSave in CollectAllBmfcSavesFor(instance: null, state, fontRanges, spacingHorizontal, spacingVertical))
                 {
                     bitmapFonts[bmfcSave.FontCacheFileName] = bmfcSave;
                 }
 
                 foreach (InstanceSave instance in element.Instances)
                 {
-                    BmfcSave? bmfcSaveInner = TryGetBmfcSaveFor(instance, state, fontRanges, spacingHorizontal, spacingVertical);
-                    if (bmfcSaveInner != null)
+                    foreach (BmfcSave bmfcSaveInner in CollectAllBmfcSavesFor(instance, state, fontRanges, spacingHorizontal, spacingVertical))
                     {
                         bitmapFonts[bmfcSaveInner.FontCacheFileName] = bmfcSaveInner;
                     }
@@ -94,20 +109,117 @@ public class FontReferenceCollector
     private static BmfcSave? TryGetBmfcSaveFor(InstanceSave? instance, StateSave stateSave,
         string fontRanges, int spacingHorizontal, int spacingVertical)
     {
-        string prefix = "";
-        if (instance != null)
+        string prefix = instance != null ? instance.Name + "." : "";
+        return BuildBmfcSave(name => stateSave.GetValueRecursive(prefix + name),
+            fontRanges, spacingHorizontal, spacingVertical);
+    }
+
+    /// <summary>
+    /// Collects every <see cref="BmfcSave"/> combination for <paramref name="instance"/> (or the
+    /// element itself when null), enumerating all branches of any conditional (ternary)
+    /// <c>VariableReferences</c> row that targets a <see cref="FontAffectingVariableNames"/>
+    /// entry, instead of only the branch <c>ApplyVariableReferences</c> already
+    /// baked into <paramref name="stateSave"/>. Yields a single combo (the baseline already
+    /// applied) when none of the owner's font-affecting properties are set via a conditional
+    /// reference. See #4042.
+    /// </summary>
+    private static IEnumerable<BmfcSave> CollectAllBmfcSavesFor(InstanceSave? instance, StateSave stateSave,
+        string fontRanges, int spacingHorizontal, int spacingVertical)
+    {
+        string prefix = instance != null ? instance.Name + "." : "";
+        string? ownerName = instance?.Name;
+
+        VariableListSave? variableList = stateSave.VariableLists
+            .FirstOrDefault(vl => vl.GetRootName() == "VariableReferences"
+                && vl.ValueAsIList.Count > 0
+                && string.Equals(vl.SourceObject, ownerName, StringComparison.Ordinal));
+
+        Dictionary<string, List<object>> branchValuesByProperty = new();
+
+        if (variableList != null)
         {
-            prefix = instance.Name + ".";
+            foreach (string referenceString in variableList.ValueAsIList.Cast<string>())
+            {
+                var parsed = ElementSaveExtensions.GetAllVariableReferenceBranches(instance, referenceString, stateSave);
+                if (parsed == null)
+                {
+                    continue;
+                }
+
+                (string variableName, IEnumerable<object> values) = parsed.Value;
+                string unqualified = variableName.Contains('.')
+                    ? variableName.Substring(variableName.LastIndexOf('.') + 1)
+                    : variableName;
+
+                if (!FontAffectingVariableNames.Contains(unqualified))
+                {
+                    continue;
+                }
+
+                List<object> distinctValues = values.Where(v => v != null).Distinct().ToList();
+                if (distinctValues.Count > 1)
+                {
+                    branchValuesByProperty[unqualified] = distinctValues;
+                }
+            }
         }
 
-        int? fontSize = stateSave.GetValueRecursive(prefix + "FontSize") as int?;
-        string? fontValue = stateSave.GetValueRecursive(prefix + "Font") as string;
-        int outlineValue = stateSave.GetValueRecursive(prefix + "OutlineThickness") as int? ?? 0;
+        if (branchValuesByProperty.Count == 0)
+        {
+            BmfcSave? baseline = TryGetBmfcSaveFor(instance, stateSave, fontRanges, spacingHorizontal, spacingVertical);
+            if (baseline != null)
+            {
+                yield return baseline;
+            }
+            yield break;
+        }
+
+        foreach (Dictionary<string, object> combo in CrossProduct(branchValuesByProperty))
+        {
+            object? Lookup(string name) => combo.TryGetValue(name, out object? overridden)
+                ? overridden
+                : stateSave.GetValueRecursive(prefix + name);
+
+            BmfcSave? bmfcSave = BuildBmfcSave(Lookup, fontRanges, spacingHorizontal, spacingVertical);
+            if (bmfcSave != null)
+            {
+                yield return bmfcSave;
+            }
+        }
+    }
+
+    /// <summary>
+    /// All combinations of one value per key in <paramref name="branchValuesByProperty"/>
+    /// (Cartesian product), used to cross-multiply multiple independently-conditional
+    /// font-affecting properties (e.g. both <c>Font</c> and <c>FontSize</c> set via ternaries).
+    /// </summary>
+    private static IEnumerable<Dictionary<string, object>> CrossProduct(Dictionary<string, List<object>> branchValuesByProperty)
+    {
+        IEnumerable<Dictionary<string, object>> combos = new[] { new Dictionary<string, object>() };
+
+        foreach (KeyValuePair<string, List<object>> property in branchValuesByProperty)
+        {
+            combos = combos.SelectMany(existing => property.Value.Select(value =>
+            {
+                Dictionary<string, object> next = new(existing) { [property.Key] = value };
+                return next;
+            }));
+        }
+
+        return combos;
+    }
+
+    private static BmfcSave? BuildBmfcSave(Func<string, object?> getValue,
+        string fontRanges, int spacingHorizontal, int spacingVertical)
+    {
+        int? fontSize = getValue("FontSize") as int?;
+        string? fontValue = getValue("Font") as string;
+        int outlineValue = getValue("OutlineThickness") as int? ?? 0;
 
         // default to true to match how old behavior worked
-        bool fontSmoothing = stateSave.GetValueRecursive(prefix + "UseFontSmoothing") as bool? ?? true;
-        bool isItalic = stateSave.GetValueRecursive(prefix + "IsItalic") as bool? ?? false;
-        bool isBold = stateSave.GetValueRecursive(prefix + "IsBold") as bool? ?? false;
+        bool fontSmoothing = getValue("UseFontSmoothing") as bool? ?? true;
+        bool isItalic = getValue("IsItalic") as bool? ?? false;
+        bool isBold = getValue("IsBold") as bool? ?? false;
 
         if (fontValue == null || fontSize == null)
         {

--- a/GumRuntime/ElementSaveExtensions.GumRuntime.cs
+++ b/GumRuntime/ElementSaveExtensions.GumRuntime.cs
@@ -34,6 +34,16 @@ namespace GumRuntime
         /// </summary>
         public static Func<StateSave, string, string, GraphicalUiElement?, object>? CustomEvaluateExpression;
 
+        /// <summary>
+        /// Enumerates every value a reference's right side could resolve to (all ternary
+        /// branches, not just the one the condition currently selects). Same arguments as
+        /// <see cref="CustomEvaluateExpression"/>. Set by <c>GumExpressionService.Initialize()</c>;
+        /// used by <see cref="GetAllVariableReferenceBranches"/> for font bulk-generation
+        /// (see issue #4042) so it can pregenerate every branch of a conditional Font-affecting
+        /// expression instead of only the one active at collection time.
+        /// </summary>
+        public static Func<StateSave, string, string, GraphicalUiElement?, IEnumerable<object>>? CustomEvaluateExpressionAllBranches;
+
         public static void RegisterGueInstantiationType(string elementName, Type gueInheritingType, bool overwriteIfAlreadyExists = true)
         {
             if(overwriteIfAlreadyExists)
@@ -81,6 +91,7 @@ namespace GumRuntime
             TemplateFunc = null;
             CustomCreateGraphicalComponentFunc = null;
             CustomEvaluateExpression = null;
+            CustomEvaluateExpressionAllBranches = null;
         }
 
 
@@ -982,6 +993,88 @@ namespace GumRuntime
                 var value = recursiveVariableFinder.GetValue(right);
                 return value;
             }
+        }
+
+        /// <summary>
+        /// Read-only counterpart to <see cref="GetRightSideValue"/>: enumerates every value the
+        /// right side could resolve to (all ternary branches) instead of applying just the one
+        /// selected by the condition's current value. Falls back to a single-item sequence
+        /// wrapping <see cref="GetRightSideValue"/> when <see cref="CustomEvaluateExpressionAllBranches"/>
+        /// is unset (no Roslyn evaluator wired up).
+        /// </summary>
+        private static IEnumerable<object> GetAllRightSideValues(StateSave stateSave, string right, string leftSideType, GraphicalUiElement? liveRoot = null)
+        {
+            if (right.TrimStart().StartsWith("!"))
+            {
+                var withoutNot = right.TrimStart().Substring(1).Trim();
+                foreach (var value in GetAllRightSideValues(stateSave, withoutNot, leftSideType, liveRoot))
+                {
+                    if (value is bool boolValue)
+                    {
+                        yield return !boolValue;
+                    }
+                }
+                yield break;
+            }
+
+            if (CustomEvaluateExpressionAllBranches != null)
+            {
+                foreach (var value in CustomEvaluateExpressionAllBranches(stateSave, right, leftSideType, liveRoot))
+                {
+                    yield return value;
+                }
+            }
+            else
+            {
+                var value = GetRightSideValue(stateSave, right, leftSideType, liveRoot);
+                if (value != null)
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses a single <c>VariableReferences</c> row (e.g.
+        /// <c>Font = IsLocaleZh ? "NotoSansCJK" : "Arial"</c>) and returns the qualified left-hand
+        /// variable name plus every value its right side could resolve to (all ternary branches).
+        /// Read-only counterpart to <see cref="ApplyVariableReferencesOnSpecificOwner(InstanceSave, string, StateSave, GraphicalUiElement)"/>
+        /// for callers that need every possible value rather than applying just one - namely font
+        /// bulk-generation (see issue #4042). Returns null for a comment row or a malformed
+        /// (non "Left = Right") reference string.
+        /// </summary>
+        public static (string VariableName, IEnumerable<object> Values)? GetAllVariableReferenceBranches(InstanceSave? instanceLeft, string referenceString, StateSave stateSave, GraphicalUiElement? liveRoot = null)
+        {
+            if (referenceString?.StartsWith("//") == true)
+            {
+                return null;
+            }
+
+            var split = referenceString
+                .Split(equalsArray, StringSplitOptions.RemoveEmptyEntries)
+                .Select(item => item.Trim()).ToArray();
+
+            if (split.Length != 2)
+            {
+                return null;
+            }
+
+            var left = split[0];
+            var leftVariableName = instanceLeft == null ? left : instanceLeft.Name + "." + left;
+
+            string leftSideType = null;
+            var variableOnState = stateSave.Variables.FirstOrDefault(item => item.Name == leftVariableName);
+            leftSideType = variableOnState?.Type;
+            if (leftSideType == null)
+            {
+                var elementOwningInstance = instanceLeft?.ParentContainer ?? stateSave.ParentContainer;
+                leftSideType = ObjectFinder.Self.GetRootVariable(leftVariableName, elementOwningInstance)?.Type;
+            }
+
+            var right = split[1];
+            var values = GetAllRightSideValues(stateSave, right, leftSideType, liveRoot).ToList();
+
+            return (leftVariableName, values);
         }
 
         public static void GetRightSideAndState(ref string right, ref StateSave stateSave)

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -103,6 +103,53 @@ public class EvaluatedSyntax
         return Evaluate(syntaxNode, restingState, fallback);
     }
 
+    /// <summary>
+    /// Enumerates every value <paramref name="syntaxNode"/> could resolve to, by evaluating
+    /// <b>both</b> branches of each <see cref="ConditionalExpressionSyntax"/> instead of picking
+    /// one via the condition's current value. Nested ternaries are cross-multiplied (a ternary
+    /// inside a branch of another ternary yields the product of both, in evaluation order).
+    /// A non-conditional expression yields its single <see cref="Evaluate"/> result, same as
+    /// <see cref="FromSyntaxNode"/>. Used by font bulk-generation to pregenerate every branch of
+    /// a conditional Font-affecting expression rather than only the one active at collection time
+    /// (see issue #4042) - ternary detection only looks at the top-level shape of the expression
+    /// (unwrapping parentheses), not inside binary/member-access operands, so e.g.
+    /// <c>"prefix" + (A ? "x" : "y")</c> is not branch-enumerated.
+    /// </summary>
+    public static IEnumerable<EvaluatedSyntax> EnumerateAllBranches(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null, GraphicalUiElement? liveRoot = null)
+    {
+        if (syntaxNode is ParenthesizedExpressionSyntax parenthesizedExpressionSyntax)
+        {
+            var child = parenthesizedExpressionSyntax.ChildNodes().FirstOrDefault();
+            if (child != null)
+            {
+                foreach (var branch in EnumerateAllBranches(child, stateForUnqualifiedRightSide, fallback, liveRoot))
+                {
+                    yield return branch;
+                }
+            }
+            yield break;
+        }
+
+        if (syntaxNode is ConditionalExpressionSyntax conditional)
+        {
+            foreach (var branch in EnumerateAllBranches(conditional.WhenTrue, stateForUnqualifiedRightSide, fallback, liveRoot))
+            {
+                yield return branch;
+            }
+            foreach (var branch in EnumerateAllBranches(conditional.WhenFalse, stateForUnqualifiedRightSide, fallback, liveRoot))
+            {
+                yield return branch;
+            }
+            yield break;
+        }
+
+        var evaluated = Evaluate(syntaxNode, stateForUnqualifiedRightSide, fallback, liveRoot);
+        if (evaluated != null)
+        {
+            yield return evaluated;
+        }
+    }
+
     private static EvaluatedSyntax Evaluate(SyntaxNode syntaxNode, StateSave stateForUnqualifiedRightSide, Func<string, object?>? fallback = null, GraphicalUiElement? liveRoot = null)
     {
         if (syntaxNode is BinaryExpressionSyntax binaryExpressionSytax)

--- a/Runtimes/GumExpressions/GumExpressionService.cs
+++ b/Runtimes/GumExpressions/GumExpressionService.cs
@@ -2,6 +2,7 @@ using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using GumRuntime;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
 
 namespace Gum.Expressions;
 
@@ -19,6 +20,7 @@ public static class GumExpressionService
     public static void Initialize()
     {
         ElementSaveExtensions.CustomEvaluateExpression = EvaluateExpression;
+        ElementSaveExtensions.CustomEvaluateExpressionAllBranches = EvaluateExpressionAllBranches;
     }
 
     private static object EvaluateExpression(StateSave stateSave, string expression, string desiredType, GraphicalUiElement? liveRoot)
@@ -40,5 +42,29 @@ public static class GumExpressionService
             }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Enumerates every value <paramref name="expression"/> could resolve to (all ternary
+    /// branches, not just the one the condition currently selects). See
+    /// <see cref="EvaluatedSyntax.EnumerateAllBranches"/>.
+    /// </summary>
+    private static IEnumerable<object> EvaluateExpressionAllBranches(StateSave stateSave, string expression, string desiredType, GraphicalUiElement? liveRoot)
+    {
+        expression = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
+        var syntax = SyntaxFactory.ParseExpression(expression);
+
+        if (syntax == null)
+        {
+            yield break;
+        }
+
+        foreach (var branch in EvaluatedSyntax.EnumerateAllBranches(syntax, stateSave, liveRoot: liveRoot))
+        {
+            if (branch.CastTo(desiredType))
+            {
+                yield return branch.Value;
+            }
+        }
     }
 }

--- a/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
@@ -20,6 +20,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Tools\Gum.ProjectServices\Gum.ProjectServices.csproj" />
+    <!-- GumExpressions wires Roslyn-based right-side evaluation for VariableReferences, needed
+         to test conditional (ternary) Font expressions in font bulk-generation. -->
+    <ProjectReference Include="..\..\Runtimes\GumExpressions\GumExpressions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -792,6 +792,50 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
         font.FontSize.ShouldBe(36);
     }
 
+    [Fact]
+    public void CollectRequiredFonts_ShouldCollectBothBranches_WhenFontSetViaConditionalVariableReference()
+    {
+        // A locale-style ternary: "Font = IsLocaleZh ? "NotoSansCJK" : "Arial"". Only the
+        // false branch is active at collection time, but both must be pregenerated - see #4042.
+        // GumExpressionService.Initialize() sets process-wide static delegates
+        // (ElementSaveExtensions.CustomEvaluateExpression*); reset them afterward so this test
+        // doesn't leak Roslyn evaluation into other tests in this class.
+        Gum.Expressions.GumExpressionService.Initialize();
+        try
+        {
+            ComponentSave component = new ComponentSave { Name = "Panel", BaseType = "Container" };
+            StateSave state = AddState(component);
+            AddTextInstance(component, "Label");
+
+            SetVar(state, "IsLocaleZh", false);
+            // Type = "string" mirrors what the tool's own VariableReferences apply path
+            // authors - EvaluatedSyntax.CastTo needs a concrete desired type to resolve the
+            // ternary's string branches (see ApplyVariableReferencesElementSaveTests for the
+            // same pattern).
+            state.Variables.Add(new VariableSave { SetsValue = true, Name = "Label.Font", Value = "Arial", Type = "string" });
+            SetVar(state, "Label.FontSize", 24); // hard value baked in by the currently-false condition
+
+            VariableListSave<string> variableReferences = new VariableListSave<string>
+            {
+                Name = "Label.VariableReferences",
+                Type = "string"
+            };
+            variableReferences.ValueAsIList.Add("Font = IsLocaleZh ? \"NotoSansCJK\" : \"Arial\"");
+            state.VariableLists.Add(variableReferences);
+
+            Project.Components.Add(component);
+
+            Dictionary<string, BmfcSave> result = _sut.CollectRequiredFonts(Project, new[] { component });
+
+            result.Values.ShouldContain(f => f.FontName == "Arial" && f.FontSize == 24);
+            result.Values.ShouldContain(f => f.FontName == "NotoSansCJK" && f.FontSize == 24);
+        }
+        finally
+        {
+            GumRuntime.ElementSaveExtensions.ClearRegistrations();
+        }
+    }
+
     #endregion
 
     // -------------------------------------------------------------------------

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -5,6 +5,8 @@ using Gum.Managers;
 using Gum.Wireframe;
 using Microsoft.CodeAnalysis.CSharp;
 using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GumExpressions.Tests;
 
@@ -747,6 +749,50 @@ public class EvaluatedSyntaxTests : BaseTestClass
 
         result.ShouldNotBeNull();
         result.Value.ShouldBe(100);
+    }
+
+    #endregion
+
+    #region EnumerateAllBranches
+
+    private static List<object> EnumerateAllBranches(string expression, StateSave state)
+    {
+        string csharp = EvaluatedSyntax.ConvertToCSharpSyntax(expression);
+        Microsoft.CodeAnalysis.SyntaxNode syntax = Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseExpression(csharp);
+        return EvaluatedSyntax.EnumerateAllBranches(syntax, state).Select(evaluated => evaluated.Value).ToList();
+    }
+
+    [Fact]
+    public void EnumerateAllBranches_NestedTernary_ReturnsAllFourLeafValues()
+    {
+        StateSave state = BuildState(
+            ("Instance.IsTall", true, "bool"),
+            ("Instance.IsWide", false, "bool"));
+
+        List<object> values = EnumerateAllBranches(
+            "Instance.IsTall ? (Instance.IsWide ? \"TallWide\" : \"TallNarrow\") : (Instance.IsWide ? \"ShortWide\" : \"ShortNarrow\")", state);
+
+        values.ShouldBe(new object[] { "TallWide", "TallNarrow", "ShortWide", "ShortNarrow" });
+    }
+
+    [Fact]
+    public void EnumerateAllBranches_NonConditionalExpression_ReturnsSingleValue()
+    {
+        StateSave state = BuildState(("Instance.Width", 100f, "float"));
+
+        List<object> values = EnumerateAllBranches("Instance.Width + 10", state);
+
+        values.ShouldBe(new object[] { 110f });
+    }
+
+    [Fact]
+    public void EnumerateAllBranches_SimpleTernary_ReturnsBothBranchesRegardlessOfCondition()
+    {
+        StateSave state = BuildState(("Instance.IsLocaleZh", false, "bool"));
+
+        List<object> values = EnumerateAllBranches("Instance.IsLocaleZh ? \"NotoSansCJK\" : \"Arial\"", state);
+
+        values.ShouldBe(new object[] { "NotoSansCJK", "Arial" });
     }
 
     #endregion

--- a/Tools/Gum.Cli/Commands/FontsCommand.cs
+++ b/Tools/Gum.Cli/Commands/FontsCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using Gum.DataTypes;
+using Gum.Expressions;
 using Gum.Managers;
 using Gum.ProjectServices;
 using Gum.ProjectServices.FontGeneration;
@@ -63,6 +64,11 @@ public static class FontsCommand
         StandardElementsManager.Self.Initialize();
         ObjectFinder.Self.GumProjectSave = project;
         FileManager.RelativeDirectory = projectDirectory;
+
+        // Wires Roslyn-based evaluation of VariableReferences so conditional (ternary) Font
+        // expressions resolve (and every branch gets pregenerated - see #4042) instead of
+        // silently failing to resolve at all (mirrors CheckReferencesCommand).
+        GumExpressionService.Initialize();
 
         IFontGenerationCallbacks callbacks = new ConsoleFontGenerationCallbacks();
         IFontFileGenerator fontFileGenerator = CreateFontFileGenerator(project, callbacks);

--- a/Tools/Gum.Cli/Commands/PackCommand.cs
+++ b/Tools/Gum.Cli/Commands/PackCommand.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using Gum.Bundle;
+using Gum.Expressions;
 using Gum.Managers;
 using Gum.ProjectServices;
 
@@ -78,6 +79,11 @@ public static class PackCommand
         // before walking so inherited font variables (e.g. Strong.Font from Standards/Text)
         // resolve correctly.
         ObjectFinder.Self.GumProjectSave = loadResult.Project;
+
+        // Wires Roslyn-based evaluation of VariableReferences so conditional (ternary) Font
+        // expressions resolve (and every branch gets pregenerated for FontCache - see #4042)
+        // instead of silently failing to resolve at all (mirrors CheckReferencesCommand).
+        GumExpressionService.Initialize();
 
         string resolvedOutputPath = outputPath != null
             ? Path.GetFullPath(outputPath)


### PR DESCRIPTION
## Summary

Font bulk-generation baked in only the ternary branch active at collection time for a conditional (locale-style) `Font`-affecting `VariableReferences` row, so the untaken branch's font was never pregenerated — a locale switch at runtime could hit a missing bitmap font.

- `EvaluatedSyntax.EnumerateAllBranches` (Gum.Expressions) walks both sides of every ternary instead of picking one via the condition, cross-multiplying nested ternaries.
- `FontReferenceCollector` now cross-multiplies branch values across all font-affecting properties (`Font`, `FontSize`, `OutlineThickness`, `UseFontSmoothing`, `IsItalic`, `IsBold`) and generates a `BmfcSave` per combination, instead of the single baked-in value.
- Fixed a related prerequisite bug: `gumcli fonts`/`gumcli pack` never called `GumExpressionService.Initialize()`, so ternary `VariableReferences` didn't resolve *at all* in those headless paths (not even the active branch). Now wired, matching `CheckReferencesCommand`.

Known limitation (documented in `FontReferenceCollector`'s remarks): a conditional reference reached only through a nested component instance's inner Text instances still resolves a single value — that path uses a separate `RecursiveVariableFinder`-based lookup not covered by this change.

Closes #4042

## Test plan
- [x] `Tests/GumExpressions.Tests` (64 passed) — new `EnumerateAllBranches` coverage (simple ternary, nested ternary, non-conditional)
- [x] `Tests/Gum.ProjectServices.Tests` (379 passed) — new `CollectRequiredFonts_ShouldCollectBothBranches_WhenFontSetViaConditionalVariableReference`
- [x] `Tests/Gum.Bundle.Tests` (67 passed), `Tests/Gum.Cli.Tests` (55 passed), `MonoGameGum.Tests` (1921 passed) — full regression, no manual test needed (pure data/logic change)
