### PR TITLE
Add per-element hit-test transform for externally-scaled render targets (#4096)

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -6,6 +6,10 @@ type: skill
 
 # Gum Docs Writing Reference
 
+## Organize by Functionality, Not API Type
+
+A page's home is the functional section a user browses when they have the problem it solves, not a type-indexed folder chosen because that's where the class lives. A new feature's primary explanation goes in its task-based section (e.g. cursor hit-testing for scaled/render-target rendering under `events-and-interactivity/`); the `gum-code-reference/<Type>/` folders hold only terse per-member stubs that link back to it.
+
 ## Verify Behavior Claims Before Writing Them
 
 Before writing a claim like "X isn't available on backend Y" or "X requires package Z," verify it against the relevant domain skill (e.g. `gum-runtime-fonts`, `gum-kernsmith-integrations`, `gum-cross-platform-unification`) or source — this skill covers GitBook mechanics only, not product behavior. A missing per-platform package is not proof of a capability gap: the platform may get the capability another way (Silk.NET has no KernSmith package because it renders through SkiaSharp, which rasterizes fonts natively — parity, not a gap).

--- a/.claude/skills/gum-service/SKILL.md
+++ b/.claude/skills/gum-service/SKILL.md
@@ -26,6 +26,8 @@ GumService.Default.Uninitialize()
 
 `Initialize` throws if called twice without an intervening `Uninitialize`.
 
+`Draw()` draws everything through `SystemManagers.Default` in one call — for manual control over what's drawn when/to-which-target (e.g. compositing onto multiple `RenderTarget2D`s in one frame), use `GumBatch`'s immediate-mode `Begin`/`Draw`/`End` instead (`docs/code/rendering/gumbatch.md`; internals in the **gum-monogame-rendering** skill).
+
 **Only the `gumProjectFile` overload loads a project.** `Initialize(game, gumProjectFile)` loads the `.gumx` and runs the project-load path — which applies project-level settings (standard-element defaults, localization, and the project's `TextureFilter` → `Renderer.TextureFilter`, issue #3199). The `Initialize(game, DefaultVisualsVersion)` / parameterless overloads are **code-only** and never touch that path. So when manually verifying anything that depends on a loaded project, you must pass the `.gumx` path or the behavior under test never runs. The cheapest from-file smoke test is `Initialize(game, "GumProject/GumProject.gumx")` plus a `SpriteRuntime` (`SourceFileName` set, scaled up) added to `Root`.
 
 ## Singleton Pattern
@@ -55,6 +57,10 @@ GumService.Default.Uninitialize()
 | `ModalRoot` | Topmost layer; blocks input to everything below |
 
 `PopupRoot` and `ModalRoot` are `FrameworkElement` statics, not instance fields — they are shared across all `GumService` instances.
+
+## Multiple GumService Instances
+
+The constructor is public (`new GumService()`), but two instances don't give two independent UI spaces — `GraphicalUiElement.CanvasWidth`/`CanvasHeight`, `FormsUtilities`'s `Cursor`/`Keyboard`, and `SystemManagers.Default`/`ISystemManagers.Default` are static, so the second instance's `Initialize()` overwrites state the first depends on (e.g. `Cursor`'s zoom-aware hit-testing reads `SystemManagers.Default` directly, not its owning instance). Tracked as issue #4096.
 
 ## Key Files
 

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -313,6 +313,37 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
+    /// <summary>
+    /// A transform applied to the cursor's raw screen position during hit-testing on this
+    /// element and its descendants (resolved through <see cref="EffectiveHitTestTransformMatrix"/>).
+    /// Set it to map a window pixel back into the coordinate space this subtree was drawn in —
+    /// e.g. the inverse of the scale/letterbox blit used to composite a subtree that was rendered
+    /// into an externally-managed RenderTarget2D. Null (the default) means no transform. This is
+    /// consumed by hit-testing only and is never read by rendering or layout (issue #4096).
+    /// </summary>
+    public System.Numerics.Matrix3x2? HitTestTransformMatrix { get; set; }
+
+    /// <summary>
+    /// Returns this instance's <see cref="HitTestTransformMatrix"/>, or climbs the parent/child
+    /// relationship to the nearest ancestor that set one. Returns null when none is set. Mirrors
+    /// <see cref="EffectiveManagers"/>: nearest ancestor wins, null means "no transform."
+    /// </summary>
+    public System.Numerics.Matrix3x2? EffectiveHitTestTransformMatrix
+    {
+        get
+        {
+            if (HitTestTransformMatrix != null)
+            {
+                return HitTestTransformMatrix;
+            }
+            else
+            {
+                return this.ElementGueContainingThis?.EffectiveHitTestTransformMatrix ??
+                    this.EffectiveParentGue?.EffectiveHitTestTransformMatrix;
+            }
+        }
+    }
+
     /// <inheritdoc/>
     public bool AbsoluteVisible => ((IVisible)this).GetAbsoluteVisible();
 

--- a/GumRuntime/InteractiveGue.cs
+++ b/GumRuntime/InteractiveGue.cs
@@ -684,14 +684,28 @@ public partial class InteractiveGue : GraphicalUiElement
 
             if (managers != null)
             {
-                int cursorScreenX = cursor.X;
-                int cursorScreenY = cursor.Y;
+                float cursorScreenX = cursor.X;
+                float cursorScreenY = cursor.Y;
                 float worldX;
                 float worldY;
                 // Adjust by viewport values:
                 // todo ...
                 //cursorScreenX -= managers.Renderer.GraphicsDevice.Viewport.X;
                 //cursorScreenY -= managers.Renderer.GraphicsDevice.Viewport.Y;
+
+                // A subtree drawn into an externally-scaled render target can supply a transform
+                // that maps the raw window pixel back into the space it was drawn in (issue #4096).
+                // Apply it before screen-to-world so the camera/layer transform still composes on
+                // top. Resolved by climbing to the nearest ancestor that set one.
+                var hitTestTransform = thisInstance.EffectiveHitTestTransformMatrix;
+                if (hitTestTransform != null)
+                {
+                    var transformed = System.Numerics.Vector2.Transform(
+                        new System.Numerics.Vector2(cursorScreenX, cursorScreenY),
+                        hitTestTransform.Value);
+                    cursorScreenX = transformed.X;
+                    cursorScreenY = transformed.Y;
+                }
 
                 var camera = managers.Renderer.Camera;
 

--- a/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Screens/RenderTargetScreen.cs
+++ b/Samples/MonoGameGumImmediateMode/MonoGameGumImmediateMode/Screens/RenderTargetScreen.cs
@@ -1,31 +1,51 @@
+using Gum.Forms;
 using Gum.GueDeriving;
+using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary.Graphics;
+
+// This immediate-mode sample intentionally uses the non-shape ColoredRectangleRuntime: no
+// ShapeRenderer is initialized here, so the shape-based RectangleRuntime replacement it's
+// obsoleted in favor of would silently not draw.
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete
 
 namespace MonoGameGumImmediateMode.Screens
 {
     /// <summary>
     /// Demonstrates using <see cref="GumBatch"/> to draw onto a <see cref="RenderTarget2D"/>,
-    /// then presenting that texture via <see cref="SpriteBatch"/>. Also shows the
-    /// custom BlendState pattern required when drawing partially-transparent objects
+    /// then presenting that texture via <see cref="SpriteBatch"/> at a different scale. Also
+    /// shows the custom BlendState pattern required when drawing partially-transparent objects
     /// onto a render target.
+    ///
+    /// The blue box is interactive even though it lives inside a render target that is blitted
+    /// to the screen at 1.5x: its container carries a <see cref="GraphicalUiElement.HitTestTransformMatrix"/>
+    /// that maps the raw window pixel back into render-target space, so hit-testing lines up with
+    /// where the content actually appears (issue #4096). Hover the blue box — it highlights.
     /// </summary>
     public class RenderTargetScreen : IImmediateModeScreen
     {
+        // The render target is blitted to the backbuffer scaled up by this factor and offset by
+        // this amount, so a raw window pixel must be mapped back by the inverse before hit-testing.
+        private const float BlitScale = 1.5f;
+        private static readonly Vector2 BlitOffset = new Vector2(60, 100);
+        private const int RenderTargetSize = 300;
+
         private GraphicsDevice _graphicsDevice;
         private RenderTarget2D _renderTarget;
         private ColoredRectangleRuntime _redBackground;
         private ColoredRectangleRuntime _halfTransparentRectangle;
+        private ContainerRuntime _interactiveButton;
+        private ColoredRectangleRuntime _buttonBackground;
 
         public void Initialize(GraphicsDevice graphicsDevice)
         {
             _graphicsDevice = graphicsDevice;
-            _renderTarget = new RenderTarget2D(graphicsDevice, 300, 300);
+            _renderTarget = new RenderTarget2D(graphicsDevice, RenderTargetSize, RenderTargetSize);
 
             _redBackground = new ColoredRectangleRuntime();
-            _redBackground.Width = 300;
-            _redBackground.Height = 300;
+            _redBackground.Width = RenderTargetSize;
+            _redBackground.Height = RenderTargetSize;
             _redBackground.Color = Color.Red;
 
             _halfTransparentRectangle = new ColoredRectangleRuntime();
@@ -47,20 +67,52 @@ namespace MonoGameGumImmediateMode.Screens
             blendState.AlphaDestinationBlend = Blend.DestinationAlpha;
             blendState.AlphaBlendFunction = BlendFunction.Add;
             _halfTransparentRectangle.BlendState = blendState;
+
+            // A clickable box living inside the render target. Its visible background is a child
+            // rectangle whose color reflects hover; the container is the hit-test target.
+            _interactiveButton = new ContainerRuntime();
+            _interactiveButton.X = 75;
+            _interactiveButton.Y = 75;
+            _interactiveButton.Width = 150;
+            _interactiveButton.Height = 150;
+
+            _buttonBackground = new ColoredRectangleRuntime();
+            _buttonBackground.Width = 150;
+            _buttonBackground.Height = 150;
+            _interactiveButton.Children.Add(_buttonBackground);
+            _interactiveButton.UpdateLayout();
+
+            // Map a raw window pixel back into render-target space: undo the blit offset, then the
+            // blit scale. Consumed only by hit-testing (never rendering), and inherited by the
+            // container's descendants via the climbing EffectiveHitTestTransformMatrix getter.
+            _interactiveButton.HitTestTransformMatrix =
+                System.Numerics.Matrix3x2.CreateTranslation(-BlitOffset.X, -BlitOffset.Y) *
+                System.Numerics.Matrix3x2.CreateScale(1f / BlitScale);
         }
 
         public void Draw(GumBatch gumBatch, SpriteBatch spriteBatch)
         {
+            ICursor cursor = FormsUtilities.Cursor;
+            bool isOver = cursor != null && _interactiveButton.HasCursorOver(cursor);
+            _buttonBackground.Color = isOver ? Color.Yellow : new Color(40, 60, 200);
+
             _graphicsDevice.SetRenderTarget(_renderTarget);
             _graphicsDevice.Clear(Color.Transparent);
             gumBatch.Begin();
             gumBatch.Draw(_redBackground);
             gumBatch.Draw(_halfTransparentRectangle);
+            gumBatch.Draw(_interactiveButton);
             gumBatch.End();
             _graphicsDevice.SetRenderTarget(null);
 
+            Rectangle destination = new Rectangle(
+                (int)BlitOffset.X,
+                (int)BlitOffset.Y,
+                (int)(RenderTargetSize * BlitScale),
+                (int)(RenderTargetSize * BlitScale));
+
             spriteBatch.Begin();
-            spriteBatch.Draw(_renderTarget, new Vector2(60, 100), Color.White);
+            spriteBatch.Draw(_renderTarget, destination, Color.White);
             spriteBatch.End();
         }
 
@@ -70,3 +122,5 @@ namespace MonoGameGumImmediateMode.Screens
         }
     }
 }
+
+#pragma warning restore CS0618

--- a/Tests/MonoGameGum.Tests.V2/Runtimes/HitTestTransformTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Runtimes/HitTestTransformTests.cs
@@ -1,0 +1,73 @@
+using System.Numerics;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using MonoGameGum.Input;
+using Moq;
+using Shouldly;
+
+namespace MonoGameGum.Tests.V2.Runtimes;
+
+/// <summary>
+/// Regression tests for <see cref="GraphicalUiElement.HitTestTransformMatrix"/> /
+/// <see cref="GraphicalUiElement.EffectiveHitTestTransformMatrix"/> (issue #4096).
+///
+/// The transform lets a subtree drawn into an externally-scaled render target stay
+/// cursor-interactive: the caller sets the matrix that maps a raw window pixel back into
+/// the coordinate space the subtree was drawn in (the inverse of the caller's RT-to-screen
+/// blit). It is resolved by climbing to the nearest ancestor that set it, mirroring
+/// <c>EffectiveManagers</c>, and is consumed ONLY in hit-testing.
+///
+/// The invariant these tests guard: setting the transform changes hit-test results but
+/// never render/layout output — the same draw-vs-hit-test split <c>MatrixRoutingTests</c>
+/// guards for <c>Layer</c>.
+/// </summary>
+public class HitTestTransformTests : BaseTestClass
+{
+    [Fact]
+    public void HasCursorOver_UsesEffectiveHitTestTransform_ClimbedFromAncestor()
+    {
+        // Game container drawn into a half-scale render target: a click at window pixel
+        // (150, 50) lands over a child that only occupies world [0,100] once the pixel is
+        // mapped back through a 0.5x transform to (75, 25).
+        ContainerRuntime gameContainer = new() { X = 0, Y = 0, Width = 200, Height = 200 };
+        ContainerRuntime button = new() { X = 0, Y = 0, Width = 100, Height = 100 };
+        gameContainer.Children.Add(button);
+        GumService.Default.Root.Children.Add(gameContainer);
+        GumService.Default.Root.UpdateLayout();
+
+        Mock<ICursor> cursor = new();
+        cursor.Setup(c => c.LastInputDevice).Returns(InputDevice.Mouse);
+        cursor.Setup(c => c.X).Returns(150);
+        cursor.Setup(c => c.Y).Returns(50);
+
+        // Without a transform the raw window pixel (150, 50) is outside the button.
+        button.HasCursorOver(cursor.Object).ShouldBeFalse();
+
+        // Set the transform on the ANCESTOR only; the child must resolve it by climbing.
+        gameContainer.HitTestTransformMatrix = Matrix3x2.CreateScale(0.5f);
+
+        // (150, 50) maps to (75, 25), which is inside the button.
+        button.HasCursorOver(cursor.Object).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HitTestTransformMatrix_DoesNotAffectRenderCoordinates()
+    {
+        ContainerRuntime gameContainer = new() { X = 30, Y = 40, Width = 200, Height = 200 };
+        ContainerRuntime button = new() { X = 10, Y = 20, Width = 100, Height = 100 };
+        gameContainer.Children.Add(button);
+        GumService.Default.Root.Children.Add(gameContainer);
+        GumService.Default.Root.UpdateLayout();
+
+        float baselineLeft = button.AbsoluteLeft;
+        float baselineTop = button.AbsoluteTop;
+
+        // A hit-test transform must never feed layout/rendering, so absolute positions
+        // stay put — this is the "changes hit-testing, not render output" half of #4096.
+        gameContainer.HitTestTransformMatrix = Matrix3x2.CreateScale(0.5f);
+        GumService.Default.Root.UpdateLayout();
+
+        button.AbsoluteLeft.ShouldBe(baselineLeft);
+        button.AbsoluteTop.ShouldBe(baselineTop);
+    }
+}

--- a/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
+++ b/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
@@ -14,7 +14,7 @@ Touch support varies by runtime. Where a runtime has no real touch API, touch is
 | Silk.NET | Full | ✅ |
 | MonoGame (DesktopGL) | Full | ✅ |
 
-raylib's default desktop backend (GLFW) has no real touch input — see raylib's own [source comment acknowledging this](https://github.com/raysan5/raylib/blob/4640c849208079d758d8f0dbb4b5b7816db5ed0c/src/platforms/rcore_desktop_glfw.c#L1305-L1310). raylib's SDL backend does support real touch, but isn't what Gum's raylib runtime currently uses.
+raylib's default desktop backend (GLFW) has no real touch input. See raylib's own [source comment acknowledging this](https://github.com/raysan5/raylib/blob/4640c849208079d758d8f0dbb4b5b7816db5ed0c/src/platforms/rcore_desktop_glfw.c#L1305-L1310). raylib's SDL backend does support real touch, but isn't what Gum's raylib runtime currently uses.
 
 ## Code Example: Accessing the Cursor
 

--- a/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
+++ b/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
@@ -159,9 +159,47 @@ protected override void Update(GameTime gameTime)
 
 ## Adjusting the Cursor for Scaled or Offset Rendering
 
-If your game draws Gum's output through a `RenderTarget2D`, scales it with a `SpriteBatch` matrix, or otherwise transforms the rendered UI, the raw cursor position will no longer line up with what the player sees. The `Cursor` exposes a `TransformMatrix` property that compensates for these transformations so clicks land on the visual under the mouse.
+If your game draws Gum's output through a `RenderTarget2D`, scales it with a `SpriteBatch` matrix, or otherwise transforms the rendered UI, the raw cursor position no longer lines up with what the player sees. Gum offers two ways to compensate, depending on whether all of your UI shares one coordinate space or several coexist in the same frame.
 
-See [TransformMatrix](../gum-code-reference/cursor/transformmatrix.md) for a full example.
+### One coordinate space: Cursor.TransformMatrix
+
+When every Gum visual is transformed the same way (for example, the entire UI is drawn into one render target and scaled to fit the window), set a single `Cursor.TransformMatrix`. It is applied once to the cursor position before any hit-testing, so clicks land on the visual under the mouse. See [TransformMatrix](../gum-code-reference/cursor/transformmatrix.md) for a full example.
+
+### Several coordinate spaces at once: HitTestTransformMatrix
+
+A single cursor transform cannot serve two coordinate spaces at the same time. A common case is game UI drawn into a scaled `RenderTarget2D` while a separate editor or debug UI is drawn straight to the window at 1:1, with both clickable in the same frame. For this, set `HitTestTransformMatrix` on the root of each subtree that needs its own mapping.
+
+`HitTestTransformMatrix` is a `System.Numerics.Matrix3x2?` on `GraphicalUiElement`. It is resolved by climbing to the nearest ancestor that set one, so setting it on a container covers that whole subtree, and content drawn at 1:1 simply leaves it unset (the default). Set it to the matrix that maps a raw window pixel back into the space the subtree was drawn in, which is the inverse of the scale and offset used to blit the render target. It affects hit-testing only and never changes rendering or layout.
+
+```csharp
+// Class scope
+ContainerRuntime gameUi;
+
+float blitScale = 1.5f;
+System.Numerics.Vector2 blitOffset = new System.Numerics.Vector2(60, 100);
+
+protected override void Initialize()
+{
+    GumUI.Initialize(this);
+
+    gameUi = new ContainerRuntime { Width = 300, Height = 300 };
+    // ...add the game UI's controls as children of gameUi...
+
+    // Map a raw window pixel back into render-target space: undo the blit
+    // offset, then the blit scale. Descendants inherit this by climbing.
+    gameUi.HitTestTransformMatrix =
+        System.Numerics.Matrix3x2.CreateTranslation(-blitOffset.X, -blitOffset.Y) *
+        System.Numerics.Matrix3x2.CreateScale(1f / blitScale);
+
+    base.Initialize();
+}
+```
+
+Draw `gameUi` into the render target and blit it to the window just as in the [TransformMatrix example](../gum-code-reference/cursor/transformmatrix.md), using `blitOffset` and `blitScale` for the blit destination. Any UI drawn straight to the window stays at 1:1 with no transform, so both are clickable in the same frame. Check hits with the `HasCursorOver(ICursor)` overload, for example `gameUi.HasCursorOver(GumUI.Cursor)`.
+
+{% hint style="info" %}
+Only the `HasCursorOver(ICursor)` path applies `HitTestTransformMatrix`, and this is the path normal Forms interaction uses. The pure-bounds `HasCursorOver(float, float)` overload shown earlier on this page does not.
+{% endhint %}
 
 ## Disabling the Cursor Globally
 

--- a/docs/code/gum-code-reference/cursor/transformmatrix.md
+++ b/docs/code/gum-code-reference/cursor/transformmatrix.md
@@ -69,3 +69,7 @@ public class Game1 : Game
 ```
 
 <figure><img src="../../../.gitbook/assets/11_05 57 54.gif" alt=""><figcaption><p>Cursor interacting with a Button drawn on an offset render target</p></figcaption></figure>
+
+{% hint style="info" %}
+`TransformMatrix` applies one transform to the whole cursor, so it fits when all of your UI shares a single coordinate space. If several coordinate spaces coexist in the same frame (for example, game UI in a scaled render target plus a window-pinned editor UI), use the per-subtree [`HitTestTransformMatrix`](../../events-and-interactivity/mouse-and-touch-screen-cursor.md#several-coordinate-spaces-at-once-hittesttransformmatrix) instead.
+{% endhint %}

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -4,7 +4,7 @@
 
 GumBatch is an object which supports _immediate mode_ rendering, similar to MonoGame's SpriteBatch. GumBatch can support rendering text with DrawString as well as any IRenderableIpso.
 
-For information on getting your project set up to use GumBatch — including how to wire up KernSmith so you do not need to ship any `.fnt` files — see the [Setup for GumBatch](../getting-started/setup/setup-for-gumbatch.md) page.
+For information on getting your project set up to use GumBatch, including how to wire up KernSmith so you do not need to ship any `.fnt` files, see the [Setup for GumBatch](../getting-started/setup/setup-for-gumbatch.md) page.
 
 {% hint style="info" %}
 GumBatch draws only what you pass it. In some cases controls may create additional controls on the popup layer, such as ComboBox and Tooltip. If your UI includes these controls, you may need to also draw your popup layers, as shown in the following code:
@@ -21,11 +21,11 @@ Core.GumBatch.End();
 
 ### Relationship with the Camera
 
-GumBatch draws through the same `Camera` as the rest of Gum — the one at `GumService.Default.Renderer.Camera`. It does **not** ignore the camera: the camera's `Zoom`, `Position` (`X` and `Y`), and `CameraCenterOnScreen` all apply to everything you draw between `Begin` and `End`. So if you zoom the camera to handle a window resize (see [Resolution and Resizing the Game Window](../layout/resizing-the-game-window.md)), your GumBatch output zooms along with the rest of your UI.
+GumBatch draws through the same `Camera` as the rest of Gum, the one at `GumService.Default.Renderer.Camera`. It does **not** ignore the camera: the camera's `Zoom`, `Position` (`X` and `Y`), and `CameraCenterOnScreen` all apply to everything you draw between `Begin` and `End`. So if you zoom the camera to handle a window resize (see [Resolution and Resizing the Game Window](../layout/resizing-the-game-window.md)), your GumBatch output zooms along with the rest of your UI.
 
 `Begin` also refreshes the camera's client dimensions from the current `GraphicsDevice.Viewport` on every call, so GumBatch always matches the live viewport size.
 
-`Begin` accepts an optional transform: `Begin(Matrix)`. This matrix **composes on top of** the camera transform rather than replacing it — the effective transform is your matrix multiplied with the camera's view.
+`Begin` accepts an optional transform: `Begin(Matrix)`. This matrix **composes on top of** the camera transform rather than replacing it. The effective transform is your matrix multiplied with the camera's view.
 
 {% hint style="warning" %}
 Because the matrix composes on top of the camera, setting `Camera.Zoom` to a non-default value **and** passing a scaling matrix to `Begin(Matrix)` applies the scale twice. Drive scaling from a single source: either leave the matrix off and use `Camera.Zoom`, or pass a matrix and keep `Camera.Zoom` at `1`.
@@ -33,7 +33,7 @@ Because the matrix composes on top of the camera, setting `Camera.Zoom` to a non
 
 ### Rendering TextRuntimes
 
-The most flexible way to draw text with GumBatch is to create a `TextRuntime`. TextRuntimes support all of Gum's layout rules — wrapping, alignment, rotation, sizing — and integrate with Gum's font system so you can set `Font` and `FontSize` directly and let KernSmith create the atlas on demand.
+The most flexible way to draw text with GumBatch is to create a `TextRuntime`. TextRuntimes support all of Gum's layout rules (wrapping, alignment, rotation, sizing) and integrate with Gum's font system so you can set `Font` and `FontSize` directly and let KernSmith create the atlas on demand.
 
 The following code shows how to create a `TextRuntime` and render it using GumBatch:
 
@@ -44,7 +44,7 @@ TextRuntime textRuntime;
 protected override void Initialize()
 {
     // This assumes CustomSetPropertyOnRenderable.InMemoryFontCreator
-    // has already been assigned to a KernSmithFontCreator — see the
+    // has already been assigned to a KernSmithFontCreator. See the
     // Setup for GumBatch page.
     textRuntime = new TextRuntime();
     textRuntime.Font = "Arial";
@@ -84,7 +84,7 @@ If you would rather load a specific `.fnt` file instead of using KernSmith, set 
 
 ### Rendering Strings
 
-GumBatch can also render strings directly via `DrawString`. This is a lower-level API than `TextRuntime` — it does not support layout, wrapping, or rotation — but the call shape matches `SpriteBatch.DrawString` and is convenient for quick HUD-style text.
+GumBatch can also render strings directly via `DrawString`. This is a lower-level API than `TextRuntime` (it does not support layout, wrapping, or rotation) but the call shape matches `SpriteBatch.DrawString` and is convenient for quick HUD-style text.
 
 `DrawString` takes a `BitmapFont`. The recommended way to obtain one is to ask KernSmith for it directly:
 
@@ -217,7 +217,7 @@ protected override void Draw(GameTime gameTime)
 
 ### Mixing with SpriteBatch
 
-GumBatch wraps an internal `SpriteBatch` and exposes it through the `SpriteBatch` property. This lets you issue your own SpriteBatch draw calls between `GumBatch.Begin` and `GumBatch.End` without managing a second batch — both your draws and Gum's draws land in the same batch, so they share sort order, blend state, and transform matrix.
+GumBatch wraps an internal `SpriteBatch` and exposes it through the `SpriteBatch` property. This lets you issue your own SpriteBatch draw calls between `GumBatch.Begin` and `GumBatch.End` without managing a second batch. Both your draws and Gum's draws land in the same batch, so they share sort order, blend state, and transform matrix.
 
 This is useful when you want to draw a few of your own textures alongside Gum's immediate-mode output without paying for two Begin/End pairs.
 
@@ -237,7 +237,7 @@ gumBatch.Draw(someGumObject);
 gumBatch.End();
 ```
 
-The underlying `SpriteBatch` instance is stable for the lifetime of the GumBatch — Gum may mutate its state (clip regions, blend, transform) but never swaps the instance — so it is safe to cache the reference if you want.
+The underlying `SpriteBatch` instance is stable for the lifetime of the GumBatch. Gum may mutate its state (clip regions, blend, transform) but never swaps the instance, so it is safe to cache the reference if you want.
 
 {% hint style="warning" %}
 You are sharing a batch with Gum, so any state you change on the SpriteBatch directly (e.g. by calling `End` and re-issuing `Begin` with different parameters) will affect subsequent Gum draws. If you need independent state, use your own separate SpriteBatch instead.

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -262,6 +262,10 @@ GraphicsDevice.SetRenderTarget(null);
 spriteBatch.Draw(MyRenderTarget, new Vector2(0, 0), Color.White);
 ```
 
+{% hint style="info" %}
+Content drawn to a render target this way is not interactive by default, because the cursor is measured in window pixels while the content was drawn, and then scaled or offset, into the render target. To keep it clickable, map the cursor back into render-target space with [`HitTestTransformMatrix`](../events-and-interactivity/mouse-and-touch-screen-cursor.md#several-coordinate-spaces-at-once-hittesttransformmatrix).
+{% endhint %}
+
 Note that if you are rendering multiple objects on a render target, the BlendState must be set as to add the transparency. Using the default BlendState may result in alpha being "removed" from the render target when new instances are drawn.
 
 The following shows how to create a BlendState for objects which have partial transparency and are to be drawn on RenderTargets:

--- a/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
+++ b/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
@@ -69,4 +69,6 @@ protected override void Update(GameTime gameTime)
 
 {% hint style="info" %}
 Currently the ListBox is not interactive because the original ListBox is invisible so it does not receive events from the Cursor. Future versions of Gum may provide a way to interact with invisible controls rendered to a RenderTarget.
+
+This limitation applies to Gum's own `IsRenderTarget` baking. If you instead draw a subtree into a `RenderTarget2D` yourself (for example with `GumBatch`), you can keep it interactive by mapping the cursor with [`HitTestTransformMatrix`](../../events-and-interactivity/mouse-and-touch-screen-cursor.md#several-coordinate-spaces-at-once-hittesttransformmatrix).
 {% endhint %}


### PR DESCRIPTION
Closes #4096.

Adds a hit-test-only transform so a subtree drawn into an externally-managed `RenderTarget2D` (scaled/letterboxed onto the backbuffer by the caller) stays cursor-interactive, while sibling window-pinned UI stays at 1:1 in the same frame.

## Change
- `GraphicalUiElement.HitTestTransformMatrix` (`System.Numerics.Matrix3x2?`) + `EffectiveHitTestTransformMatrix` climbing getter — nearest ancestor wins, `null` = no transform, shaped exactly like the existing `EffectiveManagers`.
- `InteractiveGue.CheckHasCursorOverOnThis` applies it to the raw cursor screen position **before** `ScreenToWorld`, so camera/`Layer` transforms still compose on top. Never read by rendering or layout.
- `Layer`/`LayerCameraSettings` untouched (they feed the render matrix too, so an RT-compensation transform there would clip the bake).

## Why `Matrix3x2`
It's the type `Cursor.TransformMatrix` already uses on the non-XNA backends (Raylib/Silk/Sokol), and `GraphicalUiElement` lives in the XNA-free GumCommon. A letterbox/scale is a pure 2D affine, so 4×4 would carry dead cells.

## Tests
`HitTestTransformTests` pins both halves (mirroring `MatrixRoutingTests`): the transform changes hit-test results (resolved by climbing from an ancestor) but leaves render coordinates unchanged.

## Sample
`RenderTargetScreen` (immediate-mode sample) now blits its RT at 1.5× with an interactive box that highlights on hover — a runtime proof the click maps through the scale.

## Not in scope
Static `CanvasWidth`/`CanvasHeight` per-subtree override (the issue defers it as a separate field).

Also pulls in a pending `gum-service` SKILL.md note (the "Multiple GumService Instances" limitation that motivated this issue).
