### PR TITLE
Independent drop-shadow color via two-pass runtime draw (#4001)

### DIFF
--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -68,11 +68,10 @@ public static class GumFontGenerator
     /// </summary>
     private static void ApplyChannelLayout(BmfcSave bmfcSave, FontGeneratorOptions options)
     {
-        // Drop shadow (and outline/shadow combos) are composited to RGBA by KernSmith's effect
-        // pipeline. A custom ChannelConfig routes through ChannelCompositor, which rebuilds RGB from
-        // alpha masks only — discarding baked shadow color and forcing white (RGB=One), so the
-        // runtime's text-color modulate tints the shadow the same as the glyph. Leave Channels unset
-        // so AtlasBuilder blits the RGBA glyphs directly.
+        // Issue #4001: drop shadow is a ShadowSilhouette atlas variant (see ApplyShadowOptions), and
+        // KernSmith forbids a custom ChannelConfig alongside Variants. Leave Channels at the default
+        // glyph-coverage layout so the primary stays a plain glyph atlas the runtime can tint on its
+        // own, with the shadow drawn separately underneath.
         if (bmfcSave.HasDropshadow)
         {
             return;
@@ -106,13 +105,15 @@ public static class GumFontGenerator
             return;
         }
 
-        options.ShadowOffsetX = (int)MathF.Round(bmfcSave.DropshadowOffsetX);
-        options.ShadowOffsetY = (int)MathF.Round(bmfcSave.DropshadowOffsetY);
-        options.ShadowBlur = (int)MathF.Round(bmfcSave.DropshadowBlur);
-        options.ShadowR = bmfcSave.DropshadowRed;
-        options.ShadowG = bmfcSave.DropshadowGreen;
-        options.ShadowB = bmfcSave.DropshadowBlue;
-        options.ShadowOpacity = bmfcSave.DropshadowAlpha / 255f;
+        // Issue #4001: request a ShadowSilhouette variant packed into the same shared atlas as the
+        // primary glyphs, instead of baking a colored shadow into the primary. Offset and color are
+        // applied by the runtime at draw time, so BlurRadius is the only shadow parameter that
+        // affects the baked silhouette shape.
+        options.Variants = new[]
+        {
+            new AtlasVariant("shadow", AtlasVariantKind.ShadowSilhouette,
+                BlurRadius: (int)MathF.Round(bmfcSave.DropshadowBlur)),
+        };
     }
 
     /// <summary>

--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.16.0" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.16.0" />
+    <PackageReference Include="KernSmith" Version="0.18.0" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -126,6 +126,22 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
         Assert.Throws<InvalidOperationException>(() => new BitmapFont((Texture2D)null!, bmFontData));
     }
 
+    [Theory]
+    [InlineData("FontCache/Font24Arial_ds2.fnt", "FontCache/Font24Arial_ds2-shadow.fnt")]
+    [InlineData("Font18Arial.FNT", "Font18Arial-shadow.fnt")]
+    public void GetShadowSiblingFntPath_AppendsShadowSuffix(string fontFile, string expected)
+    {
+        BitmapFont.GetShadowSiblingFntPath(fontFile).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("Font18Arial_0.png")]
+    [InlineData("FontCache/Font24Arial")]
+    public void GetShadowSiblingFntPath_ReturnsNull_ForNonFntPath(string fontFile)
+    {
+        BitmapFont.GetShadowSiblingFntPath(fontFile).ShouldBeNull();
+    }
+
     [Fact]
     public void MeasureString_ShouldProperlyMeasureWhitespace()
     {

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -444,6 +444,7 @@ public class TextRuntime : InteractiveGue
 
             hasDropshadow = value;
             UpdateToFontValues();
+            ApplyDropshadowToRenderable();
         }
     }
 
@@ -472,45 +473,46 @@ public class TextRuntime : InteractiveGue
             dropshadowAlpha = value.A;
 #endif
             UpdateToFontValues();
