### PR TITLE
Converge Text/TextNoTranslate SetProperty dispatch onto TextRuntime (core+Raylib)

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -957,6 +957,9 @@ public partial class CustomSetPropertyOnRenderable
 #else
             // Runtime-type-first: delegate to TextRuntime.Text/SetTextNoTranslate, which own the
             // logic via the shared SetText helper. Matches the shape dispatcher's pattern (#3706).
+            // Unlike Font/FontScale/etc. below, a bare GraphicalUiElement(Text) with no TextRuntime
+            // is a real, supported combination (e.g. the tool's WireframeObjectManager), so fall
+            // back to calling SetText directly rather than silently no-op'ing.
             if (textRuntime != null)
             {
                 if (propertyName == "Text")
@@ -967,6 +970,10 @@ public partial class CustomSetPropertyOnRenderable
                 {
                     textRuntime.SetTextNoTranslate(value as string);
                 }
+            }
+            else
+            {
+                SetText(textRenderable, graphicalUiElement, propertyName, value);
             }
 #endif
             handled = true;

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -848,6 +848,83 @@ public partial class CustomSetPropertyOnRenderable
 
     #region Text
 
+    // The single owner of Text/TextNoTranslate assignment: localization, BBCode detection, and the
+    // width-wrapper/re-layout logic. Called directly by TextRuntime.Text/SetTextNoTranslate
+    // (MonoGameGum/GueDeriving/TextRuntime.cs) and, for FRB (which has no TextRuntime), by
+    // TrySetPropertyOnText below. Public so both call sites can reach it (#3706).
+    public static void SetText(Text textRenderable, GraphicalUiElement graphicalUiElement, string propertyName, object value)
+    {
+        var widthBefore = textRenderable.WrappedTextWidth;
+        var heightBefore = textRenderable.WrappedTextHeight;
+
+        if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren)
+        {
+            if (graphicalUiElement.MaxWidth == null)
+            {
+                // make it have no line wrap width before assignign the text:
+                textRenderable.Width = null;
+            }
+            else
+            {
+                textRenderable.Width = graphicalUiElement.MaxWidth;
+            }
+        }
+
+        var valueAsString = value as string;
+
+        // Track the original (untranslated) value so RefreshLocalization can
+        // re-translate this element if CurrentLanguage changes later.
+        // - "Text" with an active LocalizationService stores the raw input.
+        // - "TextNoTranslate" always clears any previously-stored key so user
+        //   input or explicitly-untranslated values aren't re-translated later.
+        if (propertyName == "TextNoTranslate")
+        {
+            _localizationKeys.Remove(graphicalUiElement);
+        }
+        else if (LocalizationService != null && valueAsString != null)
+        {
+            _localizationKeys.AddOrUpdate(graphicalUiElement, valueAsString);
+        }
+        else
+        {
+            _localizationKeys.Remove(graphicalUiElement);
+        }
+
+        textRenderable.InlineVariables.Clear();
+        if (valueAsString?.Contains("[") == true)
+        {
+            textRenderable.StoredMarkupText = valueAsString;
+            SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
+        }
+        else
+        {
+            textRenderable.StoredMarkupText = null;
+            var rawText = valueAsString;
+            if(LocalizationService != null && propertyName == "Text")
+            {
+                rawText = LocalizationService.Translate(rawText);
+            }
+
+            if(rawText?.Contains("[") == true)
+            {
+                textRenderable.StoredMarkupText = rawText;
+                SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
+            }
+            else
+            {
+                textRenderable.RawText = rawText;
+            }
+        }
+        // we want to update if the text's size actually changed (the letters it contains)
+        var shouldUpdate = widthBefore != textRenderable.WrappedTextWidth || heightBefore != textRenderable.WrappedTextHeight;
+        if (shouldUpdate)
+        {
+            graphicalUiElement.UpdateLayout(
+                GraphicalUiElement.ParentUpdateType.IfParentWidthHeightDependOnChildren |
+                GraphicalUiElement.ParentUpdateType.IfParentStacks, int.MaxValue / 2);
+        }
+    }
+
     // Public (not private) is deliberate: FlatRedBall's Glue tool generates FRB game projects'
     // TextRuntime.Generated.cs with a hardcoded direct call to
     // global::Gum.Wireframe.CustomSetPropertyOnRenderable.TrySetPropertyOnText(...) (and the same for
