### PR TITLE
Raise named animation events at runtime (#4053)

### DIFF
--- a/GumCommon/Runtime/AnimationController.cs
+++ b/GumCommon/Runtime/AnimationController.cs
@@ -64,6 +64,13 @@ public class AnimationController
     public event Action? OnResumed;
 
     /// <summary>
+    /// Raised when playback crosses the time of a named event authored on the animation timeline.
+    /// Games typically switch on <see cref="NamedAnimationEventArgs.Name"/> to trigger sound effects,
+    /// hitboxes, and similar. For looping animations the event fires once per loop.
+    /// </summary>
+    public event Action<NamedAnimationEventArgs>? NamedEventOccurred;
+
+    /// <summary>
     /// Starts playing the specified animation from the beginning.
     /// </summary>
     /// <param name="animation">The AnimationRuntime to play.</param>
@@ -200,16 +207,66 @@ public class AnimationController
     {
         if (_state == AnimationState.Playing && CurrentAnimation != null)
         {
+            AnimationRuntime animation = CurrentAnimation;
+            double previousTime = CurrentTime;
             CurrentTime += secondDifference;
-            CurrentAnimation.ApplyAtTimeTo(CurrentTime, target);
+            animation.ApplyAtTimeTo(CurrentTime, target);
+
+            RaiseNamedEvents(animation, previousTime, CurrentTime);
 
             // Check if animation has completed
-            if (!CurrentAnimation.Loops && CurrentTime >= CurrentAnimation.Length)
+            if (CurrentAnimation != null && !CurrentAnimation.Loops && CurrentTime >= CurrentAnimation.Length)
             {
                 _state = AnimationState.Stopped;
                 CurrentAnimation = null;
                 CurrentTime = 0;
                 OnCompleted?.Invoke();
+            }
+        }
+    }
+
+    // Fires NamedEventOccurred for every named event whose time falls within (previousTime, currentTime].
+    // For looping animations each authored event recurs every Length seconds, so all occurrences in the
+    // interval are raised. Skipped entirely when nothing is subscribed to avoid per-frame work.
+    private void RaiseNamedEvents(AnimationRuntime animation, double previousTime, double currentTime)
+    {
+        if (NamedEventOccurred == null)
+        {
+            return;
+        }
+
+        double length = animation.Length;
+        bool loops = animation.Loops && length > 0;
+
+        // Plain loop rather than LINQ: this runs per frame for every playing animation.
+        for (int i = 0; i < animation.Keyframes.Count; i++)
+        {
+            KeyframeRuntime keyframe = animation.Keyframes[i];
+            if (string.IsNullOrEmpty(keyframe.EventName))
+            {
+                continue;
+            }
+
+            float eventTime = keyframe.Time;
+
+            if (loops)
+            {
+                // Advance to the first occurrence strictly after previousTime, then fire each up to currentTime.
+                double occurrence = eventTime;
+                if (occurrence <= previousTime)
+                {
+                    double loopsToSkip = Math.Floor((previousTime - eventTime) / length) + 1;
+                    occurrence = eventTime + loopsToSkip * length;
+                }
+                while (occurrence <= currentTime)
+                {
+                    NamedEventOccurred?.Invoke(new NamedAnimationEventArgs(keyframe.EventName!, eventTime));
+                    occurrence += length;
+                }
+            }
+            else if (eventTime > previousTime && eventTime <= currentTime)
+            {
+                NamedEventOccurred?.Invoke(new NamedAnimationEventArgs(keyframe.EventName!, eventTime));
             }
         }
     }

--- a/GumCommon/Runtime/NamedAnimationEventArgs.cs
+++ b/GumCommon/Runtime/NamedAnimationEventArgs.cs
@@ -1,0 +1,26 @@
+namespace Gum.StateAnimation.Runtime;
+
+/// <summary>
+/// Carries information about a named event raised during animation playback.
+/// Raised via <see cref="AnimationController.NamedEventOccurred"/> when playback
+/// crosses the time of a named event authored on an animation timeline.
+/// </summary>
+public class NamedAnimationEventArgs
+{
+    /// <summary>
+    /// The name of the event, as authored in the animation. Typically switched on
+    /// by game code to decide which action to take (play a sound, enable a hitbox, etc.).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The time, in seconds from the start of the animation, at which the event is authored.
+    /// </summary>
+    public float Time { get; }
+
+    public NamedAnimationEventArgs(string name, float time)
+    {
+        Name = name;
+        Time = time;
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
+++ b/MonoGameGum.Tests/Runtimes/AnimationControllerTests.cs
@@ -450,6 +450,56 @@ public class AnimationControllerTests : BaseTestClass
         controller.IsPlaying.ShouldBeTrue();
     }
 
+    [Fact]
+    public void Update_ShouldRaiseNamedEventOccurred_WhenCrossingEventTime()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateAnimationWithEvent("Footstep", 0.5f, loops: false);
+        GraphicalUiElement gue = CreateTestGraphicalUiElement();
+        NamedAnimationEventArgs raised = null;
+        int raiseCount = 0;
+
+        controller.NamedEventOccurred += args => { raised = args; raiseCount++; };
+        controller.Play(animation);
+        controller.Update(0.6, gue);
+
+        raiseCount.ShouldBe(1);
+        raised.Name.ShouldBe("Footstep");
+        raised.Time.ShouldBe(0.5f);
+    }
+
+    [Fact]
+    public void Update_ShouldNotRaiseNamedEventOccurred_BeforeEventTime()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateAnimationWithEvent("Footstep", 0.5f, loops: false);
+        GraphicalUiElement gue = CreateTestGraphicalUiElement();
+        int raiseCount = 0;
+
+        controller.NamedEventOccurred += _ => raiseCount++;
+        controller.Play(animation);
+        controller.Update(0.3, gue);
+
+        raiseCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Update_ShouldRaiseNamedEventOccurred_OncePerLoop()
+    {
+        AnimationController controller = new AnimationController();
+        AnimationRuntime animation = CreateAnimationWithEvent("Footstep", 0.5f, loops: true);
+        GraphicalUiElement gue = CreateTestGraphicalUiElement();
+        int raiseCount = 0;
+
+        controller.NamedEventOccurred += _ => raiseCount++;
+        controller.Play(animation);
+        // Animation length is 1.0; 2.2s crosses the 0.5 event on the first (0.5)
+        // and second (1.5) loop, but not a third (2.5).
+        controller.Update(2.2, gue);
+
+        raiseCount.ShouldBe(2);
+    }
+
     #endregion
 
     #region State Property Tests
@@ -681,6 +731,18 @@ public class AnimationControllerTests : BaseTestClass
         animation.Keyframes.Add(keyframe1);
         animation.Keyframes.Add(keyframe2);
 
+        return animation;
+    }
+
+    private static AnimationRuntime CreateAnimationWithEvent(string eventName, float eventTime, bool loops)
+    {
+        AnimationRuntime animation = CreateTestAnimation();
+        animation.Loops = loops;
+        animation.Keyframes.Add(new KeyframeRuntime
+        {
+            EventName = eventName,
+            Time = eventTime
+        });
         return animation;
     }
 

