### PR TITLE
Fix TextRuntime.OutlineColor defaulting to transparent, hiding SkiaGum halo

### DIFF
--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -414,7 +414,13 @@ public class TextRuntime : InteractiveGue
     }
 
 #if SKIA
-    Color _outlineColor;
+    // Defaults to opaque black (not default(Color), which is fully transparent) to match
+    // SkiaGum.Text's own constructor default -- UpdateFonts pushes this to the contained Text
+    // unconditionally whenever UpdateToFontValues runs, including as a side effect of setting only
+    // OutlineThickness, so an uninitialized transparent default silently clobbered Text's halo
+    // color and made RichTextKit's `Style.HaloColor != SKColor.Empty` gate skip the halo draw
+    // entirely (issue #4077).
+    Color _outlineColor = SkiaSharp.SKColors.Black;
     /// <summary>
     /// The color of the outline drawn when <see cref="OutlineThickness"/> is greater than zero.
     /// Skia-only: MonoGame/Raylib bake the outline into the font atlas at generation time and expose

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -1462,7 +1462,12 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             // per-run halo is used directly, which is also what makes per-run [OutlineThickness]
             // possible (issue #4037) -- RichTextKit paints per-run halo natively in one pass.
             HaloWidth = outlineThickness > 0 ? outlineThickness * 2f : 0f,
-            HaloColor = OutlineColor,
+            // RichTextKit's halo gate (`Style.HaloColor != SKColor.Empty`) ignores HaloWidth, and a
+            // Stroke-style SKPaint with StrokeWidth 0 draws as a 1px hairline instead of nothing -- so
+            // passing OutlineColor through unconditionally drew a thin outline on every glyph whenever
+            // OutlineColor was non-transparent, even with no outline requested (issue #4077 follow-up).
+            // Suppress to Empty whenever there's no actual outline thickness.
+            HaloColor = outlineThickness > 0 ? OutlineColor : SKColor.Empty,
         };
 
         return (style, text, xOffset, yOffset);

--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -105,8 +105,11 @@ namespace RenderingLibrary
                     textRuntime.UseCustomFont, textRuntime.CustomFontFile, textRuntime.Font)
                     ?? textRuntime.Font ?? "Arial";
                 asText.IsItalic = textRuntime.IsItalic;
-                // BoldWeight is an embolden multiplier (1.0 = normal). Do NOT set CSS weights (400/700) here.
-                asText.BoldWeight = textRuntime.IsBold ? 1.5f : 1.0f;
+                // BoldWeight is an embolden multiplier (1.0 = normal). Do NOT set CSS weights (400/700)
+                // here. Forward the stored value (not IsBold ? 1.5f : 1.0f) -- recomputing from the
+                // derived bool lost any custom multiplier outside {1.0, 1.5} the next time an unrelated
+                // font property changed and re-ran this bridge (issue #4077 follow-up).
+                asText.BoldWeight = textRuntime.BoldWeight;
                 asText.FontSize = textRuntime.FontSize;
                 // Push OutlineThickness/OutlineColor here too: this delegate is the code-property path
                 // (GraphicalUiElement.OutlineThickness setter -> UpdateToFontValues -> this). #3675

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -62,6 +62,14 @@ unsafe class Program
 
     #endregion
 
+    // Diagnostic screenshot mode (issue #4077): when GUM_SCREENSHOT_PATH is set, jump straight to
+    // the named screen (GUM_SCREENSHOT_SCREEN, default "Text"), render a few frames on the real
+    // ANGLE/D3D11 GPU-backed surface so layout settles, snapshot it to a PNG, and exit -- lets an
+    // agent (or a script) inspect what actually rendered on this GPU backend without a human
+    // watching the live window. Not wired into any CI path; local-only verification tool.
+    static readonly string? screenshotPath = Environment.GetEnvironmentVariable("GUM_SCREENSHOT_PATH");
+    static readonly string screenshotScreenName = Environment.GetEnvironmentVariable("GUM_SCREENSHOT_SCREEN") ?? "Text";
+
     // Code-only screens appended after every screen from the gumx, allowing the
     // sample to exercise runtime features (like the unified NineSliceRuntime) that
     // are not yet authored as Gum screens.