@@ -874,77 +951,24 @@ public partial class CustomSetPropertyOnRenderable
 
         if (propertyName == "Text" || propertyName == "TextNoTranslate")
         {
-            // Mirrors TextRuntime.Text's own wrapper (MonoGameGum/GueDeriving/TextRuntime.cs) so both
-            // entry points measure/re-layout identically instead of each doing it slightly differently.
-            var widthBefore = textRenderable.WrappedTextWidth;
-            var heightBefore = textRenderable.WrappedTextHeight;
-
-            if (graphicalUiElement.WidthUnits == DimensionUnitType.RelativeToChildren)
+#if FRB
+            // FRB has no TextRuntime to delegate to, so SetText remains the direct owner here.
+            SetText(textRenderable, graphicalUiElement, propertyName, value);
+#else
+            // Runtime-type-first: delegate to TextRuntime.Text/SetTextNoTranslate, which own the
+            // logic via the shared SetText helper. Matches the shape dispatcher's pattern (#3706).
+            if (textRuntime != null)
             {
-                if (graphicalUiElement.MaxWidth == null)
+                if (propertyName == "Text")
                 {
-                    // make it have no line wrap width before assignign the text:
-                    textRenderable.Width = null;
+                    textRuntime.Text = value as string;
                 }
                 else
                 {
-                    textRenderable.Width = graphicalUiElement.MaxWidth;
+                    textRuntime.SetTextNoTranslate(value as string);
                 }
             }
-
-            var valueAsString = value as string;
-
-            // Track the original (untranslated) value so RefreshLocalization can
-            // re-translate this element if CurrentLanguage changes later.
-            // - "Text" with an active LocalizationService stores the raw input.
-            // - "TextNoTranslate" always clears any previously-stored key so user
-            //   input or explicitly-untranslated values aren't re-translated later.
-            if (propertyName == "TextNoTranslate")
-            {
-                _localizationKeys.Remove(graphicalUiElement);
-            }
-            else if (LocalizationService != null && valueAsString != null)
-            {
-                _localizationKeys.AddOrUpdate(graphicalUiElement, valueAsString);
-            }
-            else
-            {
-                _localizationKeys.Remove(graphicalUiElement);
-            }
-
-            textRenderable.InlineVariables.Clear();
-            if (valueAsString?.Contains("[") == true)
-            {
-                textRenderable.StoredMarkupText = valueAsString;
-                SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
-            }
-            else
-            {
-                textRenderable.StoredMarkupText = null;
-                var rawText = valueAsString;
-                if(LocalizationService != null && propertyName == "Text")
-                {
-                    rawText = LocalizationService.Translate(rawText);
-                }
-
-                if(rawText?.Contains("[") == true)
-                {
-                    textRenderable.StoredMarkupText = rawText;
-                    SetBbCodeText(textRenderable, graphicalUiElement, textRenderable.StoredMarkupText);
-                }
-                else
-                {
-                    textRenderable.RawText = rawText;
-                }
-            }
-            // we want to update if the text's size actually changed (the letters it contains)
-            var shouldUpdate = widthBefore != textRenderable.WrappedTextWidth || heightBefore != textRenderable.WrappedTextHeight;
-            if (shouldUpdate)
-            {
-                graphicalUiElement.UpdateLayout(
-                    GraphicalUiElement.ParentUpdateType.IfParentWidthHeightDependOnChildren |
-                    GraphicalUiElement.ParentUpdateType.IfParentStacks, int.MaxValue / 2);
-            }
+#endif
             handled = true;
         }
         else if (propertyName == "Font Scale" || propertyName == "FontScale")

--- a/MonoGameGum/Forms/Controls/TextBox.cs
+++ b/MonoGameGum/Forms/Controls/TextBox.cs
@@ -59,12 +59,10 @@ public class TextBox : TextBoxBase
                     value = value.Substring(0, MaxLength.Value);
                 }
 
