### PR TITLE
Add [HasDropshadow] BBCode tag for per-run shadow toggling

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1399,7 +1399,7 @@ public partial class CustomSetPropertyOnRenderable
         return handled;
     }
 
-    // The seven font-resolution stacks (mirroring the MonoGame path). Inline [FontSize]/[IsBold]/etc. tags
+    // The eight font-resolution stacks (mirroring the MonoGame path). Inline [FontSize]/[IsBold]/etc. tags
     // push their value on open and pop on close, so a run resolves to the font implied by every tag currently
     // open over it - the whole reason nested markup needs a stack rather than a flat lookup.
     static Stack<int> fontSizeStack = new Stack<int>();
@@ -1409,12 +1409,15 @@ public partial class CustomSetPropertyOnRenderable
     static Stack<bool> isItalicStack = new Stack<bool>();
     static Stack<bool> isBoldStack = new Stack<bool>();
     static Stack<bool> useCustomFontStack = new Stack<bool>();
+    // A [HasDropshadow] tag toggles just this on/off flag per run - offset/blur/color stay whole-text
+    // (set via TextRuntime.Dropshadow*), the same split [OutlineThickness] uses against the whole-text
+    // OutlineColor. See #3528.
+    static Stack<bool> hasDropshadowStack = new Stack<bool>();
 
-    // The base text's dropshadow, snapshotted once per SetBbCodeText call (no BBCode tag toggles
-    // dropshadow mid-text, so unlike the seven stacks above this needs no push/pop) and applied to
-    // every per-run font resolved by GetAndCreateFontIfNecessary, matching the base-font path
+    // The base text's dropshadow offset/blur/color, snapshotted once per SetBbCodeText call (no BBCode
+    // tag varies these mid-text - only on/off, via hasDropshadowStack above) and applied to every per-run
+    // font resolved by GetAndCreateFontIfNecessary, matching the base-font path
     // (TextRuntime.CopyFontGenerationFieldsTo / GetFontCacheFileName). See #3625.
-    static bool currentHasDropshadow;
     static float currentDropshadowOffsetX;
     static float currentDropshadowOffsetY;
     static float currentDropshadowBlur;
@@ -1423,10 +1426,11 @@ public partial class CustomSetPropertyOnRenderable
     static byte currentDropshadowBlue;
     static byte currentDropshadowAlpha;
 
-    // Copies the snapshotted base-text dropshadow (see the fields above) onto a per-run BmfcSave.
+    // Copies the current run's HasDropshadow (from the stack) and the snapshotted base-text
+    // offset/blur/color (see the fields above) onto a per-run BmfcSave.
     static void ApplyCurrentDropshadowTo(BmfcSave bmfcSave)
     {
-        bmfcSave.HasDropshadow = currentHasDropshadow;
+        bmfcSave.HasDropshadow = hasDropshadowStack.Peek();
         bmfcSave.DropshadowOffsetX = currentDropshadowOffsetX;
         bmfcSave.DropshadowOffsetY = currentDropshadowOffsetY;
         bmfcSave.DropshadowBlur = currentDropshadowBlur;
@@ -1516,7 +1520,7 @@ public partial class CustomSetPropertyOnRenderable
     private static readonly HashSet<string> StateBbCodeAllowlist = new HashSet<string>
     {
         "Color", "Red", "Green", "Blue", "FontScale",
-        "Font", "FontSize", "OutlineThickness", "IsItalic", "IsBold", "UseCustomFont",
+        "Font", "FontSize", "OutlineThickness", "IsItalic", "IsBold", "UseCustomFont", "HasDropshadow",
     };
 
     /// <summary>
@@ -1609,7 +1613,7 @@ public partial class CustomSetPropertyOnRenderable
     /// Parses BBCode markup, assigns the tag-stripped text to <see cref="Text.RawText"/>, and populates
     /// <see cref="Text.InlineVariables"/> with the per-run styling the renderer applies: Color / Red /
     /// Green / Blue and FontScale runs in the loop below, plus the resolved-font runs for the font family
-    /// tags (Font / FontSize / OutlineThickness / IsBold / IsItalic) produced by
+    /// tags (Font / FontSize / OutlineThickness / IsBold / IsItalic / HasDropshadow) produced by
     /// <see cref="ApplyFontVariables"/> using the same stack model on every platform. A <c>[Custom]</c> tag's
     /// per-letter callback is applied identically on every platform: it produces one
     /// <see cref="ParameterizedLetterCustomizationCall"/> InlineVariable per character, which each
@@ -1706,8 +1710,8 @@ public partial class CustomSetPropertyOnRenderable
                     // we apply the inline ourselves
                     shouldApply = false;
                     break;
-                    // Font / FontSize / OutlineThickness / IsBold / IsItalic family swaps are handled below in
-                    // ApplyFontVariables (stack model), not here.
+                    // Font / FontSize / OutlineThickness / IsBold / IsItalic / HasDropshadow family swaps
+                    // are handled below in ApplyFontVariables (stack model), not here.
             }
 
             if (shouldApply)
