### PR TITLE
Add PlayAnimationAsync to AnimationController

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -127,8 +127,9 @@ This applies to: "as of <date>", "starting in <date>", "before <date>", "in vers
 - Use numbered lists for procedures; bullet lists for non-sequential items.
 - **Bold** UI element names: menu items, button labels, tab names, category names shown in the tool (e.g., **Source** category, **Variables** tab).
 - Backticks for property names, variable names, property values, file names, and code: `Width Units`, `Relative To Children`, `Is Tiling Middle Sections`.
-- Avoid passive voice — prefer "Gum displays a label" over "a label is displayed."
+- Avoid passive voice, prefer "Gum displays a label" over "a label is displayed."
 - Screenshots (`.png`) for single states; animated GIFs (`.gif`) for multi-step interactions. Use them liberally.
+- **Never use an em dash (—).** Use a comma, period, or parenthetical instead. Check new/edited text for the character before finishing a doc pass.
 
 ## Code Sample Placement Comments
 

--- a/GumCommon/Runtime/AnimationController.cs
+++ b/GumCommon/Runtime/AnimationController.cs
@@ -1,5 +1,7 @@
 using Gum.Wireframe;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Gum.StateAnimation.Runtime;
 
@@ -9,6 +11,7 @@ namespace Gum.StateAnimation.Runtime;
 public class AnimationController
 {
     private AnimationState _state = AnimationState.Stopped;
+    private TaskCompletionSource<bool>? _asyncCompletionSource;
 
     /// <summary>
     /// Gets the currently playing or paused animation, or null if no animation is loaded.
@@ -70,10 +73,67 @@ public class AnimationController
         if (animation == null)
             throw new ArgumentNullException(nameof(animation));
 
+        // Interrupting a pending PlayAnimationAsync task cancels it rather than
+        // leaving it unresolved, since only one animation can play at a time.
+        _asyncCompletionSource?.TrySetCanceled();
+
         CurrentAnimation = animation;
         CurrentTime = 0;
         _state = AnimationState.Playing;
         OnStarted?.Invoke();
+    }
+
+    /// <summary>
+    /// Starts playing the specified animation from the beginning and returns a <see cref="Task"/>
+    /// that completes when the animation finishes.
+    /// </summary>
+    /// <param name="animation">The AnimationRuntime to play.</param>
+    /// <param name="cancellationToken">
+    /// A token used to stop the animation and cancel the returned task before it finishes.
+    /// </param>
+    /// <returns>
+    /// A task that completes successfully when the animation reaches its end. If the animation
+    /// is stopped, replaced by another <see cref="Play(AnimationRuntime)"/>/<see cref="PlayAnimationAsync"/>
+    /// call, or the <paramref name="cancellationToken"/> is triggered before it finishes, the task
+    /// is cancelled (<see cref="TaskCanceledException"/>) instead of completing.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when animation is null.</exception>
+    public Task PlayAnimationAsync(AnimationRuntime animation, CancellationToken cancellationToken = default)
+    {
+        Play(animation);
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _asyncCompletionSource = tcs;
+
+        void OnCompletedHandler() => tcs.TrySetResult(true);
+        void OnStoppedHandler() => tcs.TrySetCanceled();
+
+        OnCompleted += OnCompletedHandler;
+        OnStopped += OnStoppedHandler;
+
+        CancellationTokenRegistration registration = cancellationToken.CanBeCanceled
+            ? cancellationToken.Register(() =>
+            {
+                if (tcs.TrySetCanceled(cancellationToken))
+                {
+                    Stop();
+                }
+            })
+            : default;
+
+        tcs.Task.ContinueWith(_ =>
+        {
+            OnCompleted -= OnCompletedHandler;
+            OnStopped -= OnStoppedHandler;
+            registration.Dispose();
+
+            if (ReferenceEquals(_asyncCompletionSource, tcs))
+            {
+                _asyncCompletionSource = null;
+            }
+        }, TaskScheduler.Default);
+
+        return tcs.Task;
     }
 
     /// <summary>

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1657,6 +1657,26 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         AnimationController.Play(animation);
     }
 
