### PR TITLE
Raylib runtime two-pass dropshadow draw (#4057)

### DIFF
--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -579,14 +579,13 @@ public class TextRuntime : InteractiveGue
     }
 
     /// <summary>
-    /// Issue #4001: forwards the dropshadow color/offset to the XNALIKE Text renderable so the runtime
+    /// Issues #4001/#4057: forwards the dropshadow color/offset to the Text renderable so the runtime
     /// draws the shadow as a second (offset, independently tinted) pass under the glyphs. Skia renders
-    /// its own blurred shadow, and raylib's separate Text/Raylib_cs.Font stack does not yet implement
-    /// the two-pass shadow, so this is XNALIKE-only.
+    /// its own blurred shadow instead, so this is XNALIKE/Raylib-only.
     /// </summary>
     void ApplyDropshadowToRenderable()
     {
-#if XNALIKE
+#if XNALIKE || RAYLIB
         ContainedText.HasDropshadow = HasDropshadow;
         ContainedText.DropshadowColor = DropshadowColor.ToContainerColor();
         ContainedText.DropshadowOffsetX = DropshadowOffsetX;

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -418,6 +418,19 @@ public class Text : IVisible, IRenderableIpso,
         get; set;
     } = Color.White;
 
+    /// <summary>
+    /// When true and a "-shadow.fnt" sibling was loaded for the font(s) this Text draws with (see
+    /// <see cref="RenderingLibrary.RaylibFontShadowRegistry"/>), a drop shadow is drawn as a second
+    /// pass (issue #4057, the Raylib counterpart of #4001): the shadow silhouette is drawn offset by
+    /// <see cref="DropshadowOffsetX"/>/<see cref="DropshadowOffsetY"/> and tinted
+    /// <see cref="DropshadowColor"/>, with the primary glyphs drawn on top. Degrades gracefully to no
+    /// shadow when no shadow companion font was loaded for a given run's font.
+    /// </summary>
+    public bool HasDropshadow { get; set; }
+    public Color DropshadowColor { get; set; } = new Color(0, 0, 0, 180);
+    public float DropshadowOffsetX { get; set; }
+    public float DropshadowOffsetY { get; set; }
+
 
     public bool IsTruncatingWithEllipsisOnLastLine { get; set; }
 
@@ -1002,6 +1015,13 @@ public class Text : IVisible, IRenderableIpso,
         linePosition = SnapToPixelIfNeeded(linePosition);
         origin = SnapToPixelIfNeeded(origin);
 
+        if (HasDropshadow && RaylibFontShadowRegistry.TryGet(fontValue.Texture.Id, out Font shadowFont))
+        {
+            var shadowPosition = SnapToPixelIfNeeded(
+                linePosition + new Vector2(DropshadowOffsetX, DropshadowOffsetY) * FontScale);
+            DrawTextPro(shadowFont, line, shadowPosition, origin, 0, fontValue.BaseSize * FontScale, 0, DropshadowColor);
+        }
+
         // Texture filtering is applied once when the font's atlas texture is loaded/built (see
         // ContentLoader.DefaultTextureFilter, #3496), not per-draw — a per-line GPU state reset here
         // was both redundant and ignored the project's texture filter setting.
@@ -1252,6 +1272,16 @@ public class Text : IVisible, IRenderableIpso,
 
             runPosition = SnapToPixelIfNeeded(runPosition);
             runOrigin = SnapToPixelIfNeeded(runOrigin);
+
+            // Issue #4057: each run looks up its OWN font's shadow companion (a run may draw with a
+            // swapped [FontSize]/[IsBold]/etc. font), so a run whose font has no shadow companion
+            // simply draws no shadow - the same graceful degradation as the base-font path.
+            if (HasDropshadow && RaylibFontShadowRegistry.TryGet(runFonts[s].Texture.Id, out Font runShadowFont))
+            {
+                var shadowRunPosition = SnapToPixelIfNeeded(
+                    runPosition + new Vector2(DropshadowOffsetX, DropshadowOffsetY) * runScales[s]);
+                DrawTextPro(runShadowFont, runTexts[s], shadowRunPosition, runOrigin, runRotations[s], runDrawSizes[s], 0, DropshadowColor);
+            }
 
             DrawTextPro(runFonts[s], runTexts[s], runPosition, runOrigin, runRotations[s], runDrawSizes[s], 0, runColors[s]);
 

--- a/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ContentLoader.cs
@@ -87,6 +87,10 @@ public class ContentLoader : IContentLoader
                 // file to record them (same registry the in-memory/KernSmith path populates via
                 // BuildFont). Keyed by atlas texture id so the Text renderable can recover them.
                 RegisterFontMetricsFromFnt(File.ReadAllText(contentName), loadedFont.Texture.Id);
