### PR TITLE
Fix color swatch showing gray when read-only via VariableReferences

### DIFF
--- a/Gum/Controls/ColorDisplay.xaml
+++ b/Gum/Controls/ColorDisplay.xaml
@@ -32,6 +32,16 @@
             MouseUp="ColorPicker_MouseUp"
             PreviewMouseUp="ColorPicker_PreviewMouseUp" />
 
+        <!--  Overlays the (disabled) picker with the real resolved color when read-only, since WPF's
+              disabled-control rendering blanks the third-party picker's swatch to solid gray (#4072).  -->
+        <Rectangle
+            x:Name="ReadOnlySwatch"
+            Grid.Column="1"
+            Margin="0,5,0,5"
+            VerticalAlignment="Stretch"
+            IsHitTestVisible="False"
+            Visibility="Collapsed" />
+
         <!--  Inline hex entry: paste/type a 6- or 8-digit hex (alpha stripped) without opening the picker popup.  -->
         <StackPanel
             Grid.Column="2"

--- a/Gum/Controls/ColorDisplay.xaml.cs
+++ b/Gum/Controls/ColorDisplay.xaml.cs
@@ -111,14 +111,10 @@ namespace Gum.Controls.DataUi
 
         private void RefreshIsEnabled()
         {
-            if (InstanceMember?.IsReadOnly == true)
-            {
-                IsEnabled = false;
-            }
-            else
-            {
-                IsEnabled = true;
-            }
+            bool isReadOnly = InstanceMember?.IsReadOnly == true;
+
+            IsEnabled = !isReadOnly;
+            ReadOnlySwatch.Visibility = isReadOnly ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public ApplyValueResult TrySetValueOnUi(object valueOnInstance)
@@ -133,6 +129,7 @@ namespace Gum.Controls.DataUi
                 windowsColor.B = color.B;
 
                 this.ColorPicker.SelectedColor = windowsColor;
+                ReadOnlySwatch.Fill = new SolidColorBrush(ColorDisplayLogic.ToOpaqueSwatchColor(windowsColor));
                 SyncHexTextFromPicker();
                 // This is beign set from the underlying data object to the UI
                 // which means the UI hasn't updated yet, so we don't want to push
@@ -141,7 +138,7 @@ namespace Gum.Controls.DataUi
 
                 return ApplyValueResult.Success;
             }
-            else 
+            else
 #endif
             if(valueOnInstance is System.Drawing.Color drawingColor)
             {
@@ -152,6 +149,7 @@ namespace Gum.Controls.DataUi
                 windowsColor.B = drawingColor.B;
 
                 this.ColorPicker.SelectedColor = windowsColor;
+                ReadOnlySwatch.Fill = new SolidColorBrush(ColorDisplayLogic.ToOpaqueSwatchColor(windowsColor));
                 SyncHexTextFromPicker();
                 return ApplyValueResult.Success;
             }

--- a/Gum/Controls/ColorDisplayLogic.cs
+++ b/Gum/Controls/ColorDisplayLogic.cs
@@ -1,0 +1,17 @@
+using System.Windows.Media;
+
+namespace Gum.Controls.DataUi
+{
+    /// <summary>
+    /// Pure color logic for <see cref="ColorDisplay"/>'s read-only swatch overlay.
+    /// </summary>
+    public static class ColorDisplayLogic
+    {
+        /// <summary>
+        /// Returns the color to fill the read-only swatch overlay with, always fully opaque.
+        /// Alpha is discarded so a resolved color with zero or partial alpha still renders as a
+        /// solid swatch instead of blending into (or disappearing into) the background.
+        /// </summary>
+        public static Color ToOpaqueSwatchColor(Color color) => Color.FromRgb(color.R, color.G, color.B);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Controls/ColorDisplayLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/ColorDisplayLogicTests.cs
@@ -1,0 +1,44 @@
+using System.Windows.Media;
+using Gum.Controls.DataUi;
+using Shouldly;
+
+namespace GumToolUnitTests.Controls;
+
+public class ColorDisplayLogicTests
+{
+    [Fact]
+    public void ToOpaqueSwatchColor_FullyTransparentColor_ReturnsOpaqueRgb()
+    {
+        Color transparent = Color.FromArgb(0, 10, 20, 30);
+
+        Color result = ColorDisplayLogic.ToOpaqueSwatchColor(transparent);
+
+        result.A.ShouldBe((byte)255);
+        result.R.ShouldBe((byte)10);
+        result.G.ShouldBe((byte)20);
+        result.B.ShouldBe((byte)30);
+    }
+
+    [Fact]
+    public void ToOpaqueSwatchColor_OpaqueColor_ReturnsSameRgb()
+    {
+        Color opaque = Color.FromArgb(255, 100, 150, 200);
+
+        Color result = ColorDisplayLogic.ToOpaqueSwatchColor(opaque);
+
+        result.ShouldBe(opaque);
+    }
+
+    [Fact]
+    public void ToOpaqueSwatchColor_PartiallyTransparentColor_DiscardsAlpha()
+    {
+        Color partial = Color.FromArgb(128, 200, 50, 75);
+
+        Color result = ColorDisplayLogic.ToOpaqueSwatchColor(partial);
+
+        result.A.ShouldBe((byte)255);
+        result.R.ShouldBe((byte)200);
+        result.G.ShouldBe((byte)50);
+        result.B.ShouldBe((byte)75);
+    }
+}


### PR DESCRIPTION
Closes #4072

## Summary
Color swatch in the Variables tab showed solid gray for a color driven by a `VariableReferences` entry, because `RefreshIsEnabled()` disabled the whole `ColorDisplay` control and WPF blanks the third-party picker's swatch when disabled.

Kept `IsEnabled = false` (still blocks direct edits) but overlaid a `Rectangle` on top of the picker, filled with the resolved color. The overlay always forces full alpha (`ColorDisplayLogic.ToOpaqueSwatchColor`), so a resolved color with 0 or partial alpha still renders as a solid swatch instead of gray or invisible.

## Test plan
- [x] `ColorDisplayLogicTests` (new, TDD'd red -> green)
- [x] `GumFull.sln` builds clean
- [x] Manual: verified in the tool that a color channel driven by `VariableReferences` now shows the real resolved color in the swatch
