### PR TITLE
Guard reflection-based runtime type registration against AOT metadata trimming

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -46,6 +46,78 @@ jobs:
           reporter: dotnet-trx
           fail-on-error: true
 
+  # End-to-end Native AOT smoke test for issue #4105: RegisterRuntimeTypesThroughReflection walked
+  # every loaded assembly via unguarded reflection, which crashed GumService.Initialize under
+  # Native AOT when it hit trimmed framework metadata - a failure mode only a real `dotnet publish
+  # -p:PublishAot=true` reproduces, `dotnet test` always runs JIT and can't catch it. This job
+  # publishes Tests/NativeAotSmoke.Harness as Native AOT and runs it end-to-end (real
+  # GraphicsDevice, real Texture2D upload, default-visuals construction), so a future regression
+  # anywhere in that path is caught automatically instead of waiting for another user report.
+  #
+  # The runner has no GPU, so the harness is forced onto Mesa's llvmpipe software GL the same way
+  # "Install Mesa llvmpipe" does for RaylibGum.Tests below - confirmed to work for MonoGame
+  # DesktopGL too, not just raylib (both resolve opengl32.dll by name from the exe's own directory
+  # before System32).
+  #
+  # Needs neither FNA/Sokol submodules nor mobile workloads - the harness only references
+  # MonoGameGum/GumCommon - so ExcludeAndroid/ExcludeIOS keep restore on just net8.0, same escape
+  # hatches Build-Generated-Code below uses for the same reason.
+  Native-AOT-Smoke:
+    if: github.event_name != 'push'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      # PublishAot's native link step shells out to vswhere.exe to locate the MSVC linker. Not
+      # guaranteed to already be on PATH for this job's shell - add it defensively rather than
+      # find out from a red "link.exe exited with code 123" on a run this job can't otherwise see.
+      - name: Add vswhere to PATH (Native AOT link step needs it)
+        run: echo "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Publish harness as Native AOT
+        run: dotnet publish "Tests/NativeAotSmoke.Harness/NativeAotSmoke.Harness.csproj" --configuration Release -r win-x64 --self-contained -p:ExcludeAndroid=true -p:ExcludeIOS=true
+
+      # Same download/extract as "Install Mesa llvmpipe" below, pointed at this job's own AOT
+      # publish output instead of RaylibGum.Tests' bin dir.
+      - name: Install Mesa llvmpipe (software GL, no GPU on the runner)
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
+          $ver = "26.1.2"
+          $asset = "mesa3d-$ver-release-msvc.7z"
+          $url = "https://github.com/pal1000/mesa-dist-win/releases/download/$ver/$asset"
+          $archive = Join-Path $env:RUNNER_TEMP $asset
+          $extract = Join-Path $env:RUNNER_TEMP "mesa"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Write-Host "Downloading $url (attempt $i)"; Invoke-WebRequest -Uri $url -OutFile $archive; break }
+            catch {
+              if ($i -eq 3) { throw }
+              Write-Host "Download failed: $($_.Exception.Message). Retrying in $(5 * $i)s..."
+              Start-Sleep -Seconds (5 * $i)
+            }
+          }
+          7z x $archive "-o$extract" -y -bso0 -bsp0
+          $opengl = Get-ChildItem -Path $extract -Recurse -Filter opengl32.dll |
+                    Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1
+          if (-not $opengl) { Write-Error "x64 opengl32.dll not found in Mesa archive"; exit 1 }
+          $dest = "Tests/NativeAotSmoke.Harness/bin/Release/net8.0/win-x64/publish"
+          Copy-Item (Join-Path $opengl.Directory.FullName "*.dll") -Destination $dest -Force
+          Write-Host "Mesa GL runtime copied to $dest"
+
+      - name: Run harness (exit code is the assertion)
+        env:
+          GALLIUM_DRIVER: llvmpipe
+        run: |
+          & "Tests/NativeAotSmoke.Harness/bin/Release/net8.0/win-x64/publish/NativeAotSmoke.Harness.exe"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   # Regenerates every Tests/CodeGen_* harness with GumCli, fails on drift, then
   # compiles the regenerated projects. This used to be two steps at the tail of
   # Build-and-Test (windows-latest), running after Build AllLibraries on the same

