### PR TITLE
Redispatch Skia NineSlice through NineSliceRuntime (ADR 0011)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1096,13 +1096,15 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if(containedObjectAsIpso is NineSlice asNineSlice)
         {
-            if(!handled)
-            {
-                handled = TrySetPropertiesOnRenderableBase(asNineSlice, graphicalUiElement, propertyName, value);
-            }
+            // Route through NineSliceRuntime first (ADR 0011), same reasoning as the Sprite branch
+            // above: mechanical properties need the runtime's NotifyPropertyChanged side effect.
             if(!handled)
             {
                 handled = TrySetPropertyOnNineSlice(asNineSlice, graphicalUiElement, propertyName, value);
+            }
+            if(!handled)
+            {
+                handled = TrySetPropertiesOnRenderableBase(asNineSlice, graphicalUiElement, propertyName, value);
             }
         }
         else if(containedObjectAsIpso is Polygon asPolygon)
@@ -1253,6 +1255,8 @@ public partial class CustomSetPropertyOnRenderable
 
     private static bool TrySetPropertyOnNineSlice(NineSlice asNineSlice, GraphicalUiElement graphicalUiElement, string propertyName, object value)
     {
+        var nineSliceRuntime = graphicalUiElement as NineSliceRuntime;
+
         switch(propertyName)
         {
             case "SourceFile":
@@ -1266,6 +1270,77 @@ public partial class CustomSetPropertyOnRenderable
                 else
                 {
                     asNineSlice.Texture = null;
+                }
+                return true;
+            case nameof(NineSlice.Alpha):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.Alpha = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSlice.Red):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.Red = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSlice.Green):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.Green = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSlice.Blue):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.Blue = (int)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSlice.Color):
+                if (nineSliceRuntime != null)
+                {
+                    if (value is System.Drawing.Color drawingColor)
+                    {
+                        nineSliceRuntime.Color = drawingColor.ToSkia();
+                        return true;
+                    }
+                    else if (value is SKColor skColor)
+                    {
+                        nineSliceRuntime.Color = skColor;
+                        return true;
+                    }
+                }
+                break;
+            case "Blend":
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSliceRuntime.BorderScale):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.BorderScale = (float)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSliceRuntime.IsTilingMiddleSections):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.IsTilingMiddleSections = (bool)value;
+                    return true;
+                }
+                break;
+            case nameof(NineSliceRuntime.CustomFrameTextureCoordinateWidth):
+                if (nineSliceRuntime != null)
+                {
+                    nineSliceRuntime.CustomFrameTextureCoordinateWidth = (float?)value;
+                    return true;
                 }
                 break;
         }

--- a/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
@@ -1,6 +1,8 @@
 using Gum.Graphics.Animation;
 using Gum.GueDeriving;
+using Gum.Wireframe;
 using RenderingLibrary.Graphics.Animation;
+using SkiaGum;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using Shouldly;
@@ -10,6 +12,95 @@ namespace SkiaGum.Tests.GueDeriving;
 
 public class NineSliceRuntimeTests
 {
+    public NineSliceRuntimeTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    // ---- Dispatcher routing pins (issue #3639 / ADR 0011) -----------------------------------
+    // These drive the STRING property name through the production Skia dispatcher (via
+    // SetProperty) and assert the value lands on NineSliceRuntime, including its
+    // NotifyPropertyChanged side effect -- before the ADR 0011 redispatch these wrote straight to
+    // the contained NineSlice renderable and skipped that notification.
+
+    [Fact]
+    public void Dispatch_Alpha_RoutesToRuntimeAndNotifies()
+    {
+        NineSliceRuntime sut = new();
+        var seen = new System.Collections.Generic.List<string>();
+        sut.PropertyChanged += (_, e) => seen.Add(e.PropertyName!);
+
+        sut.SetProperty("Alpha", 128);
+
+        sut.Alpha.ShouldBe(128);
+        seen.ShouldContain(nameof(NineSliceRuntime.Alpha));
+    }
+
+    [Fact]
+    public void Dispatch_RedGreenBlue_RouteToRuntime()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("Red", 10);
+        sut.SetProperty("Green", 20);
+        sut.SetProperty("Blue", 30);
+
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void Dispatch_Color_ConvertsDrawingColorAndRoutesToRuntime()
+    {
+        NineSliceRuntime sut = new();
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(10, 20, 30, 40);
+
+        sut.SetProperty("Color", drawingColor);
+
+        sut.Color.ShouldBe(new SKColor(20, 30, 40, 10));
+    }
+
+    [Fact]
+    public void Dispatch_Blend_RoutesToRuntime()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("Blend", Gum.RenderingLibrary.Blend.Additive);
+
+        sut.Blend.ShouldBe(Gum.RenderingLibrary.Blend.Additive);
+    }
+
+    [Fact]
+    public void Dispatch_BorderScale_RoutesToRuntime()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("BorderScale", 2.5f);
+
+        sut.BorderScale.ShouldBe(2.5f);
+    }
+
+    [Fact]
+    public void Dispatch_IsTilingMiddleSections_RoutesToRuntime()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("IsTilingMiddleSections", true);
+
+        sut.IsTilingMiddleSections.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_CustomFrameTextureCoordinateWidth_RoutesToRuntime()
+    {
+        NineSliceRuntime sut = new();
+
+        sut.SetProperty("CustomFrameTextureCoordinateWidth", 0.25f);
+
+        sut.CustomFrameTextureCoordinateWidth.ShouldBe(0.25f);
+    }
+
     [Fact]
     public void Animate_ShouldRouteThroughContainedAnimationLogic()
     {


### PR DESCRIPTION
## Summary
- Routes Skia's NineSlice dispatch (Alpha/Red/Green/Blue/Color/Blend/BorderScale/IsTilingMiddleSections/CustomFrameTextureCoordinateWidth) through `NineSliceRuntime` ahead of `TrySetPropertiesOnRenderableBase`, matching the core dispatcher and the Sprite branch (#4107, ADR 0011).
- Fixes `NotifyPropertyChanged` not firing for these properties via the string-path dispatcher, and `Color` not converting `System.Drawing.Color` → `SKColor` (previously a silent no-op, same bug class as Sprite's Color).

Second of 4 PRs for issue #3639 (Sprite: #4107; Container/Polygon to follow).

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 403/403 passed
- [x] New pinning tests verified red pre-fix (Alpha/Color), green post-fix
- [x] `dotnet build` SkiaGum, SilkNetGum, MonoGameGumShapes — all clean (change is `#if SKIA`-gated)

Manual test: not needed — new tests drive the exact production dispatch path (`SetProperty` → `CustomSetPropertyOnRenderable.SetPropertyOnRenderable`), asserting exact resulting state.

FRB canary: not needed — file isn't in `GumCoreShared.projitems` (Skia/Apos/SilkNet only).
