### PR TITLE
Fix Alignment tab and Add Variable button not refreshing after Add Object

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -51,9 +51,11 @@ Every `StateSave` must have `ParentContainer` set — `GetValueRecursive` traver
 
 ## WPF-touching tool code (GumToolUnitTests) needs an STA thread
 
-xUnit's runner is **MTA**, but WPF `FrameworkElement`s (`MenuItem`, `Menu`, `ComboBox`, …) throw `InvalidOperationException: The calling thread must be STA` when constructed. If a tool class news up a WPF control — often a ViewModel building right-click `MenuItem`s in its constructor — build it inside a `RunOnSta(() => { ... })` helper that runs the body on an `ApartmentState.STA` thread and rethrows. Copy the helper from `MenuStripManagerTests` / `RenameManagerTests`; there is no shared base for it.
+xUnit's runner is **MTA**, but WPF `FrameworkElement`s (`MenuItem`, `Menu`, `ComboBox`, …) throw `InvalidOperationException: The calling thread must be STA` when constructed. If a tool class news up a WPF control — often a ViewModel building right-click `MenuItem`s in its constructor, or a plugin's `StartUp()` — mark the test `[StaFact]` (Xunit.StaFact), which runs it on an `ApartmentState.STA` thread. See `MenuStripManagerTests`.
 
 **Verify the real construction blocker empirically before designing around an assumed one.** A quick throwaway probe (construct the object, see what actually throws) beats reasoning: e.g. `BitmapFrame` PNG decode and most non-control VM constructors run fine on MTA, so the blocker is usually the WPF control, not the singleton/resource you suspected.
+
+**`[StaFact]` alone isn't enough for a control that pulls `StaticResource`s from an App-level merged `ResourceDictionary`** — those only exist inside the real running `Application`, so construction throws `XamlParseException` ("Cannot find resource named '...'") even under STA. Don't construct the real control to test a plugin's event-driven show/hide logic; extract that logic into a small class taking `ISelectedState`/`IPluginTab` via the constructor (mirrors `VariableGridSelectionCoordinator`) and test it without touching the control.
 
 ## Plugin/DI composition tests (GumToolUnitTests)
 

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Managers;
+﻿using Gum.DataTypes;
+using Gum.Managers;
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
 using System.ComponentModel.Composition;