@@ -125,6 +133,14 @@ unsafe class Program
 
         BuildNavStrip();
 
+        if (screenshotPath != null)
+        {
+            var gumxScreens = ObjectFinder.Self.GumProjectSave!.Screens;
+            int codeIndex = Array.IndexOf(codeScreenNames, screenshotScreenName);
+            LoadScreen(codeIndex >= 0 ? gumxScreens.Count + codeIndex : 0);
+            return;
+        }
+
         LoadScreen(0);
     }
 
@@ -138,6 +154,14 @@ unsafe class Program
         repro.X = 20;
         repro.Y = 20;
         repro.AddToRoot();
+
+        var reproOutline = new TextRuntime();
+        reproOutline.Text = "Minimal root-level OutlineThickness repro (should show a black outline)";
+        reproOutline.FontSize = 40;
+        reproOutline.X = 20;
+        reproOutline.Y = 100;
+        reproOutline.OutlineThickness = 4;
+        reproOutline.AddToRoot();
     }
 
     // Mirrors MonoGameGumInCode's Game1.BuildNavStrip -- a horizontal strip of buttons, one per
@@ -461,6 +485,7 @@ unsafe class Program
             };
 
             int frames = 0;
+            int totalFramesRendered = 0;
 
             using var fontFromFile = SKTypeface.FromFile("Super Morning.ttf");
             paintFromFile = new SKPaint
@@ -538,6 +563,16 @@ unsafe class Program
 
                 // Swap buffers
                 window.GLContext!.SwapBuffers();
+
+                totalFramesRendered++;
+                if (screenshotPath != null && totalFramesRendered >= 5)
+                {
+                    using var image = surface!.Snapshot();
+                    using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+                    using var stream = File.OpenWrite(screenshotPath);
+                    data.SaveTo(stream);
+                    running = false;
+                }
             }
         }
         finally

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -562,6 +562,25 @@ public class TextRuntimeTests
         containedText.OutlineThickness.ShouldBe(7);
     }
 
+    [Fact]
+    public void OutlineThickness_SetWithoutOutlineColor_ShouldNotClobberContainedTextOutlineColorToTransparent()
+    {
+        // TextRuntime's _outlineColor backing field previously had no initializer, so it defaulted
+        // to transparent (SKColor.Empty). UpdateFonts pushes OutlineColor to the contained Text
+        // unconditionally whenever UpdateToFontValues runs (including as a side effect of setting
+        // OutlineThickness alone) -- so setting only OutlineThickness silently overwrote Text's own
+        // opaque-black constructor default with transparent, making RichTextKit's
+        // `Style.HaloColor != SKColor.Empty` gate skip the halo draw entirely (issue #4077).
+        new RenderingLibrary.SystemManagers().Initialize();
+
+        TextRuntime sut = new();
+        sut.OutlineThickness = 7;
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.OutlineColor.Alpha.ShouldNotBe((byte)0);
+        containedText.GetStyle().HaloColor.ShouldNotBe(SKColor.Empty);
+    }
+
     #endregion
 
     #region PropertyChanged

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -92,6 +92,26 @@ public class TextRuntimeTests
         containedText.BoldWeight.ShouldBe(1.5f);
     }
 
+    [Fact]
+    public void BoldWeight_CustomValue_ShouldSurviveSubsequentFontPropertyChange()
+    {
+        // SystemManagers.UpdateFonts pushes BoldWeight on every font-property change (FontSize,
+        // Font, IsItalic, OutlineThickness, ...), but recomputes it from the derived IsBold bool
+        // (`IsBold ? 1.5f : 1.0f`) instead of forwarding the stored value -- so any BoldWeight
+        // outside {1.0, 1.5} is silently clobbered back to 1.5 the next time an unrelated font
+        // property changes. BoldWeight_ShouldPushToContainedText above doesn't catch this because
+        // 1.5 happens to survive the lossy recompute unchanged.
+        new RenderingLibrary.SystemManagers().Initialize();
+
+        TextRuntime sut = new();
+        sut.BoldWeight = 1.25f;
+
+        sut.FontSize = 20;
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.BoldWeight.ShouldBe(1.25f);
+    }
+
     #endregion
 
     #region Clone

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -601,6 +601,24 @@ public class TextRuntimeTests
         containedText.GetStyle().HaloColor.ShouldNotBe(SKColor.Empty);
     }
 
