### PR TITLE
Fix Text localization double/triple-translating on edit

### DIFF
--- a/Gum/Managers/LocalizationServiceExtensions.cs
+++ b/Gum/Managers/LocalizationServiceExtensions.cs
@@ -19,16 +19,16 @@ public static class LocalizationServiceExtensions
     /// <param name="delimiter">The delimiter character used in the CSV file.</param>
     public static void AddDatabaseFromCsv(this ILocalizationService service, string fileName, char delimiter)
     {
-        RuntimeCsvRepresentation rcr;
-
         Dictionary<string, string[]> entryDictionary = new Dictionary<string, string[]>();
 
-        CsvFileManager.CsvDeserializeDictionary<string, string[]>(
-            fileName,
+        // CsvFileManager.CsvDeserializeDictionary hardcodes ',' internally (via the parameterless
+        // CsvDeserializeToRuntime(fileName) overload), silently ignoring any other delimiter passed
+        // to this method - call the delimiter-aware overload directly instead.
+        RuntimeCsvRepresentation rcr = CsvFileManager.CsvDeserializeToRuntime(fileName, delimiter);
+        rcr.FillObjectDictionary(
             entryDictionary,
             // FRB supports multiple lines of text per single string ID. We don't support this in Gum (yet?), so just use the first:
-            DuplicateDictionaryEntryBehavior.PreserveFirst,
-            out rcr);
+            duplicateDictionaryEntryBehavior: DuplicateDictionaryEntryBehavior.PreserveFirst);
 
         // Remove comment lines (lines starting with //)
         var keys = entryDictionary.Keys.ToArray();
@@ -40,12 +40,13 @@ public static class LocalizationServiceExtensions
             }
         }
 
-        List<string> headerList = new List<string>();
-
-        foreach (CsvHeader header in rcr.Headers)
-        {
-            headerList.Add(header.Name);
-        }
+        // The first column is the string ID itself, not a language - ILocalizationService.Languages
+        // must list only translation languages so its index lines up with a per-ID array's index
+        // (array[0] is the ID, array[i+1] is Languages[i]'s translation). Skip it here to match
+        // GumCommon's AddCsvDatabase, which does the same via HeaderRecord.Skip(1). Including it was
+        // an off-by-one: e.g. selecting the last of 2 languages resolved to array index 3 on a
+        // length-3 array and threw IndexOutOfRangeException.
+        List<string> headerList = rcr.Headers.Skip(1).Select(header => header.Name).ToList();
 
         service.AddDatabase(entryDictionary, headerList);
     }

--- a/GumCommon/Localization/LocalizationService.cs
+++ b/GumCommon/Localization/LocalizationService.cs
@@ -106,9 +106,16 @@ public class LocalizationService : ILocalizationService
         {
             return stringID;
         }
