### PR TITLE
Fix MinAlpha-masked render-target content leaking past its clip bounds

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/RenderTargetBakeBlendStateTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/RenderTargetBakeBlendStateTests.cs
@@ -62,4 +62,49 @@ public class RenderTargetBakeBlendStateTests : BaseTestClass
             Renderer.NormalBlendState = previous;
         }
     }
+
+    // Pins the #4091 fix. MinAlpha (e.g. GameUiSamples' ManaOrb wave mask) deliberately leaves
+    // color untouched (ColorSourceBlend=Zero, ColorDestinationBlend=One) and only clips alpha via
+    // Min. Baked under _bakeToRenderTargetBlendState's premultiply-on-bake convention, that leaves
+    // a masked-out pixel's color premultiplied against its OLD (pre-mask) alpha instead of its new
+    // (zero) alpha — DrawRenderTargetToScreen's premultiplied composite-back blit then bleeds that
+    // leftover color through instead of treating the pixel as transparent. MinAlphaPremultiplied's
+    // Min-for-color-too formula drops the leftover color to whatever the mask's own
+    // (premultiplied-authored) texture color contributes instead.
+    //
+    // A round-trip through SpriteRuntime.Blend (Gum enum -> XNA BlendState -> back to Gum
+    // BlendState) does NOT preserve reference identity for anything but the four core presets
+    // (Opaque/AlphaBlend/Additive/NonPremultiplied) — MinAlpha loses its singleton reference and
+    // arrives here as a field-identical but distinct instance. So this constructs a fresh
+    // Gum.BlendState with MinAlpha's exact field values rather than referencing the static
+    // BlendState.MinAlpha, to pin the fix against structural (not reference) comparison.
+    [Fact]
+    public void AdjustBlendStateForRenderTargetBake_SubstitutesMinAlphaPremultiplied_ForFieldEquivalentMinAlpha_WhenStraightAlphaPipeline()
+    {
+        var previous = Renderer.NormalBlendState;
+        try
+        {
+            Renderer.NormalBlendState = BlendState.NonPremultiplied;
+
+            var fieldEquivalentMinAlpha = new BlendState
+            {
+                ColorSourceBlend = BlendState.MinAlpha.ColorSourceBlend,
+                ColorBlendFunction = BlendState.MinAlpha.ColorBlendFunction,
+                ColorDestinationBlend = BlendState.MinAlpha.ColorDestinationBlend,
+                AlphaSourceBlend = BlendState.MinAlpha.AlphaSourceBlend,
+                AlphaBlendFunction = BlendState.MinAlpha.AlphaBlendFunction,
+                AlphaDestinationBlend = BlendState.MinAlpha.AlphaDestinationBlend,
+            };
+            fieldEquivalentMinAlpha.ShouldNotBeSameAs(BlendState.MinAlpha);
+
+            var result = Renderer.AdjustBlendStateForRenderTargetBake(
+                fieldEquivalentMinAlpha, isBakingRenderTarget: true);
+
+            result.ShouldBeSameAs(BlendState.MinAlphaPremultiplied);
+        }
+        finally
+        {
+            Renderer.NormalBlendState = previous;
+        }
+    }
 }

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1236,16 +1236,47 @@ public class Renderer : IRenderer
     // has already premultiplied the color, so premultiplying again during the bake would double-
     // darken it (a 50%-alpha child would bake to 25% color). In that case the ambient AlphaBlend
     // already accumulates correctly over the transparent clear, so leave the blend unchanged.
+    //
+    // MinAlpha (e.g. GameUiSamples' ManaOrb wave mask) is a second, narrower case under the same
+    // straight-alpha pipeline: it deliberately leaves color untouched and only clips alpha
+    // (ColorSourceBlend=Zero, ColorDestinationBlend=One), so after it reduces a pixel's alpha, that
+    // pixel's leftover color is still premultiplied against its OLD (higher) alpha rather than its
+    // new one — violating the premultiplied-by-construction invariant the composite-back blit in
+    // DrawRenderTargetToScreen relies on, which bled the leftover color through as if the pixel
+    // were still opaque instead of masked out (#4091). Swap to MinAlphaPremultiplied, whose
+    // Min-for-color-too formula drops the leftover color to whatever the mask's own
+    // (premultiplied-authored) texture color contributes instead.
     internal static BlendState AdjustBlendStateForRenderTargetBake(BlendState renderBlendState, bool isBakingRenderTarget)
     {
-        if (isBakingRenderTarget
-            && renderBlendState == Renderer.NormalBlendState
-            && Renderer.NormalBlendState != BlendState.AlphaBlend)
+        if (!isBakingRenderTarget || Renderer.NormalBlendState == BlendState.AlphaBlend)
+        {
+            return renderBlendState;
+        }
+
+        if (renderBlendState == Renderer.NormalBlendState)
         {
             return _bakeToRenderTargetBlendState;
         }
+
+        if (IsFieldEquivalentToMinAlpha(renderBlendState))
+        {
+            return BlendState.MinAlphaPremultiplied;
+        }
+
         return renderBlendState;
     }
