### PR TITLE
Attach KernSmith shadow variant to in-memory fonts (#4061)

### DIFF
--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.18.1" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.1" />
+    <PackageReference Include="KernSmith" Version="0.18.2" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
@@ -112,6 +112,15 @@ public class KernSmithFontCreator : IInMemoryFontCreator
             textures[i] = texture;
         }
 
-        return new BitmapFont(textures, result.FntText);
+        BitmapFont bitmapFont = new BitmapFont(textures, result.FntText);
+
+        // Issue #4061: attach the shadow AtlasVariant (if requested) as ShadowFont. It shares the
+        // primary's atlas pages (same shared texture array), so no extra texture upload is needed.
+        if (result.VariantModels.ContainsKey("shadow"))
+        {
+            bitmapFont.ShadowFont = new BitmapFont(textures, result.GetVariantFntText("shadow"));
+        }
+
+        return bitmapFont;
     }
 }

--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -3,6 +3,7 @@ using KernSmith.Output;
 using KernSmith.Rasterizer;
 using Raylib_cs;
 using RaylibGum.Renderables;
+using RenderingLibrary;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics.Fonts;
 
@@ -84,32 +85,58 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
             return null;
         }
 
-        if (result.Pages.Count == 1)
-        {
-            AtlasPage page = result.Pages[0];
-            Texture2D texture = UploadTexture(page.PixelData, page.Width, page.Height);
-            return ContentLoader.BuildFontFromFntText(result.FntText, texture);
-        }
-
-        // Merge KernSmith's pages into a single texture. KernSmith sizes every page identically
-        // (PackResult.PageWidth/Height), so stacking them vertically is a contiguous copy and each
-        // glyph's atlas Y is shifted by its page's offset. Mirrors the MonoGame creator, which hands
-        // BitmapFont a texture array — same behavior (a usable font for any glyph set), no fallback.
+        Texture2D primaryTexture;
+        Raylib_cs.Font font;
+        int[]? pageYOffsets = null;
+        byte[] pixelData;
         int pageWidth = result.Pages[0].Width;
         int pageHeight = result.Pages[0].Height;
-        int pageCount = result.Pages.Count;
+        int textureHeight;
 
-        byte[] merged = new byte[pageWidth * pageHeight * pageCount * 4];
-        int[] pageYOffsets = new int[pageCount];
-        for (int i = 0; i < pageCount; i++)
+        if (result.Pages.Count == 1)
         {
-            byte[] pagePixels = result.Pages[i].PixelData;
-            System.Array.Copy(pagePixels, 0, merged, i * pagePixels.Length, pagePixels.Length);
-            pageYOffsets[i] = i * pageHeight;
+            pixelData = result.Pages[0].PixelData;
+            textureHeight = pageHeight;
+            primaryTexture = UploadTexture(pixelData, pageWidth, textureHeight);
+            font = ContentLoader.BuildFontFromFntText(result.FntText, primaryTexture);
+        }
+        else
+        {
+            // Merge KernSmith's pages into a single texture. KernSmith sizes every page identically
+            // (PackResult.PageWidth/Height), so stacking them vertically is a contiguous copy and each
+            // glyph's atlas Y is shifted by its page's offset. Mirrors the MonoGame creator, which hands
+            // BitmapFont a texture array — same behavior (a usable font for any glyph set), no fallback.
+            int pageCount = result.Pages.Count;
+
+            pixelData = new byte[pageWidth * pageHeight * pageCount * 4];
+            pageYOffsets = new int[pageCount];
+            for (int i = 0; i < pageCount; i++)
+            {
+                byte[] pagePixels = result.Pages[i].PixelData;
+                System.Array.Copy(pagePixels, 0, pixelData, i * pagePixels.Length, pagePixels.Length);
+                pageYOffsets[i] = i * pageHeight;
+            }
+
+            textureHeight = pageHeight * pageCount;
+            primaryTexture = UploadTexture(pixelData, pageWidth, textureHeight);
+            font = ContentLoader.BuildFontFromFntText(result.FntText, primaryTexture, pageYOffsets);
         }
 
-        Texture2D mergedTexture = UploadTexture(merged, pageWidth, pageHeight * pageCount);
-        return ContentLoader.BuildFontFromFntText(result.FntText, mergedTexture, pageYOffsets);
+        // Issue #4061: attach the shadow AtlasVariant (if requested) as a companion Font, registered
+        // against the primary's atlas texture id (RaylibFontShadowRegistry — the Raylib counterpart of
+        // MonoGame's BitmapFont.ShadowFont). The shadow gets its OWN texture upload (from the same
+        // pixel data) rather than reusing primaryTexture: ManagedFont.Dispose calls Raylib.UnloadFont
+        // on both fonts, which unloads each font's Texture — sharing one GPU texture between them
+        // would double-free it.
+        if (result.VariantModels.ContainsKey("shadow"))
+        {
+            string shadowFntText = result.GetVariantFntText("shadow");
+            Texture2D shadowTexture = UploadTexture(pixelData, pageWidth, textureHeight);
+            Raylib_cs.Font shadowFont = ContentLoader.BuildFontFromFntText(shadowFntText, shadowTexture, pageYOffsets);
+            RaylibFontShadowRegistry.Register(font.Texture.Id, shadowFont);
+        }
+
+        return font;
     }
 
     private static unsafe Texture2D UploadTexture(byte[] pixels, int width, int height)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