-        else if (mStringDatabase.ContainsKey(stringID))
+        else if (mStringDatabase.TryGetValue(stringID, out string[] translations))
         {
-            return mStringDatabase[stringID][language];
+            // A malformed/short database (e.g. a ragged CSV row, or Languages/CurrentLanguage out of
+            // sync with a per-ID array's actual length) must degrade gracefully rather than crash -
+            // fall back to the string ID itself, same as "not found".
+            if (language < 0 || language >= translations.Length)
+            {
+                return stringID;
+            }
+            return translations[language];
         }
         else if (ShouldExcludeFromTranslation(stringID))
         {

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5661,6 +5661,15 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     public static Action<GraphicalUiElement>? RefreshLocalizationOnElementAction;
 
     /// <summary>
+    /// Optional lookup for the original (untranslated) string ID last assigned to this element's
+    /// "Text" property via the localized path, if any. Wired by the tool/runtime since GumRuntime
+    /// cannot reference <c>CustomSetPropertyOnRenderable</c> directly. Used by callers (e.g. the
+    /// Gum tool's <c>WireframeObjectManager.ApplyLocalization</c>) that need to re-translate an
+    /// element without re-translating its already-translated live text.
+    /// </summary>
+    public static Func<GraphicalUiElement, string?>? TryGetLocalizationKey;
+
+    /// <summary>
     /// Re-applies the most recently assigned localization key on this element
     /// and all descendants via <see cref="RefreshLocalizationOnElementAction"/>.
     /// Each element that had its <c>Text</c> set via the localization path

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -5670,6 +5670,17 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     public static Func<GraphicalUiElement, string?>? TryGetLocalizationKey;
 
     /// <summary>
+    /// Optional hook to enable/disable translation for every subsequent <c>SetProperty("Text",
+    /// ...)</c> call (the tool's design-time "show localized text" preview toggle). Wired by the
+    /// tool since GumRuntime cannot reference <c>CustomSetPropertyOnRenderable</c> directly - the
+    /// wired implementation swaps its static <c>LocalizationService</c> between the real,
+    /// database-populated instance and null. Passing false must be indistinguishable from no
+    /// localization database ever having been loaded (raw string IDs display unchanged); passing
+    /// true restores translation.
+    /// </summary>
+    public static Action<bool>? SetLocalizationEnabled;
+
+    /// <summary>
     /// Re-applies the most recently assigned localization key on this element
     /// and all descendants via <see cref="RefreshLocalizationOnElementAction"/>.
     /// Each element that had its <c>Text</c> set via the localization path

--- a/MonoGameGum.Tests/Localization/LocalizationServiceOutOfRangeTests.cs
+++ b/MonoGameGum.Tests/Localization/LocalizationServiceOutOfRangeTests.cs
@@ -1,0 +1,62 @@
+using Gum.Localization;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MonoGameGum.Tests.Localization;
+
+/// <summary>
+/// Regression coverage for a live crash: a malformed database (a per-ID translations array
+/// shorter than the requested language index) threw IndexOutOfRangeException instead of
+/// degrading gracefully. Surfaced by a real project where the tool's CSV loader built
+/// Languages one entry too long (including the "String ID" column itself), so selecting the
+/// last language resolved to an index one past the end of every per-ID array.
+/// </summary>
+public class LocalizationServiceOutOfRangeTests
+{
+    private readonly LocalizationService _service;
+
+    public LocalizationServiceOutOfRangeTests()
+    {
+        _service = new LocalizationService();
+    }
+
+    [Fact]
+    public void TranslateForLanguage_ShouldReturnStringId_WhenLanguageIndexIsBeyondTheIdsTranslationArray()
+    {
+        Dictionary<string, string[]> entryDictionary = new()
+        {
+            { "T_Cancel", new[] { "T_Cancel", "Cancel", "Cancelar" } }
+        };
+        List<string> headers = new() { "English", "Spanish" };
+        _service.AddDatabase(entryDictionary, headers);
+
+        _service.TranslateForLanguage("T_Cancel", 3).ShouldBe("T_Cancel");
+    }
+
+    [Fact]
+    public void TranslateForLanguage_ShouldReturnStringId_WhenLanguageIndexIsNegative()
+    {
+        Dictionary<string, string[]> entryDictionary = new()
+        {
+            { "T_Cancel", new[] { "T_Cancel", "Cancel", "Cancelar" } }
+        };
+        List<string> headers = new() { "English", "Spanish" };
+        _service.AddDatabase(entryDictionary, headers);
+
+        _service.TranslateForLanguage("T_Cancel", -1).ShouldBe("T_Cancel");
+    }
+
+    [Fact]
+    public void TranslateForLanguage_ShouldStillReturnTranslation_ForAnInRangeLanguageIndex()
+    {
+        Dictionary<string, string[]> entryDictionary = new()
+        {
+            { "T_Cancel", new[] { "T_Cancel", "Cancel", "Cancelar" } }
+        };
+        List<string> headers = new() { "English", "Spanish" };
+        _service.AddDatabase(entryDictionary, headers);
+
+        _service.TranslateForLanguage("T_Cancel", 2).ShouldBe("Cancelar");
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -282,6 +282,14 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
         GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
         GraphicalUiElement.TryGetLocalizationKey = CustomSetPropertyOnRenderable.TryGetLocalizationKey;
+        // Without this, CustomSetPropertyOnRenderable.LocalizationService defaults (via
+        // RenderingLibrary.SystemManagers' "??= new LocalizationService()") to a separate,
+        // permanently-empty instance - distinct from this plugin's DI-injected _localizationService,
+        // the one FileCommands.LoadLocalizationFile actually populates. Unwired, every
+        // SetProperty("Text", ...) translate (the tool's and the runtime-shared path alike) reads an
+        // empty database and passes the string ID through untouched, no matter what's loaded or what
+        // CurrentLanguage is set to.
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
         CustomSetPropertyOnRenderable.FontService = Locator.GetRequiredService<IFontManager>();
         // Gum core ships no shader loader, so the tool registers a resolver that compiles a
         // render-target Container's SourceShaderFile (.fx) into an Effect at runtime (ShadowDusk),

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -281,6 +281,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         GraphicalUiElement.ThrowExceptionsForMissingFiles = CustomSetPropertyOnRenderable.ThrowExceptionsForMissingFiles;
         GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
         GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
+        GraphicalUiElement.TryGetLocalizationKey = CustomSetPropertyOnRenderable.TryGetLocalizationKey;
         CustomSetPropertyOnRenderable.FontService = Locator.GetRequiredService<IFontManager>();
         // Gum core ships no shader loader, so the tool registers a resolver that compiles a
         // render-target Container's SourceShaderFile (.fx) into an Effect at runtime (ShadowDusk),
@@ -777,10 +778,6 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
                     //gue.ApplyVariableReferences(_selectedState.SelectedStateSave);
 
                     handledByDirectSet = didPush && !disposedFile;
-                }
-                if (gue != null && value is string valueAsString && unqualifiedMember == "Text" && _localizationService.HasDatabase)
-                {
-                    _wireframeObjectManager.ApplyLocalization(gue, valueAsString);
                 }
             }
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -290,6 +290,11 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         // empty database and passes the string ID through untouched, no matter what's loaded or what
         // CurrentLanguage is set to.
         CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+        // Backs the "Show Localization" project setting: WireframeObjectManager calls this before
+        // rebuilding the wireframe so every SetProperty("Text", ...) - not just the tool's own
+        // ApplyLocalization sweep - either translates or passes the raw string ID through unchanged.
+        GraphicalUiElement.SetLocalizationEnabled = enabled =>
+            CustomSetPropertyOnRenderable.LocalizationService = enabled ? _localizationService : null;
         CustomSetPropertyOnRenderable.FontService = Locator.GetRequiredService<IFontManager>();
         // Gum core ships no shader loader, so the tool registers a resolver that compiles a
         // render-target Container's SourceShaderFile (.fx) into an Effect at runtime (ShadowDusk),

--- a/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Commands/FileCommandsTests.cs
@@ -72,6 +72,51 @@ public class FileCommandsTests : BaseTestClass
         _localizationService.Translate("T_OK").ShouldBe("Aceptar");
     }
 
