### PR TITLE
Add ColorPicker Forms control with saturation/value + hue picker (#4047)

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -284,6 +284,7 @@
 		<Compile Include="..\MonoGameGum\Forms\FrameworkElementTreeExtensions.cs" Link="Forms\FrameworkElementTreeExtensions.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\Button.cs" Link="Forms\Controls\Button.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\CheckBox.cs" Link="Forms\Controls\CheckBox.cs" />
+		<Compile Include="..\MonoGameGum\Forms\Controls\ColorPicker.cs" Link="Forms\Controls\ColorPicker.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\ColumnDefinition.cs" Link="Forms\Controls\ColumnDefinition.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\ComboBox.cs" Link="Forms\Controls\ComboBox.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\Expander.cs" Link="Forms\Controls\Expander.cs" />

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1731,6 +1731,21 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     public static Action<IRenderableIpso, ISystemManagers, Layer>? AddRenderableToManagers;
     public static Action<string, GraphicalUiElement>? ApplyMarkup;
 
+    /// <summary>
+    /// Applies constant RGBA pixel data (width*height*4 bytes) to the sprite renderable of the target
+    /// as a texture shared/cached under the given key. For backgrounds identical across every instance
+    /// (e.g. a color picker hue bar). Assigned per rendering backend; null on backends that don't support it.
+    /// </summary>
+    public static Action<GraphicalUiElement, string, byte[], int, int>? ApplyCachedTextureFromPixelData;
+
+    /// <summary>
+    /// Applies changing RGBA pixel data (width*height*4 bytes) to the sprite renderable of the target
+    /// using a texture pooled per owner (second argument). Pooled textures whose owner has detached from
+    /// the visual tree are reclaimed, so repeated create/destroy cycles reuse a bounded set. For per-instance
+    /// procedural backgrounds (e.g. a color picker saturation/value square). Assigned per rendering backend.
+    /// </summary>
+    public static Action<GraphicalUiElement, GraphicalUiElement, byte[], int, int>? ApplyPooledTextureFromPixelData;
+
     public static Action<IRenderableIpso, GraphicalUiElement, string, object?> SetPropertyOnRenderable =
         // This is the default fallback to make Gum work. Specific rendering libraries can change this to provide
         // better performance.

--- a/MonoGameGum.Tests/Forms/ColorPickerTests.cs
+++ b/MonoGameGum.Tests/Forms/ColorPickerTests.cs
@@ -1,6 +1,6 @@
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
-using Microsoft.Xna.Framework;
+using Color = System.Drawing.Color;
 using Shouldly;
 using Xunit;
 
@@ -32,7 +32,7 @@ public class ColorPickerTests : BaseTestClass
         ColorPickerVisual visual = new();
         ColorPicker picker = visual.FormsControl;
 
-        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+        picker.SelectedColor = Color.FromArgb(255, 0, 0);
 
         picker.Hue.ShouldBe(0f);
         picker.Saturation.ShouldBe(100f);
@@ -48,8 +48,8 @@ public class ColorPickerTests : BaseTestClass
         int raisedCount = 0;
         picker.SelectedColorChanged += (_, _) => raisedCount++;
 
-        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
-        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+        picker.SelectedColor = Color.FromArgb(255, 0, 0);
+        picker.SelectedColor = Color.FromArgb(255, 0, 0);
 
         raisedCount.ShouldBe(1);
     }
@@ -60,10 +60,10 @@ public class ColorPickerTests : BaseTestClass
         ColorPickerVisual visual = new();
         ColorPicker picker = visual.FormsControl;
 
-        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+        picker.SelectedColor = Color.FromArgb(255, 0, 0);
         picker.Hue = 120f;
 
-        picker.SelectedColor.ShouldBe(new Color((byte)0, (byte)255, (byte)0));
+        picker.SelectedColor.ShouldBe(Color.FromArgb(0, 255, 0));
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/ColorPickerTests.cs
+++ b/MonoGameGum.Tests/Forms/ColorPickerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Color = System.Drawing.Color;
@@ -15,6 +16,23 @@ public class ColorPickerTests : BaseTestClass
         ColorPicker.HsvToRgb(120f, 100f, 100f).ShouldBe(((byte)0, (byte)255, (byte)0));
         ColorPicker.HsvToRgb(240f, 100f, 100f).ShouldBe(((byte)0, (byte)0, (byte)255));
         ColorPicker.HsvToRgb(0f, 0f, 0f).ShouldBe(((byte)0, (byte)0, (byte)0));
