### PR TITLE
Document TextureAddress dependency on texture coordinate properties

### DIFF
--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -14,10 +14,23 @@ namespace Gum.Managers;
 
 #region Enums
 
+/// <summary>
+/// Controls how the source rectangle for a texture-rendering element (e.g. Sprite, NineSlice) is determined.
+/// </summary>
 public enum TextureAddress
 {
+    /// <summary>
+    /// The entire texture is shown. TextureLeft, TextureTop, TextureWidth, and TextureHeight are ignored.
+    /// </summary>
     EntireTexture,
+    /// <summary>
+    /// TextureLeft, TextureTop, TextureWidth, and TextureHeight are used as an explicit source rectangle.
+    /// </summary>
     Custom,
+    /// <summary>
+    /// TextureLeft and TextureTop set the source rectangle's position, but its width and height are derived
+    /// from the element's own dimensions divided by TextureWidthScale and TextureHeightScale.
+    /// </summary>
     DimensionsBased
 }
 

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -1476,7 +1476,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
     }
 
     /// <summary>
-    /// The pixel coorinate of the top of the displayed region.
+    /// The pixel coordinate of the top of the displayed region.
+    /// Ignored unless <see cref="TextureAddress"/> is Custom or DimensionsBased.
     /// </summary>
     public int TextureTop
     {
@@ -1496,6 +1497,7 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     /// <summary>
     /// The pixel coordinate of the left of the displayed region.
+    /// Ignored unless <see cref="TextureAddress"/> is Custom or DimensionsBased.
     /// </summary>
     public int TextureLeft
     {
@@ -1512,6 +1514,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     /// <summary>
     /// The pixel width of the source rectangle on the referenced texture.
+    /// Only applied when <see cref="TextureAddress"/> is Custom; ignored for EntireTexture and
+    /// DimensionsBased (which derives width from <see cref="TextureWidthScale"/> instead).
     /// </summary>
     public int TextureWidth
     {
@@ -1531,6 +1535,8 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
 
     /// <summary>
     /// The pixel height of the source rectangle on the referenced texture.
+    /// Only applied when <see cref="TextureAddress"/> is Custom; ignored for EntireTexture and
+    /// DimensionsBased (which derives height from <see cref="TextureHeightScale"/> instead).
     /// </summary>
     public int TextureHeight
     {
@@ -1588,6 +1594,11 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         }
     }
 
+    /// <summary>
+    /// Controls how the source rectangle on the texture is determined. Defaults to EntireTexture, which
+    /// ignores <see cref="TextureLeft"/>, <see cref="TextureTop"/>, <see cref="TextureWidth"/>, and
+    /// <see cref="TextureHeight"/>. Must be set to Custom (or DimensionsBased) for those values to take effect.
+    /// </summary>
     public TextureAddress TextureAddress
     {
         get

--- a/MonoGameGum/GueDeriving/SpriteRuntime.cs
+++ b/MonoGameGum/GueDeriving/SpriteRuntime.cs
@@ -194,6 +194,7 @@ public class SpriteRuntime : GraphicalUiElement
     /// <summary>
     /// The source rectangle in the texture to render, using platform-specific Rectangle type.
     /// Setting this also updates TextureLeft, TextureTop, TextureWidth, and TextureHeight.
+    /// TextureAddress must be set to Custom for these values to affect rendering.
     /// </summary>
     public Rectangle SourceRectangle
     {


### PR DESCRIPTION
## Summary
- #4111 reports that setting `TextureLeft`/`TextureTop`/`TextureWidth`/`TextureHeight` is silently ignored unless `TextureAddress` is also set to `Custom`.
- Auto-switching `TextureAddress` inside those setters was considered and rejected: those setters are also driven by the tool's state/variable system (loading `.gumx` state, undo/redo, copy/paste), where property-application order isn't guaranteed — an old project with residual `TextureWidth`/`Height` values while `TextureAddress` stays `EntireTexture` could silently start rendering cropped instead of full-texture.
- Instead, this documents the dependency: XML doc comments on `TextureLeft`/`TextureTop`/`TextureWidth`/`TextureHeight`/`TextureAddress` in `GraphicalUiElement.cs`, the `TextureAddress` enum and its members in `StandardElementsManager.cs`, and `SpriteRuntime.SourceRectangle`.
- No behavior change.

Closes #4111

## Test plan
- [x] `dotnet build MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 0 errors
- Manual test: not needed — doc-only change, no behavior change
- FRB canary: not needed — no new/changed members, only doc comments on existing ones
