### PR TITLE
Fix BehaviorSave compact round trip drift (#4080)

### DIFF
--- a/GumDataTypes/Serialization/GumFileSerializer.cs
+++ b/GumDataTypes/Serialization/GumFileSerializer.cs
@@ -22,14 +22,28 @@ public static class GumFileSerializer
         "StandardizedName", "IsFile", "IsFont", "IsHiddenInPropertyGrid", "IsCustomVariable"
     ];
 
-    private static void AddVariableSaveOverrides(XmlAttributeOverrides overrides)
+    private static void AddVariableSaveOverrides(XmlAttributeOverrides overrides, bool suppressDefaultSetsValue = false)
     {
         foreach (var prop in AttributeProps)
         {
             XmlAttributes attrs = new XmlAttributes();
             attrs.XmlAttribute = new XmlAttributeAttribute(prop);
+            if (suppressDefaultSetsValue && prop == "SetsValue")
+            {
+                // VariableSave.SetsValue defaults to true, but BehaviorSave.RequiredVariables/FormsProperties
+                // never write it explicitly when true - suppressing it here keeps behavior save/load round trips
+                // byte-identical (see issue #4080).
+                attrs.XmlDefaultValue = true;
+            }
             overrides.Add(typeof(VariableSave), prop, attrs);
         }
+    }
+
+    private static void AddBehaviorRequiredVariablesNameOverride(XmlAttributeOverrides overrides)
+    {
+        XmlAttributes attrs = new XmlAttributes();
+        attrs.XmlDefaultValue = string.Empty;
+        overrides.Add(typeof(StateSave), "Name", attrs);
     }
 
     private static void AddInstanceSaveOverrides(XmlAttributeOverrides overrides)
@@ -58,9 +72,15 @@ public static class GumFileSerializer
             if (_compactSerializers.TryGetValue(rootType, out var cached))
                 return cached;
 
+            bool isBehaviorSave = rootType == typeof(BehaviorSave);
+
             XmlAttributeOverrides overrides = new XmlAttributeOverrides();
-            AddVariableSaveOverrides(overrides);
+            AddVariableSaveOverrides(overrides, suppressDefaultSetsValue: isBehaviorSave);
             AddInstanceSaveOverrides(overrides);
+            if (isBehaviorSave)
+            {
+                AddBehaviorRequiredVariablesNameOverride(overrides);
+            }
 
             var serializer = new XmlSerializer(rootType, overrides);
             _compactSerializers[rootType] = serializer;

--- a/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumFileSerializerTests.cs
@@ -173,6 +173,42 @@ public class GumFileSerializerTests
     }
 
     [Fact]
+    public void SerializeBehaviorSave_CompactFormat_FormsPropertyWithoutExplicitSetsValue_OmitsSetsValueAttribute()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip" });
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        xml.ShouldNotContain("SetsValue");
+    }
+
+    [Fact]
+    public void SerializeBehaviorSave_CompactFormat_FormsPropertyWithExplicitFalseSetsValue_KeepsSetsValueAttribute()
+    {
+        BehaviorSave original = new BehaviorSave();
+        original.FormsProperties.Add(new VariableSave { Type = "string", Name = "ToolTip", SetsValue = false });
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        xml.ShouldContain("SetsValue=\"false\"");
+    }
+
+    [Fact]
+    public void SerializeBehaviorSave_CompactFormat_EmptyRequiredVariables_OmitsNameElement()
+    {
+        BehaviorSave original = new BehaviorSave();
+
+        XmlSerializer compactSerializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        string xml = SerializeToString(compactSerializer, original);
+
+        xml.ShouldContain("<RequiredVariables />");
+        xml.ShouldNotContain("<Name />");
+    }
+
+    [Fact]
     public void SerializeBehaviorSave_EmptyToolOnlyVariableReferences_OmittedFromXml()
     {
         BehaviorSave original = new BehaviorSave();


### PR DESCRIPTION
Closes #4080

`GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave))` always emitted `SetsValue="true"` on `FormsProperty` entries and always emitted a `<Name>` element inside `RequiredVariables`, even when the source `.behx` never wrote them. Both equal their in-memory defaults (`VariableSave.SetsValue = true`, `StateSave.Name = ""`), so this is pure drift on load/save round trip.

Suppress both via `XmlAttributeOverrides.XmlDefaultValue`, scoped to `BehaviorSave`'s compact serializer only (doesn't touch regular Screen/Component variable serialization, which already writes `SetsValue="true"` intentionally).

Verified against the real `gumcli stage-forms-behaviors` output on the Bubblegum theme templates: staged `.behx` files now match source byte-for-byte apart from the expected theme override values.

FRB canary: pass (built `GumCore.DesktopGlNet6.csproj` clean from the primary checkout, baseline and with this change).