--- a/docs/code/animationruntime.md
+++ b/docs/code/animationruntime.md
@@ -329,6 +329,42 @@ protected override void Initialize()
 
 <figure><img src="../.gitbook/assets/06_11 02 23.gif" alt=""><figcaption><p>Button reacting to hover</p></figcaption></figure>
 
+## Named Events
+
+An animation can carry **named events** on its timeline — markers with a name and a time. When playback crosses a marker's time, Gum raises an event so your game can react: play a sound effect, enable a hitbox, spawn a particle, and so on. Named events are authored in the Gum tool's animation editor (see the [Animation Tutorials](../gum-tool/tutorials-and-examples/animation-tutorials/)) or added in code.
+
+Subscribe through the visual's `AnimationController`. The `NamedEventOccurred` event passes a `NamedAnimationEventArgs` whose `Name` you typically switch on:
+
+```csharp
+// Initialize
+_animatedScreen.Visual.AnimationController.NamedEventOccurred += args =>
+{
+    switch (args.Name)
+    {
+        case "Footstep":
+            // play a footstep sound
+            break;
+        case "EnableHitbox":
+            // turn on a hitbox
+            break;
+    }
+};
+```
+
+The same `AnimationController` also exposes playback events such as `OnStarted`, `OnCompleted`, `OnStopped`, `OnPaused`, and `OnResumed`.
+
+For looping animations, `NamedEventOccurred` fires once each loop. An event fires when playback passes its time, so it does not fire if the animation is stopped or restarted before reaching it.
+
+To add a named event to an animation created in code, add a `KeyframeRuntime` with its `EventName` and `Time` set (leave `StateName` unset — an event keyframe carries no state):
+
+```csharp
+// Initialize
+var footstepEvent = new KeyframeRuntime();
+growAnimation.Keyframes.Add(footstepEvent);
+footstepEvent.EventName = "Footstep";
+footstepEvent.Time = 0.5f;
+```
+
 ## Playing Multiple Animations on the Same Instance
 
 {% hint style="warning" %}


### PR DESCRIPTION
Closes #4053.

Named events authored on a Gum state-animation timeline (`AnimationSave.Events`) were never raised at runtime. This wires them up.

## Interface

`AnimationController` gains one event — the general, backend-agnostic place, since every runtime drives playback through `GraphicalUiElement.AnimationController`:

```csharp
public event Action<NamedAnimationEventArgs>? NamedEventOccurred;
```

`NamedAnimationEventArgs` carries `Name` + `Time`. It's a class (not a bare `string`) so future named-event parameters slot in without changing the signature. Subscribe and switch on `Name`:

```csharp
gue.AnimationController.NamedEventOccurred += args =>
{
    switch (args.Name)
    {
        case "Footstep": PlaySound(); break;
    }
};
```

## Behavior

- Fires when playback crosses an event's `Time`, in `(previousTime, currentTime]` — each event fires once per pass.
- Looping animations fire the event once per loop.
- Skipped entirely when nothing is subscribed (no per-frame cost).

The conversion `AnimationSave.Events` → event keyframes already existed (`KeyframeRuntime.EventName`); only the dispatch in `AnimationController.Update` was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
