### PR TITLE
Fix NRE when switching to polygon editor on single-file-published Gum.exe

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Editors/Visuals/AddPointSpriteVisual.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Visuals/AddPointSpriteVisual.cs
@@ -43,11 +43,9 @@ public class AddPointSpriteVisual : EditorVisualBase
         // Load texture if not already loaded
         if (_addPointTexture == null)
         {
-            var gumExePath = System.IO.Path.GetDirectoryName(
-                System.Reflection.Assembly.GetEntryAssembly()!.Location)!
-                .ToLower().Replace("/", "\\") + "\\";
-
-            var fileName = gumExePath + "Content/AddPoint.png";
+            // Assembly.GetEntryAssembly().Location returns empty string in single-file published apps.
+            // AppContext.BaseDirectory is the correct way to locate the executable's directory.
+            var fileName = System.IO.Path.Combine(System.AppContext.BaseDirectory, "Content", "AddPoint.png");
 
             using (var stream = FileManager.GetStreamForFile(fileName))
             {


### PR DESCRIPTION
## Summary
- `AddPointSpriteVisual` used `Assembly.GetEntryAssembly().Location` to find `Content/AddPoint.png`. In the single-file-published Gum.exe, `.Location` returns `""`, so `Path.GetDirectoryName(...)!` threw NRE.
- Reported as a crash when drag+dropping polygons / selecting a polygon (both double-click and normal-click selection route through the polygon editor constructor).
- Switched to `AppContext.BaseDirectory`, matching the existing convention used elsewhere in the tool (`ToolFontService`, `FileManager`, `PluginManager`, etc.) for the same single-file-publish gotcha.

## Test plan
- [x] `dotnet build GumFull.sln` succeeds
- [ ] Manually verify polygon selection/drag+drop no longer crashes in a single-file-published build

🤖 Generated with [Claude Code](https://claude.com/claude-code)