@@ -1728,7 +1732,7 @@ public partial class CustomSetPropertyOnRenderable
         var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 #endif
 
-        // Per-run font resolution requires the seven stacks to be seeded from a TextRuntime's base font
+        // Per-run font resolution requires the eight stacks to be seeded from a TextRuntime's base font
         // values. A Text owned by a non-TextRuntime GraphicalUiElement has no such values, so we neither seed
         // nor resolve here - otherwise ApplyFontVariables would peek/pop unseeded (stale or empty) stacks,
         // giving a wrong font or an InvalidOperationException. One guard covers seeding and resolution; the
@@ -1769,10 +1773,11 @@ public partial class CustomSetPropertyOnRenderable
             useCustomFontStack.Clear();
             useCustomFontStack.Push(textRuntime.UseCustomFont);
 
+            hasDropshadowStack.Clear();
 #if FRB
             // FRB's GraphicalUiElement has no dropshadow font properties (see the FRB extension
             // methods below), so per-run resolution never applies a dropshadow there either.
-            currentHasDropshadow = false;
+            hasDropshadowStack.Push(false);
             currentDropshadowOffsetX = 0f;
             currentDropshadowOffsetY = 0f;
             currentDropshadowBlur = 0f;
@@ -1781,7 +1786,7 @@ public partial class CustomSetPropertyOnRenderable
             currentDropshadowBlue = 0;
             currentDropshadowAlpha = 0;
 #else
-            currentHasDropshadow = textRuntime.HasDropshadow;
+            hasDropshadowStack.Push(textRuntime.HasDropshadow);
             currentDropshadowOffsetX = textRuntime.DropshadowOffsetX;
             currentDropshadowOffsetY = textRuntime.DropshadowOffsetY;
             currentDropshadowBlur = textRuntime.DropshadowBlur;
@@ -1805,7 +1810,7 @@ public partial class CustomSetPropertyOnRenderable
     }
 
     /// <summary>
-    /// Resolves the Font / FontSize / OutlineThickness / IsBold / IsItalic BBCode tags into per-run
+    /// Resolves the Font / FontSize / OutlineThickness / IsBold / IsItalic / HasDropshadow BBCode tags into per-run
     /// resolved-font (<c>"BitmapFont"</c>) inline variables using a stack model: each open tag pushes its
     /// value and each close tag pops it, so a run resolves to the font implied by every tag open over it.
     /// The push/pop/sort/character-count loop is identical on every platform; only the font-CREATION body
@@ -1915,6 +1920,17 @@ public partial class CustomSetPropertyOnRenderable
                     else
                     {
                         useCustomFontStack.Pop();
+                    }
+                    castedValue = GetAndCreateFontIfNecessary();
+                    break;
+                case "HasDropshadow":
+                    if (bool.TryParse(tag.Argument, out bool parsedHasDropshadow))
+                    {
+                        hasDropshadowStack.Push(parsedHasDropshadow);
+                    }
+                    else
+                    {
+                        hasDropshadowStack.Pop();
                     }
                     castedValue = GetAndCreateFontIfNecessary();
                     break;