+    }
+
+    [Fact]
+    public void BuildSaturationValuePixels_HasExpectedCorners_ForRedHue()
+    {
+        byte[] rgba = ColorPicker.BuildSaturationValuePixels(0f);
+        int size = (int)Math.Sqrt(rgba.Length / 4);
+
+        PixelAt(rgba, size, 0, 0).ShouldBe(((byte)255, (byte)255, (byte)255));        // sat 0, value 100 => white
+        PixelAt(rgba, size, 0, size - 1).ShouldBe(((byte)0, (byte)0, (byte)0));        // sat 0, value 0 => black
+        PixelAt(rgba, size, size - 1, 0).ShouldBe(((byte)255, (byte)0, (byte)0));      // sat 100, value 100, hue 0 => red
+    }
+
+    private static (byte R, byte G, byte B) PixelAt(byte[] rgba, int size, int x, int y)
+    {
+        int i = (y * size + x) * 4;
+        return (rgba[i], rgba[i + 1], rgba[i + 2]);
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/ColorPickerTests.cs
+++ b/MonoGameGum.Tests/Forms/ColorPickerTests.cs
@@ -1,0 +1,79 @@
+using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
+using Microsoft.Xna.Framework;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class ColorPickerTests : BaseTestClass
+{
+    [Fact]
+    public void HsvToRgb_ReturnsExpected_ForPrimaryColors()
+    {
+        ColorPicker.HsvToRgb(0f, 100f, 100f).ShouldBe(((byte)255, (byte)0, (byte)0));
+        ColorPicker.HsvToRgb(120f, 100f, 100f).ShouldBe(((byte)0, (byte)255, (byte)0));
+        ColorPicker.HsvToRgb(240f, 100f, 100f).ShouldBe(((byte)0, (byte)0, (byte)255));
+        ColorPicker.HsvToRgb(0f, 0f, 0f).ShouldBe(((byte)0, (byte)0, (byte)0));
+    }
+
+    [Fact]
+    public void RgbToHsv_ReturnsExpected_ForPrimaryColors()
+    {
+        ColorPicker.RgbToHsv(255, 0, 0).ShouldBe((0f, 100f, 100f));
+        ColorPicker.RgbToHsv(0, 255, 0).ShouldBe((120f, 100f, 100f));
+        ColorPicker.RgbToHsv(0, 0, 255).ShouldBe((240f, 100f, 100f));
+        ColorPicker.RgbToHsv(0, 0, 0).ShouldBe((0f, 0f, 0f));
+    }
+
+    [Fact]
+    public void SelectedColor_Set_UpdatesHsvState()
+    {
+        ColorPickerVisual visual = new();
+        ColorPicker picker = visual.FormsControl;
+
+        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+
+        picker.Hue.ShouldBe(0f);
+        picker.Saturation.ShouldBe(100f);
+        picker.Value.ShouldBe(100f);
+    }
+
+    [Fact]
+    public void SelectedColor_Set_RaisesSelectedColorChangedOnce()
+    {
+        ColorPickerVisual visual = new();
+        ColorPicker picker = visual.FormsControl;
+
+        int raisedCount = 0;
+        picker.SelectedColorChanged += (_, _) => raisedCount++;
+
+        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+
+        raisedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Hue_Set_UpdatesSelectedColor()
+    {
+        ColorPickerVisual visual = new();
+        ColorPicker picker = visual.FormsControl;
+
+        picker.SelectedColor = new Color((byte)255, (byte)0, (byte)0);
+        picker.Hue = 120f;
+
+        picker.SelectedColor.ShouldBe(new Color((byte)0, (byte)255, (byte)0));
+    }
+
+    [Fact]
+    public void Hue_Set_IsClampedToValidRange()
+    {
+        ColorPickerVisual visual = new();
+        ColorPicker picker = visual.FormsControl;
+
+        picker.Hue = 400f;
+
+        picker.Hue.ShouldBe(360f);
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -133,6 +133,7 @@
 		<Compile Remove="..\Forms\VisualTemplate.cs" />
 		<Compile Remove="..\Forms\Controls\Button.cs" />
 		<Compile Remove="..\Forms\Controls\CheckBox.cs" />
+		<Compile Remove="..\Forms\Controls\ColorPicker.cs" />
 		<Compile Remove="..\Forms\Controls\ColumnDefinition.cs" />
 		<Compile Remove="..\Forms\Controls\ComboBox.cs" />
 		<Compile Remove="..\Forms\Controls\Expander.cs" />

--- a/MonoGameGum/Forms/Controls/ColorPicker.cs
+++ b/MonoGameGum/Forms/Controls/ColorPicker.cs
@@ -1,0 +1,420 @@
+using System;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+
+namespace Gum.Forms.Controls;
+
+/// <summary>
+/// Implemented by a <see cref="ColorPicker"/> visual that can procedurally regenerate its
+/// saturation/value background for a given hue. The regeneration is backend-specific (it uploads
+/// pixels to a texture), so it lives on the visual rather than on the runtime-agnostic control.
+/// </summary>
+public interface IColorPickerVisual
+{
+    /// <summary>
+    /// Regenerates the saturation/value square so it displays every saturation (X) and value (Y)
+    /// combination for the given <paramref name="hue"/>.
+    /// </summary>
+    /// <param name="hue">The hue in degrees (0-360).</param>
+    void RefreshSaturationValueBackground(float hue);
+}
+
+/// <summary>
+/// A control for visually selecting a color through a saturation/value square and a hue bar.
+/// The selected color is available through <see cref="SelectedColor"/>, and changes raise
+/// <see cref="SelectedColorChanged"/>.
+/// </summary>
+public class ColorPicker : FrameworkElement
+{
+    #region Fields/Properties
+
+    private IColorPickerVisual? _colorPickerVisual;
+
+    // The interactive areas the user drags on, plus the indicators moved to reflect the selection.
+    private InteractiveGue? _saturationValueContainer;
+    private InteractiveGue? _hueContainer;
+    private GraphicalUiElement? _saturationValueIndicator;
+    private GraphicalUiElement? _hueIndicator;
+
+    private bool _isDraggingSaturationValue;
+    private bool _isDraggingHue;
+
+    // Guards against re-entrant sync when a property setter derives and stores the other
+    // representation of the same color.
+    private bool _isUpdatingColor;
+
+    private byte _red;
+    private byte _green;
+    private byte _blue;
+    private float _hue;
+    private float _saturation;
+    private float _value;
+
+    /// <summary>
+    /// The currently selected color. Setting this value updates the hue/saturation/value state,
+    /// repositions the indicators, and raises <see cref="SelectedColorChanged"/>.
+    /// </summary>
+    public Color SelectedColor
+    {
+        get => new Color(_red, _green, _blue);
+        set
+        {
+            if (value.R != _red || value.G != _green || value.B != _blue)
+            {
+                _red = value.R;
+                _green = value.G;
+                _blue = value.B;
+
+                (_hue, _saturation, _value) = RgbToHsv(_red, _green, _blue);
+
+                RefreshVisuals();
+                RaiseSelectedColorChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The hue of the selected color in degrees (0-360).
+    /// </summary>
+    public float Hue
+    {
+        get => _hue;
+        set => SetHsv(value, _saturation, _value);
+    }
+
+    /// <summary>
+    /// The saturation of the selected color (0-100).
+    /// </summary>
+    public float Saturation
+    {
+        get => _saturation;
+        set => SetHsv(_hue, value, _value);
+    }
+
+    /// <summary>
+    /// The value (brightness) of the selected color (0-100).
+    /// </summary>
+    public float Value
+    {
+        get => _value;
+        set => SetHsv(_hue, _saturation, value);
+    }
+
+    #endregion
+
+    #region Events
+
+    /// <summary>
+    /// Raised whenever <see cref="SelectedColor"/> changes, whether through user interaction or
+    /// by setting a property in code.
+    /// </summary>
+    public event EventHandler? SelectedColorChanged;
+
+    #endregion
+
+    #region Initialize
+
+    /// <summary>
+    /// Creates a new ColorPicker using the default registered visual.
+    /// </summary>
+    public ColorPicker() : base()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new ColorPicker using the provided visual.
+    /// </summary>
+    public ColorPicker(InteractiveGue visual) : base(visual)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override void ReactToVisualChanged()
+    {
+        base.ReactToVisualChanged();
+
+        _colorPickerVisual = Visual as IColorPickerVisual;
+
+        _saturationValueContainer = Visual.GetGraphicalUiElementByName("SaturationValueContainer") as InteractiveGue;
+        _hueContainer = Visual.GetGraphicalUiElementByName("HueContainer") as InteractiveGue;
+        _saturationValueIndicator = Visual.GetGraphicalUiElementByName("SaturationValueIndicator");
+        _hueIndicator = Visual.GetGraphicalUiElementByName("HueIndicator");
+
+        if (_saturationValueContainer != null)
+        {
+            _saturationValueContainer.Push += HandleSaturationValuePush;
+            _saturationValueContainer.RollOver += HandleSaturationValueRollOver;
+            _saturationValueContainer.RemovedAsPushed += HandleSaturationValueRemovedAsPushed;
+        }
+
+        if (_hueContainer != null)
+        {
+            _hueContainer.Push += HandleHuePush;
+            _hueContainer.RollOver += HandleHueRollOver;
+            _hueContainer.RemovedAsPushed += HandleHueRemovedAsPushed;
+        }
+
+        RefreshVisuals();
+    }
+
+    #endregion
+
+    #region Event Handlers
+
+    private void HandleSaturationValuePush(object? sender, EventArgs e)
+    {
+        _isDraggingSaturationValue = true;
+        PickSaturationValueFromCursor();
+    }
+
+    private void HandleSaturationValueRollOver(object? sender, EventArgs e)
+    {
+        if (_isDraggingSaturationValue)
+        {
+            PickSaturationValueFromCursor();
+        }
+    }
+
+    private void HandleSaturationValueRemovedAsPushed(object? sender, EventArgs e)
+    {
+        _isDraggingSaturationValue = false;
+    }
+
+    private void HandleHuePush(object? sender, EventArgs e)
+    {
+        _isDraggingHue = true;
+        PickHueFromCursor();
+    }
+
+    private void HandleHueRollOver(object? sender, EventArgs e)
+    {
+        if (_isDraggingHue)
+        {
+            PickHueFromCursor();
+        }
+    }
+
+    private void HandleHueRemovedAsPushed(object? sender, EventArgs e)
+    {
+        _isDraggingHue = false;
+    }
+
+    #endregion
+
+    #region Cursor Picking
+
+    private void PickSaturationValueFromCursor()
+    {
+        if (_saturationValueContainer == null)
+        {
+            return;
+        }
+
+        float width = _saturationValueContainer.AbsoluteWidth;
+        float height = _saturationValueContainer.AbsoluteHeight;
+        if (width <= 1 || height <= 1)
+        {
+            return;
+        }
+
+        float relativeX = MainCursor.XRespectingGumZoomAndBounds() - _saturationValueContainer.AbsoluteLeft;
+        float relativeY = MainCursor.YRespectingGumZoomAndBounds() - _saturationValueContainer.AbsoluteTop;
+
+        relativeX = Math.Clamp(relativeX, 0, width - 1);
+        relativeY = Math.Clamp(relativeY, 0, height - 1);
+
+        float saturation = relativeX / (width - 1) * 100f;
+        float value = (1f - relativeY / (height - 1)) * 100f;
+
+        SetHsv(_hue, saturation, value);
+    }
+
+    private void PickHueFromCursor()
+    {
+        if (_hueContainer == null)
+        {
+            return;
+        }
+
+        float height = _hueContainer.AbsoluteHeight;
+        if (height <= 1)
+        {
+            return;
+        }
+
+        float relativeY = MainCursor.YRespectingGumZoomAndBounds() - _hueContainer.AbsoluteTop;
+        relativeY = Math.Clamp(relativeY, 0, height - 1);
+
+        float hue = relativeY / (height - 1) * 360f;
+
+        SetHsv(hue, _saturation, _value);
+    }
+
+    #endregion
+
+    #region Color State
+
+    private void SetHsv(float hue, float saturation, float value)
+    {
+        hue = Math.Clamp(hue, 0f, 360f);
+        saturation = Math.Clamp(saturation, 0f, 100f);
+        value = Math.Clamp(value, 0f, 100f);
+
+        (byte r, byte g, byte b) = HsvToRgb(hue, saturation, value);
+
+        bool colorChanged = r != _red || g != _green || b != _blue;
+
+        _hue = hue;
+        _saturation = saturation;
+        _value = value;
+        _red = r;
+        _green = g;
+        _blue = b;
+
+        RefreshVisuals();
+
+        if (colorChanged)
+        {
+            RaiseSelectedColorChanged();
+        }
+    }
+
+    private void RaiseSelectedColorChanged()
+    {
+        if (!_isUpdatingColor)
+        {
+            SelectedColorChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private void RefreshVisuals()
+    {
+        _isUpdatingColor = true;
+        try
+        {
+            _colorPickerVisual?.RefreshSaturationValueBackground(_hue);
+
+            if (_saturationValueContainer != null && _saturationValueIndicator != null)
+            {
+                float width = _saturationValueContainer.AbsoluteWidth;
+                float height = _saturationValueContainer.AbsoluteHeight;
+                _saturationValueIndicator.X = _saturation / 100f * width;
+                _saturationValueIndicator.Y = (1f - _value / 100f) * height;
+            }
+
+            if (_hueContainer != null && _hueIndicator != null)
+            {
+                float height = _hueContainer.AbsoluteHeight;
+                _hueIndicator.Y = _hue / 360f * height;
+            }
+        }
+        finally
+        {
+            _isUpdatingColor = false;
+        }
+    }
+
+    #endregion
+
+    #region Color Conversion
+
+    /// <summary>
+    /// Converts RGB (0-255) to HSV, returning hue (0-360), saturation (0-100) and value (0-100).
+    /// </summary>
+    internal static (float Hue, float Saturation, float Value) RgbToHsv(byte r, byte g, byte b)
+    {
+        float rf = r / 255f;
+        float gf = g / 255f;
+        float bf = b / 255f;
+        float max = MathF.Max(rf, MathF.Max(gf, bf));
+        float min = MathF.Min(rf, MathF.Min(gf, bf));
+        float delta = max - min;
+
+        float hue;
+        if (delta == 0)
+        {
+            hue = 0;
+        }
+        else if (max == rf)
+        {
+            hue = 60f * (((gf - bf) / delta) % 6f);
+        }
+        else if (max == gf)
+        {
+            hue = 60f * ((bf - rf) / delta + 2f);
+        }
+        else
+        {
+            hue = 60f * ((rf - gf) / delta + 4f);
+        }
+
+        if (hue < 0)
+        {
+            hue += 360f;
+        }
+
+        float saturation = max == 0 ? 0 : delta / max;
+
+        return (hue, saturation * 100f, max * 100f);
+    }
+
+    /// <summary>
+    /// Converts HSV (hue 0-360, saturation 0-100, value 0-100) to RGB bytes (0-255).
+    /// </summary>
+    internal static (byte R, byte G, byte B) HsvToRgb(float hue, float saturation, float value)
+    {
+        float s = saturation / 100f;
+        float v = value / 100f;
+
+        float c = v * s;
+        float x = c * (1f - MathF.Abs(hue / 60f % 2f - 1f));
+        float m = v - c;
+
+        float rf;
+        float gf;
+        float bf;
+        if (hue < 60)
+        {
+            rf = c;
+            gf = x;
+            bf = 0;
+        }
+        else if (hue < 120)
+        {
+            rf = x;
+            gf = c;
+            bf = 0;
+        }
+        else if (hue < 180)
+        {
+            rf = 0;
+            gf = c;
+            bf = x;
+        }
+        else if (hue < 240)
+        {
+            rf = 0;
+            gf = x;
+            bf = c;
+        }
+        else if (hue < 300)
+        {
+            rf = x;
+            gf = 0;
+            bf = c;
+        }
+        else
+        {
+            rf = c;
+            gf = 0;
+            bf = x;
+        }
+
+        return (
+            (byte)MathF.Round((rf + m) * 255f),
+            (byte)MathF.Round((gf + m) * 255f),
+            (byte)MathF.Round((bf + m) * 255f));
+    }
+
+    #endregion
+}

--- a/MonoGameGum/Forms/Controls/ColorPicker.cs
+++ b/MonoGameGum/Forms/Controls/ColorPicker.cs
@@ -36,9 +36,6 @@ public class ColorPicker : FrameworkElement
     private GraphicalUiElement? _saturationValueIndicator;
     private GraphicalUiElement? _hueIndicator;
 
-    private bool _isDraggingSaturationValue;
-    private bool _isDraggingHue;
-
     // Guards against re-entrant sync when a property setter derives and stores the other
     // representation of the same color.
     private bool _isUpdatingColor;
@@ -140,18 +137,19 @@ public class ColorPicker : FrameworkElement
         _saturationValueIndicator = Visual.GetGraphicalUiElementByName("SaturationValueIndicator");
         _hueIndicator = Visual.GetGraphicalUiElementByName("HueIndicator");
 
+        // Push handles the initial click; Dragging continues to fire on the pushed element every
+        // frame the cursor moves, even once it leaves the element's bounds, so a drag keeps tracking
+        // the cursor outside the picker (matching Slider/ScrollBar).
         if (_saturationValueContainer != null)
         {
-            _saturationValueContainer.Push += HandleSaturationValuePush;
-            _saturationValueContainer.RollOver += HandleSaturationValueRollOver;
-            _saturationValueContainer.RemovedAsPushed += HandleSaturationValueRemovedAsPushed;
+            _saturationValueContainer.Push += HandleSaturationValueInput;
+            _saturationValueContainer.Dragging += HandleSaturationValueInput;
         }
 
         if (_hueContainer != null)
         {
-            _hueContainer.Push += HandleHuePush;
-            _hueContainer.RollOver += HandleHueRollOver;
-            _hueContainer.RemovedAsPushed += HandleHueRemovedAsPushed;
+            _hueContainer.Push += HandleHueInput;
+            _hueContainer.Dragging += HandleHueInput;
         }
 
         RefreshVisuals();
@@ -161,42 +159,14 @@ public class ColorPicker : FrameworkElement
 
     #region Event Handlers
 
-    private void HandleSaturationValuePush(object? sender, EventArgs e)
+    private void HandleSaturationValueInput(object? sender, EventArgs e)
     {
-        _isDraggingSaturationValue = true;
         PickSaturationValueFromCursor();
     }
 
-    private void HandleSaturationValueRollOver(object? sender, EventArgs e)
+    private void HandleHueInput(object? sender, EventArgs e)
     {
-        if (_isDraggingSaturationValue)
-        {
-            PickSaturationValueFromCursor();
-        }
-    }
-
-    private void HandleSaturationValueRemovedAsPushed(object? sender, EventArgs e)
-    {
-        _isDraggingSaturationValue = false;
-    }
-
-    private void HandleHuePush(object? sender, EventArgs e)
-    {
-        _isDraggingHue = true;
         PickHueFromCursor();
-    }
-
-    private void HandleHueRollOver(object? sender, EventArgs e)
-    {
-        if (_isDraggingHue)
-        {
-            PickHueFromCursor();
-        }
-    }
-
-    private void HandleHueRemovedAsPushed(object? sender, EventArgs e)
-    {
-        _isDraggingHue = false;
     }
 
     #endregion
@@ -212,7 +182,7 @@ public class ColorPicker : FrameworkElement
 
         float width = _saturationValueContainer.AbsoluteWidth;
         float height = _saturationValueContainer.AbsoluteHeight;
-        if (width <= 1 || height <= 1)
+        if (width <= 0 || height <= 0)
         {
             return;
         }
@@ -220,11 +190,11 @@ public class ColorPicker : FrameworkElement
         float relativeX = MainCursor.XRespectingGumZoomAndBounds() - _saturationValueContainer.AbsoluteLeft;
         float relativeY = MainCursor.YRespectingGumZoomAndBounds() - _saturationValueContainer.AbsoluteTop;
 
-        relativeX = Math.Clamp(relativeX, 0, width - 1);
-        relativeY = Math.Clamp(relativeY, 0, height - 1);
+        relativeX = Math.Clamp(relativeX, 0, width);
+        relativeY = Math.Clamp(relativeY, 0, height);
 
-        float saturation = relativeX / (width - 1) * 100f;
-        float value = (1f - relativeY / (height - 1)) * 100f;
+        float saturation = relativeX / width * 100f;
+        float value = (1f - relativeY / height) * 100f;
 
         SetHsv(_hue, saturation, value);
     }
@@ -237,15 +207,15 @@ public class ColorPicker : FrameworkElement
         }
 
         float height = _hueContainer.AbsoluteHeight;
-        if (height <= 1)
+        if (height <= 0)
         {
             return;
         }
 
         float relativeY = MainCursor.YRespectingGumZoomAndBounds() - _hueContainer.AbsoluteTop;
-        relativeY = Math.Clamp(relativeY, 0, height - 1);
+        relativeY = Math.Clamp(relativeY, 0, height);
 
-        float hue = relativeY / (height - 1) * 360f;
+        float hue = relativeY / height * 360f;
 
         SetHsv(hue, _saturation, _value);
     }

--- a/MonoGameGum/Forms/Controls/ColorPicker.cs
+++ b/MonoGameGum/Forms/Controls/ColorPicker.cs
@@ -8,21 +8,6 @@ using Color = System.Drawing.Color;
 namespace Gum.Forms.Controls;
 
 /// <summary>
-/// Implemented by a <see cref="ColorPicker"/> visual that can procedurally regenerate its
-/// saturation/value background for a given hue. The regeneration is backend-specific (it uploads
-/// pixels to a texture), so it lives on the visual rather than on the runtime-agnostic control.
-/// </summary>
-public interface IColorPickerVisual
-{
-    /// <summary>
-    /// Regenerates the saturation/value square so it displays every saturation (X) and value (Y)
-    /// combination for the given <paramref name="hue"/>.
-    /// </summary>
-    /// <param name="hue">The hue in degrees (0-360).</param>
-    void RefreshSaturationValueBackground(float hue);
-}
-
-/// <summary>
 /// A control for visually selecting a color through a saturation/value square and a hue bar.
 /// The selected color is available through <see cref="SelectedColor"/>, and changes raise
 /// <see cref="SelectedColorChanged"/>.
@@ -31,7 +16,16 @@ public class ColorPicker : FrameworkElement
 {
     #region Fields/Properties
 
-    private IColorPickerVisual? _colorPickerVisual;
+    // Internal texture resolution for the procedurally generated backgrounds. The display sprites
+    // stretch it to their on-screen size, so it's independent of layout.
+    private const int SaturationValueTextureSize = 256;
+    private const int HueTextureHeight = 256;
+    private const string HueBarCacheKey = "GumColorPickerHueBar";
+
+    // The sprite children whose textures are generated at runtime. Found by name so any visual --
+    // code-only or tool-authored -- works, as long as it contains sprites with these names.
+    private GraphicalUiElement? _saturationValueDisplay;
+    private GraphicalUiElement? _hueDisplay;
 
     // The interactive areas the user drags on, plus the indicators moved to reflect the selection.
     private InteractiveGue? _saturationValueContainer;
@@ -133,12 +127,14 @@ public class ColorPicker : FrameworkElement
     {
         base.ReactToVisualChanged();
 
-        _colorPickerVisual = Visual as IColorPickerVisual;
-
         _saturationValueContainer = Visual.GetGraphicalUiElementByName("SaturationValueContainer") as InteractiveGue;
         _hueContainer = Visual.GetGraphicalUiElementByName("HueContainer") as InteractiveGue;
+        _saturationValueDisplay = Visual.GetGraphicalUiElementByName("SaturationValueDisplay");
+        _hueDisplay = Visual.GetGraphicalUiElementByName("HueDisplay");
         _saturationValueIndicator = Visual.GetGraphicalUiElementByName("SaturationValueIndicator");
         _hueIndicator = Visual.GetGraphicalUiElementByName("HueIndicator");
+
+        PaintHueBar();
 
         // Push handles the initial click; Dragging continues to fire on the pushed element every
         // frame the cursor moves, even once it leaves the element's bounds, so a drag keeps tracking
@@ -265,7 +261,7 @@ public class ColorPicker : FrameworkElement
         _isUpdatingColor = true;
         try
         {
-            _colorPickerVisual?.RefreshSaturationValueBackground(_hue);
+            PaintSaturationValue();
 
             if (_saturationValueContainer != null && _saturationValueIndicator != null)
             {
@@ -285,6 +281,82 @@ public class ColorPicker : FrameworkElement
         {
             _isUpdatingColor = false;
         }
+    }
+
+    #endregion
+
+    #region Texture Generation
+
+    private void PaintHueBar()
+    {
+        if (_hueDisplay == null)
+        {
+            return;
+        }
+
+        // The hue bar is identical for every picker, so it's generated once and shared via the cache.
+        GraphicalUiElement.ApplyCachedTextureFromPixelData?.Invoke(
+            _hueDisplay, HueBarCacheKey, BuildHueBarPixels(), 1, HueTextureHeight);
+    }
+
+    private void PaintSaturationValue()
+    {
+        if (_saturationValueDisplay == null)
+        {
+            return;
+        }
+
+        // The saturation/value square depends on the current hue, so each picker gets its own pooled
+        // texture (keyed by this control's Visual) rather than a shared one.
+        GraphicalUiElement.ApplyPooledTextureFromPixelData?.Invoke(
+            _saturationValueDisplay, Visual, BuildSaturationValuePixels(_hue),
+            SaturationValueTextureSize, SaturationValueTextureSize);
+    }
+
+    /// <summary>
+    /// Builds the saturation/value square as RGBA bytes for a hue: X is saturation (0-100), Y is value
+    /// (100 at top to 0 at bottom).
+    /// </summary>
+    internal static byte[] BuildSaturationValuePixels(float hue)
+    {
+        int size = SaturationValueTextureSize;
+        byte[] rgba = new byte[size * size * 4];
+        for (int y = 0; y < size; y++)
+        {
+            float value = (1f - (float)y / (size - 1)) * 100f;
+            for (int x = 0; x < size; x++)
+            {
+                float saturation = (float)x / (size - 1) * 100f;
+                (byte r, byte g, byte b) = HsvToRgb(hue, saturation, value);
+                int i = (y * size + x) * 4;
+                rgba[i] = r;
+                rgba[i + 1] = g;
+                rgba[i + 2] = b;
+                rgba[i + 3] = 255;
+            }
+        }
+        return rgba;
+    }
+
+    /// <summary>
+    /// Builds the hue bar as a 1-pixel-wide RGBA column: hue runs 0-360 from top to bottom at full
+    /// saturation and value.
+    /// </summary>
+    internal static byte[] BuildHueBarPixels()
+    {
+        int height = HueTextureHeight;
+        byte[] rgba = new byte[height * 4];
+        for (int y = 0; y < height; y++)
+        {
+            float hue = (float)y / (height - 1) * 360f;
+            (byte r, byte g, byte b) = HsvToRgb(hue, 100f, 100f);
+            int i = y * 4;
+            rgba[i] = r;
+            rgba[i + 1] = g;
+            rgba[i + 2] = b;
+            rgba[i + 3] = 255;
+        }
+        return rgba;
     }
 
     #endregion

--- a/MonoGameGum/Forms/Controls/ColorPicker.cs
+++ b/MonoGameGum/Forms/Controls/ColorPicker.cs
@@ -1,6 +1,9 @@
 using System;
 using Gum.Wireframe;
-using Microsoft.Xna.Framework;
+// System.Drawing.Color is a plain BCL struct (no GDI). The control lives in the runtime-agnostic
+// GumCommon layer alongside the other Forms controls, so it exposes a backend-neutral color rather
+// than any one runtime's native color type.
+using Color = System.Drawing.Color;
 
 namespace Gum.Forms.Controls;
 
@@ -53,7 +56,7 @@ public class ColorPicker : FrameworkElement
     /// </summary>
     public Color SelectedColor
     {
-        get => new Color(_red, _green, _blue);
+        get => Color.FromArgb(_red, _green, _blue);
         set
         {
             if (value.R != _red || value.G != _green || value.B != _blue)

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
@@ -1,0 +1,227 @@
+#pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGameGum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+
+namespace Gum.Forms.DefaultVisuals.V3;
+
+/// <summary>
+/// Default V3 visual for a <see cref="ColorPicker"/> control. Builds a saturation/value square and
+/// a hue bar, each backed by a procedurally generated texture, plus the indicators the control
+/// moves to reflect the selected color. This visual is XNA-family only (MonoGame/KNI/FNA); other
+/// backends require their own texture-generation implementation.
+/// </summary>
+public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
+{
+    private const int SaturationValueSize = 160;
+    private const int HueBarWidth = 20;
+    private const int HueBarHeight = 160;
+    private const int Spacing = 4;
+
+    /// <summary>
+    /// The interactive square displaying every saturation/value combination for the current hue.
+    /// </summary>
+    public ContainerRuntime SaturationValueContainer { get; private set; }
+
+    /// <summary>
+    /// The interactive vertical bar displaying the full range of hues.
+    /// </summary>
+    public ContainerRuntime HueContainer { get; private set; }
+
+    private SpriteRuntime _saturationValueDisplay;
+    private SpriteRuntime _hueDisplay;
+
+    private Texture2D? _saturationValueTexture;
+    private Texture2D? _hueTexture;
+    private Color[]? _saturationValuePixels;
+
+    /// <summary>
+    /// Returns the strongly-typed ColorPicker Forms control backing this visual.
+    /// </summary>
+    public ColorPicker FormsControl => (ColorPicker)FormsControlAsObject;
+
+    /// <summary>
+    /// Creates a new ColorPickerVisual, optionally building the backing Forms control.
+    /// </summary>
+    public ColorPickerVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true) : base(new InvisibleRenderable())
+    {
+        Width = SaturationValueSize + Spacing + HueBarWidth;
+        Height = SaturationValueSize;
+        WidthUnits = DimensionUnitType.Absolute;
+        HeightUnits = DimensionUnitType.Absolute;
+
+        SaturationValueContainer = new ContainerRuntime();
+        SaturationValueContainer.Name = "SaturationValueContainer";
+        SaturationValueContainer.Width = SaturationValueSize;
+        SaturationValueContainer.Height = SaturationValueSize;
+        SaturationValueContainer.HasEvents = true;
+        SaturationValueContainer.ClipsChildren = true;
+        this.AddChild(SaturationValueContainer);
+
+        _saturationValueDisplay = new SpriteRuntime();
+        _saturationValueDisplay.Name = "SaturationValueDisplay";
+        _saturationValueDisplay.Width = 0;
+        _saturationValueDisplay.WidthUnits = DimensionUnitType.RelativeToParent;
+        _saturationValueDisplay.Height = 0;
+        _saturationValueDisplay.HeightUnits = DimensionUnitType.RelativeToParent;
+        _saturationValueDisplay.TextureAddress = global::Gum.Managers.TextureAddress.EntireTexture;
+        SaturationValueContainer.AddChild(_saturationValueDisplay);
+
+        AddOutline(SaturationValueContainer);
+        AddSaturationValueIndicator(SaturationValueContainer);
+
+        HueContainer = new ContainerRuntime();
+        HueContainer.Name = "HueContainer";
+        HueContainer.X = SaturationValueSize + Spacing;
+        HueContainer.Width = HueBarWidth;
+        HueContainer.Height = HueBarHeight;
+        HueContainer.HasEvents = true;
+        HueContainer.ClipsChildren = true;
+        this.AddChild(HueContainer);
+
+        _hueDisplay = new SpriteRuntime();
+        _hueDisplay.Name = "HueDisplay";
+        _hueDisplay.Width = 0;
+        _hueDisplay.WidthUnits = DimensionUnitType.RelativeToParent;
+        _hueDisplay.Height = 0;
+        _hueDisplay.HeightUnits = DimensionUnitType.RelativeToParent;
+        _hueDisplay.TextureAddress = global::Gum.Managers.TextureAddress.EntireTexture;
+        HueContainer.AddChild(_hueDisplay);
+
+        AddOutline(HueContainer);
+        AddHueIndicator(HueContainer);
+
+        GenerateHueTexture();
+        RefreshSaturationValueBackground(0);
+
+        if (tryCreateFormsObject)
+        {
+            FormsControlAsObject = new ColorPicker(this);
+        }
+    }
+
+    private static void AddOutline(ContainerRuntime parent)
+    {
+        RectangleRuntime outline = new RectangleRuntime();
+        outline.IsFilled = false;
+        outline.StrokeColor = new Color((byte)80, (byte)80, (byte)80);
+        outline.Width = 0;
+        outline.WidthUnits = DimensionUnitType.RelativeToParent;
+        outline.Height = 0;
+        outline.HeightUnits = DimensionUnitType.RelativeToParent;
+        parent.AddChild(outline);
+    }
+
+    private static void AddSaturationValueIndicator(ContainerRuntime parent)
+    {
+        ContainerRuntime indicator = new ContainerRuntime();
+        indicator.Name = "SaturationValueIndicator";
+        indicator.Width = 11;
+        indicator.Height = 11;
+        indicator.XOrigin = HorizontalAlignment.Center;
+        indicator.YOrigin = VerticalAlignment.Center;
+        parent.AddChild(indicator);
+
+        AddContrastingOutlinePair(indicator);
+    }
+
+    private static void AddHueIndicator(ContainerRuntime parent)
+    {
+        ContainerRuntime indicator = new ContainerRuntime();
+        indicator.Name = "HueIndicator";
+        indicator.Width = HueBarWidth;
+        indicator.Height = 5;
+        indicator.YOrigin = VerticalAlignment.Center;
+        parent.AddChild(indicator);
+
+        AddContrastingOutlinePair(indicator);
+    }
+
+    // A black outline with a white outline inset one pixel, so the indicator reads against both
+    // light and dark backgrounds.
+    private static void AddContrastingOutlinePair(ContainerRuntime parent)
+    {
+        RectangleRuntime outer = new RectangleRuntime();
+        outer.IsFilled = false;
+        outer.StrokeColor = new Color((byte)0, (byte)0, (byte)0);
+        outer.Width = 0;
+        outer.WidthUnits = DimensionUnitType.RelativeToParent;
+        outer.Height = 0;
+        outer.HeightUnits = DimensionUnitType.RelativeToParent;
+        parent.AddChild(outer);
+
+        RectangleRuntime inner = new RectangleRuntime();
+        inner.IsFilled = false;
+        inner.StrokeColor = new Color((byte)255, (byte)255, (byte)255);
+        inner.X = 1;
+        inner.Y = 1;
+        inner.Width = -2;
+        inner.WidthUnits = DimensionUnitType.RelativeToParent;
+        inner.Height = -2;
+        inner.HeightUnits = DimensionUnitType.RelativeToParent;
+        parent.AddChild(inner);
+    }
+
+    /// <inheritdoc/>
+    public void RefreshSaturationValueBackground(float hue)
+    {
+        GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
+        if (graphicsDevice == null)
+        {
+            return;
+        }
+
+        int width = SaturationValueSize;
+        int height = SaturationValueSize;
+        _saturationValuePixels ??= new Color[width * height];
+
+        for (int y = 0; y < height; y++)
+        {
+            float value = (1f - (float)y / (height - 1)) * 100f;
+            for (int x = 0; x < width; x++)
+            {
+                float saturation = (float)x / (width - 1) * 100f;
+                (byte r, byte g, byte b) = ColorPicker.HsvToRgb(hue, saturation, value);
+                _saturationValuePixels[y * width + x] = new Color(r, g, b);
+            }
+        }
+
+        _saturationValueTexture ??= new Texture2D(graphicsDevice, width, height);
+        _saturationValueTexture.SetData(_saturationValuePixels);
+        _saturationValueDisplay.Texture = _saturationValueTexture;
+    }
+
+    private void GenerateHueTexture()
+    {
+        GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
+        if (graphicsDevice == null)
+        {
+            return;
+        }
+
+        int width = HueBarWidth;
+        int height = HueBarHeight;
+        Color[] pixels = new Color[width * height];
+
+        for (int y = 0; y < height; y++)
+        {
+            float hue = (float)y / (height - 1) * 360f;
+            (byte r, byte g, byte b) = ColorPicker.HsvToRgb(hue, 100f, 100f);
+            Color color = new Color(r, g, b);
+            for (int x = 0; x < width; x++)
+            {
+                pixels[y * width + x] = color;
+            }
+        }
+
+        _hueTexture = new Texture2D(graphicsDevice, width, height);
+        _hueTexture.SetData(pixels);
+        _hueDisplay.Texture = _hueTexture;
+    }
+}

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
@@ -1,23 +1,20 @@
 #pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
-using Gum.Converters;
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using MonoGameGum.GueDeriving;
-using RenderingLibrary;
 using RenderingLibrary.Graphics;
 
 namespace Gum.Forms.DefaultVisuals.V3;
 
 /// <summary>
-/// Default V3 visual for a <see cref="ColorPicker"/> control. Builds a saturation/value square and
-/// a hue bar, each backed by a procedurally generated texture, plus the indicators the control
-/// moves to reflect the selected color. This visual is XNA-family only (MonoGame/KNI/FNA); other
-/// backends require their own texture-generation implementation.
+/// Default V3 visual for a <see cref="ColorPicker"/> control. Builds the saturation/value square, the
+/// hue bar, and the indicators the control moves to reflect the selected color. The square/bar
+/// textures are generated at runtime by the control (via the sprites named "SaturationValueDisplay"
+/// and "HueDisplay"), so this visual is purely structural and backend-agnostic.
 /// </summary>
-public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
+public class ColorPickerVisual : InteractiveGue
 {
     private const int SaturationValueSize = 160;
     private const int HueBarWidth = 20;
@@ -33,13 +30,6 @@ public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
     /// The interactive vertical bar displaying the full range of hues.
     /// </summary>
     public ContainerRuntime HueContainer { get; private set; }
-
-    private SpriteRuntime _saturationValueDisplay;
-    private SpriteRuntime _hueDisplay;
-
-    private Texture2D? _saturationValueTexture;
-    private Texture2D? _hueTexture;
-    private Color[]? _saturationValuePixels;
 
     /// <summary>
     /// Returns the strongly-typed ColorPicker Forms control backing this visual.
@@ -64,15 +54,7 @@ public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
         SaturationValueContainer.ClipsChildren = true;
         this.AddChild(SaturationValueContainer);
 
-        _saturationValueDisplay = new SpriteRuntime();
-        _saturationValueDisplay.Name = "SaturationValueDisplay";
-        _saturationValueDisplay.Width = 0;
-        _saturationValueDisplay.WidthUnits = DimensionUnitType.RelativeToParent;
-        _saturationValueDisplay.Height = 0;
-        _saturationValueDisplay.HeightUnits = DimensionUnitType.RelativeToParent;
-        _saturationValueDisplay.TextureAddress = global::Gum.Managers.TextureAddress.EntireTexture;
-        SaturationValueContainer.AddChild(_saturationValueDisplay);
-
+        AddDisplaySprite(SaturationValueContainer, "SaturationValueDisplay");
         AddOutline(SaturationValueContainer);
         AddSaturationValueIndicator(SaturationValueContainer);
 
@@ -85,25 +67,27 @@ public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
         HueContainer.ClipsChildren = true;
         this.AddChild(HueContainer);
 
-        _hueDisplay = new SpriteRuntime();
-        _hueDisplay.Name = "HueDisplay";
-        _hueDisplay.Width = 0;
-        _hueDisplay.WidthUnits = DimensionUnitType.RelativeToParent;
-        _hueDisplay.Height = 0;
-        _hueDisplay.HeightUnits = DimensionUnitType.RelativeToParent;
-        _hueDisplay.TextureAddress = global::Gum.Managers.TextureAddress.EntireTexture;
-        HueContainer.AddChild(_hueDisplay);
-
+        AddDisplaySprite(HueContainer, "HueDisplay");
         AddOutline(HueContainer);
         AddHueIndicator(HueContainer);
-
-        GenerateHueTexture();
-        RefreshSaturationValueBackground(0);
 
         if (tryCreateFormsObject)
         {
             FormsControlAsObject = new ColorPicker(this);
         }
+    }
+
+    // The sprite that fills the container and whose texture the control generates at runtime.
+    private static void AddDisplaySprite(ContainerRuntime parent, string name)
+    {
+        SpriteRuntime display = new SpriteRuntime();
+        display.Name = name;
+        display.Width = 0;
+        display.WidthUnits = DimensionUnitType.RelativeToParent;
+        display.Height = 0;
+        display.HeightUnits = DimensionUnitType.RelativeToParent;
+        display.TextureAddress = global::Gum.Managers.TextureAddress.EntireTexture;
+        parent.AddChild(display);
     }
 
     private static void AddOutline(ContainerRuntime parent)
@@ -166,62 +150,5 @@ public class ColorPickerVisual : InteractiveGue, IColorPickerVisual
         inner.Height = -2;
         inner.HeightUnits = DimensionUnitType.RelativeToParent;
         parent.AddChild(inner);
-    }
-
-    /// <inheritdoc/>
-    public void RefreshSaturationValueBackground(float hue)
-    {
-        GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
-        if (graphicsDevice == null)
-        {
-            return;
-        }
-
-        int width = SaturationValueSize;
-        int height = SaturationValueSize;
-        _saturationValuePixels ??= new Color[width * height];
-
-        for (int y = 0; y < height; y++)
-        {
-            float value = (1f - (float)y / (height - 1)) * 100f;
-            for (int x = 0; x < width; x++)
-            {
-                float saturation = (float)x / (width - 1) * 100f;
-                (byte r, byte g, byte b) = ColorPicker.HsvToRgb(hue, saturation, value);
-                _saturationValuePixels[y * width + x] = new Color(r, g, b);
-            }
-        }
-
-        _saturationValueTexture ??= new Texture2D(graphicsDevice, width, height);
-        _saturationValueTexture.SetData(_saturationValuePixels);
-        _saturationValueDisplay.Texture = _saturationValueTexture;
-    }
-
-    private void GenerateHueTexture()
-    {
-        GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
-        if (graphicsDevice == null)
-        {
-            return;
-        }
-
-        int width = HueBarWidth;
-        int height = HueBarHeight;
-        Color[] pixels = new Color[width * height];
-
-        for (int y = 0; y < height; y++)
-        {
-            float hue = (float)y / (height - 1) * 360f;
-            (byte r, byte g, byte b) = ColorPicker.HsvToRgb(hue, 100f, 100f);
-            Color color = new Color(r, g, b);
-            for (int x = 0; x < width; x++)
-            {
-                pixels[y * width + x] = color;
-            }
-        }
-
-        _hueTexture = new Texture2D(graphicsDevice, width, height);
-        _hueTexture.SetData(pixels);
-        _hueDisplay.Texture = _hueTexture;
     }
 }

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -228,6 +228,11 @@ public class FormsUtilities
                 TryAdd(typeof(ScrollViewer), (_, c) => new DefaultVisuals.V3.ScrollViewerVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(TextBox), (_, c) => new DefaultVisuals.V3.TextBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Slider), (_, c) => new DefaultVisuals.V3.SliderVisual(tryCreateFormsObject: c));
+#if XNALIKE
+                // ColorPickerVisual generates its saturation/value and hue textures per-pixel, which
+                // is XNA-family only for now. Raylib/Skia need their own visual (issue #4047).
+                TryAdd(typeof(ColorPicker), (_, c) => new DefaultVisuals.V3.ColorPickerVisual(tryCreateFormsObject: c));
+#endif
                 TryAdd(typeof(Splitter), (_, c) => new DefaultVisuals.V3.SplitterVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ToggleButton), (_, c) => new DefaultVisuals.V3.ToggleButtonVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Window), (_, c) => new DefaultVisuals.V3.WindowVisual(tryCreateFormsObject: c));

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -166,6 +166,7 @@
 		<Compile Remove="..\Forms\VisualTemplate.cs" />
 		<Compile Remove="..\Forms\Controls\Button.cs" />
 		<Compile Remove="..\Forms\Controls\CheckBox.cs" />
+		<Compile Remove="..\Forms\Controls\ColorPicker.cs" />
 		<Compile Remove="..\Forms\Controls\ColumnDefinition.cs" />
 		<Compile Remove="..\Forms\Controls\ComboBox.cs" />
 		<Compile Remove="..\Forms\Controls\Expander.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -143,6 +143,7 @@
 		<Compile Remove="Forms\VisualTemplate.cs" />
 		<Compile Remove="Forms\Controls\Button.cs" />
 		<Compile Remove="Forms\Controls\CheckBox.cs" />
+		<Compile Remove="Forms\Controls\ColorPicker.cs" />
 		<Compile Remove="Forms\Controls\ColumnDefinition.cs" />
 		<Compile Remove="Forms\Controls\ComboBox.cs" />
 		<Compile Remove="Forms\Controls\Expander.cs" />

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -267,6 +267,8 @@ public partial class SystemManagers : ISystemManagers
             //GraphicalUiElement.CanvasWidth = graphicsDevice.Viewport.Width;
             //GraphicalUiElement.CanvasHeight = graphicsDevice.Viewport.Height;
             GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+            GraphicalUiElement.ApplyCachedTextureFromPixelData = PixelDataTextureApplier.ApplyCached;
+            GraphicalUiElement.ApplyPooledTextureFromPixelData = PixelDataTextureApplier.ApplyPooled;
             CustomSetPropertyOnRenderable.LocalizationService ??= new LocalizationService();
             GraphicalUiElement.UpdateFontFromProperties = CustomSetPropertyOnRenderable.UpdateToFontValues;
             GraphicalUiElement.ThrowExceptionsForMissingFiles = CustomSetPropertyOnRenderable.ThrowExceptionsForMissingFiles;
@@ -455,5 +457,94 @@ public partial class SystemManagers : ISystemManagers
     public void InvalidateSurface()
     {
         throw new NotImplementedException();
+    }
+}
+
+/// <summary>
+/// XNA-family backend for <see cref="GraphicalUiElement.ApplyCachedTextureFromPixelData"/> and
+/// <see cref="GraphicalUiElement.ApplyPooledTextureFromPixelData"/>. Cached textures live in the
+/// <see cref="LoaderManager"/> (shared across instances, disposed on content unload). Pooled textures
+/// are reused across control instances, reclaiming entries whose owner has detached from the visual
+/// tree, so repeated create/destroy cycles never grow the pool.
+/// </summary>
+internal static class PixelDataTextureApplier
+{
+    private class PoolEntry
+    {
+        public PoolEntry(Texture2D texture) => Texture = texture;
+        public Texture2D Texture { get; }
+        public GraphicalUiElement? Owner { get; set; }
+    }
+
+    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+
+    public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        LoaderManager loader = LoaderManager.Self;
+        Texture2D? texture = loader.TryGetCachedDisposable<Texture2D>(cacheKey);
+        if (texture == null)
+        {
+            GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
+            if (graphicsDevice == null)
+            {
+                return;
+            }
+            texture = new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color);
+            texture.SetData(rgba);
+            loader.AddDisposable(cacheKey, texture);
+        }
+
+        sprite.Texture = texture;
+    }
+
+    public static void ApplyPooled(GraphicalUiElement target, GraphicalUiElement owner, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        GraphicsDevice? graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice;
+        if (graphicsDevice == null)
+        {
+            return;
+        }
+
+        PoolEntry? entry = null;
+        PoolEntry? reclaimable = null;
+        foreach (PoolEntry candidate in Pool)
+        {
+            if (candidate.Owner == owner)
+            {
+                entry = candidate;
+                break;
+            }
+            // An entry whose owner has left the visual tree (removed from root) can be reused.
+            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
+            {
+                reclaimable = candidate;
+            }
+        }
+
+        if (entry == null)
+        {
+            entry = reclaimable ?? AddPoolEntry(graphicsDevice, width, height);
+            entry.Owner = owner;
+        }
+
+        entry.Texture.SetData(rgba);
+        sprite.Texture = entry.Texture;
+    }
+
+    private static PoolEntry AddPoolEntry(GraphicsDevice graphicsDevice, int width, int height)
+    {
+        PoolEntry entry = new PoolEntry(new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color));
+        Pool.Add(entry);
+        return entry;
     }
 }

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -460,6 +460,9 @@ public partial class SystemManagers : ISystemManagers
     }
 }
 