+    /// <summary>
+    /// Convenience wrapper for <see cref="AnimationController.PlayAnimationAsync(AnimationRuntime, System.Threading.CancellationToken)"/>.
+    /// Starts playing the specified <see cref="AnimationRuntime"/> and returns a task that completes
+    /// when it finishes.
+    /// <para>
+    /// If the animation is stopped or replaced by another <see cref="PlayAnimation(AnimationRuntime)"/>/
+    /// <c>PlayAnimationAsync</c> call before it finishes, the returned task is cancelled
+    /// (<see cref="System.Threading.Tasks.TaskCanceledException"/>) rather than completing. Callers awaiting
+    /// this method must handle that case, since code after the <c>await</c> should only run once the
+    /// animation actually finished.
+    /// </para>
+    /// </summary>
+    /// <param name="animation">The AnimationRuntime object to play.</param>
+    /// <param name="cancellationToken">A token used to stop the animation and cancel the task early.</param>
+    /// <exception cref="ArgumentNullException">Thrown when animation is null.</exception>
+    public System.Threading.Tasks.Task PlayAnimationAsync(AnimationRuntime animation, System.Threading.CancellationToken cancellationToken = default)
+    {
+        return AnimationController.PlayAnimationAsync(animation, cancellationToken);
+    }
+
 
     /// <summary>
     /// Convenience wrapper for <see cref="AnimationController.Stop()"/>.

--- a/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
+++ b/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
@@ -7,6 +7,8 @@ using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace MonoGameGum.Tests.Runtimes;
@@ -563,6 +565,87 @@ public class AnimationControllerTests : BaseTestClass
 
         controller.CurrentTime.ShouldBe(0.3);
         gue.X.ShouldBeInRange(29.99f, 30.01f);
+    }
+
+    #endregion
+
+    #region PlayAnimationAsync Tests
+
+    [Fact]
+    public async Task PlayAnimationAsync_ShouldCompleteTask_WhenAnimationCompletes()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateTestAnimation();
+        animation.Loops = false;
+        GraphicalUiElement gue = CreateTestGraphicalUiElement();
+
+        Task task = controller.PlayAnimationAsync(animation);
+        controller.Update(1.5, gue);
+
+        await task;
+
+        task.IsCompletedSuccessfully.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PlayAnimationAsync_ShouldCancelTask_WhenStopped()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateTestAnimation();
+
+        Task task = controller.PlayAnimationAsync(animation);
+        controller.Stop();
+
+        await Should.ThrowAsync<TaskCanceledException>(task);
+    }
+
+    [Fact]
+    public async Task PlayAnimationAsync_ShouldCancelTask_WhenReplacedByAnotherPlayCall()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime firstAnimation = CreateTestAnimation();
+        AnimationRuntime secondAnimation = CreateTestAnimation();
+
+        Task task = controller.PlayAnimationAsync(firstAnimation);
+        controller.Play(secondAnimation);
+
+        await Should.ThrowAsync<TaskCanceledException>(task);
+    }
+
+    [Fact]
+    public async Task PlayAnimationAsync_ShouldCancelTask_WhenReplacedByAnotherPlayAnimationAsyncCall()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime firstAnimation = CreateTestAnimation();
+        AnimationRuntime secondAnimation = CreateTestAnimation();
+
+        Task firstTask = controller.PlayAnimationAsync(firstAnimation);
+        Task secondTask = controller.PlayAnimationAsync(secondAnimation);
+
+        await Should.ThrowAsync<TaskCanceledException>(firstTask);
+        controller.CurrentAnimation.ShouldBe(secondAnimation);
+    }
+
+    [Fact]
+    public void PlayAnimationAsync_ShouldThrow_IfAnimationIsNull()
+    {
+        AnimationController controller = new AnimationController();
+
+        Should.Throw<ArgumentNullException>(() => controller.PlayAnimationAsync(null!));
+    }
+
+    [Fact]
+    public async Task PlayAnimationAsync_ShouldCancelTask_WhenCancellationTokenIsTriggered()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateTestAnimation();
+        CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        Task task = controller.PlayAnimationAsync(animation, cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        await Should.ThrowAsync<TaskCanceledException>(task);
+        controller.IsStopped.ShouldBeTrue();
     }
 
     #endregion