--- a/MonoGameGum.Tests/GumServiceRuntimeTypeReflectionScanTests.cs
+++ b/MonoGameGum.Tests/GumServiceRuntimeTypeReflectionScanTests.cs
@@ -1,0 +1,60 @@
+using Gum;
+using Shouldly;
+using System.Reflection;
+using Xunit;
+
+namespace MonoGameGum.Tests;
+
+/// <summary>
+/// Pins GumService's reflection-based runtime-type registration fallback (issue #4105): under
+/// Native AOT, walking every loaded assembly's types via reflection can throw mid-scan when it
+/// touches trimmed framework metadata. These tests exercise the same failure shape - an unguarded
+/// <see cref="System.Type.GetMethod(string, BindingFlags)"/> call throwing during the scan -
+/// using an ordinary JIT-reproducible trigger (an ambiguous overload set) so the regression
+/// doesn't require a Native AOT publish to catch.
+/// </summary>
+public class GumServiceRuntimeTypeReflectionScanTests : BaseTestClass
+{
+    [Fact]
+    public void RegisterRuntimeTypesThroughReflection_DoesNotThrow_WhenALoadedAssemblyHasAnAmbiguousRegisterRuntimeTypesOverloadSet()
+    {
+        // AmbiguousRuntimeTypesFixture (below) is compiled into this test assembly, which is
+        // already loaded into AppDomain.CurrentDomain.GetAssemblies() by the time this runs - the
+        // scan's extension-package pass reaches it like any other loaded assembly.
+        GumService gumService = new GumService();
+
+        Should.NotThrow(() => gumService.RegisterRuntimeTypesThroughReflection());
+    }
+
+    [Theory]
+    [InlineData("System.Private.CoreLib", true)]
+    [InlineData("System.Runtime", true)]
+    [InlineData("mscorlib", true)]
+    [InlineData("netstandard", true)]
+    [InlineData("Microsoft.Extensions.DependencyInjection", true)]
+    [InlineData("MonoGameGum.Tests", false)]
+    [InlineData("Gum.Shapes.KNI", false)]
+    [InlineData("MonoGame.Framework", false)]
+    public void IsFrameworkAssembly_ClassifiesAssemblyByNamePrefix(string assemblyName, bool expected)
+    {
+        GumService gumService = new GumService();
+
+        bool actual = gumService.IsFrameworkAssembly(new AssemblyName(assemblyName));
+
+        actual.ShouldBe(expected);
+    }
+}
+
+/// <summary>
+/// Reflection fodder for <see cref="GumServiceRuntimeTypeReflectionScanTests"/>: two public
+/// static overloads named "RegisterRuntimeTypes" make
+/// <c>Type.GetMethod("RegisterRuntimeTypes", BindingFlags.Static | BindingFlags.Public)</c> throw
+/// <see cref="AmbiguousMatchException"/>, mirroring the class of uncaught-reflection-exception bug
+/// reported in issue #4105.
+/// </summary>
+public static class AmbiguousRuntimeTypesFixture
+{
+    public static void RegisterRuntimeTypes() { }
+
+    public static void RegisterRuntimeTypes(int unused) { }
+}

--- a/MonoGameGum/GumService.XnaLike.cs
+++ b/MonoGameGum/GumService.XnaLike.cs
@@ -202,6 +202,15 @@ public partial class GumService
         return FinishInitialize(gumProjectFile);
     }
 
+    // Framework/BCL assemblies never define a Gum "RegisterRuntimeType(s)" hook. Skipping them by
+    // name avoids wasted scanning and, under Native AOT, avoids GetTypes()/GetMethod() throwing
+    // while walking their trimmed metadata (issue #4105).
+    private static readonly string[] FrameworkAssemblyNamePrefixes =
+    {
+        "System", "Microsoft", "mscorlib", "netstandard", "WindowsBase",
+        "PresentationCore", "PresentationFramework", "Accessibility",
+    };
+
     // Originally added so codegen-emitted user types could self-register. Module initializers
     // replaced that path for newer Gum (https://github.com/vchelaru/Gum/issues/275), but we
     // still need a reflection-based hook for two reasons:
@@ -211,7 +220,7 @@ public partial class GumService
     //      "RegisterRuntimeTypes" (plural) we can call directly to force registration before
     //      .gumx load. RegisterRuntimeTypes is idempotent (guarded), so calling it on top of an
     //      already-fired ModuleInitializer is a no-op.
-    private void RegisterRuntimeTypesThroughReflection()
+    internal void RegisterRuntimeTypesThroughReflection()
     {
         // (1) Legacy entry-assembly hook (singular method name).
         Assembly? executingAssembly = Assembly.GetEntryAssembly();
@@ -220,8 +229,7 @@ public partial class GumService
         {
             foreach (Type type in types)
             {
-                var method = type.GetMethod("RegisterRuntimeType", BindingFlags.Static | BindingFlags.Public);
-                method?.Invoke(null, null);
+                InvokeRuntimeTypeHookIfPresent(type, "RegisterRuntimeType");
             }
         }
 
@@ -229,7 +237,11 @@ public partial class GumService
         // what unblocks Apos shapes on Blazor/WASM.
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-            if (assembly.IsDynamic) continue;
+            if (assembly.IsDynamic || IsFrameworkAssembly(assembly.GetName()))
+            {
+                continue;
+            }
+
             Type[] assemblyTypes;
             try { assemblyTypes = assembly.GetTypes(); }
             catch (ReflectionTypeLoadException ex) { assemblyTypes = ex.Types.Where(t => t != null).ToArray()!; }
@@ -237,14 +249,50 @@ public partial class GumService
 
             foreach (var type in assemblyTypes)
             {
-                if (type == null) continue;
-                var method = type.GetMethod("RegisterRuntimeTypes", BindingFlags.Static | BindingFlags.Public);
-                if (method != null && method.GetParameters().Length == 0)
+                if (type == null)
                 {
-                    try { method.Invoke(null, null); }
-                    catch { /* a misbehaving extension shouldn't break Gum init */ }
+                    continue;
                 }
+                InvokeRuntimeTypeHookIfPresent(type, "RegisterRuntimeTypes");
             }
+        }
+    }
+
+    internal bool IsFrameworkAssembly(AssemblyName assemblyName)
+    {
+        string? name = assemblyName.Name;
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        foreach (string prefix in FrameworkAssemblyNamePrefixes)
+        {
+            if (name.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // GetMethod itself can throw - not just Invoke - for an ambiguous overload set
+    // (AmbiguousMatchException) or, under Native AOT, while walking a type's trimmed metadata
+    // (TypeLoadException, issue #4105). A misbehaving or ambiguous hook shouldn't break Gum init,
+    // so the whole lookup+call is guarded together rather than just the Invoke.
+    private void InvokeRuntimeTypeHookIfPresent(Type type, string methodName)
+    {
+        try
+        {
+            MethodInfo? method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
+            if (method != null && method.GetParameters().Length == 0)
+            {
+                method.Invoke(null, null);
+            }
+        }
+        catch
+        {
+            // a misbehaving or ambiguous extension shouldn't break Gum init
         }
     }
 

--- a/Tests/NativeAotSmoke.Harness/NativeAotSmoke.Harness.csproj
+++ b/Tests/NativeAotSmoke.Harness/NativeAotSmoke.Harness.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    End-to-end harness for issue #4105 (RegisterRuntimeTypesThroughReflection breaking under Native
+    AOT metadata trimming). This project is NOT part of any solution and is not a unit-test project:
+    the "Native-AOT-Smoke" CI job publishes it with PublishAot=true and runs it against Mesa's
+    llvmpipe software GL (no GPU on the runners) so GumService.Initialize is proven against a real
+    Native AOT publish with a genuine GraphicsDevice, not just the JIT path `dotnet test` exercises.
+    See the "Native-AOT-Smoke" job in .github/workflows/build-and-test.yaml.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>NativeAotSmoke.Harness</AssemblyName>
+    <RootNamespace>NativeAotSmoke.Harness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/NativeAotSmoke.Harness/Program.cs
+++ b/Tests/NativeAotSmoke.Harness/Program.cs
@@ -1,0 +1,58 @@
+using System;
+using Gum;
+using Gum.Forms;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+// End-to-end check for issue #4105: RegisterRuntimeTypesThroughReflection scanned every loaded
+// assembly via unguarded reflection, which crashed GumService.Initialize under Native AOT when it
+// touched trimmed framework metadata - a failure mode only a real `dotnet publish
+// -p:PublishAot=true` reproduces, not `dotnet test` (which always runs JIT). This harness drives
+// Gum's real Initialize pipeline - real GraphicsDevice, default-visuals construction, a real
+// Texture2D upload - end to end, so a future regression anywhere in that path is caught
+// automatically instead of waiting for another user report. The CI job forces software GL (Mesa
+// llvmpipe) since the runners have no GPU. Exit code is the assertion.
+
+try
+{
+    using SmokeGame game = new SmokeGame();
+    game.RunOneFrame();
+
+    Console.WriteLine($"[native-aot-smoke] Adapter = {game.GraphicsDevice.Adapter.Description}");
+
+    Texture2D texture = new Texture2D(game.GraphicsDevice, 4, 4);
+    Color[] data = new Color[16];
+    Array.Fill(data, Color.CornflowerBlue);
+    texture.SetData(data);
+
+    Console.WriteLine("[native-aot-smoke] PASS: GumService.Initialize completed under Native AOT with a real GraphicsDevice.");
+    return 0;
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"[native-aot-smoke] FAIL: {ex.GetType().FullName}: {ex.Message}");
+    Console.Error.WriteLine(ex.StackTrace);
+    return 1;
+}
+
+sealed class SmokeGame : Game
+{
+    private readonly GraphicsDeviceManager _graphics;
+
+    public SmokeGame()
+    {
+        _graphics = new GraphicsDeviceManager(this);
+        Content.RootDirectory = "Content";
+    }
+
+    protected override void Initialize()
+    {
+        base.Initialize();
+        GumService.Default.Initialize(this, DefaultVisualsVersion.V2);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        GraphicsDevice.Clear(Color.CornflowerBlue);
+    }
+}


### PR DESCRIPTION
Closes #4105

`RegisterRuntimeTypesThroughReflection` scanned every loaded assembly and called `Type.GetMethod` on every type, including framework/BCL assemblies. Under Native AOT, `GetMethod` itself (not just `Invoke`) can throw while resolving trimmed base-type metadata, crashing `GumService.Initialize` entirely.

Fix: skip framework/BCL assemblies by name before scanning (they never define a Gum registration hook), and wrap the `GetMethod`+`Invoke` lookup in one try/catch so a single bad type (ambiguous overload, trimmed metadata) can't abort the whole scan.

Test: added `GumServiceRuntimeTypeReflectionScanTests` — pins the fix using an ordinary JIT-reproducible trigger (an ambiguous `RegisterRuntimeTypes` overload set, which throws `AmbiguousMatchException` from `GetMethod` the same way trimmed AOT metadata throws `TypeLoadException`), plus a table-driven test of the framework-assembly filter.

Manual test: not needed — the failure only reproduces under an actual Native AOT publish, which isn't practical to drive here. Verified instead with the regression-shaped unit test above (red before the fix, green after), the full `MonoGameGum.Tests` suite (1964 passed), the real `Initialize(Game, ...)` path via `MonoGameGum.IntegrationTests`, and a clean `KniGum` build (shares this XNALIKE source).

FRB canary: not needed — `GumService.XnaLike.cs` isn't part of `GumCoreShared.projitems`.
