### PR TITLE
Guard VS-only CodeSharing imports in GumCoreShared.shproj with Exists()

### DIFF
--- a/GumCoreShared.shproj
+++ b/GumCoreShared.shproj
@@ -5,9 +5,9 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props')" />
   <PropertyGroup />
   <Import Project="GumCoreShared.projitems" Label="Shared" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets')" />
 </Project>

--- a/Tests/Gum.ProjectServices.Tests/SharedProjectFileTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/SharedProjectFileTests.cs
@@ -1,0 +1,53 @@
+using System.Xml.Linq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+public class SharedProjectFileTests
+{
+    private static readonly XNamespace MsBuildNs = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+    [Fact]
+    public void GumCoreShared_VsSpecificImports_HaveExistsCondition()
+    {
+        // GumCoreShared.shproj is a legacy VS Shared Project. Its <Import>
+        // elements referencing VS-only CodeSharing targets must be guarded with
+        // Exists() conditions so the file can be evaluated outside Visual Studio
+        // (Rider, dotnet CLI). Without the guards, MSBuild throws an unhandled
+        // exception when the VS CodeSharing components are missing.
+        string repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        string shprojPath = Path.Combine(repoRoot, "GumCoreShared.shproj");
+
+        File.Exists(shprojPath).ShouldBeTrue($"Expected to find {shprojPath}");
+
+        XDocument doc = XDocument.Load(shprojPath);
+        XElement project = doc.Root!;
+
+        List<XElement> imports = project.Elements(MsBuildNs + "Import").ToList();
+
+        imports.ShouldNotBeEmpty("GumCoreShared.shproj should contain <Import> elements");
+
+        // Only check imports that reference VS-specific paths (CodeSharing,
+        // VisualStudio). The projitems import and MSBuild common props are
+        // always available and do not need Exists() guards.
+        foreach (XElement import in imports)
+        {
+            string projectPath = import.Attribute("Project")?.Value ?? "";
+            bool isVsSpecific =
+                projectPath.Contains("VisualStudio", StringComparison.OrdinalIgnoreCase) ||
+                projectPath.Contains("CodeSharing", StringComparison.OrdinalIgnoreCase);
+
+            if (isVsSpecific)
+            {
+                string condition = import.Attribute("Condition")?.Value ?? "";
+                condition.ShouldNotBeNullOrWhiteSpace(
+                    $"VS-specific import \"{projectPath}\" must have a Condition attribute " +
+                    "with an Exists() guard so GumCoreShared.shproj can be evaluated " +
+                    "outside Visual Studio (e.g. Rider, dotnet CLI).");
+                condition.Contains("Exists(").ShouldBeTrue(
+                    $"VS-specific import \"{projectPath}\" Condition should use Exists() " +
+                    "to gracefully skip missing VS components outside Visual Studio.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`GumCoreShared.shproj` is a legacy Visual Studio Shared Project that lives at the repo root. Three of its `<Import>` elements reference VS-only CodeSharing components without any `Condition` guard:

```xml
<Import Project="...\Microsoft.CodeSharing.Common.Default.props" />
<Import Project="...\Microsoft.CodeSharing.Common.props" />
<Import Project="...\Microsoft.CodeSharing.CSharp.targets" />
```

When this `.shproj` is evaluated outside Visual Studio — **JetBrains Rider**, `dotnet build`, or any CI runner without the VS CodeSharing workload — MSBuild throws an **unhandled exception** because those imported files do not exist:

```
Unhandled exception: The imported file
"$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props"
does not exist and appears to be part of a Visual Studio component.
```

This blocks contributors using non-VS IDEs from building any project that references `GumCoreShared.projitems` (all `GumCore*.csproj` variants).

## Fix

Add `Condition="Exists(...)"` to the three VS-specific imports, following the same pattern already used for the `Microsoft.Common.props` import on line 7 of the same file:

```xml
<Import Project="...\Microsoft.CodeSharing.Common.Default.props"
        Condition="Exists('...\Microsoft.CodeSharing.Common.Default.props')" />
<Import Project="...\Microsoft.CodeSharing.Common.props"
        Condition="Exists('...\Microsoft.CodeSharing.Common.props')" />
<Import Project="...\Microsoft.CodeSharing.CSharp.targets"
        Condition="Exists('...\Microsoft.CodeSharing.CSharp.targets')" />
```

The `GumCoreShared.projitems` import is intentionally left without a Condition — it is the core shared-items import and must always resolve.

## Regression test

Adds `SharedProjectFileTests` in `Gum.ProjectServices.Tests` that parses `GumCoreShared.shproj` and verifies every VS-specific `<Import>` carries an `Exists()` guard. The test **fails** on the original file and **passes** after this fix.

## Verified

- [x] `dotnet build GumFull.sln` succeeds
- [x] Test fails without the fix (red), passes with it (green)
- [x] No new warnings introduced
