### PR TITLE
Redispatch Skia Polygon through PolygonRuntime (ADR 0011)

### DIFF
--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1107,6 +1107,16 @@ public partial class CustomSetPropertyOnRenderable
         }
         else if(containedObjectAsIpso is Polygon asPolygon)
         {
+            // Route through the runtime first (ADR 0011), same as the Circle/Rectangle branches
+            // above -- PolygonRuntime inherits SkiaShapeRuntime, the same runtime family, and some
+            // of its properties (e.g. StrokeWidth) are backed by a runtime-only field applied at
+            // pre-render, not a pass-through to the renderable. Falling straight to
+            // TrySetPropertiesOnRenderableBase would write the renderable's own StrokeWidth, which
+            // the runtime never reads.
+            if(!handled)
+            {
+                handled = TrySetPropertyOnRuntime(graphicalUiElement, propertyName, value);
+            }
             if(!handled)
             {
                 handled = TrySetPropertiesOnRenderableBase(asPolygon, graphicalUiElement, propertyName, value);

--- a/Tests/SkiaGum.Tests/GueDeriving/PolygonRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/PolygonRuntimeTests.cs
@@ -1,6 +1,6 @@
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using Shouldly;
-using SkiaGum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using System.Numerics;
@@ -16,6 +16,56 @@ public class PolygonRuntimeTests
     public PolygonRuntimeTests()
     {
         GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    // ---- Dispatcher routing pins (issue #3639 / ADR 0011) -----------------------------------
+    // These drive the STRING property name through the production Skia dispatcher (via
+    // SetProperty) and assert the value lands on PolygonRuntime (inherited from
+    // SkiaShapeRuntime, the same runtime family as Circle/Rectangle/Arc). Mirrors those shapes'
+    // existing TrySetPropertyOnRuntime routing rather than Sprite/NineSlice's hand-written cases.
+
+    [Fact]
+    public void Dispatch_Alpha_RoutesToRuntime()
+    {
+        PolygonRuntime sut = new();
+
+        sut.SetProperty("Alpha", 128);
+
+        sut.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void Dispatch_RedGreenBlue_RouteToRuntime()
+    {
+        PolygonRuntime sut = new();
+
+        sut.SetProperty("Red", 10);
+        sut.SetProperty("Green", 20);
+        sut.SetProperty("Blue", 30);
+
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void Dispatch_FillColor_RoutesToRuntime()
+    {
+        PolygonRuntime sut = new();
+
+        sut.SetProperty("FillColor", SKColors.CornflowerBlue);
+
+        sut.FillColor.ShouldBe(SKColors.CornflowerBlue);
+    }
+
+    [Fact]
+    public void Dispatch_StrokeWidth_RoutesToRuntime()
+    {
+        PolygonRuntime sut = new();
+
+        sut.SetProperty("StrokeWidth", 3f);
+
+        sut.StrokeWidth.ShouldBe(3f);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Routes Skia's Polygon dispatch through `TrySetPropertyOnRuntime` (the reflection-based runtime-first helper already used by Circle/Rectangle/Arc, #2956) ahead of `TrySetPropertiesOnRenderableBase` — `PolygonRuntime` inherits `SkiaShapeRuntime`, the same runtime family as those shapes, so it gets the same fix rather than Sprite/NineSlice's hand-written cases (ADR 0011).
- **Real bug fix:** `SkiaShapeRuntime.StrokeWidth` is a runtime-only auto-property applied at pre-render, not a pass-through to the renderable — writing straight to the renderable's `StrokeWidth` (the prior behavior) never reached it, so `SetProperty("StrokeWidth", ...)` silently no-op'd on Polygon. `FillColor` had no dispatch path at all before this either.
- Boyscout: `PolygonRuntimeTests.cs` used the obsolete `SkiaGum.GueDeriving.PolygonRuntime` shim; switched to the real `Gum.GueDeriving.PolygonRuntime` (same fix as #3662 for `CircleRuntimeTests`).

Fourth and final PR in the sequence for #3639 (Sprite: #4107, NineSlice: #4108, Container: #4109).

## Test plan
- [x] `dotnet test Tests/SkiaGum.Tests/SkiaGum.Tests.csproj` — 400/400 passed
- [x] `Dispatch_StrokeWidth_RoutesToRuntime`/`Dispatch_FillColor_RoutesToRuntime` verified red pre-fix, green post-fix
- [x] `dotnet build` SkiaGum, SilkNetGum, MonoGameGumShapes — all clean

Manual test: not needed — new tests drive the exact production dispatch path (`SetProperty` → `CustomSetPropertyOnRenderable.SetPropertyOnRenderable`), asserting exact resulting state.

FRB canary: not needed — file isn't in `GumCoreShared.projitems` (Skia/Apos/SilkNet only).

Closes #3639.
