### PR TITLE
Materialize baked Standard-theme visual defaults onto FormsTemplate instances (#4092)

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/FormsTemplateCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/FormsTemplateCreatorTests.cs
@@ -335,6 +335,52 @@ public class FormsTemplateCreatorTests : IDisposable
         result.ProjectOnlyStandards.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void Create_NoInstanceShouldRelyOnInheritingFormerlyBakedStandardProperties()
+    {
+        // Issue #4092 follow-up: the first fix pass materialized these properties onto every
+        // Component instance but missed Screens (DemoScreenGum's "Background" and StylesScreen's
+        // swatch/text instances), so they silently picked up the reset Standards' blank defaults
+        // (no texture, no fill-parent sizing) instead of their themed look. This checks both
+        // Components AND Screens so that gap can't reopen.
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+        _sut.Create(filePath);
+
+        ProjectLoadResult result = new ProjectLoader().Load(filePath);
+        GumProjectSave project = result.Project!;
+
+        Dictionary<string, string[]> tracked = new()
+        {
+            ["NineSlice"] = ["ExposeChildrenEvents", "Height", "HeightUnits", "SourceFile", "TextureAddress",
+                "TextureHeight", "TextureTop", "TextureWidth", "Width", "WidthUnits", "XOrigin", "XUnits", "YOrigin", "YUnits"],
+            ["Text"] = ["FontSize", "Height", "HeightUnits", "Width", "WidthUnits"],
+        };
+
+        List<string> missing = [];
+
+        foreach ((string baseType, string[] props) in tracked)
+        {
+            var componentInstances = project.Components
+                .SelectMany(c => c.Instances.Where(i => i.BaseType == baseType).Select(i => (Owner: (ElementSave)c, Instance: i)));
+            var screenInstances = project.Screens
+                .SelectMany(s => s.Instances.Where(i => i.BaseType == baseType).Select(i => (Owner: (ElementSave)s, Instance: i)));
+
+            foreach (var (owner, instance) in componentInstances.Concat(screenInstances))
+            {
+                foreach (string prop in props)
+                {
+                    bool isSet = owner.DefaultState.Variables.Any(v => v.Name == $"{instance.Name}.{prop}" && v.Value != null);
+                    if (!isSet)
+                    {
+                        missing.Add($"{owner.Name}.{instance.Name}.{prop}");
+                    }
+                }
+            }
+        }
+
+        missing.ShouldBeEmpty();
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/Tests/Gum.ProjectServices.Tests/FormsTemplateCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/FormsTemplateCreatorTests.cs
@@ -316,49 +316,21 @@ public class FormsTemplateCreatorTests : IDisposable
     }
 
     [Fact]
-    public void Create_ShouldOnlyDriftFromDefaultStandardsInKnownBakedProperties()
+    public void Create_ShouldNotDriftFromDefaultStandards()
     {
-        // Issue #4089: Add Forms (Standard theme) shouldn't need to change the project's
-        // Standards at all. The StyleCategory double-indirection (same shape as #4079's
-        // ColorCategory) and a handful of stale/mismatched declarations (dead Guide variables,
-        // SetsValue flags, an unused Polygon's default point shape) are fully fixed - this pins
-        // that no new drift regresses in. What remains is deliberately deferred: baked
-        // Standard-theme visual defaults (NineSlice texture-atlas coordinates/anchoring, Text
-        // sizing, Sprite texture scale) still differ from a blank project's Standards, tracked by
-        // a dedicated follow-up issue since relocating them touches every themed component that
-        // relies on inheriting them (~50 NineSlice instances across the template).
+        // Issue #4092, follow-up to #4089: the last remaining drift was baked Standard-theme
+        // visual defaults (NineSlice texture-atlas coordinates/anchoring, Text sizing, Sprite
+        // texture scale) that differed from a blank project's Standards. Every consuming instance
+        // that relied on inheriting one of these values now sets it explicitly (materialized from
+        // the Standard's prior baked value, so appearance is unchanged), and the 3 Standards
+        // (NineSlice/Sprite/Text) were reset to match a blank project. Add Forms (Standard theme)
+        // no longer needs to change the project's Standards at all.
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
         _sut.Create(filePath);
 
         DiffStandardsResult result = new DiffStandardsService().Diff(filePath);
 
-        string[] expectedRemainingDiffs =
-        [
-            "NineSlice.ExposeChildrenEvents",
-            "NineSlice.Height",
-            "NineSlice.HeightUnits",
-            "NineSlice.SourceFile",
-            "NineSlice.TextureAddress",
-            "NineSlice.TextureHeight",
-            "NineSlice.TextureTop",
-            "NineSlice.TextureWidth",
-            "NineSlice.Width",
-            "NineSlice.WidthUnits",
-            "NineSlice.XOrigin",
-            "NineSlice.XUnits",
-            "NineSlice.YOrigin",
-            "NineSlice.YUnits",
-            "Sprite.TextureHeightScale",
-            "Sprite.TextureWidthScale",
-            "Text.FontSize",
-            "Text.Height",
-            "Text.HeightUnits",
-            "Text.Width",
-            "Text.WidthUnits",
-        ];
-
-        result.Differences.Select(d => $"{d.StandardName}.{d.VariableName}")
-            .ShouldBe(expectedRemainingDiffs, ignoreOrder: true);
+        result.Differences.ShouldBeEmpty();
         result.MissingFromProject.ShouldBeEmpty();
         result.ProjectOnlyStandards.ShouldBeEmpty();
     }

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">41</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">18</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -63,6 +72,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -74,6 +86,12 @@
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -89,6 +107,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">48</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">167</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">62</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -59,6 +68,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -71,6 +83,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -86,6 +104,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -150,6 +180,9 @@
     </Variable>
     <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">41</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">18</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -59,6 +68,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -71,6 +83,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -86,6 +104,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -150,6 +180,9 @@
     </Variable>
     <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -63,6 +72,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -75,6 +87,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -90,6 +108,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -59,6 +68,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -71,6 +83,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -86,6 +104,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -150,6 +180,9 @@
     </Variable>
     <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -63,6 +72,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -75,6 +87,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -90,6 +108,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -126,6 +156,9 @@
     </Variable>
     <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
@@ -7,11 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -31,9 +46,24 @@
     <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">4</Value>
     </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="ButtonCategory" Name="ButtonCategoryState" SetsValue="false" />
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
+    </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
@@ -49,6 +79,12 @@
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -67,6 +103,15 @@
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
       <Value xsi:type="xsd:float">-8</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -99,6 +144,9 @@
     <Variable Type="int" Name="TabText.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
+    <Variable Type="float" Name="TabText.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TabText.HeightUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -128,6 +176,12 @@
     </Variable>
     <Variable Type="VerticalAlignment" Name="TabText.VerticalAlignment" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TabText.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TabText.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="HorizontalAlignment" Name="TabText.XOrigin" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="CheckBoxBackground.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="CheckBoxBackground.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="CheckBoxBackground.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="CheckBoxBackground.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="CheckBoxBackground.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="CheckBoxBackground.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="CheckBoxBackground.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -43,9 +52,18 @@
     <Variable Type="PositionUnitType" Name="CheckBoxBackground.XUnits" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
+    <Variable Type="VerticalAlignment" Name="CheckBoxBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="CheckBoxBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="CheckBoxCategory" Name="CheckBoxCategoryState" SetsValue="false" />
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
+    </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
@@ -59,6 +77,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -74,6 +98,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -62,6 +71,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -74,6 +86,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -89,6 +107,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -168,6 +198,9 @@
     </Variable>
     <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
@@ -43,11 +43,26 @@
     <Variable Type="int" Name="NineSliceInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="NineSliceInstance.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="NineSliceInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
+    <Variable Type="float" Name="NineSliceInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="NineSliceInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="NineSliceInstance.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="NineSliceInstance.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="NineSliceInstance.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -60,6 +75,24 @@
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="NineSliceInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="NineSliceInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="NineSliceInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="NineSliceInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="NineSliceInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="NineSliceInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -166,6 +175,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -178,6 +190,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -193,6 +211,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
@@ -7,14 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
     <Variable Type="float" Name="Background.Height" SetsValue="true">
       <Value xsi:type="xsd:float">-2</Value>
     </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -31,12 +43,30 @@
     <Variable Type="float" Name="Background.Width" SetsValue="true">
       <Value xsi:type="xsd:float">-2</Value>
     </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="ButtonCategory" Name="ButtonCategoryState" SetsValue="false" />
     <Variable Type="bool" Name="ExposeChildrenEvents" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
+    </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
@@ -50,6 +80,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -68,6 +104,15 @@
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
       <Value xsi:type="xsd:float">-4</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">-4</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -169,6 +178,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -181,6 +193,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -196,6 +214,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -18,6 +21,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -58,6 +67,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -70,6 +82,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -85,6 +103,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">-2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -18,6 +21,21 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureTop" SetsValue="true">
+      <Value xsi:type="xsd:int">48</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
     </Variable>
     <Variable Type="float" Name="Background.Width" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -19,6 +22,21 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureTop" SetsValue="true">
+      <Value xsi:type="xsd:int">48</Value>
+    </Variable>
+    <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
     </Variable>
     <Variable Type="float" Name="Background.Width" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
@@ -7,11 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -24,6 +39,24 @@
     </Variable>
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="int" Name="CaretInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
@@ -125,6 +158,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -137,6 +173,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -152,6 +194,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -241,17 +295,38 @@
     <Variable Type="int" Name="SelectionInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="SelectionInstance.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="SelectionInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">-4</Value>
     </Variable>
+    <Variable Type="DimensionUnitType" Name="SelectionInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="string" Name="SelectionInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">ClipContainer</Value>
     </Variable>
     <Variable Type="int" Name="SelectionInstance.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="SelectionInstance.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="SelectionInstance.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureHeight" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureTop" SetsValue="true">
+      <Value xsi:type="xsd:int">48</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureWidth" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Width" SetsValue="true">
       <Value xsi:type="xsd:float">7</Value>
@@ -270,6 +345,12 @@
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Y" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SelectionInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="SelectionInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -34,6 +43,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -77,6 +98,9 @@
     <Variable Type="int" Name="RadioBackground.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="RadioBackground.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="RadioBackground.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -88,6 +112,12 @@
     </Variable>
     <Variable Type="int" Name="RadioBackground.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="RadioBackground.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="RadioBackground.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="RadioBackground.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -138,6 +168,9 @@
     </Variable>
     <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
       <Value xsi:type="xsd:int">4</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
@@ -61,6 +61,9 @@
     <Variable Type="int" Name="TrackBackground.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
     </Variable>
+    <Variable Type="bool" Name="TrackBackground.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="TrackBackground.Green" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
     </Variable>
@@ -75,6 +78,12 @@
     </Variable>
     <Variable Type="int" Name="TrackBackground.Red" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="TrackBackground.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="TrackBackground.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="TrackBackground.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -93,6 +102,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -105,6 +117,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -120,6 +138,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -34,6 +43,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -77,6 +98,9 @@
     <Variable Type="int" Name="TrackBackground.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="TrackBackground.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="TrackBackground.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -92,6 +116,12 @@
     <Variable Type="int" Name="TrackBackground.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable IsFile="true" Type="string" Name="TrackBackground.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="TrackBackground.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
     <Variable Type="int" Name="TrackBackground.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
     </Variable>
@@ -106,6 +136,21 @@
     </Variable>
     <Variable Type="float" Name="TrackBackground.Width" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TrackBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TrackBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TrackBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TrackBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TrackBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="float" Name="TrackInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
@@ -10,6 +10,9 @@
     <Variable Type="int" Name="NineSliceInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="NineSliceInstance.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="NineSliceInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -21,6 +24,12 @@
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="NineSliceInstance.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="NineSliceInstance.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
@@ -7,11 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -24,6 +39,24 @@
     </Variable>
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="int" Name="CaretInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
@@ -127,6 +160,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -139,6 +175,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -154,6 +196,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>
@@ -240,17 +294,38 @@
     <Variable Type="int" Name="SelectionInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="SelectionInstance.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="SelectionInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">-4</Value>
     </Variable>
+    <Variable Type="DimensionUnitType" Name="SelectionInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="string" Name="SelectionInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">ClipContainer</Value>
     </Variable>
     <Variable Type="int" Name="SelectionInstance.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="SelectionInstance.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="SelectionInstance.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureHeight" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureTop" SetsValue="true">
+      <Value xsi:type="xsd:int">48</Value>
+    </Variable>
+    <Variable Type="int" Name="SelectionInstance.TextureWidth" SetsValue="true">
+      <Value xsi:type="xsd:int">24</Value>
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Width" SetsValue="true">
       <Value xsi:type="xsd:float">7</Value>
@@ -269,6 +344,12 @@
     </Variable>
     <Variable Type="float" Name="SelectionInstance.Y" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SelectionInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="SelectionInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <Variable Type="TextBoxCategory" Name="TextBoxCategoryState" SetsValue="false" />

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -21,6 +24,12 @@
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
@@ -7,6 +7,9 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
@@ -19,6 +22,12 @@
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -87,6 +96,9 @@
     <Variable Type="int" Name="FocusedIndicator.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
+    <Variable Type="bool" Name="FocusedIndicator.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="FocusedIndicator.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
     </Variable>
@@ -99,6 +111,12 @@
     <Variable Type="string" Name="FocusedIndicator.Parent" SetsValue="true" />
     <Variable Type="int" Name="FocusedIndicator.Red" SetsValue="true">
       <Value xsi:type="xsd:int">232</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="FocusedIndicator.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="FocusedIndicator.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="FocusedIndicator.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -114,6 +132,18 @@
     </Variable>
     <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="FocusedIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="FocusedIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Y" SetsValue="true">
       <Value xsi:type="xsd:float">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
@@ -31,11 +31,26 @@
     <Variable Type="int" Name="NineSliceInstance.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="NineSliceInstance.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="NineSliceInstance.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
+    <Variable Type="float" Name="NineSliceInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="NineSliceInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="NineSliceInstance.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="NineSliceInstance.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="NineSliceInstance.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -48,6 +63,24 @@
     </Variable>
     <Variable Type="int" Name="NineSliceInstance.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="NineSliceInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="NineSliceInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="NineSliceInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="NineSliceInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="NineSliceInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="NineSliceInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <Variable Type="ToggleCategory" Name="ToggleCategoryState" SetsValue="false" />

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/UserControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/UserControl.gucx
@@ -7,14 +7,29 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="string" Name="Background.Parent" SetsValue="true">
       <Value xsi:type="xsd:string"></Value>
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -27,6 +42,24 @@
     </Variable>
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
@@ -7,12 +7,27 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="string" Name="Background.Parent" SetsValue="true" />
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -25,6 +40,24 @@
     </Variable>
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="float" Name="BorderBottomInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">10</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBar.gucx
@@ -7,11 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -25,8 +40,41 @@
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="Bar.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="Bar.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Bar.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="string" Name="Bar.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">BarContainer</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Bar.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Bar.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Bar.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -52,8 +100,17 @@
     <Variable Type="PositionUnitType" Name="Bar.XUnits" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
+    <Variable Type="VerticalAlignment" Name="Bar.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Bar.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="int" Name="BarContainer.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="bool" Name="BarContainer.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="BarContainer.Green" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -66,6 +123,12 @@
     </Variable>
     <Variable Type="int" Name="BarContainer.Red" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="BarContainer.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="BarContainer.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="BarContainer.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -98,6 +161,9 @@
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="BarDecorCategory" Name="BarDecorCategoryState" SetsValue="false" />
+    <Variable Type="ColorCategory" Name="CautionLinesInstance.ColorCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">Black</Value>
+    </Variable>
     <Variable Type="float" Name="CautionLinesInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
@@ -106,9 +172,6 @@
     </Variable>
     <Variable Type="int" Name="CautionLinesInstance.LineAlpha" SetsValue="true">
       <Value xsi:type="xsd:int">50</Value>
-    </Variable>
-    <Variable Type="ColorCategory" Name="CautionLinesInstance.ColorCategoryState" SetsValue="true">
-      <Value xsi:type="xsd:string">Black</Value>
     </Variable>
     <Variable Type="string" Name="CautionLinesInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">Bar</Value>
@@ -129,6 +192,9 @@
       <Value xsi:type="xsd:float">16</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
+    <Variable Type="ColorCategory" Name="VerticalLinesInstance.ColorCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">Black</Value>
+    </Variable>
     <Variable Type="float" Name="VerticalLinesInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
@@ -137,9 +203,6 @@
     </Variable>
     <Variable Type="int" Name="VerticalLinesInstance.LineAlpha" SetsValue="true">
       <Value xsi:type="xsd:int">50</Value>
-    </Variable>
-    <Variable Type="ColorCategory" Name="VerticalLinesInstance.ColorCategoryState" SetsValue="true">
-      <Value xsi:type="xsd:string">Black</Value>
     </Variable>
     <Variable Type="string" Name="VerticalLinesInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">Bar</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBarIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBarIcon.gucx
@@ -7,11 +7,26 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -25,8 +40,41 @@
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="Bar.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="Bar.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Bar.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
     <Variable Type="string" Name="Bar.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">BarContainer</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Bar.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Bar.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Bar.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -52,8 +100,17 @@
     <Variable Type="PositionUnitType" Name="Bar.XUnits" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
+    <Variable Type="VerticalAlignment" Name="Bar.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Bar.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="int" Name="BarContainer.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="bool" Name="BarContainer.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="BarContainer.Green" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -67,6 +124,12 @@
     <Variable Type="string" Name="BarContainer.Parent" SetsValue="true" />
     <Variable Type="int" Name="BarContainer.Red" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="BarContainer.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="BarContainer.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="BarContainer.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -102,6 +165,9 @@
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="BarDecorCategory" Name="BarDecorCategoryState" SetsValue="false" />
+    <Variable Type="ColorCategory" Name="CautionLinesInstance.ColorCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">Black</Value>
+    </Variable>
     <Variable Type="float" Name="CautionLinesInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
@@ -110,9 +176,6 @@
     </Variable>
     <Variable Type="int" Name="CautionLinesInstance.LineAlpha" SetsValue="true">
       <Value xsi:type="xsd:int">50</Value>
-    </Variable>
-    <Variable Type="ColorCategory" Name="CautionLinesInstance.ColorCategoryState" SetsValue="true">
-      <Value xsi:type="xsd:string">Black</Value>
     </Variable>
     <Variable Type="string" Name="CautionLinesInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">Bar</Value>
@@ -132,6 +195,9 @@
     <Variable Type="float" Name="Height" SetsValue="true">
       <Value xsi:type="xsd:float">16</Value>
     </Variable>
+    <Variable Type="ColorCategory" Name="IconInstance.ColorCategoryState" ExposedAsName="BarIconColor" SetsValue="true">
+      <Value xsi:type="xsd:string">Danger</Value>
+    </Variable>
     <Variable Type="float" Name="IconInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">-4</Value>
     </Variable>
@@ -140,9 +206,6 @@
     </Variable>
     <Variable Type="IconCategory" Name="IconInstance.IconCategoryState" ExposedAsName="BarIcon" SetsValue="true">
       <Value xsi:type="xsd:string">Heart</Value>
-    </Variable>
-    <Variable Type="ColorCategory" Name="IconInstance.ColorCategoryState" ExposedAsName="BarIconColor" SetsValue="true">
-      <Value xsi:type="xsd:string">Danger</Value>
     </Variable>
     <Variable Type="string" Name="IconInstance.Parent" SetsValue="true" />
     <Variable Type="float" Name="IconInstance.Width" SetsValue="true">
@@ -161,6 +224,9 @@
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="true" />
+    <Variable Type="ColorCategory" Name="VerticalLinesInstance.ColorCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">Black</Value>
+    </Variable>
     <Variable Type="float" Name="VerticalLinesInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
@@ -169,9 +235,6 @@
     </Variable>
     <Variable Type="int" Name="VerticalLinesInstance.LineAlpha" SetsValue="true">
       <Value xsi:type="xsd:int">50</Value>
-    </Variable>
-    <Variable Type="ColorCategory" Name="VerticalLinesInstance.ColorCategoryState" SetsValue="true">
-      <Value xsi:type="xsd:string">Black</Value>
     </Variable>
     <Variable Type="string" Name="VerticalLinesInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">Bar</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Styles.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Styles.gucx
@@ -112,6 +112,12 @@
     <Variable Type="int" Name="Emphasis.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
     </Variable>
+    <Variable Type="float" Name="Emphasis.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Emphasis.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="Emphasis.IsItalic" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
@@ -120,6 +126,12 @@
     </Variable>
     <Variable Type="string" Name="Emphasis.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Emphasis</Value>
+    </Variable>
+    <Variable Type="float" Name="Emphasis.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Emphasis.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="int" Name="Gray.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
@@ -142,6 +154,12 @@
     <Variable Type="int" Name="H1.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">22</Value>
     </Variable>
+    <Variable Type="float" Name="H1.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H1.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="H1.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
@@ -151,8 +169,20 @@
     <Variable Type="string" Name="H1.Text" SetsValue="true">
       <Value xsi:type="xsd:string">H1</Value>
     </Variable>
+    <Variable Type="float" Name="H1.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H1.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="H2.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">18</Value>
+    </Variable>
+    <Variable Type="float" Name="H2.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H2.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="H2.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -163,8 +193,20 @@
     <Variable Type="string" Name="H2.Text" SetsValue="true">
       <Value xsi:type="xsd:string">H2</Value>
     </Variable>
+    <Variable Type="float" Name="H2.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H2.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="H3.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">16</Value>
+    </Variable>
+    <Variable Type="float" Name="H3.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H3.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="H3.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -174,6 +216,12 @@
     </Variable>
     <Variable Type="string" Name="H3.Text" SetsValue="true">
       <Value xsi:type="xsd:string">H3</Value>
+    </Variable>
+    <Variable Type="float" Name="H3.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="H3.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="float" Name="Height" SetsValue="true">
       <Value xsi:type="xsd:float">-0</Value>
@@ -202,11 +250,23 @@
     <Variable Type="int" Name="Normal.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
     </Variable>
+    <Variable Type="float" Name="Normal.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Normal.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="string" Name="Normal.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">TextStyles</Value>
     </Variable>
     <Variable Type="string" Name="Normal.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Normal</Value>
+    </Variable>
+    <Variable Type="float" Name="Normal.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Normal.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="int" Name="Primary.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
@@ -265,17 +325,35 @@
     <Variable Type="int" Name="Small.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">12</Value>
     </Variable>
+    <Variable Type="float" Name="Small.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Small.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="string" Name="Small.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">TextStyles</Value>
     </Variable>
     <Variable Type="string" Name="Small.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Small</Value>
     </Variable>
+    <Variable Type="float" Name="Small.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Small.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
       <Value xsi:type="xsd:string">Default</Value>
     </Variable>
     <Variable Type="int" Name="Strong.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="float" Name="Strong.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Strong.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="Strong.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -285,6 +363,12 @@
     </Variable>
     <Variable Type="string" Name="Strong.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Strong</Value>
+    </Variable>
+    <Variable Type="float" Name="Strong.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Strong.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="int" Name="Success.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">48</Value>
@@ -323,14 +407,32 @@
     <Variable Type="int" Name="Tiny.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">10</Value>
     </Variable>
+    <Variable Type="float" Name="Tiny.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Tiny.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="string" Name="Tiny.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">TextStyles</Value>
     </Variable>
     <Variable Type="string" Name="Tiny.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Tiny</Value>
     </Variable>
+    <Variable Type="float" Name="Tiny.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Tiny.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="Title.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">28</Value>
+    </Variable>
+    <Variable Type="float" Name="Title.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Title.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="Title.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -340,6 +442,12 @@
     </Variable>
     <Variable Type="string" Name="Title.Text" SetsValue="true">
       <Value xsi:type="xsd:string">Title</Value>
+    </Variable>
+    <Variable Type="float" Name="Title.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Title.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="int" Name="Warning.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/DemoScreenGum.gusx
@@ -6,14 +6,29 @@
     <Variable Type="int" Name="Background.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Background.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Background.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="Background.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="string" Name="Background.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">DemoSettingsMenu</Value>
     </Variable>
     <Variable Type="int" Name="Background.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -27,8 +42,29 @@
     <Variable Type="int" Name="Background.TextureWidth" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
     </Variable>
+    <Variable Type="float" Name="Background.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="Background.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="Background.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="Background.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
     <Variable Type="int" Name="Background1.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
+    </Variable>
+    <Variable Type="bool" Name="Background1.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="int" Name="Background1.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
@@ -44,6 +80,12 @@
     </Variable>
     <Variable Type="int" Name="Background1.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Background1.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Background1.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Background1.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -198,6 +240,9 @@
     <Variable Type="int" Name="DemoHud.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="DemoHud.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="DemoHud.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -209,6 +254,12 @@
     </Variable>
     <Variable Type="int" Name="DemoHud.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="DemoHud.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="DemoHud.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="DemoHud.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -980,6 +1031,12 @@
     <Variable Type="int" Name="TitleText.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
+    <Variable Type="float" Name="TitleText.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TitleText.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
@@ -1001,6 +1058,12 @@
     <Variable Type="bool" Name="TitleText.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TitleText.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TitleText1.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
@@ -1018,6 +1081,12 @@
     </Variable>
     <Variable Type="int" Name="TitleText1.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="TitleText1.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText1.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TitleText1.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1040,6 +1109,12 @@
     <Variable Type="bool" Name="TitleText1.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TitleText1.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText1.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TitleText2.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
@@ -1057,6 +1132,12 @@
     </Variable>
     <Variable Type="int" Name="TitleText2.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="TitleText2.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText2.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TitleText2.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1078,6 +1159,12 @@
     </Variable>
     <Variable Type="bool" Name="TitleText2.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TitleText2.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TitleText2.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="float" Name="TreeViewInstance.Height" SetsValue="true">
       <Value xsi:type="xsd:float">155</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/StylesScreen.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/StylesScreen.gusx
@@ -6,6 +6,9 @@
     <Variable Type="int" Name="Bordered.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Bordered.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Bordered.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -20,6 +23,12 @@
     </Variable>
     <Variable Type="int" Name="Bordered.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Bordered.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Bordered.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Bordered.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -57,6 +66,9 @@
     <Variable Type="int" Name="BracketHorizontal.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="BracketHorizontal.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="BracketHorizontal.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -71,6 +83,12 @@
     </Variable>
     <Variable Type="int" Name="BracketHorizontal.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="BracketHorizontal.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="BracketHorizontal.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="BracketHorizontal.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -108,6 +126,9 @@
     <Variable Type="int" Name="BracketVertical.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="BracketVertical.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="BracketVertical.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -122,6 +143,12 @@
     </Variable>
     <Variable Type="int" Name="BracketVertical.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="BracketVertical.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="BracketVertical.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="BracketVertical.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -186,27 +213,6 @@
     <Variable Type="float" Name="ButtonIconInstance.Y" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>
     </Variable>
-    <Variable Type="ChildrenLayout" Name="ButtonsContainer.ChildrenLayout" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="float" Name="ButtonsContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="ButtonsContainer.HeightUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">4</Value>
-    </Variable>
-    <Variable Type="float" Name="ButtonsContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="ButtonsContainer.WidthUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">4</Value>
-    </Variable>
-    <Variable Type="float" Name="ButtonsContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">159</Value>
-    </Variable>
-    <Variable Type="float" Name="ButtonsContainer.Y" SetsValue="true">
-      <Value xsi:type="xsd:float">12</Value>
-    </Variable>
     <Variable Type="string" Name="ButtonStandardIconInstance.Parent" SetsValue="true">
       <Value xsi:type="xsd:string">ButtonsContainer</Value>
     </Variable>
@@ -239,6 +245,27 @@
     </Variable>
     <Variable Type="VerticalAlignment" Name="ButtonTabInstance.YOrigin" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ButtonsContainer.ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ButtonsContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ButtonsContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="float" Name="ButtonsContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ButtonsContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="float" Name="ButtonsContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">159</Value>
+    </Variable>
+    <Variable Type="float" Name="ButtonsContainer.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">12</Value>
     </Variable>
     <Variable Type="ColorCategory" Name="CautionLinesInstance.ColorCategoryState" SetsValue="true">
       <Value xsi:type="xsd:string">Primary</Value>
@@ -438,6 +465,9 @@
     <Variable Type="int" Name="Outlined.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Outlined.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Outlined.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -452,6 +482,12 @@
     </Variable>
     <Variable Type="int" Name="Outlined.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Outlined.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Outlined.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Outlined.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -489,6 +525,9 @@
     <Variable Type="int" Name="OutlinedHeavy.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="OutlinedHeavy.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="OutlinedHeavy.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -503,6 +542,12 @@
     </Variable>
     <Variable Type="int" Name="OutlinedHeavy.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="OutlinedHeavy.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="OutlinedHeavy.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="OutlinedHeavy.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -540,6 +585,9 @@
     <Variable Type="int" Name="Panel.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Panel.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Panel.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -554,6 +602,12 @@
     </Variable>
     <Variable Type="int" Name="Panel.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Panel.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Panel.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Panel.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -732,6 +786,9 @@
     <Variable Type="int" Name="Solid.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Solid.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Solid.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -746,6 +803,12 @@
     </Variable>
     <Variable Type="int" Name="Solid.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Solid.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Solid.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Solid.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -780,6 +843,9 @@
     <Variable Type="int" Name="Tab.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="Tab.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="Tab.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -794,6 +860,12 @@
     </Variable>
     <Variable Type="int" Name="Tab.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="Tab.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="Tab.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="Tab.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -831,6 +903,9 @@
     <Variable Type="int" Name="TabBordered.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
+    <Variable Type="bool" Name="TabBordered.ExposeChildrenEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
     <Variable Type="int" Name="TabBordered.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
     </Variable>
@@ -845,6 +920,12 @@
     </Variable>
     <Variable Type="int" Name="TabBordered.Red" SetsValue="true">
       <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable IsFile="true" Type="string" Name="TabBordered.SourceFile" SetsValue="true">
+      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+    </Variable>
+    <Variable Type="TextureAddress" Name="TabBordered.TextureAddress" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="int" Name="TabBordered.TextureHeight" SetsValue="true">
       <Value xsi:type="xsd:int">24</Value>
@@ -897,6 +978,12 @@
     <Variable Type="int" Name="TextAccent.Green" SetsValue="true">
       <Value xsi:type="xsd:int">48</Value>
     </Variable>
+    <Variable Type="float" Name="TextAccent.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextAccent.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextAccent.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -917,6 +1004,9 @@
     </Variable>
     <Variable Type="bool" Name="TextAccent.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextAccent.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextAccent.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
@@ -939,6 +1029,12 @@
     <Variable Type="int" Name="TextBlack.Green" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
+    <Variable Type="float" Name="TextBlack.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextBlack.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextBlack.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -959,6 +1055,9 @@
     </Variable>
     <Variable Type="bool" Name="TextBlack.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextBlack.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextBlack.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
@@ -987,6 +1086,12 @@
     <Variable Type="int" Name="TextDarkGray.Green" SetsValue="true">
       <Value xsi:type="xsd:int">70</Value>
     </Variable>
+    <Variable Type="float" Name="TextDarkGray.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextDarkGray.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextDarkGray.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -1007,6 +1112,9 @@
     </Variable>
     <Variable Type="bool" Name="TextDarkGray.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextDarkGray.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextDarkGray.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
@@ -1029,6 +1137,12 @@
     <Variable Type="int" Name="TextEmphasis.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
+    <Variable Type="float" Name="TextEmphasis.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextEmphasis.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextEmphasis.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -1050,6 +1164,12 @@
     <Variable Type="bool" Name="TextEmphasis.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextEmphasis.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextEmphasis.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextGray.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
     </Variable>
@@ -1067,6 +1187,12 @@
     </Variable>
     <Variable Type="int" Name="TextGray.Green" SetsValue="true">
       <Value xsi:type="xsd:int">130</Value>
+    </Variable>
+    <Variable Type="float" Name="TextGray.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextGray.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextGray.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1089,6 +1215,9 @@
     <Variable Type="bool" Name="TextGray.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextGray.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextGray.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1109,6 +1238,12 @@
     </Variable>
     <Variable Type="int" Name="TextH1.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextH1.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH1.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextH1.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1131,6 +1266,12 @@
     <Variable Type="bool" Name="TextH1.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextH1.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH1.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextH2.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -1148,6 +1289,12 @@
     </Variable>
     <Variable Type="int" Name="TextH2.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextH2.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH2.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextH2.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1170,6 +1317,12 @@
     <Variable Type="bool" Name="TextH2.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextH2.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH2.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextH3.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -1187,6 +1340,12 @@
     </Variable>
     <Variable Type="int" Name="TextH3.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextH3.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH3.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextH3.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1209,6 +1368,12 @@
     <Variable Type="bool" Name="TextH3.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextH3.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextH3.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextLightGray.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">170</Value>
     </Variable>
@@ -1226,6 +1391,12 @@
     </Variable>
     <Variable Type="int" Name="TextLightGray.Green" SetsValue="true">
       <Value xsi:type="xsd:int">170</Value>
+    </Variable>
+    <Variable Type="float" Name="TextLightGray.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextLightGray.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextLightGray.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1248,6 +1419,9 @@
     <Variable Type="bool" Name="TextLightGray.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextLightGray.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextLightGray.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1268,6 +1442,12 @@
     </Variable>
     <Variable Type="int" Name="TextNormal.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextNormal.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextNormal.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextNormal.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1290,6 +1470,12 @@
     <Variable Type="bool" Name="TextNormal.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextNormal.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextNormal.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextPrimary.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">177</Value>
     </Variable>
@@ -1307,6 +1493,12 @@
     </Variable>
     <Variable Type="int" Name="TextPrimary.Green" SetsValue="true">
       <Value xsi:type="xsd:int">159</Value>
+    </Variable>
+    <Variable Type="float" Name="TextPrimary.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextPrimary.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextPrimary.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1329,6 +1521,9 @@
     <Variable Type="bool" Name="TextPrimary.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextPrimary.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextPrimary.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1349,6 +1544,12 @@
     </Variable>
     <Variable Type="int" Name="TextPrimaryDark.Green" SetsValue="true">
       <Value xsi:type="xsd:int">120</Value>
+    </Variable>
+    <Variable Type="float" Name="TextPrimaryDark.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextPrimaryDark.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextPrimaryDark.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1371,6 +1572,9 @@
     <Variable Type="bool" Name="TextPrimaryDark.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextPrimaryDark.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextPrimaryDark.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1391,6 +1595,12 @@
     </Variable>
     <Variable Type="int" Name="TextPrimaryLight.Green" SetsValue="true">
       <Value xsi:type="xsd:int">180</Value>
+    </Variable>
+    <Variable Type="float" Name="TextPrimaryLight.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextPrimaryLight.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextPrimaryLight.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1413,6 +1623,9 @@
     <Variable Type="bool" Name="TextPrimaryLight.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextPrimaryLight.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextPrimaryLight.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1433,6 +1646,12 @@
     </Variable>
     <Variable Type="int" Name="TextSmall.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextSmall.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextSmall.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextSmall.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1455,6 +1674,12 @@
     <Variable Type="bool" Name="TextSmall.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextSmall.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextSmall.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextStrong.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -1472,6 +1697,12 @@
     </Variable>
     <Variable Type="int" Name="TextStrong.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextStrong.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextStrong.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextStrong.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1493,6 +1724,12 @@
     </Variable>
     <Variable Type="bool" Name="TextStrong.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextStrong.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextStrong.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="ChildrenLayout" Name="TextStyleContainer.ChildrenLayout" SetsValue="true">
       <Value xsi:type="xsd:int">1</Value>
@@ -1531,6 +1768,12 @@
     <Variable Type="int" Name="TextSuccess.Green" SetsValue="true">
       <Value xsi:type="xsd:int">167</Value>
     </Variable>
+    <Variable Type="float" Name="TextSuccess.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextSuccess.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextSuccess.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -1551,6 +1794,9 @@
     </Variable>
     <Variable Type="bool" Name="TextSuccess.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextSuccess.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextSuccess.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
@@ -1573,6 +1819,12 @@
     <Variable Type="int" Name="TextTiny.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
+    <Variable Type="float" Name="TextTiny.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextTiny.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextTiny.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -1594,6 +1846,12 @@
     <Variable Type="bool" Name="TextTiny.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextTiny.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextTiny.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextTitle.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
@@ -1611,6 +1869,12 @@
     </Variable>
     <Variable Type="int" Name="TextTitle.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextTitle.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextTitle.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextTitle.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
@@ -1633,6 +1897,12 @@
     <Variable Type="bool" Name="TextTitle.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextTitle.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextTitle.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="int" Name="TextWarning.Blue" SetsValue="true">
       <Value xsi:type="xsd:int">25</Value>
     </Variable>
@@ -1650,6 +1920,12 @@
     </Variable>
     <Variable Type="int" Name="TextWarning.Green" SetsValue="true">
       <Value xsi:type="xsd:int">171</Value>
+    </Variable>
+    <Variable Type="float" Name="TextWarning.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextWarning.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextWarning.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1672,6 +1948,9 @@
     <Variable Type="bool" Name="TextWarning.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextWarning.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextWarning.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1692,6 +1971,12 @@
     </Variable>
     <Variable Type="int" Name="TextWarning1.Green" SetsValue="true">
       <Value xsi:type="xsd:int">18</Value>
+    </Variable>
+    <Variable Type="float" Name="TextWarning1.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextWarning1.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
     <Variable Type="bool" Name="TextWarning1.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -1714,6 +1999,9 @@
     <Variable Type="bool" Name="TextWarning1.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
+    <Variable Type="float" Name="TextWarning1.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
     <Variable Type="DimensionUnitType" Name="TextWarning1.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
@@ -1735,6 +2023,12 @@
     <Variable Type="int" Name="TextWhite.Green" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
+    <Variable Type="float" Name="TextWhite.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextWhite.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
     <Variable Type="bool" Name="TextWhite.IsBold" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -1755,6 +2049,9 @@
     </Variable>
     <Variable Type="bool" Name="TextWhite.UseCustomFont" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="TextWhite.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="TextWhite.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/NineSlice.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/NineSlice.gutx
@@ -21,7 +21,7 @@
     <Variable Type="string" Name="CurrentChainName" Category="Animation" SetsValue="true" />
     <Variable Type="float?" Name="CustomFrameTextureCoordinateWidth" Category="Source" SetsValue="true" />
     <Variable Type="bool" Name="ExposeChildrenEvents" Category="Behavior" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
+      <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="int" Name="Green" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
@@ -30,10 +30,10 @@
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="float" Name="Height" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">64</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="HeightUnits" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="bool" Name="IgnoredByParentSize" Category="Parent" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
@@ -53,52 +53,52 @@
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable IsFile="true" Type="string" Name="SourceFile" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:string">UISpriteSheet.png</Value>
+      <Value xsi:type="xsd:string"></Value>
     </Variable>
     <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
       <Value xsi:type="xsd:string">Default</Value>
     </Variable>
     <Variable Type="TextureAddress" Name="TextureAddress" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="int" Name="TextureHeight" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:int">24</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="int" Name="TextureLeft" Category="Source" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="int" Name="TextureTop" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:int">48</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="int" Name="TextureWidth" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:int">24</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="bool" Name="Visible" Category="States and Visibility" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="Width" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">64</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="WidthUnits" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="float" Name="X" Category="Position" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="HorizontalAlignment" Name="XOrigin" Category="Position" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="PositionUnitType" Name="XUnits" Category="Position" SetsValue="true">
-      <Value xsi:type="xsd:int">6</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="float" Name="Y" Category="Position" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="VerticalAlignment" Name="YOrigin" Category="Position" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="PositionUnitType" Name="YUnits" Category="Position" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
+      <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <VariableList xsi:type="VariableListSaveOfString">
       <Type>string</Type>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Sprite.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Sprite.gutx
@@ -64,7 +64,7 @@
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="float" Name="TextureHeightScale" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">1</Value>
     </Variable>
     <Variable Type="int" Name="TextureLeft" Category="Source" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -76,7 +76,7 @@
       <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="float" Name="TextureWidthScale" Category="Source" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">1</Value>
     </Variable>
     <Variable Type="bool" Name="Visible" Category="States and Visibility" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Text.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Text.gutx
@@ -22,7 +22,7 @@
       <Value xsi:type="xsd:float">1</Value>
     </Variable>
     <Variable Type="int" Name="FontSize" Category="Font" SetsValue="true">
-      <Value xsi:type="xsd:int">14</Value>
+      <Value xsi:type="xsd:int">18</Value>
     </Variable>
     <Variable Type="int" Name="Green" Category="Rendering" SetsValue="true">
       <Value xsi:type="xsd:int">255</Value>
@@ -31,10 +31,10 @@
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="float" Name="Height" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">50</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="HeightUnits" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:int">4</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="HorizontalAlignment" Name="HorizontalAlignment" Category="Text" SetsValue="true">
       <Value xsi:type="xsd:int">0</Value>
@@ -92,10 +92,10 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="Width" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">100</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="WidthUnits" Category="Dimensions" SetsValue="true">
-      <Value xsi:type="xsd:int">4</Value>
+      <Value xsi:type="xsd:int">0</Value>
     </Variable>
     <Variable Type="float" Name="X" Category="Position" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>


### PR DESCRIPTION
Closes #4092.

## Summary
- The 21 remaining `gumcli diff-standards` diffs (baked NineSlice/Sprite/Text visual defaults) are gone - `gumcli diff-standards` now reports no drift for FormsTemplate.
- Every consuming instance that relied on inheriting one of these values from the Standard now sets it explicitly, using the Standard's prior baked value - rendered appearance is unchanged.
- The 3 Standards (NineSlice/Sprite/Text) were reset to a blank project's defaults, so a brand-new instance created after Add Forms (Standard theme) no longer silently inherits theme-specific values.
- `Sprite.TextureHeightScale`/`TextureWidthScale` needed no per-instance materialization: confirmed dead code for this template (only read by `UpdateTextureCoordinatesDimensionBased()`, which only runs for `TextureAddress.DimensionsBased`; every FormsTemplate Sprite instance uses `TextureAddress.Custom`) - reset directly.
- `FormsTemplateCreatorTests.Create_ShouldOnlyDriftFromDefaultStandardsInKnownBakedProperties` (pinning the 21 known diffs) replaced with `Create_ShouldNotDriftFromDefaultStandards` asserting zero drift.

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests` - 405 passed, 2 skipped (pre-existing manual helpers)
- [x] `dotnet test Tests/Gum.Cli.Tests` - 57 passed
- [x] `gumcli diff-standards`, `check`, `check-references` on the FormsTemplate - all clean
- [x] `dotnet build GumFull.sln` - 0 errors
- [x] Manual: Add Forms (Standard theme) on a blank project, spot-check a few controls render identically to before, and confirm a brand-new NineSlice/Sprite/Text created afterward gets sane (non-theme) defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)
