### PR TITLE
Note why font props are absent from TrySetValueOnThis (#4088)

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6615,6 +6615,11 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
                     this.WrapsChildren = (bool)value!;
                     toReturn = true;
                     break;
+
+                // No Font/FontSize/CustomFontFile/UseCustomFont cases here by design: those properties
+                // exist on GraphicalUiElement only under #if FRB (see the Font/Text region below). Every
+                // other backend owns them on TextRuntime and dispatches via CustomSetPropertyOnRenderable,
+                // so there is no backend-agnostic property here to route them to (see issue #4088).
             }
 
             if (!toReturn)


### PR DESCRIPTION
#4088 proposed centralizing `Font`/`FontSize`/`CustomFontFile`/`UseCustomFont` dispatch into `GraphicalUiElement.TrySetValueOnThis` as one backend-agnostic location. It can't be.

Those four properties exist on `GraphicalUiElement` only under `#if FRB` (FRB has no native `TextRuntime` yet). Every other backend owns them on `TextRuntime` and dispatches via `CustomSetPropertyOnRenderable`. A case in the always-compiled switch would either fail to compile off-FRB or, if `#if FRB`-gated, be a no-op for every other backend. It also runs against the TextRuntime-convergence direction (ADRs 0009/0010).

So declining the refactor. This adds a breadcrumb at the end of the switch so the next reader sees why the font cases are deliberately absent instead of concluding they can be centralized here.

Closes #4088