-                // go through the component instead of the core text object to force a layout refresh if necessary
-                // Calling SetProperty.
-                // This bypasses the Text change event so we need to explicitly handle text changing.
+                // go through the component instead of the core text object to force a layout refresh if necessary.
+                // SetProperty raises textComponent's PropertyChanged("Text"), which TextBoxBase's
+                // HandleTextComponentPropertyChanged forwards into OnTextChanged -- no explicit call needed here.
                 textComponent.SetProperty("Text", value);
-
-                OnTextChanged(value);
             }
         }
     }
@@ -87,9 +85,8 @@ public class TextBox : TextBoxBase
                 value = value.Substring(0, MaxLength.Value);
             }
 
+            // See the Text setter above: PropertyChanged("Text") drives OnTextChanged.
             textComponent.SetProperty("TextNoTranslate", value);
-
-            OnTextChanged(value);
         }
     }
 

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -2,6 +2,10 @@
 #if RAYLIB
 using Gum.Renderables;
 using RaylibGum.Helpers;
+// This file (via Gum/Wireframe/CustomSetPropertyOnRenderable.cs, RAYLIB-namespaced) is the same
+// shared dispatcher source XNALIKE compiles, just under a different namespace -- see that file's
+// own #if RAYLIB/#else namespace switch.
+using CustomSetPropertyOnRenderableType = RaylibGum.Renderables.CustomSetPropertyOnRenderable;
 #elif SKIA
 using SkiaGum;
 using SkiaGum.Helpers;
@@ -9,6 +13,7 @@ using SkiaSharp;
 #else
 using Gum.Graphics;
 using Gum.RenderingLibrary;
+using CustomSetPropertyOnRenderableType = Gum.Wireframe.CustomSetPropertyOnRenderable;
 #endif
 using Gum.Wireframe;
 using RenderingLibrary;
@@ -724,6 +729,10 @@ public class TextRuntime : InteractiveGue
         }
         set
         {
+#if SKIA
+            // Skia's own SetProperty("Text", ...) dispatch (Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs)
+            // parses BBCode lazily at render time rather than eagerly like the shared SetText helper below,
+            // so it isn't safe to redirect here yet -- tracked as a separate follow-up on #3706.
             var widthBefore = ContainedText.WrappedTextWidth;
             var heightBefore = ContainedText.WrappedTextHeight;
             if (this.WidthUnits == Gum.DataTypes.DimensionUnitType.RelativeToChildren)
@@ -740,7 +749,6 @@ public class TextRuntime : InteractiveGue
             }
 
             // Use SetProperty so it goes through the BBCode-checking methods
-            //ContainedText.RawText = value;
             this.SetProperty("Text", value);
 
             NotifyPropertyChanged();
@@ -751,6 +759,10 @@ public class TextRuntime : InteractiveGue
                     Gum.Wireframe.GraphicalUiElement.ParentUpdateType.IfParentWidthHeightDependOnChildren |
                     Gum.Wireframe.GraphicalUiElement.ParentUpdateType.IfParentStacks, int.MaxValue / 2);
             }
+#else
+            CustomSetPropertyOnRenderableType.SetText(ContainedText, this, "Text", value);
+            NotifyPropertyChanged();
+#endif
         }
     }
 
@@ -766,6 +778,8 @@ public class TextRuntime : InteractiveGue
     /// </remarks>
     public void SetTextNoTranslate(string? value)
     {
+#if SKIA
+        // See the Text setter above for why Skia stays on the SetProperty path for now.
         var widthBefore = ContainedText.WrappedTextWidth;
         var heightBefore = ContainedText.WrappedTextHeight;
         if (this.WidthUnits == Gum.DataTypes.DimensionUnitType.RelativeToChildren)
@@ -790,6 +804,10 @@ public class TextRuntime : InteractiveGue
                 Gum.Wireframe.GraphicalUiElement.ParentUpdateType.IfParentWidthHeightDependOnChildren |
                 Gum.Wireframe.GraphicalUiElement.ParentUpdateType.IfParentStacks, int.MaxValue / 2);
         }
+#else
+        CustomSetPropertyOnRenderableType.SetText(ContainedText, this, "TextNoTranslate", value);
+        NotifyPropertyChanged(nameof(Text));
+#endif
     }
 
     /// <summary>

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/TextRuntimeTests.cs
@@ -208,7 +208,7 @@ public class TextRuntimeTests : BaseTestClass
     }
 
     [Fact]
