### PR TITLE
Reconcile TrySetPropertyOnText's Text wrapper with TextRuntime.Text's

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -874,12 +874,22 @@ public partial class CustomSetPropertyOnRenderable
 
         if (propertyName == "Text" || propertyName == "TextNoTranslate")
         {
-            if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
-                // If height is relative to children, it could be in a stack
-                graphicalUiElement.HeightUnits == DimensionUnitType.RelativeToChildren)
+            // Mirrors TextRuntime.Text's own wrapper (MonoGameGum/GueDeriving/TextRuntime.cs) so both
+            // entry points measure/re-layout identically instead of each doing it slightly differently.
+            var widthBefore = textRenderable.WrappedTextWidth;
+            var heightBefore = textRenderable.WrappedTextHeight;
+
+            if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren)
             {
-                // make it have no line wrap width before assignign the text:
-                textRenderable.Width = null;
+                if (graphicalUiElement.MaxWidth == null)
+                {
+                    // make it have no line wrap width before assignign the text:
+                    textRenderable.Width = null;
+                }
+                else
+                {
+                    textRenderable.Width = graphicalUiElement.MaxWidth;
+                }
             }
 
             var valueAsString = value as string;
@@ -927,12 +937,13 @@ public partial class CustomSetPropertyOnRenderable
                     textRenderable.RawText = rawText;
                 }
             }
-            // we want to update if the text's size is based on its "children" (the letters it contains)
-            if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren ||
-                // If height is relative to children, it could be in a stack
-                graphicalUiElement.HeightUnits == DimensionUnitType.RelativeToChildren)
+            // we want to update if the text's size actually changed (the letters it contains)
+            var shouldUpdate = widthBefore != textRenderable.WrappedTextWidth || heightBefore != textRenderable.WrappedTextHeight;
+            if (shouldUpdate)
             {
-                graphicalUiElement.UpdateLayout();
+                graphicalUiElement.UpdateLayout(
+                    GraphicalUiElement.ParentUpdateType.IfParentWidthHeightDependOnChildren |
+                    GraphicalUiElement.ParentUpdateType.IfParentStacks, int.MaxValue / 2);
             }
             handled = true;
         }

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
@@ -1,4 +1,5 @@
 using Gum.GueDeriving;
+using Gum.Wireframe;
 using RenderingLibrary.Graphics;
 using Shouldly;
 
@@ -204,6 +205,25 @@ public class TextRuntimeTests : BaseTestClass
             (first, value) => first.SetProperty(propertyName, value));
 
         ySettingViaSetProperty.ShouldBe(ySettingViaDirect);
+    }
+
+    [Fact]
+    public void Text_ViaDirectPropertySet_WhenSizeChanges_StillTriggersTwoUpdateLayoutCalls()
+    {
+        TextRuntime sut = new();
+        sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        sut.Text = "Short";
+
+        int countBefore = GraphicalUiElement.UpdateLayoutCallCount;
+        sut.Text = "This is a much longer string that changes the wrapped size";
+        int callCount = GraphicalUiElement.UpdateLayoutCallCount - countBefore;
+
+        // TextRuntime.Text's own wrapper AND the dispatcher's wrapper (reached via the SetProperty call
+        // in between) both still run and both now agree the size changed, so each independently calls
+        // UpdateLayout -- reconciling the two wrappers' *conditions* didn't collapse them into one call.
+        // That only happens once the dispatcher delegates directly to TextRuntime.Text (a follow-up PR),
+        // at which point this should drop to 1 -- update this test when that lands.
+        callCount.ShouldBe(2);
     }
 
     private static void AssertWrapsIdentically(string propertyName, string? text, bool expectMultipleLines, Action<TextRuntime> configure)

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
@@ -138,6 +138,78 @@ public class TextRuntimeTests : BaseTestClass
         sut.WrappedText.ShouldNotBeEmpty();
     }
 
