### PR TITLE
Redispatch Skia Sprite through SpriteRuntime (ADR 0011)

### DIFF
--- a/Direction/decisions/0011-route-skia-sprite-nineslice-container-polygon-dispatch.md
+++ b/Direction/decisions/0011-route-skia-sprite-nineslice-container-polygon-dispatch.md
@@ -1,0 +1,80 @@
+# 0011. Route Skia's Sprite/NineSlice/Container/Polygon dispatch through their Runtimes
+
+- **Status:** Accepted
+- **Date:** 2026-07-29
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+[0010](0010-converge-sprite-nineslice-container-polygon-dispatch.md) converged the **core**
+dispatcher's (`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`) Sprite/NineSlice/Container/Polygon
+branches onto their Runtime types (`SpriteRuntime`/`NineSliceRuntime`/`ContainerRuntime`/
+`PolygonRuntime`), but explicitly scoped out doing the same for the **Skia** dispatcher
+(`Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs`), because those four branches there route
+through `TrySetPropertiesOnRenderableBase` — a function shared with the shape dispatch
+(Circle/Rectangle/Arc/RoundedRectangle) — so a mechanical redirect risked disturbing shape
+handling too.
+
+Runtime parity is already satisfied for all four: `SpriteRuntime`, `NineSliceRuntime`,
+`ContainerRuntime`, and `PolygonRuntime` are the same linked source files across MonoGame/Raylib/
+Skia (file-linked into `SkiaGum.csproj` from `MonoGameGum/GueDeriving/`), not merely
+API-compatible. [0008](0008-sequence-runtime-dispatch-convergence.md)'s phase-1 parity
+precondition needs no dedicated work here — same situation 0010 found for the core file.
+
+As on the core file, the direct-to-renderable writes skip the runtime's `NotifyPropertyChanged`
+side effect, and in some cases skip the runtime setter's logic entirely — e.g. `SetProperty
+("Animate", ...)`/`SetProperty("CurrentChainName", ...)` on Skia's `SpriteRuntime` today falls
+through every dispatcher branch to a final reflection call against the raw `Sprite` renderable,
+which has no `Animate`/`CurrentChainName` property (only `AnimationLogic`) — so those two
+currently silently no-op through the string-path dispatcher, a real (if narrow) bug this fixes as
+a side effect.
+
+The shape dispatcher already demonstrates the pattern to follow: `TrySetPropertyOnRuntime`
+(a reflection-based fallback keyed off the strongly-typed runtime, added for #2956) already
+routes any property the concrete runtime type declares, and the Circle/Rectangle branches already
+call it **before** falling through to `TrySetPropertiesOnRenderableBase`. Sprite/NineSlice/
+Container/Polygon need the same ordering, not a new mechanism.
+
+## Decision
+
+We will route the Skia dispatcher's Sprite/NineSlice/Container/Polygon mechanical properties
+(Alpha/Red/Green/Blue/Color/Blend, plus Sprite's Animate/CurrentChainName/RenderTargetTextureSource
+and Container's IsRenderTarget) through their Runtime types **ahead of**
+`TrySetPropertiesOnRenderableBase`/the direct `InvisibleRenderable` write, mirroring core's
+`TrySetPropertyOnSprite`/`TrySetPropertyOnNineSlice`/`TrySetPropertyOnContainer`/
+`TrySetPropertyOnLinePolygon` branches. One runtime class per PR, smallest/cleanest first
+(Sprite, then NineSlice, then Container, then Polygon) — same sequencing rule as 0010, so each
+change stays independently reviewable and bisectable. Each PR gets pinning tests first (per the
+`tdd` skill), following the `Dispatch_<Property>_RoutesToRuntime` naming already established in
+`CircleRuntimeTests`/`RectangleRuntimeTests` (#3662).
+
+`SourceFile` on Sprite and NineSlice stays out of scope, as it already is for the core file — it's
+real atlas/loader logic, not a mechanical redirect, and Skia's own `TrySetPropertyOnSprite`/
+`TrySetPropertyOnNineSlice` already special-case it (`SourceFile` already forwards to
+`SpriteRuntime.SourceFile` when the GUE is a runtime instance).
+
+This is not a physical file merge — the two dispatcher files stay separate, per the blocker
+[0007](0007-converge-skia-property-dispatch.md) already documented (namespace/FRB-Glue coupling).
+It shrinks the *behavioral* gap and cross-file diff for these four branches, consistent with
+[0008](0008-sequence-runtime-dispatch-convergence.md)'s phase 2 (redispatch).
+
+## Consequences
+
+- Sprite/NineSlice/Container/Polygon property assignment on Skia gains `NotifyPropertyChanged`
+  parity with the other three backends, and `Animate`/`CurrentChainName` become settable through
+  the string-path dispatcher (previously silent no-ops).
+- `TrySetPropertiesOnRenderableBase` and the shape branches that also call it are untouched — the
+  new runtime-typed checks sit ahead of it, they don't modify it.
+- `SourceFile` on Sprite/NineSlice remains renderable/runtime-direct outside the mechanical
+  redispatch, same carve-out as 0010.
+
+## Alternatives considered
+
+- **Do all four types in one PR.** Rejected for the same reason as 0010: mixes independently
+  low-risk changes into one diff.
+- **Rely solely on the generic `TrySetPropertyOnRuntime` reflection fallback instead of explicit
+  branches.** Rejected for `Color`: the incoming value is `System.Drawing.Color` (the cross-platform
+  convention every other backend's dispatcher uses) but the runtime's `Color` property is
+  `SKColor`-typed on Skia, and reflection's `Convert.ChangeType` cannot bridge unrelated structs — it
+  would silently fail and fall through. An explicit branch converts via the existing
+  `ColorExtensions.ToSkia()` helper, mirroring core's `ToRaylib()`/XNA-conversion arms.

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 
 #if SKIA
 using HarfBuzzSharp;
+using RenderingLibrary;
 using SkiaGum.Content;
 using SkiaGum.Helpers;
 using Gum.GueDeriving;
@@ -1081,17 +1082,19 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if(containedObjectAsIpso is Sprite asSprite)
         {
-            // Route base-class properties (Blend, gradient/dropshadow channels, etc.) first.
-            // These branches historically skipped TrySetPropertiesOnRenderableBase and relied
-            // on the reflection fallback, which works for int/float properties but throws on
-            // enum -> Nullable<enum> (the Blend case).
-            if(!handled)
-            {
-                handled = TrySetPropertiesOnRenderableBase(asSprite, graphicalUiElement, propertyName, value);
-            }
+            // Route through SpriteRuntime first (ADR 0011) so mechanical properties
+            // (Alpha/Red/Green/Blue/Color/Blend/Animate/CurrentChainName) pick up the runtime's
+            // NotifyPropertyChanged side effect, matching core's TrySetPropertyOnSprite. Falling
+            // straight to TrySetPropertiesOnRenderableBase would write the renderable directly and
+            // skip that notification, and Animate/CurrentChainName have no equivalent on the
+            // renderable at all (only on SpriteRuntime.AnimationLogic).
             if(!handled)
             {
                 handled = TrySetPropertyOnSprite(asSprite, graphicalUiElement, propertyName, value);
+            }
+            if(!handled)
+            {
+                handled = TrySetPropertiesOnRenderableBase(asSprite, graphicalUiElement, propertyName, value);
             }
         }
         else if(containedObjectAsIpso is NineSlice asNineSlice)
@@ -1274,11 +1277,13 @@ public partial class CustomSetPropertyOnRenderable
 
     private static bool TrySetPropertyOnSprite(Sprite asSprite, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
+        var spriteRuntime = graphicalUiElement as SpriteRuntime;
+
         switch(propertyName)
         {
             case "SourceFile":
                 var asString = value as string;
-                if(graphicalUiElement is SpriteRuntime spriteRuntime)
+                if(spriteRuntime != null)
                 {
                     spriteRuntime.SourceFile = asString;
                 }
@@ -1292,6 +1297,91 @@ public partial class CustomSetPropertyOnRenderable
                 else
                 {
                     asSprite.Texture = null;
+                }
+                return true;
+            case nameof(Sprite.Alpha):
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Alpha = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(Sprite.Red):
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Red = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(Sprite.Green):
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Green = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(Sprite.Blue):
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Blue = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(Sprite.Color):
+                if (spriteRuntime != null)
+                {
+                    if (value is System.Drawing.Color drawingColor)
+                    {
+                        spriteRuntime.Color = drawingColor.ToSkia();
+                        return true;
+                    }
+                    else if (value is SKColor skColor)
+                    {
+                        spriteRuntime.Color = skColor;
+                        return true;
+                    }
+                }
+                break;
+            case "Blend":
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
+                    return true;
+                }
+                break;
+            case "Animate":
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.Animate = (bool)value;
+                    return true;
+                }
+                break;
+            case "CurrentChainName":
+                if (spriteRuntime != null)
+                {
+                    spriteRuntime.CurrentChainName = (string)value;
+                    graphicalUiElement.UpdateTextureValuesFrom(asSprite);
+                    graphicalUiElement.UpdateLayout();
+                    return true;
+                }
+                break;
+            case nameof(SpriteRuntime.RenderTargetTextureSource):
+                if (spriteRuntime != null)
+                {
+                    if (value == null)
+                    {
+                        spriteRuntime.RenderTargetTextureSource = null;
+                    }
+                    else if (value is IRenderableIpso renderableIpso)
+                    {
+                        spriteRuntime.RenderTargetTextureSource = renderableIpso;
+                    }
+                    else if (value is string sourceName)
+                    {
+                        spriteRuntime.RenderTargetTextureSource =
+                            (graphicalUiElement.GetTopParent() as GraphicalUiElement)?.FindByName(sourceName);
+                    }
+                    return true;
                 }
                 break;
         }

--- a/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
@@ -1,5 +1,6 @@
+using Gum.GueDeriving;
 using Gum.Wireframe;
-using SkiaGum.GueDeriving;
+using SkiaGum;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using Shouldly;
@@ -41,6 +42,98 @@ public class MockContentLoader : IContentLoader
 
 public class SpriteRuntimeTests
 {
+    public SpriteRuntimeTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    // ---- Dispatcher routing pins (issue #3639 / ADR 0011) -----------------------------------
+    // These drive the STRING property name through the production Skia dispatcher (via
+    // SetProperty) and assert the value lands on SpriteRuntime, including its NotifyPropertyChanged
+    // side effect -- not just that the value is retrievable. Before the ADR 0011 redispatch, Alpha/
+    // Red/Green/Blue/Blend wrote straight to the contained Sprite renderable (skipping
+    // NotifyPropertyChanged), and Animate/CurrentChainName had no dispatch path at all (silent
+    // no-op), since Sprite has no such properties itself -- only SpriteRuntime.AnimationLogic does.
+
+    [Fact]
+    public void Dispatch_Alpha_RoutesToRuntimeAndNotifies()
+    {
+        SpriteRuntime sut = new();
+        var seen = new System.Collections.Generic.List<string>();
+        sut.PropertyChanged += (_, e) => seen.Add(e.PropertyName!);
+
+        sut.SetProperty("Alpha", 128);
+
+        sut.Alpha.ShouldBe(128);
+        seen.ShouldContain(nameof(SpriteRuntime.Alpha));
+    }
+
+    [Fact]
+    public void Dispatch_RedGreenBlue_RouteToRuntime()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty("Red", 10);
+        sut.SetProperty("Green", 20);
+        sut.SetProperty("Blue", 30);
+
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void Dispatch_Color_ConvertsDrawingColorAndRoutesToRuntime()
+    {
+        SpriteRuntime sut = new();
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(10, 20, 30, 40);
+
+        sut.SetProperty("Color", drawingColor);
+
+        sut.Color.ShouldBe(new SKColor(20, 30, 40, 10));
+    }
+
+    [Fact]
+    public void Dispatch_Blend_RoutesToRuntime()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void Dispatch_Animate_RoutesToRuntime()
+    {
+        SpriteRuntime sut = new();
+
+        sut.SetProperty("Animate", true);
+
+        sut.Animate.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_CurrentChainName_RoutesToRuntime()
+    {
+        SpriteRuntime sut = new();
+        AnimationChainList chains = new();
+        AnimationChain idleChain = new() { Name = "Idle" };
+        idleChain.Add(new AnimationFrame { Texture = new SKBitmap(4, 4), FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f });
+        AnimationChain walkChain = new() { Name = "Walk" };
+        walkChain.Add(new AnimationFrame { Texture = new SKBitmap(4, 4), FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f });
+        chains.Add(idleChain);
+        chains.Add(walkChain);
+        sut.AnimationChains = chains;
+
+        // "Idle" (index 0) is the AnimationChainLogic default -- assigning "Walk" (index 1) via
+        // the dispatcher is the only thing that can produce this value, unlike a same-as-default
+        // name which would pass even with no dispatch path.
+        sut.SetProperty("CurrentChainName", "Walk");
+
+        sut.CurrentChainName.ShouldBe("Walk");
+    }
+
     [Fact]
     public void Constructor_ShouldSetDefaults()
     {


### PR DESCRIPTION
## Summary
- Routes Skia's Sprite dispatch (Alpha/Red/Green/Blue/Color/Blend/Animate/CurrentChainName/RenderTargetTextureSource) through `SpriteRuntime` ahead of `TrySetPropertiesOnRenderableBase`, matching the core dispatcher's `TrySetPropertyOnSprite` (ADR 0011).
- Fixes two real bugs: `NotifyPropertyChanged` wasn't firing for Alpha/Red/Green/Blue/Blend (direct renderable writes skip it), and `Animate`/`CurrentChainName` had no dispatch path at all — `SetProperty("Animate", ...)` was a silent no-op since `Sprite` only exposes them via `AnimationLogic`, not directly.
- Boyscout: `SpriteRuntimeTests.cs` used the obsolete `SkiaGum.GueDeriving.SpriteRuntime` shim; switched to the real `Gum.GueDeriving.SpriteRuntime` (same fix as #3662 did for `CircleRuntimeTests`).
- Adds `Direction/decisions/0011-*.md` documenting the decision and the remaining NineSlice/Container/Polygon follow-ups.

First PR in a 4-PR sequence (NineSlice, Container, Polygon to follow), per issue #3639.

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 402/402 passed
- [x] New pinning tests fail red pre-fix, green post-fix (verified manually before commit)
- [x] `dotnet build Runtimes/SkiaGum/SkiaGum.csproj`, `Runtimes/SilkNetGum/SilkNetGum.csproj`, `Runtimes/GumShapes/MonoGameGumShapes.csproj` — all clean (change is `#if SKIA`-gated, no-op for the Apos.Shapes build)

Manual test: not needed — the new tests drive the exact production dispatch path (`SetProperty` → `CustomSetPropertyOnRenderable.SetPropertyOnRenderable`) that a `.gum` load or data binding would use, asserting exact resulting state (not an approximation).

FRB canary: not needed — this file isn't referenced by `GumCoreShared.projitems` (Skia/Apos/SilkNet only).

Closes #3639 is NOT included — this is 1 of 4 PRs closing that issue; the last one will close it.
