### PR TITLE
Fix NRE when pasting into a TextBox with null Text

### DIFF
--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -660,6 +660,23 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleKeyDown_Paste_ShouldNotThrow_WhenTextIsNull()
+    {
+        // #4099: Text is string? and can legitimately be assigned null (e.g. to clear a box).
+        // Pasting into it NREd because HandlePaste called this.Text.Insert without a null guard.
+        Gum.Clipboard.ClipboardImplementation.PushStringToClipboard("pasted");
+
+        TextBox textBox = new();
+        textBox.IsFocused = true;
+        textBox.Text = null;
+        textBox.Text.ShouldBeNull();
+
+        Should.NotThrow(() => textBox.HandleKeyDown(Gum.Forms.Input.Keys.V, false, false, isCtrlDown: true));
+
+        textBox.Text.ShouldBe("pasted");
+    }
+
+    [Fact]
     public void HandleKeyDown_Paste_ShouldReplaceSlashRSlashN_WithSlashN()
     {
         Gum.Clipboard.ClipboardImplementation.PushStringToClipboard("Line1\r\nLine2");

--- a/MonoGameGum/Forms/Controls/TextBox.cs
+++ b/MonoGameGum/Forms/Controls/TextBox.cs
@@ -392,8 +392,10 @@ public class TextBox : TextBoxBase
             }
             foreach (var character in whatToPaste)
             {
-                // Use SetTextFromUi because this is user-pasted input
-                SetTextFromUi(this.Text.Insert(caretIndex, "" + character));
+                // Use SetTextFromUi because this is user-pasted input.
+                // Text may legitimately be null (e.g. explicitly cleared), so guard it
+                // the same way HandleCharEntered does (#4099).
+                SetTextFromUi((this.Text ?? "").Insert(caretIndex, "" + character));
                 caretIndex++;
             }
 


### PR DESCRIPTION
Closes #4099

`HandlePaste` called `this.Text.Insert(...)` without a null guard. `Text` is `string?` and can legitimately be null (e.g. explicitly cleared) — every other mutating call site in `TextBox.cs` already handles that (`HandleCharEntered` uses `Text ?? ""`, `HandleBackspace`/`HandleDelete` null-check). `HandlePaste` was the one spot that missed it.

## Test plan
- [x] Added `HandleKeyDown_Paste_ShouldNotThrow_WhenTextIsNull`, confirmed it reproduces the NRE before the fix
- [x] `MonoGameGum.Tests` TextBoxTests suite green (49/49)
- [x] `RaylibGum` builds clean (shared source file)