+    [Fact]
+    public void LoadLocalizationFile_ShouldTranslateCorrectly_ForEveryLanguageInAThreeLanguageCsv()
+    {
+        // Pins the header-skip fix (Languages must not include the "String ID" column) against
+        // more than the minimal 2-language case: every language index from 0 (the ID itself,
+        // untranslated) through the last real language must resolve correctly, with no
+        // off-by-one for the middle or last entries.
+        _tempDirectory = CreateTempDirectory();
+        string csvPath = Path.Combine(_tempDirectory, "Strings.csv");
+        File.WriteAllText(csvPath, "StringId,English,Spanish,French\nT_Cancel,Cancel,Cancelar,Annuler\n");
+        _gumProject.LocalizationFiles.Add("Strings.csv");
+
+        _fileCommands.LoadLocalizationFile();
+
+        _localizationService.Languages.ShouldBe(new[] { "English", "Spanish", "French" });
+
+        _localizationService.CurrentLanguage = 0;
+        _localizationService.Translate("T_Cancel").ShouldBe("T_Cancel");
+        _localizationService.CurrentLanguage = 1;
+        _localizationService.Translate("T_Cancel").ShouldBe("Cancel");
+        _localizationService.CurrentLanguage = 2;
+        _localizationService.Translate("T_Cancel").ShouldBe("Cancelar");
+        _localizationService.CurrentLanguage = 3;
+        _localizationService.Translate("T_Cancel").ShouldBe("Annuler");
+    }
+
+    [Fact]
+    public void LoadLocalizationFile_ShouldClearPreviousDatabase_WhenSwitchingToAProjectWithNoLocalizationFiles()
+    {
+        // Pins that switching between projects (or screens) doesn't leak a previously-loaded
+        // CSV's translations into a project that has none configured.
+        _tempDirectory = CreateTempDirectory();
+        string csvPath = Path.Combine(_tempDirectory, "Strings.csv");
+        File.WriteAllText(csvPath, "StringId,English\nT_OK,OK\n");
+        _gumProject.LocalizationFiles.Add("Strings.csv");
+        _fileCommands.LoadLocalizationFile();
+        _localizationService.HasDatabase.ShouldBeTrue();
+
+        _gumProject.LocalizationFiles.Clear();
+        _fileCommands.LoadLocalizationFile();
+
+        _localizationService.HasDatabase.ShouldBeFalse();
+        _localizationService.Translate("T_OK").ShouldBe("T_OK");
+    }
+
     private static string CreateTempDirectory()
     {
         string tempDir = Path.Combine(Path.GetTempPath(),

--- a/Tool/Tests/GumToolUnitTests/Managers/LocalizationServiceExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/LocalizationServiceExtensionsTests.cs
@@ -1,0 +1,82 @@
+using System.IO;
+using Gum.Localization;
+using Gum.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Managers;
+
+/// <summary>
+/// Regression coverage for the tool's CSV localization loader (distinct from GumCommon's
+/// AddCsvDatabase, which the runtime uses). Two bugs found investigating a live crash:
+/// 1. Languages included the "String ID" header column itself, off-by-one-ing every language
+///    index against the per-ID arrays (which correctly start translations at index 1) - selecting
+///    the last of N languages threw IndexOutOfRangeException in LocalizationService.
+/// 2. The delimiter parameter was silently ignored (CsvFileManager.CsvDeserializeDictionary always
+///    parsed with ',' internally), so a non-comma-delimited file passed through this method
+///    couldn't work no matter what the caller specified.
+/// </summary>
+public class LocalizationServiceExtensionsTests
+{
+    [Fact]
+    public void AddDatabaseFromCsv_LanguagesShouldNotIncludeTheStringIdColumn()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "String ID,English,Spanish\nT_Cancel,Cancel,Cancelar\n");
+
+            LocalizationService service = new();
+            service.AddDatabaseFromCsv(path, ',');
+
+            service.Languages.ShouldBe(new[] { "English", "Spanish" });
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AddDatabaseFromCsv_SelectingTheLastLanguage_ShouldTranslateCorrectly_NotThrow()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "String ID,English,Spanish\nT_Cancel,Cancel,Cancelar\n");
+
+            LocalizationService service = new();
+            service.AddDatabaseFromCsv(path, ',');
+
+            // Mirrors ProjectPropertiesChangeLogic's `Languages.IndexOf(name) + 1`: selecting the
+            // last language ("Spanish", index 1) resolves to CurrentLanguage 2.
+            service.CurrentLanguage = service.Languages.Count;
+            service.Translate("T_Cancel").ShouldBe("Cancelar");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AddDatabaseFromCsv_ShouldRespectTheGivenDelimiter()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "String ID;English;Spanish\nT_Cancel;Cancel;Cancelar\n");
+
+            LocalizationService service = new();
+            service.AddDatabaseFromCsv(path, ';');
+
+            service.Languages.ShouldBe(new[] { "English", "Spanish" });
+            service.CurrentLanguage = 2;
+            service.Translate("T_Cancel").ShouldBe("Cancelar");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerApplyLocalizationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerApplyLocalizationTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+/// <summary>
+/// Regression coverage: editing a Text variable with a localization database loaded produced
+/// "Hello(loc)(loc)(loc)" instead of "Hello(loc)" for a missing string ID. Root cause was
+/// WireframeObjectManager.ApplyLocalization translating the string itself and then passing the
+/// already-translated result into GraphicalUiElement.SetProperty("Text", ...), which internally
+/// translates again via CustomSetPropertyOnRenderable.TrySetPropertyOnText - a double translate.
+/// A second contributor: when called with no forcedId, ApplyLocalization fell back to the live
+/// (possibly already-translated) RawText instead of the originally-assigned string ID, so repeated
+/// no-arg calls (e.g. RefreshAll) kept compounding the suffix further.
+/// </summary>
+public class WireframeObjectManagerApplyLocalizationTests : BaseTestClass
+{
+    private readonly WireframeObjectManager _wireframeObjectManager;
+    private readonly LocalizationService _localizationService;
+
+    public WireframeObjectManagerApplyLocalizationTests()
+    {
+        ObjectFinder.Self.GumProjectSave = new GumProjectSave();
+
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+        GraphicalUiElement.TryGetLocalizationKey = CustomSetPropertyOnRenderable.TryGetLocalizationKey;
+
+        _localizationService = new LocalizationService();
+        // Loaded database that doesn't contain "Hello": any translate call on it appends
+        // "(loc)" - this is what makes repeated/duplicate translation visible.
+        _localizationService.AddDatabase(
+            new Dictionary<string, string[]> { { "SomeOtherId", new[] { "SomeOtherId", "Translated" } } },
+            new List<string> { "Default", "English" });
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+
+        Mock<IProjectState> projectState = new();
+        projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave { ShowLocalizationInGum = true });
+
+        _wireframeObjectManager = new WireframeObjectManager(
+            Mock.Of<IFontManager>(),
+            Mock.Of<ISelectedState>(),
+            Mock.Of<IDialogService>(),
+            Mock.Of<IGuiCommands>(),
+            _localizationService,
+            Mock.Of<IPluginManager>(),
+            projectState.Object);
+    }
+
+    public override void Dispose()
+    {
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+        GraphicalUiElement.TryGetLocalizationKey = null;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void ApplyLocalization_WithForcedId_ShouldNotDoubleTranslate()
+    {
+        GraphicalUiElement gue = new(new Text());
+        // Mirrors MainEditorTabPlugin.HandleVariableSetLate's first push: the raw committed value
+        // goes straight through SetProperty, which translates it once.
+        gue.SetProperty("Text", "Hello");
+
+        // Mirrors the second, redundant push at MainEditorTabPlugin.cs:783, passing the same raw
+        // string ID as forcedId.
+        _wireframeObjectManager.ApplyLocalization(gue, "Hello");
+
+        Text containedText = (Text)gue.RenderableComponent;
+        containedText.RawText.ShouldBe("Hello(loc)");
+    }
+
+    [Fact]
+    public void ApplyLocalization_WithoutForcedId_ShouldNotReTranslateAlreadyTranslatedText()
+    {
+        GraphicalUiElement gue = new(new Text());
+        gue.SetProperty("Text", "Hello");
+
+        // A no-arg refresh pass (e.g. RefreshAll / a full ApplyLocalization() sweep) must
+        // re-translate from the original string ID, not the already-translated live RawText.
+        _wireframeObjectManager.ApplyLocalization(gue);
+
+        Text containedText = (Text)gue.RenderableComponent;
+        containedText.RawText.ShouldBe("Hello(loc)");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
@@ -36,6 +36,7 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
     private readonly LocalizationService _localizationService;
     private readonly WireframeObjectManager _wireframeObjectManager;
     private readonly ScreenSave _screen;
+    private readonly GumProjectSave _toolProject;
     private GraphicalUiElement? _textGue;
 
     public WireframeObjectManagerRefreshLocalizationTests()
@@ -52,6 +53,9 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
         // singleton into the static hook GraphicalUiElement.SetProperty("Text", ...) uses to
         // translate - see that method's comment for why this must be the SAME instance.
         CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+        // Mirrors MainEditorTabPlugin.StartUp()'s wiring of the "Show Localization" toggle hook.
+        GraphicalUiElement.SetLocalizationEnabled = enabled =>
+            CustomSetPropertyOnRenderable.LocalizationService = enabled ? _localizationService : null;
 
         _screen = new ScreenSave { Name = "TextScreen" };
         StateSave defaultState = new StateSave { Name = "Default", ParentContainer = _screen };
@@ -77,8 +81,9 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
             return root;
         });
 