+    [Fact]
+    public void Text_ViaDirectPropertySetVersusSetProperty_WithMaxWidth_ShouldWrapIdentically()
+    {
+        const string longText = "This is a long piece of text that should wrap at the max width";
+
+        TextRuntime viaProperty = new();
+        viaProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        viaProperty.MaxWidth = 40;
+        viaProperty.Text = longText;
+
+        TextRuntime viaSetProperty = new();
+        viaSetProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        viaSetProperty.MaxWidth = 40;
+        viaSetProperty.SetProperty("Text", longText);
+
+        viaProperty.WrappedText.Count.ShouldBeGreaterThan(1);
+        viaSetProperty.WrappedText.ShouldBe(viaProperty.WrappedText);
+    }
+
+    [Fact]
+    public void Text_ViaSetProperty_WithFixedWidthAndHeightRelativeToChildren_ShouldWrapSameAsDirectPropertySet()
+    {
+        const string longText = "This is a long piece of text that should wrap at the fixed width";
+
+        TextRuntime viaProperty = new();
+        viaProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        viaProperty.Width = 100;
+        viaProperty.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        viaProperty.Text = longText;
+
+        TextRuntime viaSetProperty = new();
+        viaSetProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+        viaSetProperty.Width = 100;
+        viaSetProperty.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        viaSetProperty.SetProperty("Text", longText);
+
+        viaProperty.WrappedText.Count.ShouldBeGreaterThan(1);
+        viaSetProperty.WrappedText.ShouldBe(viaProperty.WrappedText);
+    }
+
+    [Fact]
+    public void Text_ViaDirectPropertySetVersusSetProperty_InStack_ShouldPositionSiblingIdentically()
+    {
+        float ySettingViaProperty = BuildStackAndGetSecondChildY(
+            (first, value) => first.Text = value);
+        float ySettingViaSetProperty = BuildStackAndGetSecondChildY(
+            (first, value) => first.SetProperty("Text", value));
+
+        ySettingViaSetProperty.ShouldBe(ySettingViaProperty);
+    }
+
+    private static float BuildStackAndGetSecondChildY(Action<TextRuntime, string> setText)
+    {
+        ContainerRuntime stack = new();
+        stack.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        stack.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        stack.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+
+        TextRuntime first = new();
+        first.Text = "Line1";
+        TextRuntime second = new();
+        second.Text = "Line2";
+        stack.Children.Add(first);
+        stack.Children.Add(second);
+
+        stack.UpdateLayout();
+
+        setText(first, "Line1\nLine1b\nLine1c");
+
+        return second.Y;
+    }
+
     #endregion
 
     #region WidthUnits

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
@@ -138,55 +138,101 @@ public class TextRuntimeTests : BaseTestClass
         sut.WrappedText.ShouldNotBeEmpty();
     }
 
-    [Fact]
-    public void Text_ViaDirectPropertySetVersusSetProperty_WithMaxWidth_ShouldWrapIdentically()
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("TextNoTranslate")]
+    public void Text_ViaDirectPropertySetVersusSetProperty_WithMaxWidth_ShouldWrapIdentically(string propertyName)
     {
         const string longText = "This is a long piece of text that should wrap at the max width";
 
-        TextRuntime viaProperty = new();
-        viaProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        viaProperty.MaxWidth = 40;
-        viaProperty.Text = longText;
-
-        TextRuntime viaSetProperty = new();
-        viaSetProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        viaSetProperty.MaxWidth = 40;
-        viaSetProperty.SetProperty("Text", longText);
-
-        viaProperty.WrappedText.Count.ShouldBeGreaterThan(1);
-        viaSetProperty.WrappedText.ShouldBe(viaProperty.WrappedText);
+        AssertWrapsIdentically(propertyName, longText, expectMultipleLines: true, sut =>
+        {
+            sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            sut.MaxWidth = 40;
+        });
     }
 
-    [Fact]
-    public void Text_ViaSetProperty_WithFixedWidthAndHeightRelativeToChildren_ShouldWrapSameAsDirectPropertySet()
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("TextNoTranslate")]
+    public void Text_ViaDirectPropertySetVersusSetProperty_WithFixedWidthAndHeightRelativeToChildren_ShouldWrapIdentically(string propertyName)
     {
         const string longText = "This is a long piece of text that should wrap at the fixed width";
 
-        TextRuntime viaProperty = new();
-        viaProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
-        viaProperty.Width = 100;
-        viaProperty.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        viaProperty.Text = longText;
-
-        TextRuntime viaSetProperty = new();
-        viaSetProperty.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
-        viaSetProperty.Width = 100;
-        viaSetProperty.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
-        viaSetProperty.SetProperty("Text", longText);
-
-        viaProperty.WrappedText.Count.ShouldBeGreaterThan(1);
-        viaSetProperty.WrappedText.ShouldBe(viaProperty.WrappedText);
+        AssertWrapsIdentically(propertyName, longText, expectMultipleLines: true, sut =>
+        {
+            sut.WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute;
+            sut.Width = 100;
+            sut.HeightUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+        });
     }
 
