### PR TITLE
Drop shadow: KernSmith 0.18.1 (white silhouette) + tool blur floor (#4001)

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StandardElementsManager.GumTool.cs
@@ -152,10 +152,11 @@ public class StandardElementsManagerGumTool : IStandardElementsManagerGumTool
                 variable.PropertiesToSetOnDisplayer["MaxValue"] = 255.0;
                 variable.PreferredDisplayer = typeof(SliderDisplay);
             }
-            else if (variable.Name == "StrokeWidth")
+            else if (variable.Name == "StrokeWidth" || variable.Name == "DropshadowBlur")
             {
-                // Stroke width has no meaningful negative value but no natural maximum either, so it
-                // stays a plain numeric field (not a slider) with only a floor of 0.
+                // Neither has a meaningful negative value but neither has a natural maximum either, so
+                // they stay plain numeric fields (not sliders) with only a floor of 0. DropshadowBlur is
+                // a radius; the runtime already clamps it, and this stops the tool from storing negatives.
                 variable.PropertiesToSetOnDisplayer["MinValue"] = 0.0;
             }
         }

--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.18.0" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.0" />
+    <PackageReference Include="KernSmith" Version="0.18.1" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -53,6 +53,22 @@ public class StandardElementsManagerTests : BaseTestClass
         variable.PropertiesToSetOnDisplayer.ContainsKey("MaxValue").ShouldBeFalse();
     }
 
+    // DropshadowBlur is a radius: negative is meaningless (and the runtime already clamps it), so the
+    // tool floors it at 0 like StrokeWidth — plain numeric textbox, no arbitrary maximum.
+    [Fact]
+    public void SetPreferredDisplayers_ClampsDropshadowBlurToMinZero_AsPlainTextBox()
+    {
+        var state = new StateSave();
+        state.Variables.Add(new VariableSave { Type = "float", Name = "DropshadowBlur" });
+
+        CreateSut().SetPreferredDisplayers(state);
+
+        var variable = state.Variables.First();
+        variable.PreferredDisplayer.ShouldBeNull();
+        variable.PropertiesToSetOnDisplayer["MinValue"].ShouldBe(0.0);
+        variable.PropertiesToSetOnDisplayer.ContainsKey("MaxValue").ShouldBeFalse();
+    }
+
     // Pins the static->instance drain: the Parent variable's type converter is built from the
     // injected ISelectedState. Before the drain SetPreferredDisplayers pulled ISelectedState from
     // the static Locator (which throws in a unit test); now it must come from the constructor.

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -22,8 +22,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="KernSmith" Version="0.18.0" />
-		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.0" />
+		<PackageReference Include="KernSmith" Version="0.18.1" />
+		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.1" />
 		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
 	</ItemGroup>
 


### PR DESCRIPTION
Two commits that missed the merge window on #4056 (PR was merged before they were pushed). Both are needed for the drop-shadow feature to actually render correctly on `main`.

- **Bump KernSmith 0.18.0 → 0.18.1.** `main` currently references 0.18.0, whose `ShadowSilhouette` variant bakes the silhouette with **black** RGB — so `DropshadowColor` multiplies against black and every shadow renders black regardless of the chosen color. 0.18.1 bakes the silhouette white so the runtime tint reaches it. No other code change needed; the runtime already tints the silhouette.
- **Floor `DropshadowBlur` at 0 in the tool variable grid.** Blur is a radius; negatives are meaningless. Same treatment as `StrokeWidth`.

Tests green: producer shadow suite (6) against 0.18.1, tool blur-floor test (1).

Manual test: confirmed in-session — colored text now shows an independently-colored shadow in the running tool after the bump; blur field no longer accepts negatives.
FRB canary: not needed — tool-only code (`Gum/`) + csproj version bumps; no `GumCommon`/`RenderingLibrary` (FRB-shared) source touched.

Part of #4001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