@@ -27,6 +27,9 @@
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
 		<ProjectReference Include="..\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
+		<!-- Referenced so the in-memory font creator can be exercised end-to-end (KernSmith atlas
+		     generation -> MonoGame Texture2D upload -> BitmapFont), mirroring RaylibGum.Tests. -->
+		<ProjectReference Include="..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorTests.cs
@@ -1,0 +1,92 @@
+using KernSmith.Gum;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Fonts;
+
+/// <summary>
+/// End-to-end regression for issue #4061: the shadow AtlasVariant KernSmith generates for a
+/// dropshadow font must be attached as <see cref="BitmapFont.ShadowFont"/>, not silently discarded.
+/// Mirrors RaylibGum.Tests's KernSmithRaylibFontCreatorTests.
+/// </summary>
+public class KernSmithFontCreatorTests : BaseTestClass
+{
+    [Fact]
+    public void TryCreateFont_WithDropshadow_AttachesShadowFont()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        KernSmithFontCreator creator = new KernSmithFontCreator(game.GraphicsDevice);
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            UseSmoothing = true,
+            Ranges = "65",
+            HasDropshadow = true,
+            DropshadowOffsetX = 2f,
+            DropshadowOffsetY = 2f,
+            DropshadowBlur = 2f,
+            DropshadowAlpha = 255,
+        };
+
+        BitmapFont? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        font!.ShadowFont.ShouldNotBeNull();
+        font.ShadowFont!.Characters.Length.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TryCreateFont_WithoutDropshadow_DoesNotAttachShadowFont()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        KernSmithFontCreator creator = new KernSmithFontCreator(game.GraphicsDevice);
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            UseSmoothing = true,
+            Ranges = "65",
+        };
+
+        BitmapFont? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        font!.ShadowFont.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Minimal Game host providing a live GraphicsDevice, since KernSmithFontCreator uploads
+    /// generated atlas pages to real Texture2D instances.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorTests.cs
@@ -1,4 +1,5 @@
 using KernSmith.Gum;
+using RenderingLibrary;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using Xunit;
@@ -64,5 +65,53 @@ public class KernSmithRaylibFontCreatorTests : BaseTestClass
         font!.Value.BaseSize.ShouldBe(32);
         font.Value.GlyphCount.ShouldBeGreaterThan(0);
         font.Value.Texture.Id.ShouldBeGreaterThan(0u);
+    }
+
+    // #4061: the shadow AtlasVariant KernSmith generates for a dropshadow font must be attached to the
+    // returned font so RenderingLibrary's Text renderable can draw it, not silently discarded.
+    [Fact]
+    public void TryCreateFont_WithDropshadow_RegistersShadowFont()
+    {
+        KernSmithRaylibFontCreator creator = new KernSmithRaylibFontCreator();
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            UseSmoothing = true,
+            Ranges = "65",
+            HasDropshadow = true,
+            DropshadowOffsetX = 2f,
+            DropshadowOffsetY = 2f,
+            DropshadowBlur = 2f,
+            DropshadowAlpha = 255,
+        };
+
+        Raylib_cs.Font? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        RaylibFontShadowRegistry.TryGet(font!.Value.Texture.Id, out Raylib_cs.Font shadowFont).ShouldBeTrue();
+        shadowFont.GlyphCount.ShouldBeGreaterThan(0);
+        shadowFont.Texture.Id.ShouldBeGreaterThan(0u);
+        shadowFont.Texture.Id.ShouldNotBe(font.Value.Texture.Id);
+    }
+
+    [Fact]
+    public void TryCreateFont_WithoutDropshadow_DoesNotRegisterShadowFont()
+    {
+        KernSmithRaylibFontCreator creator = new KernSmithRaylibFontCreator();
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            UseSmoothing = true,
+            Ranges = "65",
+        };
+
+        Raylib_cs.Font? font = creator.TryCreateFont(bmfcSave);
+
+        font.ShouldNotBeNull();
+        RaylibFontShadowRegistry.TryGet(font!.Value.Texture.Id, out _).ShouldBeFalse();
     }
 }

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -22,8 +22,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="KernSmith" Version="0.18.1" />
-		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.1" />
+		<PackageReference Include="KernSmith" Version="0.18.2" />
+		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.2" />
 		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
 	</ItemGroup>
 


### PR DESCRIPTION
Closes #4061

Both in-memory KernSmith font creators generated the shadow AtlasVariant but had no public API to serialize it into a font. Bumped KernSmith to 0.18.2 (adds BmFontResult.GetVariantFntText, kaltinril/Kernsmith#184) and wired it in:

- KernSmithFontCreator (MonoGame/KNI/FNA): sets BitmapFont.ShadowFont from the shadow variant, sharing the primary's texture array.
- KernSmithRaylibFontCreator: uploads a second texture for the shadow (raylib's UnloadFont frees the font's Texture, so sharing one GPU texture between primary and shadow would double-free it) and registers it in RaylibFontShadowRegistry.

Added e2e tests for both (RaylibGum.Tests extended, new MonoGameGum.IntegrationTests project reference + test class).

## Test plan

- [x] Unit tests: RaylibGum.Tests (544 passing), MonoGameGum.IntegrationTests (76 passing)
- [x] Manual: FontPlayground.MonoGame.sln and FontPlayground.Raylib.sln built clean; toggle the drop-shadow checkbox in each and confirm the shadow now renders (previously silently dropped for in-memory KernSmith fonts)