-    [Fact]
-    public void Text_ViaDirectPropertySetVersusSetProperty_InStack_ShouldPositionSiblingIdentically()
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("TextNoTranslate")]
+    public void Text_ViaDirectPropertySetVersusSetProperty_WithBbCodeAndMaxWidth_ShouldWrapIdentically(string propertyName)
     {
-        float ySettingViaProperty = BuildStackAndGetSecondChildY(
-            (first, value) => first.Text = value);
-        float ySettingViaSetProperty = BuildStackAndGetSecondChildY(
-            (first, value) => first.SetProperty("Text", value));
+        const string longBbCodeText = "plain [IsBold=true]bold text that should wrap at the given max width value[/IsBold] plain";
 
-        ySettingViaSetProperty.ShouldBe(ySettingViaProperty);
+        AssertWrapsIdentically(propertyName, longBbCodeText, expectMultipleLines: true, sut =>
+        {
+            sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            sut.MaxWidth = 40;
+        });
+    }
+
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("TextNoTranslate")]
+    public void Text_ViaDirectPropertySetVersusSetProperty_WithNullValue_ShouldBehaveIdentically(string propertyName)
+    {
+        AssertWrapsIdentically(propertyName, null, expectMultipleLines: false, sut =>
+        {
+            sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
+            sut.MaxWidth = 40;
+        });
+    }
+
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("TextNoTranslate")]
+    public void Text_ViaDirectPropertySetVersusSetProperty_InStack_ShouldPositionSiblingIdentically(string propertyName)
+    {
+        float ySettingViaDirect = BuildStackAndGetSecondChildY(
+            (first, value) => SetDirect(first, propertyName, value));
+        float ySettingViaSetProperty = BuildStackAndGetSecondChildY(
+            (first, value) => first.SetProperty(propertyName, value));
+
+        ySettingViaSetProperty.ShouldBe(ySettingViaDirect);
+    }
+
+    private static void AssertWrapsIdentically(string propertyName, string? text, bool expectMultipleLines, Action<TextRuntime> configure)
+    {
+        TextRuntime viaDirect = new();
+        configure(viaDirect);
+        SetDirect(viaDirect, propertyName, text);
+
+        TextRuntime viaSetProperty = new();
+        configure(viaSetProperty);
+        viaSetProperty.SetProperty(propertyName, text);
+
+        if (expectMultipleLines)
+        {
+            viaDirect.WrappedText.Count.ShouldBeGreaterThan(1);
+        }
+        viaSetProperty.WrappedText.ShouldBe(viaDirect.WrappedText);
+    }
+
+    private static void SetDirect(TextRuntime textRuntime, string propertyName, string? value)
+    {
+        if (propertyName == "TextNoTranslate")
+        {
+            textRuntime.SetTextNoTranslate(value);
+        }
+        else
+        {
+            textRuntime.Text = value;
+        }
     }
 
     private static float BuildStackAndGetSecondChildY(Action<TextRuntime, string> setText)


### PR DESCRIPTION
Part of #3706. First of two PRs converging Text's dispatch onto TextRuntime (the ADR 0009 step 2 the issue deferred) -- this one removes the behavior gap that made a direct dispatcher-to-TextRuntime redirect unsafe.

## Problem

`TrySetPropertyOnText`'s "Text"/"TextNoTranslate" branch and `TextRuntime.Text`'s setter each independently wrap the same text-assignment logic with their own width-null/UpdateLayout logic -- but the two wrappers differ:

- Dispatcher: ignores `MaxWidth` when nulling wrap width, and always runs an unconditional, full parent-climbing `UpdateLayout()`.
- `TextRuntime.Text`: respects `MaxWidth`, and only climbs to the parent if the measured wrapped size actually changed (and only as far as a parent that depends on it).

This is why converging the dispatcher onto `textRuntime.Text = value` (the direction #3706 wants, matching the shape-dispatcher pattern) previously looked risky -- it would silently swap one wrapper's behavior for the other across every `SetProperty("Text", ...)` call site (state system / project load), not just direct `.Text =` calls.

## What this does

Added characterization tests comparing both entry points across MaxWidth-wrapping, fixed-width/auto-height, and stack-sibling-position scenarios. All three show byte-identical output today -- the divergence is duplicated logic, not a real behavior split (the dispatcher's cruder approach is self-correcting via its own subsequent full layout pass). Reconciled the dispatcher's wrapper to match `TextRuntime.Text`'s (the later, more precise one), removing the duplication and clearing the way for a follow-up PR to make the dispatcher delegate directly to `textRuntime.Text =`/`SetTextNoTranslate` without changing behavior.

## Testing

- New pinning tests in `TextRuntimeTests.cs`, all green.
- Full `MonoGameGum.Tests` (1952), `MonoGameGum.Tests.V2` (132), and `RaylibGum.Tests` (544) suites green -- no regressions.
- FRB canary (`GumCore.DesktopGlNet6.csproj`): 0 errors, same warning baseline as `main`.

Manual test: not needed -- behavior-preserving, proven by the pinning tests above plus the full regression suite.
