### PR TITLE
Fix unreadable state-editing banner text in dark mode

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
@@ -29,6 +29,7 @@
     <Label
       Background="{Binding StateBackground, Converter={StaticResource ColorToBrushConverter}}"
       Content="{Binding StateInformation}"
+      Foreground="{DynamicResource Frb.Brushes.OnLightBanner}"
       Visibility="{Binding HasStateInformation, Converter={StaticResource BoolToVisibilityConverter}}" />
     <Label
       Grid.Row="1"

--- a/Gum/Themes/Frb.Brushes.xaml
+++ b/Gum/Themes/Frb.Brushes.xaml
@@ -12,6 +12,9 @@
     <SolidColorBrush x:Key="Frb.Brushes.Primary.Dark" Color="{DynamicResource Frb.Colors.Primary.Dark}" />
     <SolidColorBrush x:Key="Frb.Brushes.Primary.Contrast" Color="{DynamicResource Frb.Colors.Primary.Contrast}" />
 
+    <!-- Fixed dark foreground for banners with a fixed light background (e.g. yellow/pink state-editing notices) that must stay readable regardless of app theme. -->
+    <SolidColorBrush x:Key="Frb.Brushes.OnLightBanner" Color="Black" />
+
     <SolidColorBrush
         x:Key="Lighten"
         Opacity="0.1"


### PR DESCRIPTION
Closes #4071

The state-editing banner (yellow) and custom/animated-state banner (pink) had no explicit `Foreground`, so text fell back to the app's default color — invisible white-on-yellow/pink in dark mode.

Added `Frb.Brushes.OnLightBanner`, a fixed dark brush (not per-theme) since the banner's yellow/pink background doesn't adapt to theme either — a `ThemeContrast`-style flipping token would go white in dark mode and reproduce the bug.