+
+    // A Sprite's Blend setter round-trips MinAlpha through XNA's BlendState and back (Gum -> XNA ->
+    // Gum), and only the four core presets (Opaque/AlphaBlend/Additive/NonPremultiplied) survive
+    // that round-trip as the same static reference — MinAlpha arrives here as a field-identical but
+    // distinct instance. So detect it structurally instead of by reference.
+    private static bool IsFieldEquivalentToMinAlpha(BlendState blendState) =>
+        blendState.ColorSourceBlend == BlendState.MinAlpha.ColorSourceBlend
+        && blendState.ColorBlendFunction == BlendState.MinAlpha.ColorBlendFunction
+        && blendState.ColorDestinationBlend == BlendState.MinAlpha.ColorDestinationBlend
+        && blendState.AlphaSourceBlend == BlendState.MinAlpha.AlphaSourceBlend
+        && blendState.AlphaBlendFunction == BlendState.MinAlpha.AlphaBlendFunction
+        && blendState.AlphaDestinationBlend == BlendState.MinAlpha.AlphaDestinationBlend;
 
     private void AdjustNonClipRenderStates(RenderStateVariables renderState, Layer layer, IRenderableIpso renderable, SystemManagers managers)
     {

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/ManaOrbClipRegressionTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/ManaOrbClipRegressionTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.Managers;
+using Gum.Wireframe;
+using GumRuntime;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Reproduces issue #4091: the GameUiSamples <c>HollowKnightComponents/ManaOrb</c> component's
+/// <c>WaveMaskSprite</c> uses <see cref="Gum.RenderingLibrary.Blend.MinAlpha"/> to mask the
+/// <c>WaveTop</c>/<c>ColoredRectangleInstance</c> wave content to the orb's circular bounds inside
+/// the <c>RenderTargetContainer</c> bake. <c>MinAlpha</c> deliberately leaves color untouched and
+/// only clips alpha (<c>ColorSourceBlend=Zero, ColorDestinationBlend=One</c>), so after masking, a
+/// clipped pixel's leftover color is still premultiplied against its OLD (pre-mask) alpha rather
+/// than its new (zero) alpha. <see cref="Renderer.DrawRenderTargetToScreen"/> composites the baked
+/// texture back with a premultiplied blend (<c>BlendState.AlphaBlend</c>) whenever the container's
+/// own blend is unconfigured (#1696), which bleeds that leftover color through instead of treating
+/// the masked pixel as transparent.
+///
+/// Loads the actual sample project/component (not a hand-built synthetic scene) so the exact
+/// codegen/state-application path the sample uses is exercised.
+/// </summary>
+public class ManaOrbClipRegressionTests : BaseTestClass
+{
+    [Fact]
+    public void WaveContent_MaskedByMinAlpha_DoesNotLeakPastOrbBounds()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        var elementSave = ObjectFinder.Self.GetElementSave("HollowKnightComponents/ManaOrb");
+        elementSave.ShouldNotBeNull();
+
+        GraphicalUiElement manaOrb = elementSave!.ToGraphicalUiElement(managers, addToManagers: true);
+        manaOrb.X = 50;
+        manaOrb.Y = 50;
+        manaOrb.UpdateLayout();
+
+        // Mirrors ManaOrb.CustomInitialize()/PercentFull=50 (GameUiSamples/Components/HollowKnightComponents/ManaOrb.cs),
+        // which the real sample runs on construction but which the raw ElementSave.ToGraphicalUiElement
+        // path does not (no Forms wrapper => no CustomInitialize).
+        var emptyState = manaOrb.ElementSave.AllStates.First(item => item.Name == "Empty");
+        var fullState = manaOrb.ElementSave.AllStates.First(item => item.Name == "Full");
+        manaOrb.InterpolateBetween(emptyState, fullState, 0.5f);
+        manaOrb.UpdateLayout();
+
+        // Two warm-up draws: SpriteRenderer.CurrentZoom (used to snap the bake camera to whole
+        // pixels in RenderToRenderTarget) is only populated once a real BeginSpriteBatch cycle has
+        // run, which happens during the main compositing pass after baking — not during the bake
+        // pass itself. The first draw bakes with an uninitialized zoom; later draws re-bake
+        // correctly. See NestedRenderTargetTextureSourceTests for the same warm-up pattern.
+        renderer.Draw(managers);
+        renderer.Draw(managers);
+
+        // (52,148) is a point on the WaveMaskSprite's own mask texture (local (2,98) inside the
+        // 100x100 RenderTargetContainer, which sits at absolute (50,50)) where the mask's alpha is
+        // 0 (outside the circle) but WaveTop/ColoredRectangleInstance still paint non-transparent
+        // color there before the mask draws — exactly the leftover-color-at-zero-alpha shape the
+        // premultiplied composite-back blit mishandles.
+        Color sampled = SampleMainLayerPixel(gd, renderer, managers, sampleX: 52, sampleY: 148);
+
+        Color background = Color.CornflowerBlue;
+        System.Math.Abs(sampled.R - background.R).ShouldBeLessThan(10);
+        System.Math.Abs(sampled.G - background.G).ShouldBeLessThan(10);
+        System.Math.Abs(sampled.B - background.B).ShouldBeLessThan(10);
+    }
+
+    private static Color SampleMainLayerPixel(GraphicsDevice gd, Renderer renderer, SystemManagers managers, int sampleX, int sampleY)
+    {
+        const int w = 300;
+        const int h = 300;
+        using RenderTarget2D capture = new(gd, w, h, false, SurfaceFormat.Color, DepthFormat.None, 0,
+            RenderTargetUsage.PreserveContents);
+
+        gd.SetRenderTarget(capture);
+        gd.Clear(Color.CornflowerBlue);
+        renderer.Draw(managers);
+        gd.SetRenderTarget(null);
+
+        Color[] pixels = new Color[w * h];
+        capture.GetData(pixels);
+        return pixels[(sampleY * w) + sampleX];
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test, loading the
+    /// real GameUiSamples project so <see cref="ObjectFinder.Self"/> resolves the actual
+    /// <c>ManaOrb</c> component exactly as the sample app does.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, FindGameUiSamplesGumProjectFile());
+        }
+
+        // Walks up from the test binary's output directory to the repo root, then anchors on the
+        // real GameUiSamples project file — reproducing #4091 requires the actual sample
+        // component (state application, codegen instantiation), not a hand-built synthetic scene.
+        private static string FindGameUiSamplesGumProjectFile()
+        {
+            string current = AppContext.BaseDirectory;
+            for (int i = 0; i < 10; i++)
+            {
+                string candidate = Path.Combine(
+                    current, "Samples", "GameUiSamples", "Content", "GumProject", "GameUiSamplesGumProject.gumx");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                string? parent = Path.GetDirectoryName(current);
+                if (string.IsNullOrEmpty(parent) || parent == current)
+                {
+                    break;
+                }
+                current = parent;
+            }
+            throw new InvalidOperationException("could not locate GameUiSamples project from " + AppContext.BaseDirectory);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Closes #4091

## Root cause
`Blend.MinAlpha` (used by GameUiSamples' `ManaOrb.WaveMaskSprite` to mask the wave content to the orb's circle) deliberately leaves color untouched and only clips alpha. That violates the premultiplied-by-construction invariant the #1696 composite-back fix (PR #3512) relies on: after MinAlpha reduces a pixel's alpha, its leftover color is still premultiplied against the OLD (higher) alpha, so `DrawRenderTargetToScreen`'s premultiplied blit bleeds it through instead of treating the pixel as transparent. Bisected precisely to commit 4d5f5509c (#3512) via before/after screenshot comparison.

## Fix
`AdjustBlendStateForRenderTargetBake` now also swaps `MinAlpha` → `MinAlphaPremultiplied` while baking under the straight-alpha pipeline, mirroring the existing `NormalBlendState` substitution. Detection is structural (field comparison), not reference-based — a `Sprite.Blend` round-trip through XNA's `BlendState` and back doesn't preserve reference identity for non-core presets.

FRB's premultiplied pipeline (`NormalBlendState == AlphaBlend`) is unaffected: the new code path is gated behind the same early-return the old code already had for that case.

## Testing
- New pixel-level integration test loads the real GameUiSamples project/component and asserts the masked-out region no longer leaks wave color.
- New unit test pins the blend substitution directly.
- Full `MonoGameGum.Tests` (1954) and `MonoGameGum.IntegrationTests` (77) suites pass.
- FRB canary: pass (built `GumCore.DesktopGlNet6.csproj` from the primary checkout — 0 errors before and after, same warning count).

Manual test: not strictly needed (unit + pixel-level integration tests cover the exact regression, verified against a direct visual PNG comparison matching the pre-regression rendering), but `Samples/GameUiSamples/GameUiSamples.sln` builds clean if a visual spot-check is wanted.