### PR TITLE
Redispatch Skia Container through ContainerRuntime (ADR 0011)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1032,10 +1032,18 @@ public partial class CustomSetPropertyOnRenderable
             // reference, so SourceShaderFile resolution has its own lean copy here rather than a
             // shared call (issue #3998) -- same convention as this dispatcher's own
             // Sprite/NineSlice SourceFile handling above, which is also independent per backend.
+            //
+            // IsRenderTarget/Alpha route through ContainerRuntime (ADR 0011), matching core's
+            // TrySetPropertyOnContainer, so the string path stays behind the same setter as
+            // direct C# assignment (containerRuntime.Alpha = ...) if that setter ever grows logic.
+            var containerRuntime = graphicalUiElement as ContainerRuntime;
             switch (propertyName)
             {
                 case "IsRenderTarget":
-                    asInvisibleRenderable.IsRenderTarget = value as bool? ?? false;
+                    if (containerRuntime != null)
+                    {
+                        containerRuntime.IsRenderTarget = value as bool? ?? false;
+                    }
                     handled = true;
                     break;
 #if SKIA
@@ -1049,20 +1057,27 @@ public partial class CustomSetPropertyOnRenderable
                     break;
 #endif
                 case "Alpha":
-                    if (value is int asInt)
                     {
-                        asInvisibleRenderable.Alpha = asInt;
+                        int valueAsInt;
+                        if (value is int asInt)
+                        {
+                            valueAsInt = asInt;
+                        }
+                        else if (value is float asFloat)
+                        {
+                            valueAsInt = (int)asFloat;
+                        }
+                        else
+                        {
+                            valueAsInt = 255;
+                        }
+                        if (containerRuntime != null)
+                        {
+                            containerRuntime.Alpha = valueAsInt;
+                        }
+                        handled = true;
+                        break;
                     }
-                    else if (value is float asFloat)
-                    {
-                        asInvisibleRenderable.Alpha = (int)asFloat;
-                    }
-                    else
-                    {
-                        asInvisibleRenderable.Alpha = 255;
-                    }
-                    handled = true;
-                    break;
             }
         }
 #if SKIA

--- a/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/ContainerRuntimeTests.cs
@@ -18,6 +18,34 @@ public class ContainerRuntimeTests
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
     }
 
+    // ---- Dispatcher routing pins (issue #3639 / ADR 0011) -----------------------------------
+    // These drive the STRING property name through the production Skia dispatcher (via
+    // SetProperty) and assert the value lands on ContainerRuntime. Unlike Sprite/NineSlice,
+    // ContainerRuntime.Alpha/IsRenderTarget don't call NotifyPropertyChanged, so redispatching
+    // through the runtime here is a structural convergence with the core dispatcher (matching
+    // #4034's core-file redispatch), not a bug fix -- these pins protect that routing going
+    // forward rather than proving a red-to-green behavior change.
+
+    [Fact]
+    public void Dispatch_Alpha_RoutesToRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty("Alpha", 128);
+
+        sut.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void Dispatch_IsRenderTarget_RoutesToRuntime()
+    {
+        ContainerRuntime sut = new();
+
+        sut.SetProperty("IsRenderTarget", true);
+
+        sut.IsRenderTarget.ShouldBeTrue();
+    }
+
     [Fact]
     public void Blend_DefaultsToNormal()
     {


### PR DESCRIPTION
## Summary
- Routes Skia's Container dispatch (Alpha/IsRenderTarget) through `ContainerRuntime` ahead of the direct `InvisibleRenderable` write, matching core's `TrySetPropertyOnContainer` (#4034, ADR 0011) and the Sprite/NineSlice branches (#4107, #4108).
- Unlike Sprite/NineSlice, `ContainerRuntime.Alpha`/`IsRenderTarget` don't call `NotifyPropertyChanged` — same as core's own version of these two properties — so this is a **structural convergence, not a bug fix**: no observable behavior changes for the common case, but the string path now goes through the same setter as direct C# assignment, so future logic added to those setters applies to both.

Third of 4 PRs for issue #3639 (Sprite: #4107, NineSlice: #4108; Polygon to follow).

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 398/398 passed
- [x] New tests are characterization pins (value lands correctly via the runtime), not red/green — there's no observable behavior difference to pin, consistent with core's own Container redispatch
- [x] `dotnet build` SkiaGum, SilkNetGum, MonoGameGumShapes — all clean

Manual test: not needed — no observable behavior change; tests pin the new routing.

FRB canary: not needed — file isn't in `GumCoreShared.projitems` (Skia/Apos/SilkNet only).