--- a/docs/code/animationruntime.md
+++ b/docs/code/animationruntime.md
@@ -177,7 +177,7 @@ Every `GraphicalUiElement` owns an `AnimationController` (accessed via `Visual.A
 
 ### Waiting for an Animation to Finish with PlayAnimationAsync
 
-Use `PlayAnimationAsync` to await an animation's completion instead of subscribing to `OnCompleted`/`OnStopped` and manually unsubscribing:
+Use `PlayAnimationAsync` to await an animation's completion instead of subscribing to `OnCompleted`/`OnStopped` and manually unsubscribing. New to `async`/`await`? See [async Programming](async-programming.md).
 
 ```csharp
 // Update

--- a/docs/code/animationruntime.md
+++ b/docs/code/animationruntime.md
@@ -171,6 +171,48 @@ public class Game1 : Game
 
 <figure><img src="../.gitbook/assets/23_05 20 06.gif" alt=""><figcaption></figcaption></figure>
 
+## AnimationController
+
+Every `GraphicalUiElement` owns an `AnimationController` (accessed via `Visual.AnimationController`) which tracks playback state and raises `OnStarted`, `OnCompleted`, `OnStopped`, `OnPaused`, and `OnResumed` events. `PlayAnimation` and `StopAnimation` are convenience wrappers around this controller.
+
+### Waiting for an Animation to Finish with PlayAnimationAsync
+
+Use `PlayAnimationAsync` to await an animation's completion instead of subscribing to `OnCompleted`/`OnStopped` and manually unsubscribing:
+
+```csharp
+// Update
+try
+{
+    await buttonVisual.PlayAnimationAsync(growAnimation);
+    // Only runs if the animation actually finished.
+    DoNextThing();
+}
+catch (TaskCanceledException)
+{
+    // The animation was interrupted before it finished.
+}
+```
+
+{% hint style="warning" %}
+Calling `PlayAnimation` or `StopAnimation`/`AnimationController.Stop()` again while a `PlayAnimationAsync` call is still in flight cancels the awaited task (`TaskCanceledException`) instead of letting it complete. "Finished" and "interrupted" are different outcomes, so code after the `await` should not assume the animation actually played to the end unless the cancellation is handled, either with a `try`/`catch` as shown above or by checking `task.IsCanceled`.
+{% endhint %}
+
+An optional `System.Threading.CancellationToken` can also be passed to stop the animation and cancel the task from outside code, for example an unfocus or a scene change:
+
+```csharp
+// Class scope
+CancellationTokenSource _animationCancellation = new CancellationTokenSource();
+
+// Update
+try
+{
+    await buttonVisual.PlayAnimationAsync(growAnimation, _animationCancellation.Token);
+}
+catch (TaskCanceledException)
+{
+}
+```
+
 ## Playing Animations on Hover or Highlight
 
 Forms controls such as `Button` change their visual state (for example **Enabled**, **Highlighted**, **Pushed**, and **Disabled**) automatically as the user interacts with them. These state changes are applied instantly — they are not keyframe animations, and they do not call `PlayAnimation`.


### PR DESCRIPTION
## Summary
- `AnimationController.PlayAnimationAsync(animation, cancellationToken = default)` returns a `Task` that completes when the animation finishes, wired to `OnCompleted`/`OnStopped` via a `TaskCompletionSource`.
- Interrupting the animation (`Stop()`, another `Play`/`PlayAnimationAsync` call, or the cancellation token) cancels the task (`TaskCanceledException`) instead of leaving it unresolved.
- `GraphicalUiElement.PlayAnimationAsync` wraps it as the convenience API.
- Docs: `animationruntime.md` gets a new `AnimationController` section, first example shows the required try/catch, with an explicit warning hint about replay/stop cancelling in-flight awaits.
- `gum-docs-writing` skill: added a rule to never use an em dash in docs.

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj --filter "AnimationControllerTests"` - 41/41 passing (6 new)
- Manual test: not needed, pure logic/docs change covered by unit tests + compilation.
- FRB canary: not needed, change is inside `GraphicalUiElement.cs`'s `#if !FRB` animation block, not FRB-shared source.