+                // #4057: if a "-shadow.fnt" sibling exists (written by the font generator for a
+                // dropshadow font, sharing the same PNG - see BitmapFont.LoadShadowSiblingIfPresent on
+                // the MonoGame side), load it too and record it against the primary's texture id.
+                RegisterShadowSiblingIfPresent(contentName, loadedFont.Texture.Id);
             }
             else
             {
@@ -342,6 +346,29 @@ public class ContentLoader : IContentLoader
         catch
         {
             // Leave unregistered; line height falls back to MeasureTextEx in the Text renderable.
+        }
+    }
+
+    // #4057: loads the "-shadow.fnt" sibling next to primaryFntPath (if present) via raylib's native
+    // loader and records it in RaylibFontShadowRegistry against the primary's texture id. Absent for
+    // the vast majority of fonts (no dropshadow requested), in which case this is a no-op - the Text
+    // renderable's shadow-registry lookup simply finds nothing and draws no shadow pass.
+    private static void RegisterShadowSiblingIfPresent(string primaryFntPath, uint primaryTextureId)
+    {
+        const string fntExtension = ".fnt";
+        if (!primaryFntPath.EndsWith(fntExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string shadowFntPath = primaryFntPath.Substring(0, primaryFntPath.Length - fntExtension.Length)
+            + "-shadow" + fntExtension;
+
+        if (System.IO.File.Exists(shadowFntPath))
+        {
+            Font shadowFont = Raylib.LoadFont(shadowFntPath);
+            TextureFilterApplier(shadowFont.Texture, DefaultTextureFilter);
+            RaylibFontShadowRegistry.Register(primaryTextureId, shadowFont);
         }
     }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/ManagedFont.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/ManagedFont.cs
@@ -38,6 +38,14 @@ public class ManagedFont : IDisposable
             // Drop any recorded line metrics first — raylib may reuse this texture id after UnloadFont,
             // and a stale entry would hand the next font the wrong line height.
             RaylibFontMetricsRegistry.Remove(Font.Texture.Id);
+
+            // Unload the drop-shadow companion font (#4057), if this font had one, so its GPU texture
+            // doesn't leak — RaylibFontShadowRegistry only tracks the association, not the font's lifetime.
+            if (RaylibFontShadowRegistry.Remove(Font.Texture.Id, out Raylib_cs.Font shadowFont))
+            {
+                Raylib_cs.Raylib.UnloadFont(shadowFont);
+            }
+
             Raylib_cs.Raylib.UnloadFont(Font);
             disposed = true;
         }

--- a/Runtimes/RaylibGum/RenderingLibrary/RaylibFontShadowRegistry.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/RaylibFontShadowRegistry.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace RenderingLibrary;
+
+/// <summary>
+/// Associates a Gum bitmap font's drop-shadow companion font (issue #4057, the Raylib counterpart of
+/// <c>RenderingLibrary.Graphics.Fonts.BitmapFont.ShadowFont</c>) with the atlas texture id of the
+/// loaded primary raylib font.
+/// </summary>
+/// <remarks>
+/// <see cref="Raylib_cs.Font"/> is a value struct with no room for a "shadow companion" field, so the
+/// association is kept here instead, keyed by the primary font's atlas texture id - the same approach
+/// <see cref="RaylibFontMetricsRegistry"/> uses for line metrics. Entries are removed when the owning
+/// <see cref="ManagedFont"/> is disposed (which also unloads the shadow font's own GPU texture), since
+/// raylib may later reuse the freed texture id. Accessed only on the single render/content-load thread.
+/// </remarks>
+internal static class RaylibFontShadowRegistry
+{
+    private static readonly Dictionary<uint, Font> _shadowFontByPrimaryTextureId = new();
+
+    /// <summary>
+    /// Records the shadow companion font for the primary font whose atlas has the given texture id,
+    /// overwriting any prior entry for that id.
+    /// </summary>
+    public static void Register(uint primaryTextureId, Font shadowFont)
+    {
+        _shadowFontByPrimaryTextureId[primaryTextureId] = shadowFont;
+    }
+
+    /// <summary>
+    /// Looks up the shadow companion font recorded for the given primary atlas texture id. Returns
+    /// false when the primary font has no "-shadow.fnt" sibling (the common, non-dropshadow case).
+    /// </summary>
+    public static bool TryGet(uint primaryTextureId, out Font shadowFont)
+    {
+        return _shadowFontByPrimaryTextureId.TryGetValue(primaryTextureId, out shadowFont);
+    }
+
+    /// <summary>
+    /// Removes and returns the shadow font entry for the given primary atlas texture id, if any.
+    /// Called when the owning primary font is unloaded so its shadow companion's GPU texture can be
+    /// unloaded too, and a reused texture id cannot return a stale shadow font.
+    /// </summary>
+    public static bool Remove(uint primaryTextureId, out Font shadowFont)
+    {
+        if (_shadowFontByPrimaryTextureId.TryGetValue(primaryTextureId, out shadowFont))
+        {
+            _shadowFontByPrimaryTextureId.Remove(primaryTextureId);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
+++ b/Tests/RaylibGum.Tests/Content/ContentLoaderTests.cs
@@ -195,6 +195,86 @@ public class ContentLoaderTests : BaseTestClass
         }
     }
 
+    // Issue #4057: loading a primary .fnt whose "-shadow.fnt" sibling exists on disk (written by the
+    // KernSmith ShadowSilhouette variant, #4001) should register the shadow companion font in
+    // RaylibFontShadowRegistry, keyed by the primary's atlas texture id, so the Text renderable can
+    // find it at draw time. Mirrors BitmapFont.LoadShadowSiblingIfPresent on the MonoGame side.
+    [Fact]
+    public void LoadContent_Font_WhenShadowSiblingFntExistsOnDisk_ShouldRegisterShadowFont()
+    {
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+
+            string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+            string fntPath = Path.Combine(fixtureDirectory, "Font18Arial.fnt");
+
+            Font font = LoaderManager.Self.ContentLoader.LoadContent<Font>(fntPath);
+
+            RaylibFontShadowRegistry.TryGet(font.Texture.Id, out Font shadowFont).ShouldBeTrue();
+            shadowFont.GlyphCount.ShouldBe(2);
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+        }
+    }
+
+    // Companion to the above: a primary .fnt with no "-shadow.fnt" sibling (the common case) must not
+    // register anything - this is the "gracefully degrades to no shadow" contract #4057 preserves.
+    [Fact]
+    public void LoadContent_Font_WhenNoShadowSiblingFntExists_ShouldNotRegisterShadowFont()
+    {
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+
+            // Font18ArialNoShadow.fnt is a copy of Font18Arial.fnt with no "-shadow.fnt" sibling next to it.
+            string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+            string fntPath = Path.Combine(fixtureDirectory, "Font18ArialNoShadow.fnt");
+
+            Font font = LoaderManager.Self.ContentLoader.LoadContent<Font>(fntPath);
+
+            RaylibFontShadowRegistry.TryGet(font.Texture.Id, out _).ShouldBeFalse();
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+        }
+    }
+
+    // Companion to ManagedFont_Dispose_ShouldRemoveRegisteredLineMetrics: disposing the primary font
+    // must also unload and unregister its shadow companion, or the shadow's GPU texture leaks and a
+    // reused texture id could return a stale shadow font (#4057).
+    [Fact]
+    public void ManagedFont_Dispose_ShouldRemoveRegisteredShadowFont()
+    {
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+
+            string fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Content", "FontCache");
+            string fntPath = Path.Combine(fixtureDirectory, "Font18Arial.fnt");
+
+            Font font = LoaderManager.Self.ContentLoader.LoadContent<Font>(fntPath);
+            uint textureId = font.Texture.Id;
+
+            RaylibFontShadowRegistry.TryGet(textureId, out _).ShouldBeTrue();
+
+            ManagedFont managedFont = new ManagedFont(font);
+            managedFont.Dispose();
+
+            RaylibFontShadowRegistry.TryGet(textureId, out _).ShouldBeFalse();
+        }
+        finally
+        {
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+        }
+    }
+
     // Regression for #3037: a bundled bitmap font (.fnt + .png page) loaded via LoadFont used to
     // bypass CustomGetStreamFromFile entirely — raylib's path-based LoadFont reads straight off
     // disk. Here both files exist ONLY in memory (served through the hook) and the path handed to