@@ -2092,7 +2108,7 @@ public partial class CustomSetPropertyOnRenderable
                     isItalicStack.Peek(),
                     isBoldStack.Peek(),
                     bbCodeFontFilePath,
-                    currentHasDropshadow,
+                    hasDropshadowStack.Peek(),
                     currentDropshadowOffsetX,
                     currentDropshadowOffsetY,
                     currentDropshadowBlur,
@@ -2154,7 +2170,7 @@ public partial class CustomSetPropertyOnRenderable
                     isItalicStack.Peek(),
                     isBoldStack.Peek(),
                     bbCodeFontFilePath,
-                    currentHasDropshadow,
+                    hasDropshadowStack.Peek(),
                     currentDropshadowOffsetX,
                     currentDropshadowOffsetY,
                     currentDropshadowBlur,

--- a/GumRuntime/BbCodeParser.cs
+++ b/GumRuntime/BbCodeParser.cs
@@ -80,6 +80,7 @@ public static class BbCodeParser
         "lineheightmultiplier",
         "custom",
         "state",
+        "hasdropshadow",
     };
 
     private struct Tag

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeHasDropshadowTagTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeHasDropshadowTagTests.cs
@@ -1,0 +1,91 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// #3528: a [HasDropshadow] BBCode tag lets a run toggle the shadow independently of the base
+// TextRuntime.HasDropshadow, using the same push/pop stack model as [IsBold]/[FontSize]/etc.
+// (Gum/Wireframe/CustomSetPropertyOnRenderable.cs). Distinct from #3625 (which only propagated the
+// base shadow onto per-run font swaps) - this is the tag actually changing the per-run value.
+public class TextRuntimeBbCodeHasDropshadowTagTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithHasDropshadowFalseTag_WhenBaseHasDropshadow_ResolvesRunFontWithoutDropshadow()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var recordingCreator = new RecordingInMemoryFontCreator();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Garet";
+            textRuntime.FontSize = 12;
+            textRuntime.HasDropshadow = true;
+
+            textRuntime.Text = "normal [IsBold=true][HasDropshadow=false]off[/HasDropshadow][/IsBold] normal";
+
+            // The [IsBold] open (still base HasDropshadow=true), the [HasDropshadow=false] open, and the
+            // matching close each re-resolve a bold font - only the middle one has shadow turned off.
+            recordingCreator.Requests.ShouldContain(r => r.IsBold && !r.HasDropshadow);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WithHasDropshadowTrueTag_WhenBaseHasNoDropshadow_ResolvesRunFontWithDropshadow()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var recordingCreator = new RecordingInMemoryFontCreator();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Garet";
+            textRuntime.FontSize = 12;
+            textRuntime.HasDropshadow = false;
+
+            textRuntime.Text = "normal [IsBold=true][HasDropshadow=true]on[/HasDropshadow][/IsBold] normal";
+
+            recordingCreator.Requests.ShouldContain(r => r.IsBold && r.HasDropshadow);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Records every BmfcSave a per-request font resolution asks for, and returns a minimal valid
+    // BitmapFont (mirrors TextRuntimeBbCodeDropshadowRegressionTests.RecordingInMemoryFontCreator).
+    private sealed class RecordingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public List<BmfcSave> Requests { get; } = new();
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            BitmapFont font = new BitmapFont((Texture2D)null!, FontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        private const string FontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=1
+char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=15
+";
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeStateTests.cs
@@ -14,8 +14,8 @@ namespace MonoGameGum.Tests.Runtimes;
 // [State=Name] BBCode tag: decomposes a GraphicalUiElement's named state (States/AddStates, the
 // same runtime concept ApplyState(string) already uses) into the substring the tag wraps, but only
 // for variables already wired for per-run application - Color/Red/Green/Blue/FontScale (direct
-// InlineVariable) and Font/FontSize/OutlineThickness/IsItalic/IsBold/UseCustomFont (the font-stack
-// path in ApplyFontVariables). Anything else in the state (X, Y, Width, etc.) is silently skipped,
+// InlineVariable) and Font/FontSize/OutlineThickness/IsItalic/IsBold/UseCustomFont/HasDropshadow (the
+// font-stack path in ApplyFontVariables). Anything else in the state (X, Y, Width, etc.) is silently skipped,
 // and an unknown state name is a no-op - neither is an error.
 public class TextRuntimeBbCodeStateTests : BaseTestClass
 {

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1305,7 +1305,14 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                     var baselineDifference = maxBaseline - (fontScale * effectiveFont.BaselineY);
                     effectiveTopOfLine += baselineDifference;
 
-                    if (HasDropshadow && effectiveFont.ShadowFont != null)
+                    // Issue #3528: gate on the per-run resolved font's own ShadowFont, not the whole-Text
+                    // HasDropshadow - a [HasDropshadow] BBCode tag resolves effectiveFont with (or without)
+                    // a baked ShadowFont independently of the base text's setting, so effectiveFont.ShadowFont
+                    // already reflects this run's state (baking is gated on the same flag - see
+                    // ApplyCurrentDropshadowTo in CustomSetPropertyOnRenderable.cs). When no per-run font tag
+                    // is active, effectiveFont is just the base fontToUse, whose ShadowFont already matches
+                    // this.HasDropshadow, so this check is equivalent to the old one in that case.
+                    if (effectiveFont.ShadowFont != null)
                     {
                         effectiveFont.ShadowFont.DrawTextLines(lineByLineList, HorizontalAlignment,
                             this,

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -1025,7 +1025,11 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     // plus a post-layout glyph nudge (see GetTextBlock). "font" resolves through GumFontMapper the same
     // way the base Font property does (issue #3719). "outlinethickness" maps onto RichTextKit's per-run
     // Style.HaloWidth, doubled to compensate for the halo being a centered stroke (issue #4037) -- the
-    // outline color is not per-run, it always uses the whole Text's OutlineColor.
+    // outline color is not per-run, it always uses the whole Text's OutlineColor. "hasdropshadow" has no
+    // per-run implementation on Skia yet (its dropshadow is a whole-canvas SKImageFilter, not a per-glyph
+    // baked silhouette like MonoGame/Raylib's - see #3528) - it's recognized here purely so it parses and
+    // strips like every other tag instead of leaking as literal bracket text; BuildInlineVariables' switch
+    // has no case for it, so it's a genuine no-op.
     // Unrecognized tags are left as literal characters, matching the parser.
     private static readonly HashSet<string> SupportedTags = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -1040,6 +1044,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
         "isitalic",
         "outlinethickness",
         "custom",
+        "hasdropshadow",
     };
 
     public TextBlock GetCachedTextBlock(float? forcedWidth = null)

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -45,6 +45,7 @@ public class FontPlaygroundScreen
     private Label _dropshadowOffsetYLabel = null!;
     private Label _dropshadowBlurLabel = null!;
     private TextRuntime _previewText = null!;
+    private TextRuntime _bbCodeDropshadowPreviewText = null!;
 
     /// <summary>
     /// Builds the font-playground controls and preview text into the given root and wires up
@@ -196,6 +197,22 @@ public class FontPlaygroundScreen
         _previewText.Alpha = 255;
         root.Children.Add(_previewText);
 
+        // [HasDropshadow] BBCode tag preview (issue #3528): always has its own base shadow on, and
+        // uses the tag to turn it off for one run, independently of the "Drop Shadow" checkbox above -
+        // demonstrates the per-run toggle rather than the whole-Text HasDropshadow property.
+        _bbCodeDropshadowPreviewText = new TextRuntime();
+        _bbCodeDropshadowPreviewText.Text =
+            "Shadow on [HasDropshadow=false]shadow off[/HasDropshadow] shadow on again";
+        _bbCodeDropshadowPreviewText.X = 290;
+        _bbCodeDropshadowPreviewText.Y = 90;
+        _bbCodeDropshadowPreviewText.Width = 500;
+        _bbCodeDropshadowPreviewText.Red = 255;
+        _bbCodeDropshadowPreviewText.Green = 255;
+        _bbCodeDropshadowPreviewText.Blue = 255;
+        _bbCodeDropshadowPreviewText.Alpha = 255;
+        _bbCodeDropshadowPreviewText.HasDropshadow = true;
+        root.Children.Add(_bbCodeDropshadowPreviewText);
+
         ApplyFontSettings();
     }
 
@@ -228,5 +245,18 @@ public class FontPlaygroundScreen
         _previewText.DropshadowOffsetX = shadowOffsetX;
         _previewText.DropshadowOffsetY = shadowOffsetY;
         _previewText.DropshadowBlur = shadowBlur;
+
+        // Same font settings as the main preview, but HasDropshadow always stays true here - the
+        // [HasDropshadow=false] BBCode tag in its Text is what should turn the shadow off, not this
+        // checkbox.
+        _bbCodeDropshadowPreviewText.Font = _previewText.Font;
+        _bbCodeDropshadowPreviewText.FontSize = fontSize;
+        _bbCodeDropshadowPreviewText.IsBold = _previewText.IsBold;
+        _bbCodeDropshadowPreviewText.IsItalic = _previewText.IsItalic;
+        _bbCodeDropshadowPreviewText.OutlineThickness = outlineThickness;
+        _bbCodeDropshadowPreviewText.UseFontSmoothing = _previewText.UseFontSmoothing;
+        _bbCodeDropshadowPreviewText.DropshadowOffsetX = shadowOffsetX;
+        _bbCodeDropshadowPreviewText.DropshadowOffsetY = shadowOffsetY;
+        _bbCodeDropshadowPreviewText.DropshadowBlur = shadowBlur;
     }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -77,6 +77,8 @@ internal class TextScreen : FrameworkElement
 
         var textRuntime = new TextRuntime();
         textRuntime.Text = "Hi, I'm default text";
+        textRuntime.WidthUnits = DimensionUnitType.PercentageOfParent;
+        textRuntime.Width = 33;
         container.Children.Add(textRuntime);
 
         // Placed right after the default text -- this screen has no ScrollViewer, and the rest of the
@@ -111,6 +113,8 @@ internal class TextScreen : FrameworkElement
         var stateBbcode = new TextRuntime();
         stateBbcode.Font = "Arial";
         stateBbcode.FontSize = 24;
+        stateBbcode.WidthUnits = DimensionUnitType.PercentageOfParent;
+        stateBbcode.Width = 33;
         var highlightedState = new StateSave { Name = "Highlighted" };
         highlightedState.Variables.Add(new VariableSave { Name = "Color", Value = System.Drawing.Color.Gold });
         highlightedState.Variables.Add(new VariableSave { Name = "IsBold", Value = true });
@@ -131,6 +135,8 @@ internal class TextScreen : FrameworkElement
         var customMarkup = new TextRuntime();
         customMarkup.Font = "Arial";
         customMarkup.FontSize = 24;
+        customMarkup.WidthUnits = DimensionUnitType.PercentageOfParent;
+        customMarkup.Width = 33;
         customMarkup.Text = "[Custom=Wave]Wavy rainbow text[/Custom]";
         container.Children.Add(customMarkup);
 
@@ -138,6 +144,8 @@ internal class TextScreen : FrameworkElement
         shadowDefault.Text = "Soft shadow";
         shadowDefault.FontSize = 24;
         shadowDefault.HasDropshadow = true;
+        shadowDefault.WidthUnits = DimensionUnitType.PercentageOfParent;
+        shadowDefault.Width = 33;
         container.Children.Add(shadowDefault);
 
         var shadowColored = new TextRuntime();
@@ -148,6 +156,8 @@ internal class TextScreen : FrameworkElement
         shadowColored.DropshadowOffsetX = 2;
         shadowColored.DropshadowOffsetY = 4;
         shadowColored.DropshadowBlur = 4;
+        shadowColored.WidthUnits = DimensionUnitType.PercentageOfParent;
+        shadowColored.Width = 33;
         container.Children.Add(shadowColored);
 
         var shadowOutline = new TextRuntime();
@@ -155,12 +165,28 @@ internal class TextScreen : FrameworkElement
         shadowOutline.FontSize = 24;
         shadowOutline.OutlineThickness = 2;
         shadowOutline.HasDropshadow = true;
+        shadowOutline.WidthUnits = DimensionUnitType.PercentageOfParent;
+        shadowOutline.Width = 33;
         container.Children.Add(shadowOutline);
+
+        // [HasDropshadow] BBCode tag (#3528): toggles the shadow for just the wrapped run,
+        // independently of the base HasDropshadow=true above. On MonoGame/raylib the middle run
+        // should visibly lose its shadow; on Skia the tag is a recognized no-op (parsed and
+        // stripped, but every run keeps the base shadow -- Skia has no per-run implementation yet).
+        var shadowBbCodeToggle = new TextRuntime();
+        shadowBbCodeToggle.Text = "Shadow on, [HasDropshadow=false]shadow off[/HasDropshadow], shadow on again";
+        shadowBbCodeToggle.FontSize = 24;
+        shadowBbCodeToggle.HasDropshadow = true;
+        shadowBbCodeToggle.WidthUnits = DimensionUnitType.PercentageOfParent;
+        shadowBbCodeToggle.Width = 33;
+        container.Children.Add(shadowBbCodeToggle);
 
         var withOutline = new TextRuntime();
         withOutline.Text = "I am text with OutlineThickness = 2";
         withOutline.FontSize = 24;
         withOutline.OutlineThickness = 2;
+        withOutline.WidthUnits = DimensionUnitType.PercentageOfParent;
+        withOutline.Width = 33;
         container.Children.Add(withOutline);
 
         // #3670/#3703: CustomFontFile pointing at a bundled .ttf -- previously silently fell back
@@ -250,6 +276,8 @@ internal class TextScreen : FrameworkElement
         snapText.X = 120.5f;
         snapText.Text = "Fractional X=120.5 - SnapToPixel";
         snapText.TextRenderingPositionMode = TextRenderingPositionMode.SnapToPixel;
+        snapText.WidthUnits = DimensionUnitType.PercentageOfParent;
+        snapText.Width = 33;
         container.Children.Add(snapText);
 
         var toggleButton = new Button();
@@ -274,11 +302,15 @@ internal class TextScreen : FrameworkElement
         hitText.FontSize = 24;
         hitText.Text = "Click me to report the character index";
         hitText.HasEvents = true;
+        hitText.WidthUnits = DimensionUnitType.PercentageOfParent;
+        hitText.Width = 33;
         container.Children.Add(hitText);
 
         var hitResult = new TextRuntime();
         hitResult.FontSize = 16;
         hitResult.Text = "(no click yet)";
+        hitResult.WidthUnits = DimensionUnitType.PercentageOfParent;
+        hitResult.Width = 33;
         container.Children.Add(hitResult);
 
         hitText.Click += (_, _) =>

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeBbCodeHasDropshadowTagTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeBbCodeHasDropshadowTagTests.cs
@@ -1,0 +1,84 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using KernSmith.Gum;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// #3528 parity (Raylib): mirrors MonoGameGum.Tests.Runtimes.TextRuntimeBbCodeHasDropshadowTagTests.
+// A [HasDropshadow] BBCode tag lets a run toggle the shadow independently of the base
+// TextRuntime.HasDropshadow, using the same push/pop stack model as [IsBold]/[FontSize]/etc.
+public class TextRuntimeBbCodeHasDropshadowTagTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithHasDropshadowFalseTag_WhenBaseHasDropshadow_ResolvesRunFontWithoutDropshadow()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            RecordingRaylibFontCreator recordingCreator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.HasDropshadow = true;
+
+            textRuntime.Text = "normal [IsBold=true][HasDropshadow=false]off[/HasDropshadow][/IsBold] normal";
+
+            // The [IsBold] open (still base HasDropshadow=true), the [HasDropshadow=false] open, and the
+            // matching close each re-resolve a bold font - only the middle one has shadow turned off.
+            recordingCreator.Requests.ShouldContain(r => r.IsBold && !r.HasDropshadow);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WithHasDropshadowTrueTag_WhenBaseHasNoDropshadow_ResolvesRunFontWithDropshadow()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            RecordingRaylibFontCreator recordingCreator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.HasDropshadow = false;
+
+            textRuntime.Text = "normal [IsBold=true][HasDropshadow=true]on[/HasDropshadow][/IsBold] normal";
+
+            recordingCreator.Requests.ShouldContain(r => r.IsBold && r.HasDropshadow);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator (rather than a hand-built Raylib_cs.Font, whose
+    // unmanaged Recs/Glyphs pointers would need to be valid for UnloadFont to safely dispose it later)
+    // so it produces a genuinely usable, disposable font while recording every BmfcSave requested -
+    // mirrors TextRuntimeBbCodeDropshadowRegressionTests.RecordingRaylibFontCreator.
+    private sealed class RecordingRaylibFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public List<BmfcSave> Requests { get; } = new();
+
+        public Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            return _inner.TryCreateFont(bmfcSave);
+        }
+    }
+}

