### PR TITLE
Docs: document Forms behavior properties & behavior-driven references

### DIFF
--- a/docs/code/controls/textbox.md
+++ b/docs/code/controls/textbox.md
@@ -89,10 +89,6 @@ If `IsReadOnly` is set to true, then the user cannot modify a `TextBox`'s `Text`
 * The TextBox can receive focus
 * The Caret is optionally visible depending on whether `IsCaretVisibleWhenReadOnly` is set to true. By default `IsCaretVisibleWhenReadOnly` is false.
 
-{% hint style="info" %}
-`IsReadOnly` is also settable from the Gum tool's Variables tab, in the **Behavior** category — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties).
-{% endhint %}
-
 The following code shows how to create a read-only TextBox:
 
 ```csharp
@@ -111,10 +107,6 @@ panel.AddChild(textBox);
 ## MaxLength
 
 The `MaxLength` property can be used to restrict the number of characters that can be entered into a `TextBox`. This limit applies to both user typing and pasting. If a user attempts to type more characters than allowed, the extra characters are ignored. If a user pastes a string that would exceed the limit, the string is truncated to fit.
-
-{% hint style="info" %}
-`MaxLength` is also settable from the Gum tool's Variables tab, in the **Behavior** category — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties).
-{% endhint %}
 
 The following code creates a `TextBox` with a `MaxLength` of 10:
 
@@ -257,10 +249,6 @@ textBox.Placeholder = string.Empty;
 
 The `TextWrapping` property can be used to set whether the TextBox wraps text. By default this value is set to `TextWrapping.NoWrap` which means the text does not wrap, but instead extends horizontally.
 
-{% hint style="info" %}
-`TextWrapping` is also settable from the Gum tool's Variables tab, in the **Behavior** category, and drives a design-time line-mode preview — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties) and [Behavior-Driven References](../../gum-tool/gum-elements/general-properties/variable-references.md#behavior-driven-references).
-{% endhint %}
-
 ```csharp
 // Initialize
 var textBox = new TextBox();
@@ -293,10 +281,6 @@ The behavior of the Enter key depends on the `AcceptsReturn` property and whethe
 ### Multi-Line Entry (AcceptsReturn)
 
 `AcceptsReturn` can be set to true to add newlines when the return (enter) key is pressed.
-
-{% hint style="info" %}
-`AcceptsReturn` is also settable from the Gum tool's Variables tab, in the **Behavior** category, and drives a design-time line-mode preview — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties) and [Behavior-Driven References](../../gum-tool/gum-elements/general-properties/variable-references.md#behavior-driven-references).
-{% endhint %}
 
 ```csharp
 // Initialize

--- a/docs/code/controls/textbox.md
+++ b/docs/code/controls/textbox.md
@@ -89,6 +89,10 @@ If `IsReadOnly` is set to true, then the user cannot modify a `TextBox`'s `Text`
 * The TextBox can receive focus
 * The Caret is optionally visible depending on whether `IsCaretVisibleWhenReadOnly` is set to true. By default `IsCaretVisibleWhenReadOnly` is false.
 
+{% hint style="info" %}
+`IsReadOnly` is also settable from the Gum tool's Variables tab, in the **Behavior** category — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties).
+{% endhint %}
+
 The following code shows how to create a read-only TextBox:
 
 ```csharp
@@ -107,6 +111,10 @@ panel.AddChild(textBox);
 ## MaxLength
 
 The `MaxLength` property can be used to restrict the number of characters that can be entered into a `TextBox`. This limit applies to both user typing and pasting. If a user attempts to type more characters than allowed, the extra characters are ignored. If a user pastes a string that would exceed the limit, the string is truncated to fit.
+
+{% hint style="info" %}
+`MaxLength` is also settable from the Gum tool's Variables tab, in the **Behavior** category — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties).
+{% endhint %}
 
 The following code creates a `TextBox` with a `MaxLength` of 10:
 