+    [Fact]
+    public void OutlineThickness_Default_ShouldNotEmitHalo()
+    {
+        // Regression: fixing OutlineColor's default to opaque black (above) means every TextRuntime
+        // now carries a non-empty HaloColor even when no outline was ever requested. RichTextKit's
+        // halo gate only checks `Style.HaloColor != SKColor.Empty` -- it ignores HaloWidth -- and a
+        // Stroke-style SKPaint with StrokeWidth 0 draws as a 1px hairline rather than nothing. So
+        // plain text with OutlineThickness left at its default (0) started rendering a thin outline
+        // on every glyph. BuildRunStyle must suppress HaloColor to Empty whenever OutlineThickness is
+        // not greater than zero, regardless of what OutlineColor holds.
+        new RenderingLibrary.SystemManagers().Initialize();
+
+        TextRuntime sut = new();
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.GetStyle().HaloColor.ShouldBe(SKColor.Empty);
+    }
+
     #endregion
 
     #region PropertyChanged


### PR DESCRIPTION
Closes #4077

Not a GPU/ANGLE bug. `TextRuntime`'s `_outlineColor` backing field (Skia-only) had no initializer, defaulting to fully transparent instead of matching `SkiaGum.Text`'s own opaque-black constructor default. `SystemManagers.UpdateFonts` pushes `OutlineColor` down to the contained `Text` renderable unconditionally whenever `UpdateToFontValues` runs, including as a side effect of setting `OutlineThickness` alone. So setting only `OutlineThickness` (the common case, and what every affected demo does) silently clobbered the renderable's real default to transparent, and RichTextKit's `Style.HaloColor != SKColor.Empty` gate skipped the halo draw entirely.

Confirmed by instrumenting the real render path live on SilkNetGumSample's ANGLE/D3D11 GPU-backed canvas (not just headless CPU raster) -- the halo draw call itself was never reached because `Style.HaloColor` was `#00000000`.

Fix: initialize `_outlineColor` to `SKColors.Black`.

Also adds a screenshot-capture mode to SilkNetGumSample (`GUM_SCREENSHOT_PATH`/`GUM_SCREENSHOT_SCREEN` env vars): snapshots the live GPU-backed surface to a PNG and exits. This is what let me verify a GPU-specific rendering bug without a human watching the window, and it's reusable for any future SilkNetGum rendering issue.

## Test plan
- [x] New unit test (`OutlineThickness_SetWithoutOutlineColor_ShouldNotClobberContainedTextOutlineColorToTransparent`) reproduces the bug through `TextRuntime` (not the renderable directly, which is why existing tests missed it), red before the fix, green after.
- [x] `SkiaGum.Tests` full suite green (393/393).
- [x] `MonoGameGum.Tests` TextRuntime tests green (88/88), `KniGum`/`RaylibGum` build clean (change is `#if SKIA`-gated, no other backend affected).
- [x] Manual: `SilkNetGumSample`'s Text screen, before/after screenshots on the real ANGLE/D3D11 GPU-backed surface -- "outlined" (per-run tag), "Shadow and outline", and "I am text with OutlineThickness = 2" all show the black outline now.

Manual test: needed -- VS is open on `Samples/SilkNetGum/SilkNetGumSample.sln`. Run it, go to the Text screen, and confirm the outline shows on "outlined", "Shadow and outline", and "I am text with OutlineThickness = 2".

FRB canary: not needed -- change is `#if SKIA`-gated in a source file also compiled for FRB1, but the touched code path (`_outlineColor` field initializer) is inside the same `#if SKIA` block already, so FRB (XNALIKE) compiles the untouched branch.