+            ApplyDropshadowToRenderable();
         }
     }
 
     public int DropshadowRed
     {
         get => dropshadowRed;
-        set { dropshadowRed = (byte)value; UpdateToFontValues(); }
+        set { dropshadowRed = (byte)value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     public int DropshadowGreen
     {
         get => dropshadowGreen;
-        set { dropshadowGreen = (byte)value; UpdateToFontValues(); }
+        set { dropshadowGreen = (byte)value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     public int DropshadowBlue
     {
         get => dropshadowBlue;
-        set { dropshadowBlue = (byte)value; UpdateToFontValues(); }
+        set { dropshadowBlue = (byte)value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     public int DropshadowAlpha
     {
         get => dropshadowAlpha;
-        set { dropshadowAlpha = (byte)value; UpdateToFontValues(); }
+        set { dropshadowAlpha = (byte)value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     float dropshadowOffsetX;
     public float DropshadowOffsetX
     {
         get => dropshadowOffsetX;
-        set { dropshadowOffsetX = value; UpdateToFontValues(); }
+        set { dropshadowOffsetX = value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     float dropshadowOffsetY;
     public float DropshadowOffsetY
     {
         get => dropshadowOffsetY;
-        set { dropshadowOffsetY = value; UpdateToFontValues(); }
+        set { dropshadowOffsetY = value; UpdateToFontValues(); ApplyDropshadowToRenderable(); }
     }
 
     float dropshadowBlur;
@@ -574,6 +576,22 @@ public class TextRuntime : InteractiveGue
             _dropshadowBlurY = dropshadowBlur;
 #endif
         }
+    }
+
+    /// <summary>
+    /// Issue #4001: forwards the dropshadow color/offset to the XNALIKE Text renderable so the runtime
+    /// draws the shadow as a second (offset, independently tinted) pass under the glyphs. Skia renders
+    /// its own blurred shadow, and raylib's separate Text/Raylib_cs.Font stack does not yet implement
+    /// the two-pass shadow, so this is XNALIKE-only.
+    /// </summary>
+    void ApplyDropshadowToRenderable()
+    {
+#if XNALIKE
+        ContainedText.HasDropshadow = HasDropshadow;
+        ContainedText.DropshadowColor = DropshadowColor.ToContainerColor();
+        ContainedText.DropshadowOffsetX = DropshadowOffsetX;
+        ContainedText.DropshadowOffsetY = DropshadowOffsetY;
+#endif
     }
 
 #if !FRB

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -111,6 +111,14 @@ public class BitmapFont : IDisposable
     /// </summary>
     public BitmapCharacterInfo[] Characters => mCharacterInfo;
 
+    /// <summary>
+    /// Optional companion font holding the drop-shadow silhouette glyphs (issue #4001). When set,
+    /// <see cref="Text"/> draws these offset and tinted underneath the primary glyphs. Loaded from
+    /// the "-shadow.fnt" sibling next to this font's .fnt (or attached by an in-memory font creator),
+    /// and shares this font's atlas page(s), so no extra texture is loaded.
+    /// </summary>
+    public BitmapFont? ShadowFont { get; set; }
+
     #endregion
 
     #region Methods
@@ -136,6 +144,37 @@ public class BitmapFont : IDisposable
         ReloadTextures(fontFile, fontContents);
 
         SetFontPattern();
+
+        LoadShadowSiblingIfPresent(fontFile);
+    }
+
+    /// <summary>
+    /// Issue #4001: if a "-shadow.fnt" sibling exists next to <paramref name="fontFile"/> (written by
+    /// the font generator for a dropshadow font, sharing the same PNG), load it as <see cref="ShadowFont"/>.
+    /// The sibling has no "-shadow.fnt" of its own, so this does not recurse.
+    /// </summary>
+    private void LoadShadowSiblingIfPresent(string fontFile)
+    {
+        string? shadowFile = GetShadowSiblingFntPath(fontFile);
+        if (shadowFile != null && FileManager.FileExists(shadowFile))
+        {
+            ShadowFont = new BitmapFont(shadowFile);
+        }
+    }
+
+    /// <summary>
+    /// Returns the "-shadow.fnt" sibling path for a primary .fnt path, or null if the path is not a
+    /// .fnt. The sibling is not itself a .fnt+"-shadow", so loading it does not recurse (issue #4001).
+    /// </summary>
+    public static string? GetShadowSiblingFntPath(string fontFile)
+    {
+        const string fntExtension = ".fnt";
+        if (!fontFile.EndsWith(fntExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return fontFile.Substring(0, fontFile.Length - fntExtension.Length) + "-shadow" + fntExtension;
     }
 
     private bool ContainsAscii(string s)

--- a/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
+++ b/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
@@ -705,14 +705,11 @@ public class BmfcSave
 
         if (hasDropshadow)
         {
-            fileName += "_ds"
-                + FormatCacheKeyFloat(dropshadowOffsetX) + "_"
-                + FormatCacheKeyFloat(dropshadowOffsetY) + "_"
-                + FormatCacheKeyFloat(dropshadowBlur) + "_"
-                + dropshadowRed + "_"
-                + dropshadowGreen + "_"
-                + dropshadowBlue + "_"
-                + dropshadowAlpha;
+            // Issue #4001: the shadow is drawn at runtime as a separate silhouette, offset and
+            // tinted at draw time, so offset and color no longer affect the baked atlas and are
+            // deliberately excluded from the cache key (including them forced needless regeneration
+            // on every tweak). Only blur, which shapes the baked silhouette, remains.
+            fileName += "_ds" + FormatCacheKeyFloat(dropshadowBlur);
         }
 
         fileName += ".fnt";

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -147,7 +147,18 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         }
     }
 
-    
+    /// <summary>
+    /// When true and the active <see cref="BitmapFont"/> has a <see cref="Fonts.BitmapFont.ShadowFont"/>,
+    /// a drop shadow is drawn as a second pass (issue #4001): the shadow silhouette is drawn offset by
+    /// <see cref="DropshadowOffsetX"/>/<see cref="DropshadowOffsetY"/> and tinted <see cref="DropshadowColor"/>,
+    /// with the primary glyphs drawn on top. This keeps text and shadow color independent, which baking
+    /// the shadow into the atlas could not.
+    /// </summary>
+    public bool HasDropshadow;
+    public Color DropshadowColor = Color.FromArgb(180, 0, 0, 0);
+    public float DropshadowOffsetX;
+    public float DropshadowOffsetY;
+
     List<string> mWrappedText = new List<string>();
     float? mWidth = 200;
     float mHeight = 200;
@@ -1052,6 +1063,23 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                 }
                 else
                 {
+                    if (HasDropshadow && fontToUse.ShadowFont != null)
+                    {
+                        // Issue #4001: draw the shadow silhouette first, offset and tinted, so the
+                        // primary glyphs land on top of it. The offset scales with the font so it
+                        // stays proportional when the text is scaled.
+                        fontToUse.ShadowFont.DrawTextLines(WrappedText,
+                            HorizontalAlignment,
+                            this,
+                            requiredWidth, widths, spriteRenderer, DropshadowColor,
+                            absoluteLeft + DropshadowOffsetX * EffectiveFontScale,
+                            absoluteTop + DropshadowOffsetY * EffectiveFontScale,
+                            this.GetAbsoluteRotation(),
+                            EffectiveFontScale, EffectiveFontScale, maxLettersToShow,
+                            OverrideTextRenderingPositionMode, lineHeightMultiplier: LineHeightMultiplier,
+                            overlapDirection: OverlapDirection);
+                    }
+
                     fontToUse.DrawTextLines(WrappedText,
                         HorizontalAlignment,
                         this,
@@ -1099,6 +1127,19 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             if (substrings.Count == 0)
             {
                 lineByLineList[0] = lineOfText;
+
+                if (HasDropshadow && fontToUse.ShadowFont != null)
+                {
+                    fontToUse.ShadowFont.DrawTextLines(lineByLineList, HorizontalAlignment,
+                        this,
+                        requiredWidth, widths, spriteRenderer, DropshadowColor,
+                        absoluteLeft + DropshadowOffsetX * EffectiveFontScale,
+                        topOfLine + DropshadowOffsetY * EffectiveFontScale,
+                        this.GetAbsoluteRotation(), EffectiveFontScale,
+                        EffectiveFontScale, lettersLeft, OverrideTextRenderingPositionMode, lineHeightMultiplier: LineHeightMultiplier,
+                        overlapDirection: OverlapDirection);
+                }
+
                 fontToUse.DrawTextLines(lineByLineList, HorizontalAlignment,
                     this,
                     requiredWidth, widths, spriteRenderer, color,
@@ -1263,6 +1304,26 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
                     var baselineDifference = maxBaseline - (fontScale * effectiveFont.BaselineY);
                     effectiveTopOfLine += baselineDifference;
+
+                    if (HasDropshadow && effectiveFont.ShadowFont != null)
+                    {
+                        effectiveFont.ShadowFont.DrawTextLines(lineByLineList, HorizontalAlignment,
+                            this,
+                            requiredWidth,
+                            individualLineWidth,
+                            spriteRenderer,
+                            DropshadowColor,
+                            absoluteLeft + xOffset + DropshadowOffsetX * fontScale,
+                            effectiveTopOfLine + yOffset + DropshadowOffsetY * fontScale,
+                            rotation + rotationOffset,
+                            fontScale * scaleX,
+                            fontScale * scaleY,
+                            lettersLeft,
+                            OverrideTextRenderingPositionMode,
+                            lineHeightMultiplier: LineHeightMultiplier,
+                            shiftForOutline: substringIndex == 0,
+                            overlapDirection: OverlapDirection);
+                    }
 
                     var rect = effectiveFont.DrawTextLines(lineByLineList, HorizontalAlignment,
                         this,

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationShadowSiblingTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationShadowSiblingTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Gum.ProjectServices.FontGeneration;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Issue #4001 — a dropshadow font now consists of a primary .fnt plus a sibling "-shadow.fnt"
+/// (the shadow silhouette, sharing the same PNG). The regeneration check must treat the font as
+/// missing when the sibling is absent, so a primary left over without its shadow sibling
+/// regenerates instead of silently rendering with no shadow.
+/// </summary>
+public class HeadlessFontGenerationShadowSiblingTests : IDisposable
+{
+    private readonly string _projectDirectory;
+
+    public HeadlessFontGenerationShadowSiblingTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), "GumShadowRegen_" + Guid.NewGuid().ToString("N"))
+            + Path.DirectorySeparatorChar;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_projectDirectory))
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RegeneratesWhenShadowSiblingMissing()
+    {
+        BmfcSave bmfcSave = ShadowBmfcSave();
+        WritePrimaryFntOnly(bmfcSave);
+
+        RecordingFontFileGenerator generator = new RecordingFontFileGenerator();
+        new HeadlessFontGenerationService(generator)
+            .CreateFontIfNecessary(bmfcSave, _projectDirectory, autoSizeFontOutputs: false);
+
+        generator.CallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void SkipsRegenerationWhenBothPrimaryAndShadowSiblingExist()
+    {
+        BmfcSave bmfcSave = ShadowBmfcSave();
+        WritePrimaryFntOnly(bmfcSave);
+        WriteShadowSibling(bmfcSave);
+
+        RecordingFontFileGenerator generator = new RecordingFontFileGenerator();
+        new HeadlessFontGenerationService(generator)
+            .CreateFontIfNecessary(bmfcSave, _projectDirectory, autoSizeFontOutputs: false);
+
+        generator.CallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void NonDropshadowFont_WithPrimaryPresent_DoesNotRegenerate()
+    {
+        BmfcSave bmfcSave = new BmfcSave { FontName = "Arial", FontSize = 24 };
+        WritePrimaryFntOnly(bmfcSave);
+
+        RecordingFontFileGenerator generator = new RecordingFontFileGenerator();
+        new HeadlessFontGenerationService(generator)
+            .CreateFontIfNecessary(bmfcSave, _projectDirectory, autoSizeFontOutputs: false);
+
+        generator.CallCount.ShouldBe(0);
+    }
+
+    private static BmfcSave ShadowBmfcSave() => new BmfcSave
+    {
+        FontName = "Arial",
+        FontSize = 24,
+        HasDropshadow = true,
+        DropshadowBlur = 2f,
+    };
+
+    private string PrimaryPath(BmfcSave bmfcSave) => Path.Combine(_projectDirectory, bmfcSave.FontCacheFileName);
+
+    private void WritePrimaryFntOnly(BmfcSave bmfcSave)
+    {
+        string primary = PrimaryPath(bmfcSave);
+        Directory.CreateDirectory(Path.GetDirectoryName(primary)!);
+        File.WriteAllText(primary, "");
+    }
+
+    private void WriteShadowSibling(BmfcSave bmfcSave)
+    {
+        string primary = PrimaryPath(bmfcSave);
+        string sibling = primary.Substring(0, primary.Length - ".fnt".Length) + "-shadow.fnt";
+        File.WriteAllText(sibling, "");
+    }
+
+    private sealed class RecordingFontFileGenerator : IFontFileGenerator
+    {
+        public bool RequiresSizeEstimation { get; init; }
+        public int CallCount { get; private set; }
+
+        public Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
+        {
+            CallCount++;
+            return Task.FromResult(GeneralResponse.SuccessfulResponse);
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorShadowTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorShadowTests.cs
@@ -1,32 +1,46 @@
 using Gum.ProjectServices.FontGeneration;
 using KernSmith;
-using KernSmith.Atlas;
 using KernSmith.Output;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
-using System;
+using System.Linq;
 using Xunit;
 
 namespace Gum.ProjectServices.Tests;
 
 /// <summary>
-/// Issue #4005 — the tool's own disk-based KernSmith generator (used by
-/// HeadlessFontGenerationService/FontFileGeneratorSelector when a project's FontGenerator is
-/// KernSmith) has its own private BuildOptions, duplicated from (and independent of)
-/// KernSmith.Gum.GumFontGenerator.BuildOptions. That copy never mapped BmfcSave's dropshadow
-/// fields onto FontGeneratorOptions at all, so toggling "Has Dropshadow" in the tool regenerated
-/// a font file (the cache key changed) but the file never actually had a shadow baked into it.
+/// Issue #4001 — dropshadow is now rendered as a two-pass draw at runtime (a shadow silhouette
+/// drawn offset + tinted under the primary glyph) instead of being baked into the primary atlas.
+/// The tool's disk-based KernSmith generator must therefore request a ShadowSilhouette
+/// <see cref="AtlasVariant"/> (packed into the same shared PNG) and leave the primary atlas a
+/// plain glyph atlas — NOT bake shadow offset/color into it, which was the source of the
+/// re-tinting bug.
 /// </summary>
 public class KernSmithFileGeneratorShadowTests
 {
     [Fact]
-    public void BuildOptions_WhenHasDropshadow_MapsShadowFieldsAndDecomposesAlphaToOpacity()
+    public void BuildOptions_WhenHasDropshadow_RequestsShadowSilhouetteVariantWithBlur()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = true;
+        bmfcSave.DropshadowBlur = 4f;
+
+        FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
+
+        options.Variants.ShouldNotBeNull();
+        AtlasVariant variant = options.Variants.Single();
+        variant.Name.ShouldBe("shadow");
+        variant.Kind.ShouldBe(AtlasVariantKind.ShadowSilhouette);
+        variant.BlurRadius.ShouldBe(4);
+    }
+
+    [Fact]
+    public void BuildOptions_WhenHasDropshadow_DoesNotBakeShadowIntoPrimary()
     {
         BmfcSave bmfcSave = BaseBmfcSave();
         bmfcSave.HasDropshadow = true;
         bmfcSave.DropshadowOffsetX = 2f;
         bmfcSave.DropshadowOffsetY = 3f;
-        bmfcSave.DropshadowBlur = 4f;
         bmfcSave.DropshadowRed = 10;
         bmfcSave.DropshadowGreen = 20;
         bmfcSave.DropshadowBlue = 30;
@@ -34,32 +48,21 @@ public class KernSmithFileGeneratorShadowTests
 
         FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
 
-        options.ShadowOffsetX.ShouldBe(2);
-        options.ShadowOffsetY.ShouldBe(3);
-        options.ShadowBlur.ShouldBe(4);
-        ((int)options.ShadowR).ShouldBe(10);
-        ((int)options.ShadowG).ShouldBe(20);
-        ((int)options.ShadowB).ShouldBe(30);
-        options.ShadowOpacity.ShouldBe(128 / 255f, 0.001f);
-    }
-
-    [Fact]
-    public void BuildOptions_WhenHasDropshadow_LeavesChannelsUnsetSoAtlasPreservesShadowRgb()
-    {
-        BmfcSave bmfcSave = BaseBmfcSave();
-        bmfcSave.HasDropshadow = true;
-
-        FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
-
+        // KernSmith bakes a shadow into the primary only when HasShadow is true (any offset or
+        // blur set on the options). Leaving all three at 0 keeps the primary a plain glyph atlas —
+        // baking the shadow in is exactly the re-tinting bug this fixes.
+        options.ShadowOffsetX.ShouldBe(0);
+        options.ShadowOffsetY.ShouldBe(0);
+        options.ShadowBlur.ShouldBe(0);
+        // Variants require the default channel layout (a custom ChannelConfig throws in KernSmith).
         options.Channels.ShouldBeNull();
     }
 
     [Fact]
-    public void BuildOptions_ThenGenerate_WithDropshadow_BakesDarkPixelsIntoTheAtlas()
+    public void BuildOptions_ThenGenerate_WithDropshadow_ProducesShadowVariantAndCleanPrimary()
     {
-        // Shortcut end-to-end proof (bypassing disk I/O and the tool entirely): feed the tool's own
-        // BuildOptions output straight into KernSmith's generator and confirm the in-memory atlas
-        // actually contains dark (shadow) pixels rather than only white glyph pixels.
+        // End-to-end proof (bypassing disk I/O): a separate "shadow" variant model should exist
+        // with one entry per requested codepoint, packed into the same shared atlas as the primary.
         BmfcSave bmfcSave = BaseBmfcSave();
         bmfcSave.Ranges = "65";
         bmfcSave.HasDropshadow = true;
@@ -74,11 +77,8 @@ public class KernSmithFileGeneratorShadowTests
         FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
         BmFontResult result = BmFont.GenerateFromSystem(bmfcSave.FontName, options);
 
-        (int minR, int darkPixelCount, int brightPixelCount) = SummarizeRedChannel(result);
-
-        darkPixelCount.ShouldBeGreaterThan(0, "the atlas should contain dark shadow pixels, not just white glyph pixels");
-        brightPixelCount.ShouldBeGreaterThan(0, "the glyph itself should still be present");
-        minR.ShouldBeLessThan(32);
+        result.VariantModels.ContainsKey("shadow").ShouldBeTrue();
+        result.VariantModels["shadow"].Characters.Select(c => c.Id).ShouldContain('A');
     }
 
     private static BmfcSave BaseBmfcSave() => new BmfcSave
@@ -88,38 +88,4 @@ public class KernSmithFileGeneratorShadowTests
         UseSmoothing = true,
         Ranges = "65",
     };
-
-    private static (int minR, int darkPixelCount, int brightPixelCount) SummarizeRedChannel(BmFontResult result)
-    {
-        int minR = 255;
-        int darkPixelCount = 0;
-        int brightPixelCount = 0;
-
-        foreach (AtlasPage page in result.Pages)
-        {
-            byte[] pixels = page.PixelData;
-            for (int i = 0; i + 3 < pixels.Length; i += 4)
-            {
-                if (pixels[i + 3] == 0)
-                {
-                    continue;
-                }
-
-                byte r = pixels[i];
-                minR = Math.Min(minR, r);
-
-                if (r < 32)
-                {
-                    darkPixelCount++;
-                }
-
-                if (r > 200)
-                {
-                    brightPixelCount++;
-                }
-            }
-        }
-
-        return (minR, darkPixelCount, brightPixelCount);
-    }
 }

--- a/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveFontCacheKeyTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveFontCacheKeyTests.cs
@@ -1,0 +1,45 @@
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.V2.Fonts;
+
+/// <summary>
+/// Issue #4001 — the drop shadow is drawn at runtime as a separate silhouette (offset + tinted
+/// under the glyph), so shadow color and offset no longer affect the baked atlas and must NOT be
+/// part of the font cache key; keeping them there forced needless atlas regeneration on every
+/// tweak. Blur still shapes the baked silhouette, so it stays in the key.
+/// </summary>
+public class BmfcSaveFontCacheKeyTests
+{
+    [Fact]
+    public void CacheName_WithDropshadow_IgnoresShadowColor()
+    {
+        string redOpaque = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true,
+            dropshadowBlur: 2f, dropshadowRed: 255, dropshadowGreen: 0, dropshadowBlue: 0, dropshadowAlpha: 255);
+        string greenHalf = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true,
+            dropshadowBlur: 2f, dropshadowRed: 0, dropshadowGreen: 255, dropshadowBlue: 0, dropshadowAlpha: 128);
+
+        redOpaque.ShouldBe(greenHalf);
+    }
+
+    [Fact]
+    public void CacheName_WithDropshadow_IgnoresShadowOffset()
+    {
+        string offsetA = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true,
+            dropshadowOffsetX: 2f, dropshadowOffsetY: 2f, dropshadowBlur: 3f);
+        string offsetB = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true,
+            dropshadowOffsetX: 9f, dropshadowOffsetY: -4f, dropshadowBlur: 3f);
+
+        offsetA.ShouldBe(offsetB);
+    }
+
+    [Fact]
+    public void CacheName_WithDropshadow_DistinguishesBlur()
+    {
+        string blur2 = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true, dropshadowBlur: 2f);
+        string blur5 = BmfcSave.GetFontCacheFileNameFor(24, "Arial", 0, true, hasDropshadow: true, dropshadowBlur: 5f);
+
+        blur2.ShouldNotBe(blur5);
+    }
+}

--- a/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
@@ -98,6 +98,36 @@ public class TextRuntimeDropshadowPlumbingTests
         text.GetFontCacheFileName(fontFilePath: null).ShouldContain("_ds");
     }
 
+    [Fact]
+    public void SettingDropshadowProperties_ForwardsToTextRenderable()
+    {
+        TextRuntime text = new TextRuntime();
+        text.HasDropshadow = true;
+        text.DropshadowOffsetX = 4f;
+        text.DropshadowOffsetY = 5f;
+        text.DropshadowColor = new Microsoft.Xna.Framework.Color(10, 20, 30, 128);
+
+        RenderingLibrary.Graphics.Text renderable = (RenderingLibrary.Graphics.Text)text.RenderableComponent;
+        renderable.HasDropshadow.ShouldBeTrue();
+        renderable.DropshadowOffsetX.ShouldBe(4f);
+        renderable.DropshadowOffsetY.ShouldBe(5f);
+        renderable.DropshadowColor.R.ShouldBe((byte)10);
+        renderable.DropshadowColor.G.ShouldBe((byte)20);
+        renderable.DropshadowColor.B.ShouldBe((byte)30);
+        renderable.DropshadowColor.A.ShouldBe((byte)128);
+    }
+
+    [Fact]
+    public void ClearingHasDropshadow_ForwardsFalseToTextRenderable()
+    {
+        TextRuntime text = new TextRuntime();
+        text.HasDropshadow = true;
+        text.HasDropshadow = false;
+
+        RenderingLibrary.Graphics.Text renderable = (RenderingLibrary.Graphics.Text)text.RenderableComponent;
+        renderable.HasDropshadow.ShouldBeFalse();
+    }
+
     private sealed class CapturingInMemoryFontCreator : IInMemoryFontCreator
     {
         public BmfcSave? LastBmfcSave { get; private set; }

--- a/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorShadowTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorShadowTests.cs
@@ -1,5 +1,5 @@
+using System.Linq;
 using KernSmith;
-using KernSmith.Atlas;
 using KernSmith.Gum;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
@@ -8,19 +8,36 @@ using Xunit;
 namespace RaylibGum.Tests.Renderables;
 
 /// <summary>
-/// Spike tests for #2724 — KernSmith baked drop shadow plumbed through <see cref="GumFontGenerator"/>.
-/// Validates option mapping, color decomposition, and that generation produces a visibly larger glyph footprint.
+/// Issue #4001 — dropshadow renders as a two-pass draw at runtime (a ShadowSilhouette variant
+/// drawn offset + tinted under the primary glyph), not baked into the primary atlas. The in-memory
+/// <see cref="GumFontGenerator"/> must request that variant and leave the primary a plain glyph
+/// atlas — baking the shadow in was what let the runtime text-color modulate re-tint the shadow.
 /// </summary>
 public class GumFontGeneratorShadowTests
 {
     [Fact]
-    public void BuildOptions_WhenHasDropshadow_MapsShadowFieldsAndDecomposesAlphaToOpacity()
+    public void BuildOptions_WhenHasDropshadow_RequestsShadowSilhouetteVariantWithBlur()
+    {
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = true;
+        bmfcSave.DropshadowBlur = 4f;
+
+        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
+
+        options.Variants.ShouldNotBeNull();
+        AtlasVariant variant = options.Variants.Single();
+        variant.Name.ShouldBe("shadow");
+        variant.Kind.ShouldBe(AtlasVariantKind.ShadowSilhouette);
+        variant.BlurRadius.ShouldBe(4);
+    }
+
+    [Fact]
+    public void BuildOptions_WhenHasDropshadow_DoesNotBakeShadowIntoPrimary()
     {
         BmfcSave bmfcSave = BaseBmfcSave();
         bmfcSave.HasDropshadow = true;
         bmfcSave.DropshadowOffsetX = 2f;
         bmfcSave.DropshadowOffsetY = 3f;
-        bmfcSave.DropshadowBlur = 4f;
         bmfcSave.DropshadowRed = 10;
         bmfcSave.DropshadowGreen = 20;
         bmfcSave.DropshadowBlue = 30;
@@ -28,87 +45,15 @@ public class GumFontGeneratorShadowTests
 
         FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
 
-        options.ShadowOffsetX.ShouldBe(2);
-        options.ShadowOffsetY.ShouldBe(3);
-        options.ShadowBlur.ShouldBe(4);
-        ((int)options.ShadowR).ShouldBe(10);
-        ((int)options.ShadowG).ShouldBe(20);
-        ((int)options.ShadowB).ShouldBe(30);
-        options.ShadowOpacity.ShouldBe(128 / 255f, 0.001f);
-    }
-
-    [Fact]
-    public void BuildOptions_WhenHasDropshadowIsFalse_LeavesShadowAtDefaults()
-    {
-        BmfcSave bmfcSave = BaseBmfcSave();
-        bmfcSave.HasDropshadow = false;
-        bmfcSave.DropshadowOffsetX = 5f;
-        bmfcSave.DropshadowBlur = 9f;
-
-        FontGeneratorOptions plain = GumFontGenerator.BuildOptions(bmfcSave);
-        FontGeneratorOptions reference = GumFontGenerator.BuildOptions(BaseBmfcSave());
-
-        plain.ShadowOffsetX.ShouldBe(reference.ShadowOffsetX);
-        plain.ShadowOffsetY.ShouldBe(reference.ShadowOffsetY);
-        plain.ShadowBlur.ShouldBe(reference.ShadowBlur);
-        plain.ShadowOpacity.ShouldBe(reference.ShadowOpacity);
-    }
-
-    [Fact]
-    public void Generate_WithDropshadow_ProducesLargerGlyphFootprintThanPlainFont()
-    {
-        BmfcSave plain = BaseBmfcSave();
-        plain.Ranges = "65";
-
-        BmfcSave shadowed = BaseBmfcSave();
-        shadowed.Ranges = "65";
-        shadowed.HasDropshadow = true;
-        shadowed.DropshadowOffsetX = 2f;
-        shadowed.DropshadowOffsetY = 2f;
-        shadowed.DropshadowBlur = 2f;
-        shadowed.DropshadowRed = 0;
-        shadowed.DropshadowGreen = 0;
-        shadowed.DropshadowBlue = 0;
-        shadowed.DropshadowAlpha = 255;
-
-        int plainAlpha = CountNonZeroAlphaPixels(GumFontGenerator.Generate(plain));
-        int shadowAlpha = CountNonZeroAlphaPixels(GumFontGenerator.Generate(shadowed));
-
-        shadowAlpha.ShouldBeGreaterThan(plainAlpha);
-    }
-
-    [Fact]
-    public void FontCacheFileName_WhenHasDropshadow_IncludesShadowSignature()
-    {
-        BmfcSave bmfcSave = BaseBmfcSave();
-        string plainName = bmfcSave.FontCacheFileName;
-
-        bmfcSave.HasDropshadow = true;
-        bmfcSave.DropshadowOffsetX = 1f;
-        bmfcSave.DropshadowOffsetY = 2f;
-        bmfcSave.DropshadowBlur = 3f;
-        bmfcSave.DropshadowRed = 4;
-        bmfcSave.DropshadowGreen = 5;
-        bmfcSave.DropshadowBlue = 6;
-        bmfcSave.DropshadowAlpha = 7;
-
-        bmfcSave.FontCacheFileName.ShouldNotBe(plainName);
-        bmfcSave.FontCacheFileName.ShouldContain("_ds");
-    }
-
-    [Fact]
-    public void BuildOptions_WhenHasDropshadow_LeavesChannelsUnsetSoAtlasPreservesShadowRgb()
-    {
-        BmfcSave bmfcSave = BaseBmfcSave();
-        bmfcSave.HasDropshadow = true;
-
-        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
-
+        options.ShadowOffsetX.ShouldBe(0);
+        options.ShadowOffsetY.ShouldBe(0);
+        options.ShadowBlur.ShouldBe(0);
+        // Variants require the default channel layout (a custom ChannelConfig throws in KernSmith).
         options.Channels.ShouldBeNull();
     }
 
     [Fact]
-    public void BuildOptions_WhenHasDropshadowWithOutline_LeavesChannelsUnsetSoAtlasPreservesShadowRgb()
+    public void BuildOptions_WhenHasDropshadowWithOutline_LeavesChannelsDefaultForVariant()
     {
         BmfcSave bmfcSave = BaseBmfcSave();
         bmfcSave.OutlineThickness = 2;
@@ -120,47 +65,35 @@ public class GumFontGeneratorShadowTests
     }
 
     [Fact]
-    public void Generate_WithBlackShadow_BakesDarkAndBrightRgbPixels()
+    public void BuildOptions_WhenHasDropshadowIsFalse_LeavesShadowAndVariantsAtDefaults()
     {
-        BmfcSave plain = BaseBmfcSave();
-        plain.Ranges = "65";
+        BmfcSave bmfcSave = BaseBmfcSave();
+        bmfcSave.HasDropshadow = false;
+        bmfcSave.DropshadowOffsetX = 5f;
+        bmfcSave.DropshadowBlur = 9f;
 
+        FontGeneratorOptions options = GumFontGenerator.BuildOptions(bmfcSave);
+
+        options.ShadowOffsetX.ShouldBe(0);
+        options.ShadowBlur.ShouldBe(0);
+        (options.Variants is null || options.Variants.Count == 0).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Generate_WithDropshadow_ProducesShadowVariantSharingThePrimaryAtlas()
+    {
         BmfcSave shadowed = BaseBmfcSave();
         shadowed.Ranges = "65";
         shadowed.HasDropshadow = true;
         shadowed.DropshadowOffsetX = 2f;
         shadowed.DropshadowOffsetY = 2f;
         shadowed.DropshadowBlur = 2f;
-        shadowed.DropshadowRed = 0;
-        shadowed.DropshadowGreen = 0;
-        shadowed.DropshadowBlue = 0;
         shadowed.DropshadowAlpha = 255;
 
-        (int plainMinR, int plainMaxR, int plainDark, int plainBright) =
-            SummarizeRedChannel(GumFontGenerator.Generate(plain));
-        (int shadowMinR, int shadowMaxR, int shadowDark, int shadowBright) =
-            SummarizeRedChannel(GumFontGenerator.Generate(shadowed));
+        KernSmith.Output.BmFontResult result = GumFontGenerator.Generate(shadowed);
 
-        plainDark.ShouldBe(0);
-        plainBright.ShouldBeGreaterThan(0);
-        plainMinR.ShouldBeGreaterThan(200);
-
-        shadowDark.ShouldBeGreaterThan(0);
-        shadowBright.ShouldBeGreaterThan(0);
-        shadowMinR.ShouldBeLessThan(32);
-        shadowMaxR.ShouldBeGreaterThan(200);
-    }
-
-    [Fact]
-    public void FontCacheFileName_WhenHasDropshadowIsFalse_MatchesPlainKey()
-    {
-        BmfcSave bmfcSave = BaseBmfcSave();
-        string plainName = bmfcSave.FontCacheFileName;
-
-        bmfcSave.DropshadowOffsetX = 99f;
-        bmfcSave.DropshadowBlur = 99f;
-
-        bmfcSave.FontCacheFileName.ShouldBe(plainName);
+        result.VariantModels.ContainsKey("shadow").ShouldBeTrue();
+        result.VariantModels["shadow"].Characters.Select(c => c.Id).ShouldContain('A');
     }
 
     private static BmfcSave BaseBmfcSave() => new BmfcSave
@@ -170,58 +103,4 @@ public class GumFontGeneratorShadowTests
         UseSmoothing = true,
         Ranges = "65",
     };
-
-    private static (int minR, int maxR, int darkPixelCount, int brightPixelCount) SummarizeRedChannel(KernSmith.Output.BmFontResult result)
-    {
-        int minR = 255;
-        int maxR = 0;
-        int darkPixelCount = 0;
-        int brightPixelCount = 0;
-
-        foreach (AtlasPage page in result.Pages)
-        {
-            byte[] pixels = page.PixelData;
-            for (int i = 0; i + 3 < pixels.Length; i += 4)
-            {
-                if (pixels[i + 3] == 0)
-                {
-                    continue;
-                }
-
-                byte r = pixels[i];
-                minR = Math.Min(minR, r);
-                maxR = Math.Max(maxR, r);
-
-                if (r < 32)
-                {
-                    darkPixelCount++;
-                }
-
-                if (r > 200)
-                {
-                    brightPixelCount++;
-                }
-            }
-        }
-
-        return (minR, maxR, darkPixelCount, brightPixelCount);
-    }
-
-    private static int CountNonZeroAlphaPixels(KernSmith.Output.BmFontResult result)
-    {
-        int count = 0;
-        foreach (AtlasPage page in result.Pages)
-        {
-            byte[] pixels = page.PixelData;
-            for (int i = 3; i < pixels.Length; i += 4)
-            {
-                if (pixels[i] > 0)
-                {
-                    count++;
-                }
-            }
-        }
-
-        return count;
-    }
 }

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -388,9 +388,16 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
 
         IDisposable? spinner = null;
 
+        // Issue #4001: a dropshadow font is a primary .fnt plus a "-shadow.fnt" sibling (the shadow
+        // silhouette, sharing the primary's PNG). A primary present without its sibling — e.g. an
+        // atlas baked before the two-pass change — must regenerate, otherwise the runtime renders
+        // with no shadow at all.
+        bool shadowSiblingMissing = bmfcSave.HasDropshadow
+            && !new FilePath(desiredFntFile.RemoveExtension() + "-shadow.fnt").Exists();
+
         try
         {
-            if (!desiredFntFile.Exists() || force)
+            if (!desiredFntFile.Exists() || shadowSiblingMissing || force)
             {
                 if (showSpinner)
                 {

--- a/Tools/Gum.ProjectServices/FontGeneration/KernSmithFileGenerator.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/KernSmithFileGenerator.cs
@@ -132,10 +132,12 @@ public class KernSmithFileGenerator : IFontFileGenerator
         options.MaxTextureWidth = MaxAtlasDimension;
         options.MaxTextureHeight = MaxAtlasDimension;
 
-        // Drop shadow (and outline/shadow combos) are composited to RGBA by KernSmith's effect
-        // pipeline. A custom ChannelConfig routes through ChannelCompositor, which rebuilds RGB from
-        // alpha masks only -- discarding baked shadow color and forcing white (RGB=One). Leave
-        // Channels unset so AtlasBuilder blits the RGBA glyphs (and shadow) directly.
+        // Drop shadow renders as a two-pass draw at runtime (issue #4001): a ShadowSilhouette atlas
+        // variant, packed into the same shared PNG as the primary, is drawn offset + tinted under
+        // each glyph. Nothing about the shadow is baked into the primary anymore -- baking is what
+        // caused the runtime text-color modulate to re-tint the shadow. KernSmith forbids a custom
+        // ChannelConfig alongside Variants, so the primary keeps the default glyph-coverage layout
+        // when dropshadow is on.
         if (!bmfcSave.HasDropshadow)
         {
             // Match bmfont.exe channel layout so Gum's runtime renders correctly.
@@ -164,13 +166,14 @@ public class KernSmithFileGenerator : IFontFileGenerator
 
         if (bmfcSave.HasDropshadow)
         {
-            options.ShadowOffsetX = (int)MathF.Round(bmfcSave.DropshadowOffsetX);
-            options.ShadowOffsetY = (int)MathF.Round(bmfcSave.DropshadowOffsetY);
-            options.ShadowBlur = (int)MathF.Round(bmfcSave.DropshadowBlur);
-            options.ShadowR = bmfcSave.DropshadowRed;
-            options.ShadowG = bmfcSave.DropshadowGreen;
-            options.ShadowB = bmfcSave.DropshadowBlue;
-            options.ShadowOpacity = bmfcSave.DropshadowAlpha / 255f;
+            // Offset and color are applied by the runtime at draw time; the silhouette bakes only
+            // its blurred coverage shape, so BlurRadius is the sole shadow parameter that affects
+            // the atlas.
+            options.Variants = new[]
+            {
+                new AtlasVariant("shadow", AtlasVariantKind.ShadowSilhouette,
+                    BlurRadius: (int)MathF.Round(bmfcSave.DropshadowBlur)),
+            };
         }
 
         return options;

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -22,8 +22,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="KernSmith" Version="0.12.3" />
-		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.12.3" />
+		<PackageReference Include="KernSmith" Version="0.18.0" />
+		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.0" />
 		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
 	</ItemGroup>
 

--- a/docs/code/standard-visuals/textruntime/fonts.md
+++ b/docs/code/standard-visuals/textruntime/fonts.md
@@ -15,9 +15,9 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 | `IsBold` | `bool` | Bold style. |
 | `IsItalic` | `bool` | Italic style. |
 | `OutlineThickness` | `int` | Outline thickness in pixels (0 = no outline). |
-| `HasDropshadow` | `bool` | When `true`, KernSmith bakes a drop shadow into the font atlas (see [Baked drop shadow](#baked-drop-shadow)). |
-| `DropshadowColor` | `Color` | Shadow color. Shortcut for the four channel properties below. |
-| `DropshadowRed`, `DropshadowGreen`, `DropshadowBlue`, `DropshadowAlpha` | `int` | Shadow color channels (0–255). `DropshadowAlpha` decomposes to KernSmith `ShadowOpacity` at generation time. |
+| `HasDropshadow` | `bool` | When `true`, draws a drop shadow under the text at runtime (see [Drop shadow](#drop-shadow)). |
+| `DropshadowColor` | `Color` | Shadow color, applied at draw time independently of the text `Color`. Shortcut for the four channel properties below. |
+| `DropshadowRed`, `DropshadowGreen`, `DropshadowBlue`, `DropshadowAlpha` | `int` | Shadow color channels (0–255). |
 | `DropshadowOffsetX`, `DropshadowOffsetY` | `float` | Horizontal / vertical shadow offset in pixels. |
 | `DropshadowBlur` | `float` | Blur radius in pixels. `0` is a sharp shadow; larger values soften the edges. Single scalar (like shape `DropshadowBlur`), not a per-axis pair. |
 | `UseFontSmoothing` | `bool` | Whether to use anti-aliased glyph rasterization. |
@@ -25,15 +25,15 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 | `CustomFontFile` | `string` | Path to a specific `.fnt` file (only used when `UseCustomFont` is `true`). |
 | `BitmapFont` | `BitmapFont` | A directly-assigned font instance — bypasses the property-driven font system entirely. |
 
-### Baked drop shadow
+### Drop shadow
 
-When `HasDropshadow` is `true`, KernSmith composites the shadow into each glyph's atlas cell at font-generation time — the same baked model as `OutlineThickness`. The shadow is **not** a per-draw runtime overlay; every character in that font variant always carries the shadow. State-dependent shadows (on/off per frame, animated blur) still need a runtime overlay such as a shape behind the text — see [Shapes — Drop shadow](../shapes-apos.shapes.md#drop-shadow).
+When `HasDropshadow` is `true`, Gum draws the text a second time — a shadow silhouette offset by `DropshadowOffsetX`/`DropshadowOffsetY` and tinted `DropshadowColor` — underneath the primary glyphs. Because the shadow is its own draw, its color is fully independent of the text `Color`: white text can carry a black shadow, and either can be recolored or animated per frame without regenerating the font.
 
-Requirements and cache behavior:
+The silhouette is packed into the same atlas as the glyphs (a blurred coverage mask sharing one texture page), so drawing it adds no texture switch. Only `DropshadowBlur` shapes that baked mask; offset and color are applied at draw time and are not part of the font cache key.
 
-* **KernSmith / `InMemoryFontCreator` required** — shadow fields participate in the property-driven path only when an in-memory font creator is registered (MonoGame, KNI, or Raylib via `KernSmithRaylibFontCreator`). Without it, Gum falls back to FontCache `.fnt` files, which do not encode shadow today.
-* **Separate font variant per shadow tuple** — like outline thickness, shadow offset/blur/color are keyed into the font cache file name when `HasDropshadow` is true, so each distinct combination generates its own atlas.
-* **Channel layout** — when shadow is enabled, Gum omits a custom `ChannelConfig` so KernSmith's default RGBA atlas path is preserved. Baked shadow color survives the runtime's text-color modulate instead of being forced to white.
+{% hint style="info" %}
+Runtime shadow rendering currently applies to **MonoGame, KNI, and FNA** using tool-generated `FontCache` fonts — the generator writes a companion `<font>-shadow.fnt` next to each shadowed font, and the tool regenerates existing fonts to add it. Raylib and the in-memory `KernSmith` font creator generate the shadow data but do not yet draw it; Skia renders its own blurred shadow.
+{% endhint %}
 
 **First-enable defaults:** toggling `HasDropshadow` from `false` to `true` seeds a visible shadow when offset and blur are still zero — black (`DropshadowAlpha` 180), `DropshadowOffsetY` 3, `DropshadowBlur` 2. `DropshadowOffsetX` stays 0. Set channels explicitly before enabling if you need a different color.
 


### PR DESCRIPTION
Closes #4001.

Baked drop shadows were re-tinted by `TextRuntime.Color` (a white shadow under red text became red). The shadow is now a separate runtime draw with its own color, so text and shadow colors are fully independent.

## Approach — two-pass, KernSmith 0.18 shadow-silhouette variant
- **Font generation** (tool `KernSmithFileGenerator` + in-memory `GumFontGenerator`): request a `ShadowSilhouette` `AtlasVariant` instead of baking a colored shadow into the primary atlas. Bumps KernSmith 0.12.3/0.16.0 → 0.18.0. Produces a companion `<font>-shadow.fnt` sharing the primary's PNG.
- **Cache key**: shadow offset and color drop out of the font cache key (applied at draw time now); only blur remains (it shapes the baked silhouette). `HeadlessFontGenerationService` regenerates when the `-shadow.fnt` sibling is missing, so pre-existing atlases rebake.
- **Runtime (XNALIKE: MonoGame/KNI/FNA)**: `BitmapFont` auto-loads the `-shadow.fnt` sibling as `ShadowFont`; `Text` draws it offset + `DropshadowColor`-tinted under the primary glyphs (plain and inline/BBCode paths). `TextRuntime` forwards the properties to the renderable.

## Scope / follow-ups (all degrade gracefully to no shadow)
- **Raylib** runtime — separate `Text` + `Raylib_cs.Font` stack, not wired here.
- **In-memory `KernSmithFontCreator`** — generates the variant but can't attach it yet; blocked on KernSmith's `TextFormatter` being `internal` (needs a public "variant → .fnt text" API).
- **Skia** — unchanged (renders its own blurred shadow).

## Divergence from the issue plan
Also dropped shadow **offset** from the cache key (the issue comment said keep it). Under the silhouette approach offset is applied at draw time, not baked, so keying on it forced needless regens for byte-identical atlases. Reversible.

## Tests
Producer: variant requested + no baked shadow (both generators), cache key drops color/offset keeps blur, sibling-missing regeneration. Consumer: `TextRuntime`→renderable forwarding, shadow-sibling path derivation. Full suites green — MonoGameGum.Tests 1938, V2 129, V3 59, RaylibGum 537, Gum.ProjectServices 380.

FRB canary: pass (`BitmapFont.cs`/`BmfcSave.cs` overlaid on primary, `GumCore.DesktopGlNet6` built clean). Manual test: needed (visual — colored text with an independently-colored shadow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