+        _toolProject = new GumProjectSave { ShowLocalizationInGum = true };
         Mock<IProjectState> projectState = new();
-        projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave { ShowLocalizationInGum = true });
+        projectState.Setup(x => x.GumProjectSave).Returns(_toolProject);
 
         _wireframeObjectManager = new WireframeObjectManager(
             Mock.Of<IFontManager>(),
@@ -94,6 +99,7 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
     {
         CustomSetPropertyOnRenderable.LocalizationService = null;
         GraphicalUiElement.TryGetLocalizationKey = null;
+        GraphicalUiElement.SetLocalizationEnabled = null;
         base.Dispose();
     }
 
@@ -120,5 +126,31 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
         _textGue.ShouldNotBeNull();
         Text containedText = (Text)_textGue!.RenderableComponent;
         containedText.RawText.ShouldBe("Cancel");
+    }
+
+    [Fact]
+    public void RefreshAll_WithShowLocalizationInGumFalse_ShouldShowTheLiteralStringId()
+    {
+        _toolProject.ShowLocalizationInGum = false;
+
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _textGue.ShouldNotBeNull();
+        Text containedText = (Text)_textGue!.RenderableComponent;
+        containedText.RawText.ShouldBe("T_Cancel");
+    }
+
+    [Fact]
+    public void RefreshAll_AfterShowLocalizationInGumIsToggledBackOn_ShouldTranslateAgain()
+    {
+        _toolProject.ShowLocalizationInGum = false;
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _toolProject.ShowLocalizationInGum = true;
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _textGue.ShouldNotBeNull();
+        Text containedText = (Text)_textGue!.RenderableComponent;
+        containedText.RawText.ShouldBe("Cancelar");
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
@@ -37,6 +37,7 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
     private readonly WireframeObjectManager _wireframeObjectManager;
     private readonly ScreenSave _screen;
     private readonly GumProjectSave _toolProject;
+    private readonly VariableSave _textVariable;
     private GraphicalUiElement? _textGue;
 
     public WireframeObjectManagerRefreshLocalizationTests()
@@ -60,6 +61,10 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
         _screen = new ScreenSave { Name = "TextScreen" };
         StateSave defaultState = new StateSave { Name = "Default", ParentContainer = _screen };
         _screen.States.Add(defaultState);
+        // Stored the same way the real state system holds an instance's Text value - a
+        // VariableSave, read (never written) by ApplyState each time the tree is rebuilt.
+        _textVariable = new VariableSave { Name = "CancelLabel.Text", Value = "T_Cancel", Type = "string" };
+        defaultState.Variables.Add(_textVariable);
 
         GumProjectSave project = new();
         project.Screens.Add(_screen);
@@ -72,12 +77,13 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
 
         Mock<IPluginManager> pluginManager = new();
         // Mirrors what real ToGraphicalUiElement/ApplyState does for a Text instance's default
-        // state Text variable: GraphicalUiElement.SetProperty("Text", "T_Cancel").
+        // state Text variable: reads the stored VariableSave value and pushes it through
+        // GraphicalUiElement.SetProperty("Text", ...) - it never writes back to the VariableSave.
         pluginManager.Setup(x => x.CreateGraphicalUiElement(_screen)).Returns(() =>
         {
             GraphicalUiElement root = new(new InvisibleRenderable()) { Name = "TextScreen" };
             _textGue = new GraphicalUiElement(new Text()) { Name = "CancelLabel", Parent = root };
-            _textGue.SetProperty("Text", "T_Cancel");
+            _textGue.SetProperty("Text", (string)_textVariable.Value);
             return root;
         });
 
@@ -152,5 +158,25 @@ public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
         _textGue.ShouldNotBeNull();
         Text containedText = (Text)_textGue!.RenderableComponent;
         containedText.RawText.ShouldBe("Cancelar");
+    }
+
+    [Fact]
+    public void RefreshAll_ThroughRepeatedLanguageAndToggleChanges_ShouldNeverMutateTheStoredVariable()
+    {
+        // Regression pin for the original reported chain: an earlier (now-fixed) bug baked the
+        // translated text back into the persisted value, so turning localization off revealed an
+        // already-corrupted "Hello(loc)" instead of the real raw "Hello". This drives RefreshAll
+        // through several language switches and Show Localization toggles and asserts the
+        // VariableSave itself - the actual saved/authored value - is untouched throughout.
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+        _localizationService.CurrentLanguage = 1;
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+        _toolProject.ShowLocalizationInGum = false;
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+        _toolProject.ShowLocalizationInGum = true;
+        _localizationService.CurrentLanguage = 2;
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _textVariable.Value.ShouldBe("T_Cancel");
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerRefreshLocalizationTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services.Dialogs;
+using Gum.Services.Fonts;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Wireframe;
+
+/// <summary>
+/// Reproduces a reported regression: opening a screen whose Text is bound to a valid,
+/// database-backed string ID showed the literal string ID ("T_Cancel") instead of the
+/// translated text, and switching the language dropdown (which forces a RefreshAll) did
+/// nothing on screen.
+///
+/// Root cause: the tool's DI-registered LocalizationService singleton (injected into
+/// WireframeObjectManager/FileCommands/etc., and the one FileCommands.LoadLocalizationFile
+/// actually populates) was never wired into the static
+/// CustomSetPropertyOnRenderable.LocalizationService hook that GraphicalUiElement.SetProperty
+/// ("Text", ...) uses internally to translate - RenderingLibrary.SystemManagers only does
+/// `??= new LocalizationService()`, leaving that hook pointing at a permanently-empty database
+/// in the tool. Fixed by MainEditorTabPlugin.StartUp() assigning the same DI instance into that
+/// hook - this test mirrors that wiring in its constructor.
+/// </summary>
+public class WireframeObjectManagerRefreshLocalizationTests : BaseTestClass
+{
+    private readonly LocalizationService _localizationService;
+    private readonly WireframeObjectManager _wireframeObjectManager;
+    private readonly ScreenSave _screen;
+    private GraphicalUiElement? _textGue;
+
+    public WireframeObjectManagerRefreshLocalizationTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+        GraphicalUiElement.TryGetLocalizationKey = CustomSetPropertyOnRenderable.TryGetLocalizationKey;
+
+        _localizationService = new LocalizationService();
+        _localizationService.AddDatabase(
+            new Dictionary<string, string[]> { { "T_Cancel", new[] { "T_Cancel", "Cancel", "Cancelar" } } },
+            new List<string> { "Default", "English", "Spanish" });
+        _localizationService.CurrentLanguage = 2; // Spanish
+        // Mirrors MainEditorTabPlugin.StartUp()'s wiring of the DI-injected LocalizationService
+        // singleton into the static hook GraphicalUiElement.SetProperty("Text", ...) uses to
+        // translate - see that method's comment for why this must be the SAME instance.
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+
+        _screen = new ScreenSave { Name = "TextScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = _screen };
+        _screen.States.Add(defaultState);
+
+        GumProjectSave project = new();
+        project.Screens.Add(_screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        Mock<ISelectedState> selectedState = new();
+        selectedState.SetupGet(x => x.SelectedElements).Returns(new[] { _screen });
+        selectedState.SetupGet(x => x.SelectedElement).Returns(_screen);
+        selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+
+        Mock<IPluginManager> pluginManager = new();
+        // Mirrors what real ToGraphicalUiElement/ApplyState does for a Text instance's default
+        // state Text variable: GraphicalUiElement.SetProperty("Text", "T_Cancel").
+        pluginManager.Setup(x => x.CreateGraphicalUiElement(_screen)).Returns(() =>
+        {
+            GraphicalUiElement root = new(new InvisibleRenderable()) { Name = "TextScreen" };
+            _textGue = new GraphicalUiElement(new Text()) { Name = "CancelLabel", Parent = root };
+            _textGue.SetProperty("Text", "T_Cancel");
+            return root;
+        });
+
+        Mock<IProjectState> projectState = new();
+        projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave { ShowLocalizationInGum = true });
+
+        _wireframeObjectManager = new WireframeObjectManager(
+            Mock.Of<IFontManager>(),
+            selectedState.Object,
+            Mock.Of<IDialogService>(),
+            Mock.Of<IGuiCommands>(),
+            _localizationService,
+            pluginManager.Object,
+            projectState.Object);
+    }
+
+    public override void Dispose()
+    {
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+        GraphicalUiElement.TryGetLocalizationKey = null;
+        base.Dispose();
+    }
+
+    [Fact]
+    public void RefreshAll_ShouldShowTranslatedTextForCurrentLanguage_NotTheLiteralStringId()
+    {
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _textGue.ShouldNotBeNull();
+        Text containedText = (Text)_textGue!.RenderableComponent;
+        containedText.RawText.ShouldBe("Cancelar");
+    }
+
+    [Fact]
+    public void RefreshAll_AfterLanguageChanges_ShouldRetranslateToTheNewLanguage()
+    {
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        // Mirrors ProjectPropertiesChangeLogic reacting to the language dropdown: it sets
+        // CurrentLanguage then forces a RefreshAll.
+        _localizationService.CurrentLanguage = 1; // English
+        _wireframeObjectManager.RefreshAll(forceLayout: true);
+
+        _textGue.ShouldNotBeNull();
+        Text containedText = (Text)_textGue!.RenderableComponent;
+        containedText.RawText.ShouldBe("Cancel");
+    }
+}

--- a/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
@@ -323,6 +323,14 @@ public partial class WireframeObjectManager : IWireframeObjectManager
         if(shouldLocalize)
         {
             var stringId = forcedId;
+            if(string.IsNullOrWhiteSpace(stringId))
+            {
+                // Prefer the originally-assigned string ID (tracked whenever "Text" was set
+                // through the localized path) over the live renderable text, which may already
+                // be translated - reading RawText here would re-translate already-translated
+                // text and compound the "(loc)" suffix on every repeated call.
+                stringId = GraphicalUiElement.TryGetLocalizationKey?.Invoke(gue);
+            }
             if(string.IsNullOrWhiteSpace(stringId) && gue.RenderableComponent is IText asText)
             {
                 stringId = asText.StoredMarkupText;
@@ -333,8 +341,10 @@ public partial class WireframeObjectManager : IWireframeObjectManager
 
             }
 
-            // Go through the GraphicalUiElement to kick off a layout adjustment if necessary
-            gue.SetProperty("Text", _localizationService.Translate(stringId));
+            // Go through the GraphicalUiElement so it translates (and kicks off a layout
+            // adjustment if necessary) - SetProperty("Text", ...) already translates internally,
+            // so translating here too would double-translate.
+            gue.SetProperty("Text", stringId);
         }
     }
 