--- a/Tests/RaylibGum.Tests/Content/FontCache/Font18Arial-shadow.fnt
+++ b/Tests/RaylibGum.Tests/Content/FontCache/Font18Arial-shadow.fnt
@@ -1,0 +1,6 @@
+info face="Arial" size=-18 bold=0 italic=0 charset="" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=21 base=17 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file="Font18Arial_0.png"
+chars count=2
+char id=32   x=209   y=102   width=3     height=1     xoffset=-1    yoffset=20    xadvance=5     page=0  chnl=15
+char id=33   x=0     y=92    width=4     height=13    xoffset=1     yoffset=4     xadvance=6     page=0  chnl=15

--- a/Tests/RaylibGum.Tests/Content/FontCache/Font18ArialNoShadow.fnt
+++ b/Tests/RaylibGum.Tests/Content/FontCache/Font18ArialNoShadow.fnt
@@ -1,0 +1,266 @@
+info face="Arial" size=-18 bold=0 italic=0 charset="" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=21 base=17 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file="Font18Arial_0.png"
+chars count=191
+char id=32   x=209   y=102   width=3     height=1     xoffset=-1    yoffset=20    xadvance=5     page=0  chnl=15
+char id=33   x=0     y=92    width=4     height=13    xoffset=1     yoffset=4     xadvance=6     page=0  chnl=15
+char id=34   x=114   y=103   width=6     height=5     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=35   x=228   y=46    width=11    height=13    xoffset=-1    yoffset=4     xadvance=10    page=0  chnl=15
+char id=36   x=164   y=18    width=10    height=16    xoffset=0     yoffset=3     xadvance=10    page=0  chnl=15
+char id=37   x=146   y=35    width=16    height=13    xoffset=0     yoffset=4     xadvance=16    page=0  chnl=15
+char id=38   x=114   y=49    width=12    height=13    xoffset=0     yoffset=4     xadvance=12    page=0  chnl=15
+char id=39   x=121   y=103   width=3     height=5     xoffset=0     yoffset=4     xadvance=3     page=0  chnl=15
+char id=40   x=134   y=0     width=6     height=17    xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=41   x=160   y=0     width=5     height=17    xoffset=1     yoffset=4     xadvance=6     page=0  chnl=15
+char id=42   x=106   y=103   width=7     height=5     xoffset=0     yoffset=4     xadvance=7     page=0  chnl=15
+char id=43   x=78    y=92    width=11    height=10    xoffset=0     yoffset=6     xadvance=11    page=0  chnl=15
+char id=44   x=143   y=102   width=3     height=4     xoffset=1     yoffset=15    xadvance=5     page=0  chnl=15
+char id=45   x=187   y=102   width=6     height=2     xoffset=0     yoffset=11    xadvance=6     page=0  chnl=15
+char id=46   x=252   y=57    width=3     height=2     xoffset=1     yoffset=15    xadvance=5     page=0  chnl=15
+char id=47   x=190   y=77    width=7     height=13    xoffset=-1    yoffset=4     xadvance=5     page=0  chnl=15
+char id=48   x=192   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=49   x=237   y=74    width=6     height=13    xoffset=1     yoffset=4     xadvance=10    page=0  chnl=15
+char id=50   x=203   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=51   x=11    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=52   x=55    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=53   x=77    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=54   x=88    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=55   x=115   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=56   x=60    y=64    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=57   x=71    y=64    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=58   x=252   y=46    width=3     height=10    xoffset=1     yoffset=7     xadvance=5     page=0  chnl=15
+char id=59   x=252   y=0     width=3     height=12    xoffset=1     yoffset=7     xadvance=5     page=0  chnl=15
+char id=60   x=212   y=91    width=11    height=9     xoffset=0     yoffset=6     xadvance=11    page=0  chnl=15
+char id=61   x=74    y=103   width=11    height=6     xoffset=0     yoffset=7     xadvance=11    page=0  chnl=15
+char id=62   x=224   y=90    width=11    height=9     xoffset=0     yoffset=6     xadvance=11    page=0  chnl=15
+char id=63   x=82    y=64    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=64   x=0     y=0     width=18    height=17    xoffset=0     yoffset=4     xadvance=18    page=0  chnl=15
+char id=65   x=73    y=50    width=13    height=13    xoffset=-1    yoffset=4     xadvance=11    page=0  chnl=15
+char id=66   x=48    y=64    width=11    height=13    xoffset=1     yoffset=4     xadvance=12    page=0  chnl=15
+char id=67   x=45    y=50    width=13    height=13    xoffset=0     yoffset=4     xadvance=13    page=0  chnl=15
+char id=68   x=101   y=50    width=12    height=13    xoffset=1     yoffset=4     xadvance=13    page=0  chnl=15
+char id=69   x=192   y=49    width=11    height=13    xoffset=1     yoffset=4     xadvance=12    page=0  chnl=15
+char id=70   x=93    y=64    width=10    height=13    xoffset=1     yoffset=4     xadvance=11    page=0  chnl=15
+char id=71   x=0     y=50    width=14    height=13    xoffset=0     yoffset=4     xadvance=14    page=0  chnl=15
+char id=72   x=24    y=64    width=11    height=13    xoffset=1     yoffset=4     xadvance=13    page=0  chnl=15
+char id=73   x=15    y=92    width=4     height=13    xoffset=0     yoffset=4     xadvance=4     page=0  chnl=15
+char id=74   x=247   y=60    width=8     height=13    xoffset=0     yoffset=4     xadvance=9     page=0  chnl=15
+char id=75   x=0     y=64    width=11    height=13    xoffset=1     yoffset=4     xadvance=12    page=0  chnl=15
+char id=76   x=140   y=77    width=9     height=13    xoffset=1     yoffset=4     xadvance=10    page=0  chnl=15
+char id=77   x=59    y=50    width=13    height=13    xoffset=1     yoffset=4     xadvance=15    page=0  chnl=15
+char id=78   x=204   y=48    width=11    height=13    xoffset=1     yoffset=4     xadvance=13    page=0  chnl=15
+char id=79   x=30    y=50    width=14    height=13    xoffset=0     yoffset=4     xadvance=14    page=0  chnl=15
+char id=80   x=12    y=64    width=11    height=13    xoffset=1     yoffset=4     xadvance=12    page=0  chnl=15
+char id=81   x=227   y=17    width=14    height=14    xoffset=0     yoffset=4     xadvance=14    page=0  chnl=15
+char id=82   x=140   y=49    width=12    height=13    xoffset=1     yoffset=4     xadvance=13    page=0  chnl=15
+char id=83   x=153   y=49    width=12    height=13    xoffset=0     yoffset=4     xadvance=12    page=0  chnl=15
+char id=84   x=166   y=49    width=12    height=13    xoffset=0     yoffset=4     xadvance=12    page=0  chnl=15
+char id=85   x=36    y=64    width=11    height=13    xoffset=1     yoffset=4     xadvance=13    page=0  chnl=15
+char id=86   x=87    y=50    width=13    height=13    xoffset=-1    yoffset=4     xadvance=11    page=0  chnl=15
+char id=87   x=127   y=35    width=18    height=13    xoffset=0     yoffset=4     xadvance=17    page=0  chnl=15
+char id=88   x=127   y=49    width=12    height=13    xoffset=-1    yoffset=4     xadvance=11    page=0  chnl=15
+char id=89   x=179   y=49    width=12    height=13    xoffset=0     yoffset=4     xadvance=12    page=0  chnl=15
+char id=90   x=244   y=32    width=11    height=13    xoffset=0     yoffset=4     xadvance=11    page=0  chnl=15
+char id=91   x=148   y=0     width=5     height=17    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=92   x=230   y=75    width=6     height=13    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=93   x=154   y=0     width=5     height=17    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=94   x=46    y=103   width=7     height=7     xoffset=0     yoffset=4     xadvance=7     page=0  chnl=15
+char id=95   x=160   y=102   width=12    height=2     xoffset=-1    yoffset=19    xadvance=10    page=0  chnl=15
+char id=96   x=199   y=102   width=4     height=2     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=97   x=101   y=92    width=10    height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=98   x=104   y=64    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=99   x=175   y=91    width=9     height=10    xoffset=0     yoffset=7     xadvance=9     page=0  chnl=15
+char id=100  x=170   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=101  x=112   y=92    width=10    height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=102  x=206   y=77    width=7     height=13    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=103  x=53    y=35    width=9     height=14    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=104  x=180   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=105  x=5     y=92    width=4     height=13    xoffset=0     yoffset=4     xadvance=4     page=0  chnl=15
+char id=106  x=166   y=0     width=5     height=17    xoffset=-2    yoffset=4     xadvance=4     page=0  chnl=15
+char id=107  x=160   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=9     page=0  chnl=15
+char id=108  x=10    y=92    width=4     height=13    xoffset=0     yoffset=4     xadvance=4     page=0  chnl=15
+char id=109  x=48    y=92    width=14    height=10    xoffset=0     yoffset=7     xadvance=14    page=0  chnl=15
+char id=110  x=165   y=91    width=9     height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=111  x=90    y=92    width=10    height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=112  x=0     y=35    width=10    height=14    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=113  x=83    y=35    width=9     height=14    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=114  x=204   y=91    width=7     height=10    xoffset=0     yoffset=7     xadvance=6     page=0  chnl=15
+char id=115  x=185   y=91    width=9     height=10    xoffset=0     yoffset=7     xadvance=9     page=0  chnl=15
+char id=116  x=198   y=77    width=7     height=13    xoffset=-1    yoffset=4     xadvance=5     page=0  chnl=15
+char id=117  x=155   y=91    width=9     height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=118  x=145   y=91    width=9     height=10    xoffset=0     yoffset=7     xadvance=9     page=0  chnl=15
+char id=119  x=63    y=92    width=14    height=10    xoffset=-1    yoffset=7     xadvance=13    page=0  chnl=15
+char id=120  x=195   y=91    width=8     height=10    xoffset=0     yoffset=7     xadvance=8     page=0  chnl=15
+char id=121  x=33    y=35    width=9     height=14    xoffset=0     yoffset=7     xadvance=9     page=0  chnl=15
+char id=122  x=134   y=91    width=10    height=10    xoffset=-1    yoffset=7     xadvance=8     page=0  chnl=15
+char id=123  x=141   y=0     width=6     height=17    xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=124  x=172   y=0     width=2     height=17    xoffset=2     yoffset=4     xadvance=6     page=0  chnl=15
+char id=125  x=127   y=0     width=6     height=17    xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=126  x=125   y=102   width=11    height=4     xoffset=0     yoffset=9     xadvance=11    page=0  chnl=15
+char id=160  x=213   y=101   width=3     height=1     xoffset=-1    yoffset=20    xadvance=5     page=0  chnl=15
+char id=161  x=102   y=35    width=4     height=14    xoffset=1     yoffset=7     xadvance=6     page=0  chnl=15
+char id=162  x=96    y=0     width=10    height=17    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=163  x=126   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=164  x=9     y=106   width=10    height=7     xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=165  x=216   y=47    width=11    height=13    xoffset=-1    yoffset=4     xadvance=10    page=0  chnl=15
+char id=166  x=175   y=0     width=2     height=17    xoffset=2     yoffset=4     xadvance=6     page=0  chnl=15
+char id=167  x=74    y=0     width=10    height=17    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=168  x=180   y=102   width=6     height=2     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=169  x=180   y=35    width=15    height=13    xoffset=-1    yoffset=4     xadvance=13    page=0  chnl=15
+char id=170  x=61    y=103   width=6     height=7     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=171  x=0     y=106   width=8     height=8     xoffset=1     yoffset=8     xadvance=10    page=0  chnl=15
+char id=172  x=86    y=103   width=11    height=5     xoffset=0     yoffset=8     xadvance=11    page=0  chnl=15
+char id=173  x=173   y=102   width=6     height=2     xoffset=0     yoffset=11    xadvance=6     page=0  chnl=15
+char id=174  x=196   y=34    width=15    height=13    xoffset=-1    yoffset=4     xadvance=13    page=0  chnl=15
+char id=175  x=147   y=102   width=12    height=2     xoffset=-1    yoffset=1     xadvance=10    page=0  chnl=15
+char id=176  x=98    y=103   width=7     height=5     xoffset=0     yoffset=4     xadvance=7     page=0  chnl=15
+char id=177  x=20    y=92    width=10    height=11    xoffset=0     yoffset=6     xadvance=10    page=0  chnl=15
+char id=178  x=30    y=104   width=7     height=7     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=179  x=54    y=103   width=6     height=7     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=180  x=204   y=102   width=4     height=2     xoffset=2     yoffset=4     xadvance=6     page=0  chnl=15
+char id=181  x=93    y=35    width=8     height=14    xoffset=1     yoffset=7     xadvance=10    page=0  chnl=15
+char id=182  x=55    y=18    width=12    height=16    xoffset=-1    yoffset=4     xadvance=10    page=0  chnl=15
+char id=183  x=194   y=102   width=4     height=2     xoffset=1     yoffset=9     xadvance=6     page=0  chnl=15
+char id=184  x=137   y=102   width=5     height=4     xoffset=0     yoffset=17    xadvance=6     page=0  chnl=15
+char id=185  x=68    y=103   width=5     height=7     xoffset=0     yoffset=4     xadvance=6     page=0  chnl=15
+char id=186  x=38    y=103   width=7     height=7     xoffset=0     yoffset=4     xadvance=7     page=0  chnl=15
+char id=187  x=247   y=88    width=8     height=8     xoffset=1     yoffset=8     xadvance=10    page=0  chnl=15
+char id=188  x=163   y=35    width=16    height=13    xoffset=0     yoffset=4     xadvance=15    page=0  chnl=15
+char id=189  x=228   y=32    width=15    height=13    xoffset=0     yoffset=4     xadvance=15    page=0  chnl=15
+char id=190  x=212   y=33    width=15    height=13    xoffset=0     yoffset=4     xadvance=15    page=0  chnl=15
+char id=191  x=43    y=35    width=9     height=14    xoffset=1     yoffset=7     xadvance=11    page=0  chnl=15
+char id=192  x=28    y=18    width=13    height=16    xoffset=-1    yoffset=1     xadvance=12    page=0  chnl=15
+char id=193  x=238   y=0     width=13    height=16    xoffset=-1    yoffset=1     xadvance=12    page=0  chnl=15
+char id=194  x=0     y=18    width=13    height=16    xoffset=-1    yoffset=1     xadvance=12    page=0  chnl=15
+char id=195  x=34    y=0     width=13    height=17    xoffset=-1    yoffset=0     xadvance=12    page=0  chnl=15
+char id=196  x=14    y=18    width=13    height=16    xoffset=-1    yoffset=1     xadvance=12    page=0  chnl=15
+char id=197  x=213   y=17    width=13    height=15    xoffset=-1    yoffset=2     xadvance=12    page=0  chnl=15
+char id=198  x=107   y=35    width=19    height=13    xoffset=-1    yoffset=4     xadvance=18    page=0  chnl=15
+char id=199  x=48    y=0     width=13    height=17    xoffset=0     yoffset=4     xadvance=13    page=0  chnl=15
+char id=200  x=68    y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=12    page=0  chnl=15
+char id=201  x=80    y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=12    page=0  chnl=15
+char id=202  x=92    y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=12    page=0  chnl=15
+char id=203  x=104   y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=12    page=0  chnl=15
+char id=204  x=188   y=17    width=4     height=16    xoffset=0     yoffset=1     xadvance=5     page=0  chnl=15
+char id=205  x=193   y=17    width=4     height=16    xoffset=0     yoffset=1     xadvance=5     page=0  chnl=15
+char id=206  x=175   y=18    width=6     height=16    xoffset=-1    yoffset=1     xadvance=5     page=0  chnl=15
+char id=207  x=182   y=17    width=5     height=16    xoffset=-1    yoffset=1     xadvance=5     page=0  chnl=15
+char id=208  x=15    y=50    width=14    height=13    xoffset=-1    yoffset=4     xadvance=13    page=0  chnl=15
+char id=209  x=62    y=0     width=11    height=17    xoffset=1     yoffset=0     xadvance=13    page=0  chnl=15
+char id=210  x=178   y=0     width=14    height=16    xoffset=0     yoffset=1     xadvance=14    page=0  chnl=15
+char id=211  x=208   y=0     width=14    height=16    xoffset=0     yoffset=1     xadvance=14    page=0  chnl=15
+char id=212  x=193   y=0     width=14    height=16    xoffset=0     yoffset=1     xadvance=14    page=0  chnl=15
+char id=213  x=19    y=0     width=14    height=17    xoffset=0     yoffset=0     xadvance=14    page=0  chnl=15
+char id=214  x=223   y=0     width=14    height=16    xoffset=0     yoffset=1     xadvance=14    page=0  chnl=15
+char id=215  x=20    y=104   width=9     height=7     xoffset=1     yoffset=7     xadvance=11    page=0  chnl=15
+char id=216  x=198   y=17    width=14    height=15    xoffset=0     yoffset=3     xadvance=14    page=0  chnl=15
+char id=217  x=140   y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=13    page=0  chnl=15
+char id=218  x=128   y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=13    page=0  chnl=15
+char id=219  x=152   y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=13    page=0  chnl=15
+char id=220  x=116   y=18    width=11    height=16    xoffset=1     yoffset=1     xadvance=13    page=0  chnl=15
+char id=221  x=42    y=18    width=12    height=16    xoffset=0     yoffset=1     xadvance=12    page=0  chnl=15
+char id=222  x=240   y=46    width=11    height=13    xoffset=1     yoffset=4     xadvance=12    page=0  chnl=15
+char id=223  x=137   y=63    width=10    height=13    xoffset=1     yoffset=4     xadvance=11    page=0  chnl=15
+char id=224  x=148   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=225  x=159   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=226  x=170   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=227  x=242   y=17    width=10    height=14    xoffset=0     yoffset=3     xadvance=10    page=0  chnl=15
+char id=228  x=181   y=63    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=229  x=11    y=35    width=10    height=14    xoffset=0     yoffset=3     xadvance=10    page=0  chnl=15
+char id=230  x=31    y=92    width=16    height=10    xoffset=0     yoffset=7     xadvance=16    page=0  chnl=15
+char id=231  x=63    y=35    width=9     height=14    xoffset=0     yoffset=7     xadvance=9     page=0  chnl=15
+char id=232  x=99    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=233  x=214   y=62    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=234  x=225   y=61    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=235  x=236   y=60    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=236  x=244   y=74    width=5     height=13    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=237  x=250   y=74    width=5     height=13    xoffset=1     yoffset=4     xadvance=5     page=0  chnl=15
+char id=238  x=222   y=76    width=7     height=13    xoffset=0     yoffset=4     xadvance=5     page=0  chnl=15
+char id=239  x=214   y=76    width=7     height=13    xoffset=-1    yoffset=4     xadvance=5     page=0  chnl=15
+char id=240  x=0     y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=241  x=73    y=35    width=9     height=14    xoffset=0     yoffset=3     xadvance=10    page=0  chnl=15
+char id=242  x=22    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=243  x=33    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=244  x=44    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=245  x=22    y=35    width=10    height=14    xoffset=0     yoffset=3     xadvance=10    page=0  chnl=15
+char id=246  x=66    y=78    width=10    height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=247  x=236   y=89    width=10    height=8     xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=248  x=123   y=91    width=10    height=10    xoffset=0     yoffset=7     xadvance=10    page=0  chnl=15
+char id=249  x=150   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=250  x=130   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=251  x=120   y=77    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=252  x=110   y=78    width=9     height=13    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=253  x=117   y=0     width=9     height=17    xoffset=0     yoffset=4     xadvance=9     page=0  chnl=15
+char id=254  x=85    y=0     width=10    height=17    xoffset=0     yoffset=4     xadvance=10    page=0  chnl=15
+char id=255  x=107   y=0     width=9     height=17    xoffset=0     yoffset=4     xadvance=9     page=0  chnl=15
+kernings count=70
+kerning first=32  second=65  amount=-1  
+kerning first=121 second=46  amount=-1  
+kerning first=121 second=44  amount=-1  
+kerning first=119 second=46  amount=-1  
+kerning first=119 second=44  amount=-1  
+kerning first=118 second=46  amount=-1  
+kerning first=118 second=44  amount=-1  
+kerning first=114 second=46  amount=-1  
+kerning first=114 second=44  amount=-1  
+kerning first=89  second=118 amount=-1  
+kerning first=49  second=49  amount=-1  
+kerning first=65  second=32  amount=-1  
+kerning first=65  second=84  amount=-1  
+kerning first=65  second=86  amount=-1  
+kerning first=65  second=87  amount=-1  
+kerning first=65  second=89  amount=-1  
+kerning first=89  second=117 amount=-1  
+kerning first=89  second=113 amount=-2  
+kerning first=89  second=112 amount=-1  
+kerning first=89  second=111 amount=-2  
+kerning first=70  second=44  amount=-2  
+kerning first=70  second=46  amount=-2  
+kerning first=70  second=65  amount=-1  
+kerning first=76  second=32  amount=-1  
+kerning first=76  second=84  amount=-1  
+kerning first=76  second=86  amount=-1  
+kerning first=76  second=87  amount=-1  
+kerning first=76  second=89  amount=-1  
+kerning first=76  second=121 amount=-1  
+kerning first=89  second=105 amount=-1  
+kerning first=89  second=101 amount=-2  
+kerning first=80  second=44  amount=-2  
+kerning first=80  second=46  amount=-2  
+kerning first=80  second=65  amount=-1  
+kerning first=89  second=97  amount=-1  
+kerning first=89  second=65  amount=-1  
+kerning first=89  second=58  amount=-1  
+kerning first=89  second=46  amount=-2  
+kerning first=89  second=45  amount=-2  
+kerning first=84  second=44  amount=-2  
+kerning first=84  second=45  amount=-1  
+kerning first=84  second=46  amount=-2  
+kerning first=84  second=58  amount=-2  
+kerning first=89  second=44  amount=-2  
+kerning first=84  second=65  amount=-1  
+kerning first=87  second=97  amount=-1  
+kerning first=84  second=97  amount=-2  
+kerning first=84  second=99  amount=-2  
+kerning first=84  second=101 amount=-2  
+kerning first=84  second=105 amount=-1  
+kerning first=84  second=111 amount=-2  
+kerning first=84  second=114 amount=-1  
+kerning first=84  second=115 amount=-2  
+kerning first=84  second=117 amount=-1  
+kerning first=84  second=119 amount=-1  
+kerning first=84  second=121 amount=-1  
+kerning first=86  second=44  amount=-2  
+kerning first=86  second=45  amount=-1  
+kerning first=86  second=46  amount=-2  
+kerning first=86  second=58  amount=-1  
+kerning first=87  second=65  amount=-1  
+kerning first=86  second=65  amount=-1  
+kerning first=86  second=97  amount=-1  
+kerning first=86  second=101 amount=-1  
+kerning first=87  second=46  amount=-1  
+kerning first=86  second=111 amount=-1  
+kerning first=86  second=114 amount=-1  
+kerning first=86  second=117 amount=-1  
+kerning first=86  second=121 amount=-1  
+kerning first=87  second=44  amount=-1  

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -33,6 +33,10 @@
          raw bytes and serve them through an in-memory CustomGetStreamFromFile hook. -->
     <None Include="Content\FontCache\Font18Arial.fnt" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Content\FontCache\Font18Arial_0.png" CopyToOutputDirectory="PreserveNewest" />