@@ -10,66 +11,44 @@ namespace Gum.Plugins.AlignmentButtons
     {
         private readonly ISelectedState _selectedState;
 
-        private IPluginTab _tab;
+        private AlignmentTabVisibilityCoordinator _coordinator;
 
         [ImportingConstructor]
         public AlignmentMainPlugin(ISelectedState selectedState)
         {
             _selectedState = selectedState;
         }
-        
+
         public override void StartUp()
         {
             AssignEvents();
-            _tab = _tabManager.AddControl(new Gum.Plugins.AlignmentButtons.AlignmentPluginControl(), "Alignment");
-            RefreshTabVisibility();
+            var tab = _tabManager.AddControl(new Gum.Plugins.AlignmentButtons.AlignmentPluginControl(), "Alignment");
+            _coordinator = new AlignmentTabVisibilityCoordinator(_selectedState, tab);
+            _coordinator.Refresh();
         }
 
         private void AssignEvents()
         {
             this.TreeNodeSelected += HandleTreeNodeSelected;
             this.StateWindowTreeNodeSelected += HandleStateWindowTreeNodeSelected;
+            this.InstanceSelected += HandleInstanceSelected;
         }
 
         private void HandleStateWindowTreeNodeSelected(ITreeNode obj)
         {
-            RefreshTabVisibility();
+            _coordinator.Refresh();
         }
 
         private void HandleTreeNodeSelected(ITreeNode? treeNode)
         {
-            RefreshTabVisibility();
+            _coordinator.Refresh();
         }
 
-        private void RefreshTabVisibility()
+        private void HandleInstanceSelected(ElementSave elementSave, InstanceSave instance)
         {
-            if (DetermineIfShouldShowTab())
-            {
-                _tab.Show();
-            }
-            else
-            {
-                _tab.Hide();
-            }
-        }
-
-        private bool DetermineIfShouldShowTab()
-        {
-            var shouldAdd = _selectedState.SelectedElement != null &&
-                _selectedState.SelectedStateSave != null;
-
-            if (shouldAdd)
-            {
-                if (_selectedState.SelectedScreen != null &&
-                    _selectedState.SelectedInstance == null)
-                {
-                    // screens as a whole can't be aligned
-                    shouldAdd = false;
-                }
-
-            }
-
-            return shouldAdd;
+            // Auto-selecting a new instance (e.g. right-click Add Object on an already-selected
+            // Screen) only raises InstanceSelected, not TreeNodeSelected - see issue #4067.
+            _coordinator.Refresh();
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentTabVisibilityCoordinator.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentTabVisibilityCoordinator.cs
@@ -1,0 +1,42 @@
+using Gum.Plugins;
+using Gum.ToolStates;
+
+namespace Gum.Plugins.AlignmentButtons;
+
+internal class AlignmentTabVisibilityCoordinator
+{
+    private readonly ISelectedState _selectedState;
+    private readonly IPluginTab _tab;
+
+    public AlignmentTabVisibilityCoordinator(ISelectedState selectedState, IPluginTab tab)
+    {
+        _selectedState = selectedState;
+        _tab = tab;
+    }
+
+    public void Refresh()
+    {
+        if (ShouldShowTab())
+        {
+            _tab.Show();
+        }
+        else
+        {
+            _tab.Hide();
+        }
+    }
+
+    private bool ShouldShowTab()
+    {
+        var shouldShow = _selectedState.SelectedElement != null &&
+            _selectedState.SelectedStateSave != null;
+
+        if (shouldShow && _selectedState.SelectedScreen != null && _selectedState.SelectedInstance == null)
+        {
+            // screens as a whole can't be aligned
+            shouldShow = false;
+        }
+
+        return shouldShow;
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/AddVariableButtonVisibilityLogic.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/AddVariableButtonVisibilityLogic.cs
@@ -1,0 +1,20 @@
+using Gum.ToolStates;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+internal static class AddVariableButtonVisibilityLogic
+{
+    public static bool ShouldShow(ISelectedState selectedState)
+    {
+        var shouldShow = selectedState.SelectedBehavior != null ||
+            selectedState.SelectedComponent != null ||
+            selectedState.SelectedScreen != null;
+
+        if (shouldShow)
+        {
+            shouldShow = selectedState.SelectedInstance == null;
+        }
+
+        return shouldShow;
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -97,6 +97,11 @@ public class MainVariableGridPlugin : PriorityPlugin
 
     private void HandleInstanceSelected(ElementSave save1, InstanceSave save2)
     {
+        // Auto-selecting a new instance (e.g. right-click Add Object on an already-selected
+        // Screen) only raises InstanceSelected, not TreeNodeSelected - see issue #4067.
+        _propertyGridManager.VariableViewModel.IsAddVariableButtonVisible =
+            AddVariableButtonVisibilityLogic.ShouldShow(_selectedState);
+
         if (!_selectionCoordinator.ShouldRefreshOnInstanceSelected(save2))
         {
             // HandleStateSelected already refreshed the grid for this instance
@@ -144,14 +149,8 @@ public class MainVariableGridPlugin : PriorityPlugin
     {
         _selectionCoordinator.Reset();
         var selectedState = _selectedState;
-        var shouldShowButton = (selectedState.SelectedBehavior != null ||
-            selectedState.SelectedComponent != null ||
-            selectedState.SelectedScreen != null);
-        if(shouldShowButton)
-        {
-            shouldShowButton = _selectedState.SelectedInstance == null;
-        }
-        _propertyGridManager.VariableViewModel.IsAddVariableButtonVisible = shouldShowButton;
+        _propertyGridManager.VariableViewModel.IsAddVariableButtonVisible =
+            AddVariableButtonVisibilityLogic.ShouldShow(selectedState);
 
         if(selectedState.SelectedBehavior == null && selectedState.SelectedInstance == null && selectedState.SelectedElement == null)
         {

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/AlignmentButtons/AlignmentTabVisibilityCoordinatorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/AlignmentButtons/AlignmentTabVisibilityCoordinatorTests.cs
@@ -1,0 +1,64 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Plugins;
+using Gum.Plugins.AlignmentButtons;
+using Gum.ToolStates;
+using Moq;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.AlignmentButtons;
+
+public class AlignmentTabVisibilityCoordinatorTests : BaseTestClass
+{
+    [Fact]
+    public void Refresh_HidesTab_WhenNothingIsSelected()
+    {
+        var selectedState = new Mock<ISelectedState>();
+        var tab = new Mock<IPluginTab>();
+        var coordinator = new AlignmentTabVisibilityCoordinator(selectedState.Object, tab.Object);
+
+        coordinator.Refresh();
+
+        tab.Verify(t => t.Hide(), Times.Once);
+        tab.Verify(t => t.Show(), Times.Never);
+    }
+
+    [Fact]
+    public void Refresh_HidesTab_WhenScreenIsSelectedWithNoInstance()
+    {
+        var screen = new ScreenSave();
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(screen);
+        selectedState.Setup(s => s.SelectedScreen).Returns(screen);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(new StateSave());
+        var tab = new Mock<IPluginTab>();
+        var coordinator = new AlignmentTabVisibilityCoordinator(selectedState.Object, tab.Object);
+
+        coordinator.Refresh();
+
+        tab.Verify(t => t.Hide(), Times.Once);
+        tab.Verify(t => t.Show(), Times.Never);
+    }
+
+    [Fact]
+    public void Refresh_ShowsTab_WhenInstanceIsAutoSelectedAfterAddOnAnAlreadySelectedScreen()
+    {
+        // Bug repro for issue #4067: right-clicking an already-selected Screen and adding an
+        // object auto-selects the new instance. The coordinator's Refresh() must be called (by
+        // the plugin's InstanceSelected handler) and must show the tab for the new instance.
+        var screen = new ScreenSave();
+        var instance = new InstanceSave();
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(screen);
+        selectedState.Setup(s => s.SelectedScreen).Returns(screen);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(new StateSave());
+        selectedState.Setup(s => s.SelectedInstance).Returns(instance);
+        var tab = new Mock<IPluginTab>();
+        var coordinator = new AlignmentTabVisibilityCoordinator(selectedState.Object, tab.Object);
+
+        coordinator.Refresh();
+
+        tab.Verify(t => t.Show(), Times.Once);
+        tab.Verify(t => t.Hide(), Times.Never);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/AddVariableButtonVisibilityLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/AddVariableButtonVisibilityLogicTests.cs
@@ -1,0 +1,40 @@
+using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.VariableGrid;
+
+public class AddVariableButtonVisibilityLogicTests : BaseTestClass
+{
+    [Fact]
+    public void ShouldShow_ReturnsFalse_WhenAnInstanceIsSelectedOnAScreen()
+    {
+        // Bug repro for issue #4067: right-clicking an already-selected Screen and adding an
+        // object auto-selects the new instance. The Screen-only "Add Variable" button must hide.
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedScreen).Returns(new ScreenSave());
+        selectedState.Setup(s => s.SelectedInstance).Returns(new InstanceSave());
+
+        AddVariableButtonVisibilityLogic.ShouldShow(selectedState.Object).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_ReturnsFalse_WhenNothingIsSelected()
+    {
+        var selectedState = new Mock<ISelectedState>();
+
+        AddVariableButtonVisibilityLogic.ShouldShow(selectedState.Object).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_ReturnsTrue_WhenScreenIsSelectedWithNoInstance()
+    {
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedScreen).Returns(new ScreenSave());
+
+        AddVariableButtonVisibilityLogic.ShouldShow(selectedState.Object).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Right-clicking Add Object on an already-selected Screen auto-selects the new instance via `SelectedState.SelectedInstance`, which raises `InstanceSelected` but not `TreeNodeSelected`. `AlignmentMainPlugin` and `MainVariableGridPlugin` only recomputed the Alignment tab / Add Variable button visibility on `TreeNodeSelected`, so both stayed stale until the instance was re-selected manually.
- Extracted the visibility decisions into `AlignmentTabVisibilityCoordinator` and `AddVariableButtonVisibilityLogic` so both plugins also refresh on `InstanceSelected`.
- Added a landmine to the `gum-unit-tests` skill: a plugin's own WPF control can't be constructed in the test host if it pulls `StaticResource`s from an App-level merged `ResourceDictionary` — extract the logic instead of constructing the real control. Also fixed a stale reference to a nonexistent `RunOnSta` helper (actual pattern is `[StaFact]`).

## Test plan
- [x] New unit tests: `AlignmentTabVisibilityCoordinatorTests`, `AddVariableButtonVisibilityLogicTests` (both red before the fix, green after; sanity-checked by inverting the logic and confirming failure)
- [x] Full `GumToolUnitTests` suite green (1151 passed, incl. `AllPluginsCompositionTests`)
- [x] `GumFull.sln` builds clean
- [x] Manual: verify in the running tool (steps in PR comment)

Closes #4067