@@ -249,6 +257,10 @@ textBox.Placeholder = string.Empty;
 
 The `TextWrapping` property can be used to set whether the TextBox wraps text. By default this value is set to `TextWrapping.NoWrap` which means the text does not wrap, but instead extends horizontally.
 
+{% hint style="info" %}
+`TextWrapping` is also settable from the Gum tool's Variables tab, in the **Behavior** category, and drives a design-time line-mode preview — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties) and [Behavior-Driven References](../../gum-tool/gum-elements/general-properties/variable-references.md#behavior-driven-references).
+{% endhint %}
+
 ```csharp
 // Initialize
 var textBox = new TextBox();
@@ -281,6 +293,10 @@ The behavior of the Enter key depends on the `AcceptsReturn` property and whethe
 ### Multi-Line Entry (AcceptsReturn)
 
 `AcceptsReturn` can be set to true to add newlines when the return (enter) key is pressed.
+
+{% hint style="info" %}
+`AcceptsReturn` is also settable from the Gum tool's Variables tab, in the **Behavior** category, and drives a design-time line-mode preview — see [Behavior Properties](../../gum-tool/gum-elements/behaviors/README.md#behavior-properties) and [Behavior-Driven References](../../gum-tool/gum-elements/general-properties/variable-references.md#behavior-driven-references).
+{% endhint %}
 
 ```csharp
 // Initialize

--- a/docs/gum-tool/gum-elements/behaviors/README.md
+++ b/docs/gum-tool/gum-elements/behaviors/README.md
@@ -4,6 +4,8 @@
 
 Behaviors can define requirements which are reusable across multiple components to standardize instance names and behaviors. If a component uses a behavior, then the component is forced to include categories and instances according to the behavior definition.
 