+// GraphicalUiElement is only in scope under USE_GUMCOMMON (see the using above); FRB, which doesn't
+// define it, provides its own runtime and never uses this applier. Guard to keep the FRB build green.
+#if USE_GUMCOMMON
 /// <summary>
 /// XNA-family backend for <see cref="GraphicalUiElement.ApplyCachedTextureFromPixelData"/> and
 /// <see cref="GraphicalUiElement.ApplyPooledTextureFromPixelData"/>. Cached textures live in the
@@ -548,3 +551,4 @@ internal static class PixelDataTextureApplier
         return entry;
     }
 }
+#endif

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -199,7 +199,6 @@
 	  -->
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Button.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\CheckBox.cs" />
-	  <!-- ColorPicker's default visual generates textures per-pixel via XNA APIs; it's XNALIKE-only until raylib gets its own visual (issue #4047). -->
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ColorPicker.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ColumnDefinition.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ComboBox.cs" />

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -199,6 +199,8 @@
 	  -->
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Button.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\CheckBox.cs" />
+	  <!-- ColorPicker's default visual generates textures per-pixel via XNA APIs; it's XNALIKE-only until raylib gets its own visual (issue #4047). -->
+	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ColorPicker.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ColumnDefinition.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\ComboBox.cs" />
 	  <Compile Remove="..\..\MonoGameGum\Forms\Controls\Expander.cs" />

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -161,7 +161,6 @@
 		-->
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\Button.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\CheckBox.cs" />
-		<!-- ColorPicker's default visual generates textures per-pixel via XNA APIs; it's XNALIKE-only until Sokol gets its own visual (issue #4047). -->
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ColorPicker.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ColumnDefinition.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ComboBox.cs" />

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -161,6 +161,8 @@
 		-->
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\Button.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\CheckBox.cs" />
+		<!-- ColorPicker's default visual generates textures per-pixel via XNA APIs; it's XNALIKE-only until Sokol gets its own visual (issue #4047). -->
+		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ColorPicker.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ColumnDefinition.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\ComboBox.cs" />
 		<Compile Remove="..\..\MonoGameGum\Forms\Controls\Expander.cs" />

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FormsCustomizationScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FormsCustomizationScreen.cs
@@ -101,7 +101,8 @@ internal class FormsCustomizationScreen : ContainerRuntime
 
     private void CreateColorPicker()
     {
-        var picker = new ColorPicker();
+        // Sample's own hand-rolled picker; disambiguated from the new core Gum.Forms.Controls.ColorPicker (issue #4047).
+        var picker = new CustomForms.ColorPicker();
         _mainStackPanel.AddChild(picker);
 
 

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -344,9 +344,12 @@ namespace GumFormsSample.Screens
 
             colorPicker.SelectedColorChanged += (_, _) =>
             {
-                selectedColorSwatch.FillColor = colorPicker.SelectedColor;
+                // SelectedColor is a backend-neutral System.Drawing.Color, so convert to the XNA
+                // color the runtime visual uses.
+                var selected = colorPicker.SelectedColor;
+                selectedColorSwatch.FillColor = new Color(selected.R, selected.G, selected.B);
             };
-            colorPicker.SelectedColor = Color.CornflowerBlue;
+            colorPicker.SelectedColor = System.Drawing.Color.CornflowerBlue;
         }
 
         void CreateLayeredUi()

--- a/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
+++ b/Samples/GumFormsSample/GumFormsSampleCommon/Screens/FrameworkElementExampleScreen.cs
@@ -330,6 +330,23 @@ namespace GumFormsSample.Screens
             text.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
             text.Text = "abcdefghijklmnopqrstuvwxyz";
             stackPanel.AddChild(text);
+
+            // ColorPicker (issue #4047). Built through its visual type, mirroring the button above.
+            var colorPickerVisual = new Gum.Forms.DefaultVisuals.V3.ColorPickerVisual();
+            var colorPicker = colorPickerVisual.FormsControl;
+            stackPanel.AddChild(colorPickerVisual);
+
+            var selectedColorSwatch = new RectangleRuntime();
+            selectedColorSwatch.IsFilled = true;
+            selectedColorSwatch.Width = 60;
+            selectedColorSwatch.Height = 24;
+            stackPanel.AddChild(selectedColorSwatch);
+
+            colorPicker.SelectedColorChanged += (_, _) =>
+            {
+                selectedColorSwatch.FillColor = colorPicker.SelectedColor;
+            };
+            colorPicker.SelectedColor = Color.CornflowerBlue;
         }
 
         void CreateLayeredUi()

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -222,6 +222,7 @@
 * [Controls](code/controls/README.md)
   * [Button](code/controls/button.md)
   * [CheckBox](code/controls/checkbox.md)
+  * [ColorPicker](code/controls/colorpicker.md)
   * [ComboBox](code/controls/combobox.md)
   * [DialogBox](code/controls/dialogbox.md)
   * [File Dialog (native)](code/controls/file-dialog-native.md)

--- a/docs/code/controls/colorpicker.md
+++ b/docs/code/controls/colorpicker.md
@@ -1,0 +1,81 @@
+# ColorPicker
+
+## Introduction
+
+The ColorPicker control lets the user pick a color by dragging in a saturation/value square and a hue bar. The chosen color is available through `SelectedColor`, and changes raise `SelectedColorChanged`.
+
+{% hint style="info" %}
+The saturation/value square and hue bar are drawn with textures generated at runtime. This generation is currently implemented for the MonoGame family (MonoGame, KNI, and FNA). On other backends the control still works, but the two backgrounds render empty until that backend implements the texture seam.
+{% endhint %}
+
+## Code Example: Creating a ColorPicker
+
+The following code creates a ColorPicker and shows the selected color as a hex string in a Label whenever it changes.
+
+```csharp
+// Initialize
+var label = new Label();
+label.AddToRoot();
+label.X = 50;
+label.Y = 24;
+
+var colorPicker = new ColorPicker();
+colorPicker.AddToRoot();
+colorPicker.X = 50;
+colorPicker.Y = 50;
+colorPicker.SelectedColor = System.Drawing.Color.CornflowerBlue;
+colorPicker.SelectedColorChanged += (_, _) =>
+{
+    var color = colorPicker.SelectedColor;
+    label.Text = $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+};
+```
+
+{% hint style="warning" %}
+Screenshot pending.
+{% endhint %}
+
+## SelectedColor
+
+`SelectedColor` is a `System.Drawing.Color` representing the currently selected color. It is a backend-neutral type (a plain struct with no dependency on any runtime), so assigning it to a runtime visual requires converting to that runtime's own color type:
+
+```csharp
+// Initialize
+var color = colorPicker.SelectedColor;
+// MonoGame example: convert to an XNA color for a rectangle's FillColor
+var xnaColor = new Microsoft.Xna.Framework.Color(color.R, color.G, color.B);
+```
+
+Setting `SelectedColor` updates the hue/saturation/value state, repositions the indicators, and raises `SelectedColorChanged`.
+
+## Hue, Saturation, and Value
+
+`Hue`, `Saturation`, and `Value` are `float` properties that expose the HSV representation of the selected color, kept in sync with `SelectedColor`:
+
+* `Hue` — 0 to 360
+* `Saturation` — 0 to 100
+* `Value` — 0 to 100
+
+Setting any of them updates `SelectedColor` and raises `SelectedColorChanged`. Values outside the valid range are clamped.
+
+```csharp
+// Initialize
+colorPicker.Hue = 120;        // green
+colorPicker.Saturation = 100;
+colorPicker.Value = 100;
+```
+
+## Customizing the Visual
+
+Like all Forms controls, ColorPicker is lookless — its `Visual` can be any element tree, whether the built-in `ColorPickerVisual`, a component authored in the Gum tool, or a custom `InteractiveGue`. The control locates the pieces it drives **by name**, so a custom visual only needs to contain elements with the following names:
+
+| Named child | Expected type | Purpose | Needed? |
+|---|---|---|---|
+| `SaturationValueContainer` | `InteractiveGue` with events enabled | Drag surface; horizontal position sets saturation, vertical sets value | Required to pick saturation/value |
+| `SaturationValueDisplay` | Sprite (e.g. `SpriteRuntime`) | Shows the saturation/value gradient; the control generates its texture | Required to see the square |
+| `HueContainer` | `InteractiveGue` with events enabled | Drag surface; vertical position sets hue | Required to pick hue |
+| `HueDisplay` | Sprite (e.g. `SpriteRuntime`) | Shows the hue gradient; the control generates its texture | Required to see the hue bar |
+| `SaturationValueIndicator` | Any element | Marker moved to the current saturation/value point | Optional |
+| `HueIndicator` | Any element | Marker moved to the current hue | Optional |
+
+Every lookup is null-safe, so a missing element never throws — the corresponding feature is simply inactive. Two type requirements matter: the container elements must have events enabled to receive drag input, and the display elements must be sprites for the generated textures to appear.


### PR DESCRIPTION
Closes #4047.

Brings a color picker into core Gum Forms, following the control/visual split. Scope: minimal HSV picker (SV square + hue bar). The control is backend-neutral; texture generation goes through a backend seam.

## What's here
- `ColorPicker` (Forms control, **GumCommon** — universal, like the other controls): HSV state, `SelectedColor` (backend-neutral `System.Drawing.Color`), `SelectedColorChanged`, RGB↔HSV math, and the neutral pixel generation for the SV square / hue bar. Cursor drag picks the color and tracks outside the bounds via `Dragging` (like Slider/ScrollBar). It finds its display sprites **by name** (`SaturationValueDisplay` / `HueDisplay`), so any visual works.
- `ColorPickerVisual` (V3 default visual): purely structural — builds the containers, named sprites, and indicators. No texture code.
- **Texture seam** on `GraphicalUiElement` (mirrors `SetPropertyOnRenderable`): `ApplyCachedTextureFromPixelData` (shared, LoaderManager-cached — the hue bar) and `ApplyPooledTextureFromPixelData` (per-owner pooled, reclaimed when the owner detaches — the SV square). XNA-family impl in `RenderingLibrary/SystemManagers`.

## Why the seam (not an interface)
An `IColorPickerVisual`-style interface can only be satisfied by a code-authored visual. A tool-authored (`.gumx`) visual is just a sprite tree and can't implement it or run texture code. The seam + named-sprite lookup means a from-file ColorPicker built purely from sprites in the Gum tool works with no per-backend visual class.

## Texture lifecycle
- Hue bar: one shared texture, cached in the content manager, reused everywhere.
- SV square: one texture per picker, reused via `SetData` on hue change (no per-drag allocation). Pooled across instances and reclaimed when a picker detaches (`Visual.Parent == null` after `RemoveFromRoot`), so churning in/out of a screen never grows GPU memory — no teardown hook needed.

## Cross-platform
- Control compiles on every backend (GumCommon). Consumers convert `SelectedColor` to their native color on assignment, as the sample shows.
- The texture seam is wired for the XNA family (MonoGame/KNI/FNA). Raylib/Skia leave it null until they implement it (~a few lines each) — no per-backend visual required for the from-file path.

## Deferred (follow-ups)
- Raylib/Skia seam implementations.
- Text inputs (hex / RGB / HSL), swatches, optional modal dialog wrapper.
- FRB support (add to FlatRedBall.Forms.Shared.projitems).

## Tests
`ColorPickerTests`: RGB↔HSV conversion, SV-square pixel corners, `SelectedColor`/`Hue` sync, event-fires-once, hue clamping. Behavior tests construct `ColorPickerVisual` directly (the harness inits V1). Demoed in the MonoGame Forms sample (`FrameworkElementExampleScreen`, screen 2).
