### PR TITLE
Resolve global::Localization.CurrentLanguage in variable-reference expressions

### DIFF
--- a/.claude/skills/gum-localization/SKILL.md
+++ b/.claude/skills/gum-localization/SKILL.md
@@ -127,19 +127,21 @@ PasswordBox uses `TextNoTranslate` for mask characters (e.g., "●●●●") si
 
 ## Gotchas
 
-1. **"(loc)" suffix is intentional** — When a database is loaded but a string ID isn't found, `Translate()` appends "(loc)". This is a debugging feature, not a bug. Empty databases return strings unchanged (no suffix).
+1. **Language selection is always index-driven.** `CurrentLanguage` (int) is the only way to select a language; `Languages`/`LanguageName` (tool VM) is a display-string wrapper around that index, not a separate string-based selection mechanism.
 
-2. **Translation happens at assignment time, not read time** — The renderable stores only the final translated string. Live UI is kept in sync by a separate path: `CustomSetPropertyOnRenderable` records the original raw value in a `ConditionalWeakTable<GraphicalUiElement, string>` whenever the localized `Text` path runs, and `GumService` subscribes to `ILocalizationService.CurrentLanguageChanged` to walk the live tree and re-call `SetProperty("Text", storedKey)` on every tracked element. `SetTextNoTranslate` clears the entry, so user input and explicit literals survive language switches. Programmatic dynamic strings assigned via the localized `Text` property still get re-translated on language change and will pick up the `(loc)` suffix — use `SetTextNoTranslate` for those. Bound `Text` is overwritten by refresh; the design assumes bindings and runtime language switching aren't combined.
+2. **"(loc)" suffix is intentional** — When a database is loaded but a string ID isn't found, `Translate()` appends "(loc)". This is a debugging feature, not a bug. Empty databases return strings unchanged (no suffix).
 
-3. **Null service = no localization** — If `LocalizationService` is null, all text passes through unchanged. This is the expected state when localization isn't needed.
+3. **Translation happens at assignment time, not read time** — The renderable stores only the final translated string. Live UI is kept in sync by a separate path: `CustomSetPropertyOnRenderable` records the original raw value in a `ConditionalWeakTable<GraphicalUiElement, string>` whenever the localized `Text` path runs, and `GumService` subscribes to `ILocalizationService.CurrentLanguageChanged` to walk the live tree and re-call `SetProperty("Text", storedKey)` on every tracked element. `SetTextNoTranslate` clears the entry, so user input and explicit literals survive language switches. Programmatic dynamic strings assigned via the localized `Text` property still get re-translated on language change and will pick up the `(loc)` suffix — use `SetTextNoTranslate` for those. Bound `Text` is overwritten by refresh; the design assumes bindings and runtime language switching aren't combined.
 
-4. **BBCode interaction** — If the original string contains `[`, BBCode is parsed *before* translation (and translation is skipped for that value). If the original has no BBCode but the translated result does, BBCode is parsed on the translated result. Be careful: a string ID with `[` in it won't be translated.
+4. **Null service = no localization** — If `LocalizationService` is null, all text passes through unchanged. This is the expected state when localization isn't needed.
 
-5. **CurrentLanguage is a raw array index** — No bounds checking. Index 0 in the translation array is the string ID itself (not a translation). Actual translations start at index 1. Setting `CurrentLanguage = 0` returns the string ID.
+5. **BBCode interaction** — If the original string contains `[`, BBCode is parsed *before* translation (and translation is skipped for that value). If the original has no BBCode but the translated result does, BBCode is parsed on the translated result. Be careful: a string ID with `[` in it won't be translated.
 
-6. **RESX satellite ordering and naming** — Satellites are sorted alphabetically by file path, so `de` comes before `es` comes before `fr`. The base file is always first and labeled `"Default"`. If you need a specific order or names, use the stream-based overload.
+6. **CurrentLanguage is a raw array index** — No bounds checking. Index 0 in the translation array is the string ID itself (not a translation). Actual translations start at index 1. Setting `CurrentLanguage = 0` returns the string ID.
 
-7. **ShouldExcludeFromTranslation** — Strings with no letters (pure numbers, punctuation, whitespace, or empty) are silently excluded from translation and returned as-is, with no "(loc)" suffix. This prevents false positives on numeric display values.
+7. **RESX satellite ordering and naming** — Satellites are sorted alphabetically by file path, so `de` comes before `es` comes before `fr`. The base file is always first and labeled `"Default"`. If you need a specific order or names, use the stream-based overload.
+
+8. **ShouldExcludeFromTranslation** — Strings with no letters (pure numbers, punctuation, whitespace, or empty) are silently excluded from translation and returned as-is, with no "(loc)" suffix. This prevents false positives on numeric display values.
 
 ## Key Files
 