+Behaviors can also declare **Behavior Properties**, which surface as a **Behavior** category in the Variables tab and connect to properties on the runtime Forms control (such as `TextBox`'s `TextWrapping` or `Slider`'s `Minimum`/`Maximum`). This is covered in [Behavior Properties](#behavior-properties) below.
+
 Common behavior usage falls into one of two categories:
 
 1. Behaviors for built-in controls such as Button and TextBox exist to make customization for these types of controls easier.
@@ -99,3 +101,17 @@ By contrast, Gum cannot guess how to create instances for your components. For e
 
 Future versions of Gum may provide shortcuts to create required types.
 {% endhint %}
+
+## Behavior Properties
+
+Beyond categories, states, and instances, a behavior can declare **Behavior Properties** — design-time properties that appear in a **Behavior** category in the Variables tab and flow through to the matching property on the runtime Forms control. For example, `TextBoxBehavior` declares properties matching `TextBox`'s `TextWrapping`, `AcceptsReturn`, `IsReadOnly`, and `MaxLength`; `SliderBehavior` declares properties matching `Slider`'s `Minimum` and `Maximum`. Setting one of these in the Variables tab sets the corresponding property on the control when your game runs.
+
+Some Behavior Properties also drive a visual state automatically, so you get a design-time preview even though Forms controls don't run inside the tool. For example, setting `TextWrapping` in the Behavior category updates the component's visual line-mode state immediately. See [Behavior-Driven References](../general-properties/variable-references.md#behavior-driven-references) for how this works.
+
+{% hint style="info" %}
+Standard Forms components (Button, TextBox, Slider, and so on) are **copied into your project** the first time you add a Forms control, rather than referenced live from the Gum tool install. If a later Gum version adds a new Behavior Property to a standard control, that property only reaches components added to your project *after* upgrading — components already in your project keep whatever properties they had when they were added.
+{% endhint %}
+
+### Custom Behaviors
+
+You can add your own Behavior Properties and behavior-driven references to a custom behavior you create, but this is an advanced, rarely-needed scenario. See [Behavior Properties on Custom Behaviors](creating-new-behaviors-advanced.md#behavior-properties-on-custom-behaviors) for a brief overview.

--- a/docs/gum-tool/gum-elements/behaviors/README.md
+++ b/docs/gum-tool/gum-elements/behaviors/README.md
@@ -2,16 +2,16 @@
 
 ## Introduction
 
-Behaviors can define requirements which are reusable across multiple components to standardize instance names and behaviors. If a component uses a behavior, then the component is forced to include categories and instances according to the behavior definition.
+By default, a new Gum project has no behaviors. The most common way behaviors enter a project is automatically: adding Forms controls (Button, TextBox, Slider, and so on) adds their matching behaviors for you — see [Default Behaviors](#default-behaviors) below.
 
-Behaviors can also declare **Behavior Properties**, which surface as a **Behavior** category in the Variables tab and connect to properties on the runtime Forms control (such as `TextBox`'s `TextWrapping` or `Slider`'s `Minimum`/`Maximum`). This is covered in [Behavior Properties](#behavior-properties) below.
+Creating or editing behaviors yourself is an advanced, rarely-needed scenario. The vast majority of projects only ever use the behaviors that Forms controls bring in automatically.
+
+A behavior defines requirements that are reusable across multiple components: required categories and states, required instances, and optionally **Behavior Properties** — design-time properties that surface in a **Behavior** category in the Variables tab and connect to properties on the runtime Forms control (such as `TextBox`'s `TextWrapping` or `Slider`'s `Minimum`/`Maximum`). Behavior Properties are covered in [Behavior Properties](#behavior-properties) below. If a component uses a behavior, then the component is forced to include categories and instances according to the behavior definition.
 
 Common behavior usage falls into one of two categories:
 
 1. Behaviors for built-in controls such as Button and TextBox exist to make customization for these types of controls easier.
 2. New behaviors can be created to match the syntax of controls defined in your game project. This is considered an advanced scenario and is rarely used.
-
-The most common usage of behaviors is the automatic creation and inclusion of _Gum Forms_ behaviors. Therefore, it is unlikely that you will need to create new behaviors or edit existing behaviors.&#x20;
 
 {% hint style="info" %}
 C# programmers may find the concept of behaviors to be similar to interfaces in code. Behaviors define requirements for components, but they give components the flexibility to implement these requirements, just like interfaces define required properties and methods which classes can implement.
@@ -25,7 +25,7 @@ As of February 2026, forms controls are not implemented in Skia-based runtimes. 
 
 ## Default Behaviors
 
-By default, empty projects contain no behaviors. If your project has added forms components, then it should contain a set of default behaviors matching the forms control types.
+If your project has added forms components, then it should contain a set of default behaviors matching the forms control types.
 
 <figure><img src="../../../.gitbook/assets/image (1).png" alt=""><figcaption><p>Default behavior types</p></figcaption></figure>
 

--- a/docs/gum-tool/gum-elements/behaviors/creating-new-behaviors-advanced.md
+++ b/docs/gum-tool/gum-elements/behaviors/creating-new-behaviors-advanced.md
@@ -2,9 +2,11 @@
 
 ## Introduction
 
-Behaviors are used to standardize state, category, and instance names. The most common usage of behaviors is with Gum Forms. Of course, behaviors can also be used to standardize names in your project for components which are not intended to be with Gum Forms.
+{% hint style="warning" %}
+Standard Forms behaviors (`ButtonBehavior`, `TextBoxBehavior`, and so on) already ship with every project that uses Forms controls — see [Behaviors](README.md). Creating or editing a behavior yourself is a rare, advanced scenario, needed only when you're standardizing categories/states/instances for your own components that are **not** part of Gum Forms.
+{% endhint %}
 
-This document shows how to create a ButtonBehavior from-scratch. Keep in mind that the ButtonBehavior is a standard type of behavior that exists in most projects, so this is only for illustrative purposes.
+This document walks through creating a behavior from scratch, using a `ButtonBehavior`-style definition as a familiar illustration. You would not actually recreate `ButtonBehavior` in a real project — it already exists — but the same steps apply to any custom behavior you define for your own components.
 
 ### Creating a Behavior
 

--- a/docs/gum-tool/gum-elements/behaviors/creating-new-behaviors-advanced.md
+++ b/docs/gum-tool/gum-elements/behaviors/creating-new-behaviors-advanced.md
@@ -98,3 +98,7 @@ At this time Gum does not automatically add required instances to components whi
 
 <img src="../../../.gitbook/assets/21_07 08 10.gif" alt="" data-size="original">
 {% endhint %}
+
+### Behavior Properties on Custom Behaviors
+
+The standard Forms behaviors ship with **Behavior Properties** (see [Behavior Properties](README.md#behavior-properties)) that surface a Behavior category in the Variables tab and drive design-time preview. A custom behavior can declare these too, but there is currently no tool UI for it — they are added by hand-editing the behavior's `.behx` file. This is an advanced, rarely-needed scenario; the standard Forms behaviors already cover the common cases.

--- a/docs/gum-tool/gum-elements/general-properties/variable-references.md
+++ b/docs/gum-tool/gum-elements/general-properties/variable-references.md
@@ -200,6 +200,20 @@ ButtonCategoryState = Background.Visible ? "Enabled" : "Disabled"
 
 If the right side is a literal string, Gum validates it against the category's state names and comments out the line if there is no match.
 
+### Behavior-Driven References
+
+Standard Forms behaviors (Button, TextBox, Slider, and so on) can use a category-state assignment to drive a visual state from a **Behavior Property** — a property in the Variables tab's **Behavior** category that also flows through to the runtime Forms control. See [Behavior Properties](../behaviors/README.md#behavior-properties) for what these are.
+
+For example, a TextBox-derived component previews its multi-line layout at design time using a reference like:
+
+```csharp
+LineModeCategoryState = TextWrapping == "Wrap" ? "Multi" : (AcceptsReturn ? "Multi" : "Single")
+```
+
+This works the same as any other category-state assignment — the driven state is read-only, and changing `TextWrapping` or `AcceptsReturn` in the Behavior category updates the preview immediately. The only difference is where the right-hand variable comes from: a Behavior Property instead of an ordinary instance variable.
+
+These references ship pre-authored on the standard Forms behaviors, so you typically won't write one yourself unless you're customizing a Forms component's default visual or authoring a custom behavior.
+
 ### Enum Assignment
 
 Variables whose type is an enumeration — such as `ChildrenLayout`, or unit and alignment types like `XUnits` and `WidthUnits` — can be assigned using the enum value's name as a string. Gum converts the name to the matching enum value:

--- a/docs/gum-tool/variables/hide-from-instances.md
+++ b/docs/gum-tool/variables/hide-from-instances.md
@@ -10,6 +10,7 @@ Hiding variables is useful for:
 
 * Simplifying the **Variables** tab on instances by removing variables that are never changed per-instance
 * Preventing accidental changes to variables that could break a component's layout or behavior, such as `Children Layout` on a container that relies on a specific stacking mode
+* Keeping a single source of truth when a visual variable is driven by a [Behavior Property](../gum-elements/behaviors/README.md#behavior-properties) — the standard Forms components hide the driven visual variable so the Behavior Property in the Variables tab is the only place to set it
 
 {% hint style="info" %}
 The **Hide from Instances** option is also available on screens. Since screens cannot be instanced in the tool, this only affects runtime code generation.


### PR DESCRIPTION
Closes #3388

Full 3-edit pass per the issue plan:
- behaviors/README.md: fixed misleading framing, added Behavior Properties section
- variable-references.md: added Behavior-Driven References section
- hide-from-instances.md: cross-linked single-source-of-truth angle
- textbox.md: cross-linked TextWrapping/AcceptsReturn/IsReadOnly/MaxLength to the new Behavior Properties section

Custom-behavior authoring and internal terminology are noted briefly (they exist, no how-to) per the issue's open-question answers.