+    <!-- #4057: "-shadow.fnt" sibling sharing Font18Arial_0.png, for the shadow-companion-loading tests. -->
+    <None Include="Content\FontCache\Font18Arial-shadow.fnt" CopyToOutputDirectory="PreserveNewest" />
+    <!-- #4057: a copy of Font18Arial.fnt with no "-shadow.fnt" sibling, for the no-shadow-registered test. -->
+    <None Include="Content\FontCache\Font18ArialNoShadow.fnt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeDropshadowPlumbingTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeDropshadowPlumbingTests.cs
@@ -1,0 +1,41 @@
+using Gum.GueDeriving;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// #4057 (Raylib): mirrors MonoGameGum.Tests.V2.GueDeriving.TextRuntimeDropshadowPlumbingTests'
+// renderable-forwarding cases. ApplyDropshadowToRenderable was XNALIKE-only until this issue;
+// pins that it now also forwards onto the Raylib Text renderable.
+public class TextRuntimeDropshadowPlumbingTests : BaseTestClass
+{
+    [Fact]
+    public void SettingDropshadowProperties_ForwardsToTextRenderable()
+    {
+        TextRuntime text = new TextRuntime();
+        text.HasDropshadow = true;
+        text.DropshadowOffsetX = 4f;
+        text.DropshadowOffsetY = 5f;
+        text.DropshadowColor = new Raylib_cs.Color(10, 20, 30, 128);
+
+        Gum.Renderables.Text renderable = (Gum.Renderables.Text)text.RenderableComponent;
+        renderable.HasDropshadow.ShouldBeTrue();
+        renderable.DropshadowOffsetX.ShouldBe(4f);
+        renderable.DropshadowOffsetY.ShouldBe(5f);
+        renderable.DropshadowColor.R.ShouldBe((byte)10);
+        renderable.DropshadowColor.G.ShouldBe((byte)20);
+        renderable.DropshadowColor.B.ShouldBe((byte)30);
+        renderable.DropshadowColor.A.ShouldBe((byte)128);
+    }
+
+    [Fact]
+    public void ClearingHasDropshadow_ForwardsFalseToTextRenderable()
+    {
+        TextRuntime text = new TextRuntime();
+        text.HasDropshadow = true;
+        text.HasDropshadow = false;
+
+        Gum.Renderables.Text renderable = (Gum.Renderables.Text)text.RenderableComponent;
+        renderable.HasDropshadow.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Part of #4057.

Wires the Raylib half: a "-shadow.fnt" sibling (written by the KernSmith ShadowSilhouette variant, #4001) is now loaded through raylib's native font loader and recorded in a new `RaylibFontShadowRegistry`, keyed by the primary font's atlas texture id (`Raylib_cs.Font` is a value struct, nowhere else to carry the association). `Text` draws the shadow offset + tinted before the primary glyphs, for both the plain-line and BBCode/inline-run paths - each run looks up its own font's shadow companion, so a run whose font has no shadow just draws none.

## Scope

Only the disk-loaded FontCache path gets a shadow companion (the base-font path, and any inline BBCode run that falls back to disk). The in-memory `KernSmithRaylibFontCreator` path is unaffected - that's the issue's second bullet, and it's blocked on KernSmith exposing a public "variant model -> .fnt text" API (`TextFormatter` is currently internal). Filing that as its own issue since it depends on an upstream KernSmith change.

## Tests

New: shadow-sibling load + registry, dispose unloads the shadow font too, no-sibling-present no-op, TextRuntime -> renderable forwarding. Full suites green: RaylibGum.Tests 542, MonoGameGum.Tests 1945, V2 129, V3 59.

FRB canary: not needed - `TextRuntime.cs` is `GueDeriving/*Runtime`, not FRB-compiled; everything else touched is Raylib-only.

Manual test: confirmed in-session - ran the harness headless and traced the log: it generates a real dropshadow font pair via `KernSmithFileGenerator`, and both `Font48Arial_ds2.fnt` and its `Font48Arial_ds2-shadow.fnt` sibling load successfully (191 glyphs each). Visual Studio is open on a scratch raylib project (`4057-dropshadow-manual-test`, pointed at this worktree) with cyan text and an offset magenta shadow - run it (F5) to confirm the colors are visually independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