--- a/.claude/skills/gum-runtime-variable-references/SKILL.md
+++ b/.claude/skills/gum-runtime-variable-references/SKILL.md
@@ -43,3 +43,7 @@ The decoupling mechanism is `ElementSaveExtensions.CustomEvaluateExpression` —
 After applying variable references, call `GraphicalUiElement.RefreshStyles()` or
 `GumService.Default.RefreshStyles()` to push the updated values to live visuals. For a deep
 dive into how this works end-to-end, see the **gum-variable-deep-dive** skill.
+
+### `global::Localization.CurrentLanguage`
+
+Reserved identifier (int, mirrors `ILocalizationService.CurrentLanguage`) resolved in `EvaluatedSyntax` against `Gum.Localization.LocalizationRuntimeState.Current` — a GumCommon-level static so `Gum.Expressions` can read it without depending on any platform runtime. `CustomSetPropertyOnRenderable.LocalizationService` (per-platform-compiled) forwards to it. A `CurrentLanguage`-dependent reference needs an explicit `ApplyAllVariableReferences()` + `RefreshStyles()` after a language switch, same as any other reference — `CurrentLanguageChanged` does not trigger re-evaluation on its own.

--- a/.claude/skills/gum-tool-variable-references/SKILL.md
+++ b/.claude/skills/gum-tool-variable-references/SKILL.md
@@ -76,6 +76,10 @@ These exist only as computed properties on an already-laid-out `GraphicalUiEleme
 
 Both apply paths supply `liveRoot` when a live tree is available: the tool passes `IWireframeObjectManager.GetRepresentation(parentElement)` (null when nothing is currently rendered for that element); the runtime passes the top-level `GraphicalUiElement` already being applied against. Validation (`AddFailureForLine`) needs the same `liveRoot` as the apply call, or a valid Absolute* reference gets auto-commented out before it's ever applied.
 
+### `global::Localization.CurrentLanguage`
+
+Reserved identifier resolving the current language index — see the **gum-runtime-variable-references** skill for the resolution mechanism. Tool preview works because every property change already triggers a full wireframe rebuild (`WireframeObjectManager.RefreshAll(forceLayout: true, ...)`), which re-applies variable references; `MainEditorTabPlugin.StartUp()` wires `CustomSetPropertyOnRenderable.LocalizationService` to the DI `ILocalizationService` singleton so that re-apply sees the tool's actual current language.
+
 ### Left-Side Type Coercion
 
 Before the evaluated right side is written, it is coerced to the left variable's declared type via `EvaluatedSyntax.CastTo(desiredType)` (`desiredType` resolved from the existing state variable, else `ObjectFinder.GetRootVariable`). `CastTo` handles numeric widening/narrowing, `ToString` for string targets, **and enum targets** — a string (e.g. a ternary result `"LeftToRightStack"`) is parsed via `Enum.Parse`, an int via `Enum.ToObject`. The boxed enum is required: typed consumers like `GraphicalUiElement`'s `ChildrenLayout` setter and int-on-disk serialization reject a raw string. The enum CLR type is resolved by a cached reflection scan (`EvaluatedSyntax.ResolveEnumType`), overridable via the static `EvaluatedSyntax.TypeResolver`.

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -113,25 +113,25 @@ public interface IPolygonRuntime
 
 public partial class CustomSetPropertyOnRenderable
 {
-    private static ILocalizationService? _localizationService;
-
     /// <summary>
     /// The active localization service used by the runtime. Assigning a new
     /// instance fires <see cref="LocalizationServiceChanged"/> so consumers
     /// (e.g. <c>GumService</c>) can re-wire <see cref="ILocalizationService.CurrentLanguageChanged"/>
-    /// subscriptions for runtime language switching.
+    /// subscriptions for runtime language switching. Backed by <see cref="LocalizationRuntimeState.Current"/>
+    /// so GumCommon-layer code (e.g. Gum.Expressions' variable-reference evaluator) can read the
+    /// active service without depending on this (per-platform-runtime-compiled) type.
     /// </summary>
     public static ILocalizationService? LocalizationService
     {
-        get => _localizationService;
+        get => LocalizationRuntimeState.Current;
         set
         {
-            if (ReferenceEquals(_localizationService, value))
+            if (ReferenceEquals(LocalizationRuntimeState.Current, value))
             {
                 return;
             }
-            ILocalizationService? previous = _localizationService;
-            _localizationService = value;
+            ILocalizationService? previous = LocalizationRuntimeState.Current;
+            LocalizationRuntimeState.Current = value;
             LocalizationServiceChanged?.Invoke(previous, value);
         }
     }

--- a/GumCommon/Localization/LocalizationRuntimeState.cs
+++ b/GumCommon/Localization/LocalizationRuntimeState.cs
@@ -1,0 +1,14 @@
+namespace Gum.Localization;
+
+/// <summary>
+/// Holds the process-wide active <see cref="ILocalizationService"/> instance. Lives in
+/// GumCommon (below every platform runtime project) so GumCommon-layer consumers - such as
+/// Gum.Expressions' variable-reference evaluator - can read the current language without
+/// depending on any platform runtime assembly. <c>CustomSetPropertyOnRenderable.LocalizationService</c>,
+/// which is compiled per-platform-runtime, forwards to this static so its existing public API
+/// (assignment, the <c>LocalizationServiceChanged</c> event) is unchanged.
+/// </summary>
+public static class LocalizationRuntimeState
+{
+    public static ILocalizationService? Current { get; set; }
+}

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Bundle\WalkResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Collections\GraphicalUiElementCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumCommon\GueDeriving\RenderableRegistry.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GumCommon\Localization\LocalizationRuntimeState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorInstanceSave.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\Behaviors\BehaviorSave.cs" />
@@ -76,6 +77,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\ElementWithState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Gum\Wireframe\FallbackRenderableFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tools\Gum.Presentation\Wireframe\TimeManager.cs" />
+    <!-- Deliberately the frozen root-level duplicate, not GumCommon\Localization\ILocalizationService.cs -
+         see the comment in that file for why. -->
     <Compile Include="$(MSBuildThisFileDirectory)ILocalizationService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MonoGameIntegration\RuntimeLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Camera.cs" />

--- a/ILocalizationService.cs
+++ b/ILocalizationService.cs
@@ -4,6 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+// Intentionally frozen duplicate of GumCommon/Localization/ILocalizationService.cs, referenced only
+// by GumCoreShared.projitems (FRB1's build). Do not sync this to the real interface's current shape:
+// FRB1's own implementation (FlatRedBall repo, FRBDK/Glue/GumPlugin/GumPlugin/Embedded/LocalizationManagerWrapper.cs)
+// only implements Translate and would fail to compile against CurrentLanguage/Languages/CurrentLanguageChanged/
+// AddDatabase/Clear. Updating FRB1's wrapper to the full interface is separate, cross-repo work.
 namespace Gum.Localization;
 public interface ILocalizationService
 {

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -22,6 +22,7 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
     {
         ElementSaveExtensions.CustomEvaluateExpression = null;
         ObjectFinder.Self.GumProjectSave = null;
+        Gum.Localization.LocalizationRuntimeState.Current = null;
         base.Dispose();
     }
 
@@ -302,6 +303,35 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
         parent.ApplyVariableReferences(state);
 
         parent.Height.ShouldBe(15f);
+    }
+
+    #endregion
+
+    #region LocalizationValues
+
+    [Fact]
+    public void ApplyVariableReferences_RightSideReferencesLocalizationCurrentLanguage_ResolvesLanguageIndex()
+    {
+        // Locks in the runtime-apply plumbing the tool's own rebuild path relies on
+        // (WireframeObjectManager.RefreshAll -> RootGue.ApplyVariableReferences): the
+        // GraphicalUiElement overload must thread through to EvaluatedSyntax's
+        // global::Localization.CurrentLanguage resolution the same as any other reference.
+        GumExpressionService.Initialize();
+
+        Gum.Localization.LocalizationService localizationService = new() { CurrentLanguage = 2 };
+        Gum.Localization.LocalizationRuntimeState.Current = localizationService;
+
+        ContainerRuntime parent = new ContainerRuntime();
+        parent.Width = 0;
+
+        StateSave state = BuildStateWithVariableReference(
+            "Width = global::Localization.CurrentLanguage",
+            null,
+            ("Width", 0f, "float"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.Width.ShouldBe(2f);
     }
 
     #endregion

--- a/Runtimes/GumExpressions/EvaluatedSyntax.cs
+++ b/Runtimes/GumExpressions/EvaluatedSyntax.cs
@@ -1,5 +1,6 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Localization;
 using Gum.Managers;
 using Gum.Wireframe;
 using Microsoft.CodeAnalysis;
@@ -201,6 +202,10 @@ public class EvaluatedSyntax
             // we just need to evaluate the right-side
             var rightSideToEvaluate = memberAccess.ToString();
 
+            if (TryResolveLocalizationValue(rightSideToEvaluate, out var localizationValue))
+            {
+                return FromSyntaxAndValue(syntaxNode, localizationValue);
+            }
 
             RecursiveVariableFinder rfv = null;
 
@@ -363,6 +368,37 @@ public class EvaluatedSyntax
         }
 
         value = selector(target);
+        return true;
+    }
+
+    private const string LocalizationCurrentLanguagePath = "global::Localization.CurrentLanguage";
+
+    /// <summary>
+    /// Resolves the reserved <c>global::Localization.CurrentLanguage</c> identifier to the
+    /// current language index on <see cref="LocalizationRuntimeState.Current"/>.
+    /// This is project-wide runtime state, not data owned by any element, so it can't be resolved
+    /// through <see cref="RecursiveVariableFinder"/> (element-state lookup) or the normal
+    /// <c>global::</c> cross-element dispatch (which only knows Components/Screens/Standards
+    /// element paths). It uses the same <c>global::</c> qualifier as those for consistency, as a
+    /// distinct reserved category rather than a bare identifier, since it isn't scoped to the
+    /// current element the way every other unqualified reference is.
+    /// </summary>
+    private static bool TryResolveLocalizationValue(string path, out object? value)
+    {
+        value = null;
+
+        if (path != LocalizationCurrentLanguagePath)
+        {
+            return false;
+        }
+
+        var localizationService = LocalizationRuntimeState.Current;
+        if (localizationService == null)
+        {
+            return false;
+        }
+
+        value = localizationService.CurrentLanguage;
         return true;
     }
 

--- a/Tests/GumExpressions.Tests/BaseTestClass.cs
+++ b/Tests/GumExpressions.Tests/BaseTestClass.cs
@@ -1,3 +1,4 @@
+using Gum.Localization;
 using Gum.Managers;
 using System;
 
@@ -6,8 +7,8 @@ namespace GumExpressions.Tests;
 /// <summary>
 /// Minimal base class for expression-engine tests. Initializes the standard-element registry
 /// (some expression evaluations resolve types through it) and clears the global
-/// <see cref="ObjectFinder"/> project after each test so cross-element reference tests
-/// do not bleed into one another.
+/// <see cref="ObjectFinder"/> project and <see cref="LocalizationRuntimeState.Current"/>
+/// after each test so cross-element and localization reference tests do not bleed into one another.
 /// </summary>
 public class BaseTestClass : IDisposable
 {
@@ -19,5 +20,6 @@ public class BaseTestClass : IDisposable
     public virtual void Dispose()
     {
         ObjectFinder.Self.GumProjectSave = null;
+        LocalizationRuntimeState.Current = null;
     }
 }

--- a/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
+++ b/Tests/GumExpressions.Tests/EvaluatedSyntaxTests.cs
@@ -1,6 +1,7 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Expressions;
+using Gum.Localization;
 using Gum.Managers;
 using Gum.Wireframe;
 using Microsoft.CodeAnalysis.CSharp;
@@ -634,6 +635,47 @@ public class EvaluatedSyntaxTests : BaseTestClass
         EvaluatedSyntax result = Evaluate("Nonexistent.AbsoluteWidth", state, root);
 
         (result?.Value).ShouldBeNull();
+    }
+
+    #endregion
+
+    #region LocalizationValues
+
+    [Fact]
+    public void FromSyntaxNode_LocalizationCurrentLanguage_ResolvesLanguageIndex()
+    {
+        LocalizationService localizationService = new() { CurrentLanguage = 2 };
+        LocalizationRuntimeState.Current = localizationService;
+        StateSave state = BuildState();
+
+        EvaluatedSyntax result = Evaluate("global::Localization.CurrentLanguage", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe(2);
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LocalizationCurrentLanguage_WithNoServiceSet_ReturnsNullValue()
+    {
+        StateSave state = BuildState();
+
+        EvaluatedSyntax result = Evaluate("global::Localization.CurrentLanguage", state);
+
+        (result?.Value).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromSyntaxNode_LocalizationCurrentLanguageTernary_ResolvesMatchingBranch()
+    {
+        LocalizationService localizationService = new() { CurrentLanguage = 1 };
+        LocalizationRuntimeState.Current = localizationService;
+        StateSave state = BuildState();
+
+        EvaluatedSyntax result = Evaluate(
+            "global::Localization.CurrentLanguage == 1 ? \"NotoSansCJK\" : \"Arial\"", state);
+
+        result.ShouldNotBeNull();
+        result.Value.ShouldBe("NotoSansCJK");
     }
 
     #endregion

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -296,13 +296,6 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         GraphicalUiElement.SetLocalizationEnabled = enabled =>
             CustomSetPropertyOnRenderable.LocalizationService = enabled ? _localizationService : null;
         CustomSetPropertyOnRenderable.FontService = Locator.GetRequiredService<IFontManager>();
-        // Wires the DI-registered ILocalizationService singleton into the static
-        // LocalizationRuntimeState so GumCommon-layer code (e.g. Gum.Expressions'
-        // global::Localization.CurrentLanguage evaluator) can read the tool's actual
-        // current language. Text preview itself doesn't need this - it translates via
-        // WireframeObjectManager's own injected service - but a reserved variable-reference
-        // identifier reading a stale/empty default would silently never preview correctly.
-        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
         // Gum core ships no shader loader, so the tool registers a resolver that compiles a
         // render-target Container's SourceShaderFile (.fx) into an Effect at runtime (ShadowDusk),
         // letting the WYSIWYG preview render shaded containers. Mirrors FontService above.

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -282,6 +282,13 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
         GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
         CustomSetPropertyOnRenderable.FontService = Locator.GetRequiredService<IFontManager>();
+        // Wires the DI-registered ILocalizationService singleton into the static
+        // LocalizationRuntimeState so GumCommon-layer code (e.g. Gum.Expressions'
+        // global::Localization.CurrentLanguage evaluator) can read the tool's actual
+        // current language. Text preview itself doesn't need this - it translates via
+        // WireframeObjectManager's own injected service - but a reserved variable-reference
+        // identifier reading a stale/empty default would silently never preview correctly.
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
         // Gum core ships no shader loader, so the tool registers a resolver that compiles a
         // render-target Container's SourceShaderFile (.fx) into an Effect at runtime (ShadowDusk),
         // letting the WYSIWYG preview render shaded containers. Mirrors FontService above.


### PR DESCRIPTION
Closes #4040.

## What
- New reserved `global::Localization.CurrentLanguage` identifier in `Gum.Expressions`' Roslyn evaluator, e.g. `FontName = global::Localization.CurrentLanguage == 1 ? "NotoSansCJK" : "Arial"`. Resolves as `int` against `Gum.Localization.LocalizationRuntimeState.Current` (new `GumCommon`-level static) — reachable from the static apply path with no live `GraphicalUiElement` needed.
- `CustomSetPropertyOnRenderable.LocalizationService` (per-platform-compiled) now forwards to that static instead of holding its own field.
- Tool startup (`MainEditorTabPlugin.StartUp`) wires the DI `ILocalizationService` singleton into it, so the existing full-rebuild-on-property-change path (`WireframeObjectManager.RefreshAll` → `ApplyVariableReferences`) previews the reference correctly when the Language dropdown changes.
- Runtime games apply it like any other variable reference — `ApplyAllVariableReferences()` + `RefreshStyles()` after a language switch. No new runtime API.
- Fixed `GumCoreShared.projitems`' `ILocalizationService.cs` entry, which pointed at a stale root-level duplicate frozen at `Translate`-only (pre-`CurrentLanguage`/`Languages`/`CurrentLanguageChanged`). Left the duplicate in place rather than deleting it — FRB1's own `LocalizationManagerWrapper` only implements `Translate` and breaks against the real interface shape — but corrected the entry to point at it deliberately and commented both the file and the projitems line for future agents.
- Skill updates: `gum-runtime-variable-references`, `gum-tool-variable-references`, `gum-localization`.

## Test plan
- [x] `GumExpressions.Tests` (67/67), new tests for resolve/null-service/ternary-branch, TDD'd red→green
- [x] `MonoGameGum.Tests` full suite (1922/1922), including a new runtime-apply integration test mirroring the tool's rebuild path
- [x] RaylibGum/SkiaGum/KniGum build clean; their localization test suites pass
- [x] FRB canary: pass (built clean from primary checkout)
- [x] Tool composition tests pass; `GumFull.sln` builds clean
- Manual test: not needed — pure expression-evaluator logic, no new UI surface; covered by unit tests + compilation across every consuming runtime.