-    public void Text_ViaDirectPropertySet_WhenSizeChanges_StillTriggersTwoUpdateLayoutCalls()
+    public void Text_ViaDirectPropertySet_WhenSizeChanges_ShouldTriggerOneUpdateLayoutCall()
     {
         TextRuntime sut = new();
         sut.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToChildren;
@@ -218,12 +218,10 @@ public class TextRuntimeTests : BaseTestClass
         sut.Text = "This is a much longer string that changes the wrapped size";
         int callCount = GraphicalUiElement.UpdateLayoutCallCount - countBefore;
 
-        // TextRuntime.Text's own wrapper AND the dispatcher's wrapper (reached via the SetProperty call
-        // in between) both still run and both now agree the size changed, so each independently calls
-        // UpdateLayout -- reconciling the two wrappers' *conditions* didn't collapse them into one call.
-        // That only happens once the dispatcher delegates directly to TextRuntime.Text (a follow-up PR),
-        // at which point this should drop to 1 -- update this test when that lands.
-        callCount.ShouldBe(2);
+        // TextRuntime.Text now owns the width-wrapper logic directly (via the shared
+        // CustomSetPropertyOnRenderable.SetText helper) instead of round-tripping through
+        // SetProperty into the dispatcher's own copy, so only one UpdateLayout call fires.
+        callCount.ShouldBe(1);
     }
 
     private static void AssertWrapsIdentically(string propertyName, string? text, bool expectMultipleLines, Action<TextRuntime> configure)


### PR DESCRIPTION
## Summary
`CustomSetPropertyOnRenderable.TrySetPropertyOnText`'s "Text"/"TextNoTranslate" case now dispatches runtime-type-first: it calls `textRuntime.Text = value` / `textRuntime.SetTextNoTranslate(value)` instead of duplicating the width-wrapper/localization/BBCode logic inline. That logic is extracted into a new shared static `CustomSetPropertyOnRenderable.SetText`, which `TextRuntime.Text`/`SetTextNoTranslate` now call directly (no more round-trip through `SetProperty`).

Covers core (XNALIKE) and Raylib (shares the same dispatcher file under a namespace switch). FRB (no `TextRuntime`) and Skia (lazy BBCode parsing at render time, different semantics) keep their existing paths -- both call-outs, tracked as follow-ups on #3706.

This collapses the double `UpdateLayout` call the #4087 reconciliation left in place -- pinned by `Text_ViaDirectPropertySet_WhenSizeChanges_ShouldTriggerOneUpdateLayoutCall` (was named `...StillTriggersTwoUpdateLayoutCalls`, asserting 2; now asserts 1).

## Regression caught and fixed
The full suite caught a real bug: `TextBox`/`PasswordBox` relied on `SetProperty("Text"/"TextNoTranslate", ...)` **not** raising `PropertyChanged("Text")`, so `TextBox` called `OnTextChanged` explicitly itself once. Now that `SetProperty` routes through the real `TextRuntime.Text` setter, `PropertyChanged` fires reliably -- `TextBoxBase.HandleTextComponentPropertyChanged` was already forwarding that into `OnTextChanged`, so the explicit calls became a double-fire. Removed the now-redundant explicit calls in `TextBox.Text`/`SetTextNoTranslate`; `HandleTextComponentPropertyChanged` is the sole source now.

## Testing
- `MonoGameGum.Tests` (1953), `MonoGameGum.Tests.V2` (140), `MonoGameGum.Tests.V3` (59), `SkiaGum.Tests` (395), `RaylibGum.Tests` (544) -- all green.
- FRB canary (`GumCore.DesktopGlNet6.csproj`, from primary checkout): pass, no new errors vs `main` baseline.

Manual test: not needed -- the pinning tests assert the exact observable layout data (`WrappedText`, sibling stack `Y` position) a manual check would only approximate, and the TextBox `TextChanged`/`TextChangedByUi` event-count tests cover the behavioral regression directly.

Closes #3706? No -- Skia inversion and the `TrySetValueOnThis` centralization (#4088) are still open. Part of #3706.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