--- a/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
@@ -130,6 +130,20 @@ public class TextBbCodeTests
     }
 
     [Fact]
+    public void GetStyledRuns_HasDropshadowTag_StripsTagWithoutChangingStyle()
+    {
+        // #3528: Skia has no per-run dropshadow implementation yet, but [HasDropshadow] must still be
+        // recognized and stripped like every other tag in BbCodeParser.KnownTags - not left as literal
+        // bracket text in the rendered output.
+        Text text = MakeText();
+        text.RawText = "plain [HasDropshadow=false]off[/HasDropshadow] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        string.Concat(runs.Select(r => r.Text)).ShouldBe("plain off plain");
+    }
+
+    [Fact]
     public void GetStyledRuns_PlainText_ProducesSingleUnchangedRun()
     {
         Text text = MakeText();

--- a/docs/code/standard-visuals/textruntime/bbcode.md
+++ b/docs/code/standard-visuals/textruntime/bbcode.md
@@ -52,7 +52,7 @@ text.AddToRoot();
 ```
 
 {% hint style="info" %}
-`HasDropshadow` is currently supported on MonoGame, KNI, FNA, and raylib. It is not yet supported on SkiaSharp-based runtimes (Skia, Silk.NET, MAUI, WPF).
+`HasDropshadow` toggles the shadow on MonoGame, KNI, FNA, and raylib. On SkiaSharp-based runtimes (Skia, Silk.NET, MAUI, WPF) the tag is parsed and stripped from the text but has no effect - the shadow always follows the TextRuntime's own `HasDropshadow` value there.
 {% endhint %}
 
 ## Custom Functions

--- a/docs/code/standard-visuals/textruntime/bbcode.md
+++ b/docs/code/standard-visuals/textruntime/bbcode.md
@@ -14,6 +14,7 @@ The following BBCode variables require font generation:
 * Font
 * FontSize
 * OutlineThickness
+* HasDropshadow
 
 The Gum tool generates fonts automatically into the FontCache folder. For code-only projects, the recommended approach is to use [dynamic font generation via KernSmith](fonts.md#dynamic-font-generation-recommended), which handles font creation at runtime with no extra setup. Without the Gum tool or KernSmith, you must provide pre-built `.fnt` files for each font combination your BBCode text uses.
 
@@ -38,7 +39,21 @@ text.AddToRoot();
 
 [Try on XnaFiddle.NET](https://xnafiddle.net/#snippet=H4sIAAAAAAAACkWOTQvCMAyG7_sVoSeF4cCjsoMfODx4mbt1PXQ2zEDXQtdOUfzvdoMphECe5CHvOwFg574IHduAdwHTEZAhT1LTCyNlg3Tg8ekhB4MPuFhjC9lhdFZFwCM6Gsi0qyqelMF46nCx3NZmVCYYvZpVd-ohFj9YbV1eohIOFc-mUaQz3-uAoontv5FGAT9Z4683qTFfi4Zanv2AmLLVbP64U6qypbU-hmDJ5wu5H0Ud4QAAAA)
 
-BBCode tags can be nested and combined. Tags are written as `[TagName=Value]text[/TagName]`. The supported tags include `Color`, `Red`, `Green`, `Blue`, `FontScale`, `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, and `Custom`.
+BBCode tags can be nested and combined. Tags are written as `[TagName=Value]text[/TagName]`. The supported tags include `Color`, `Red`, `Green`, `Blue`, `FontScale`, `Font`, `FontSize`, `IsBold`, `IsItalic`, `OutlineThickness`, `HasDropshadow`, and `Custom`.
+
+`HasDropshadow` toggles the shadow for just the wrapped run, independently of the TextRuntime's own `HasDropshadow` value. The shadow's offset, blur, and color always come from the TextRuntime's `DropshadowOffsetX`/`DropshadowOffsetY`/`DropshadowBlur`/`DropshadowColor` properties; the tag only controls whether a given run draws it:
+
+```csharp
+// Initialize
+var text = new TextRuntime();
+text.HasDropshadow = true;
+text.Text = "This has a shadow, [HasDropshadow=false]this does not[/HasDropshadow], and this does again";
+text.AddToRoot();
+```
+
+{% hint style="info" %}
+`HasDropshadow` is currently supported on MonoGame, KNI, FNA, and raylib. It is not yet supported on SkiaSharp-based runtimes (Skia, Silk.NET, MAUI, WPF).
+{% endhint %}
 
 ## Custom Functions
 


### PR DESCRIPTION
Closes #3528

## Summary
- Adds an 8th push/pop stack (`hasDropshadowStack`) to the shared per-run font-resolution model in `CustomSetPropertyOnRenderable.cs`, alongside the existing `FontSize`/`IsBold`/etc. stacks.
- Registers `hasdropshadow` as a known BBCode tag.
- Fixes `Text.cs`'s per-run styled draw loop to gate the shadow draw on the resolved run's own `ShadowFont` instead of the whole-Text `HasDropshadow` flag, so a run can turn the shadow on/off independently of the base text.
- Offset/blur/color stay whole-text (set via `TextRuntime.Dropshadow*`), matching how `[OutlineThickness]` is per-run but `OutlineColor` isn't.
- Adds `HasDropshadow` to `StateBbCodeAllowlist` so `[state=Name]` can drive it too, for parity with the other font-stack tags.
- Docs: `docs/code/standard-visuals/textruntime/bbcode.md`.

Scope: MonoGame/KNI/FNA/Raylib. Skia is tracked separately - see the status comment on #3528 (Skia's dropshadow is a whole-canvas image filter, not a per-glyph baked silhouette, so it needs its own design).

## Test plan
- [x] `MonoGameGum.Tests`: 1957/1957 passing, including 2 new tests for the toggle-on/toggle-off cases.
- [x] `RaylibGum.Tests`: 546/546 passing, including the Raylib mirror of the same 2 tests.
- [x] `KniGum` builds clean.
- [ ] Manual test: needed - rendering-visible change. Steps below.