--- a/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
@@ -166,6 +166,12 @@ public partial class WireframeObjectManager : IWireframeObjectManager
 
                 GraphicalUiElement.IsAllLayoutSuspended = true;
 
+                // The "Show Localization" project setting must gate translation everywhere it
+                // happens - not just this class's own ApplyLocalization sweep below, but every
+                // SetProperty("Text", ...) call made while building the tree (SetInitialState's
+                // ApplyState translates directly, with no knowledge of this tool-only setting).
+                GraphicalUiElement.SetLocalizationEnabled?.Invoke(_projectState.GumProjectSave?.ShowLocalizationInGum ?? true);
+
                 try
                 {
                     RootGue = _pluginManager.CreateGraphicalUiElement(elementSave);


### PR DESCRIPTION
## Problem

Editing a Text variable with a localization database loaded produced "Hello(loc)(loc)(loc)" instead of "Hello(loc)" for a missing string ID.

Root cause: `WireframeObjectManager.ApplyLocalization` translated the string itself and then passed the translated result into `GraphicalUiElement.SetProperty("Text", ...)`, which internally translates again via `CustomSetPropertyOnRenderable.TrySetPropertyOnText` - a double translate. Its no-`forcedId` fallback also read the live (possibly already-translated) `RawText` instead of the originally-assigned string ID, so repeated no-arg calls (`RefreshAll`, toggling the localization setting) kept compounding the suffix further.

## Fix (commit 1)

- `ApplyLocalization` now passes the raw string ID through `SetProperty` (single translation), instead of pre-translating.
- Added a `GraphicalUiElement.TryGetLocalizationKey` hook so the no-`forcedId` path re-translates from the original key instead of live, possibly-already-translated text.
- Removed `MainEditorTabPlugin`'s redundant second `ApplyLocalization` call on a Text edit.

## Regression found via manual testing, fixed in commit 2

Routing all translation through `SetProperty("Text", ...)` assumed its internal translate uses the same `LocalizationService` as the rest of the tool. It doesn't: `RenderingLibrary.SystemManagers` only does `CustomSetPropertyOnRenderable.LocalizationService ??= new LocalizationService();` - a separate, permanently-empty instance, distinct from the DI-injected `LocalizationService` singleton that `FileCommands.LoadLocalizationFile` actually populates. This dates back to a Feb 2025 refactor that generalized localization behind `ILocalizationService` for runtime use - the tool itself was never wired to share the instance. After commit 1, a real project showed the literal string ID instead of the translation, and the language dropdown had no effect. Fix: `MainEditorTabPlugin.StartUp()` now wires the DI singleton into `CustomSetPropertyOnRenderable.LocalizationService`.

## Second regression found via manual testing, fixed in commit 3

As soon as the tool's `LocalizationService` started actually translating (commit 2), it crashed with `IndexOutOfRangeException` in `LocalizationService.TranslateForLanguage`.

Root cause: `Gum/Managers/LocalizationServiceExtensions.cs` (the tool's own CSV loader, distinct from GumCommon's `AddCsvDatabase`) included the "String ID" header column itself in `Languages`, off-by-one'ing every language index against the per-ID translation arrays. Fixed, along with two related bugs in the same method: the `delimiter` parameter was silently ignored, and `LocalizationService.TranslateForLanguage` now degrades gracefully instead of throwing on any out-of-range index (closes #4050).

## Third regression found via manual testing, fixed in commit 4

Toggling "Show Localization" off did nothing visible - Text stayed translated instead of reverting to the literal string ID.

Root cause: `ApplyLocalization` already gated its own translate call on this setting, but after commit 2's fix, the *primary* translation now happens earlier and unconditionally - inside `SetInitialState`'s `ApplyState`, via the ordinary `SetProperty("Text", ...)` path, which has no knowledge of this tool-only setting. Toggling the setting off only skipped the now-largely-redundant `ApplyLocalization` sweep. Fix: added a `GraphicalUiElement.SetLocalizationEnabled` hook (same pattern as `TryGetLocalizationKey`) that swaps `CustomSetPropertyOnRenderable.LocalizationService` between the real instance and null; `WireframeObjectManager.RefreshAll` invokes it before rebuilding the tree based on `ShowLocalizationInGum`, so every `SetProperty("Text", ...)` call - not just `ApplyLocalization`'s sweep - respects the toggle.

## Test plan

Every fix above is pinned by a test that was verified red (either at compile time, because it needs API that didn't exist yet, or at runtime, by reverting just the wiring) before the corresponding fix, and green after:

- `WireframeObjectManagerApplyLocalizationTests` - double/triple-translate bug.
- `WireframeObjectManagerRefreshLocalizationTests` - disconnected-`LocalizationService` regression, plus the Show Localization toggle (2 new tests, commit 4).
- `LocalizationServiceExtensionsTests` - CSV loader off-by-one/delimiter-ignored bugs.
- `LocalizationServiceOutOfRangeTests` - `IndexOutOfRangeException` bounds safety.
- `GumToolUnitTests` full suite: 1141 passed, 2 skipped (pre-existing skips).
- `Gum.Presentation.Tests` full suite: 741 passed.
- `MonoGameGum.Tests` localization tests: 82 passed.
- `GumFull.sln` builds with 0 errors.
- Manual test: user-verified against a real project (`PremultipliedTests`) through all four rounds above.

No existing tests were modified or removed across any of these commits - all coverage is additive.
