### PR TITLE
Fix PublishTrimmed crash on GumProjectSave.Load

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -33,6 +33,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup>
 		<Compile Include="..\GumDataTypes\Behaviors\BehaviorInstanceSave.cs" Link="Behaviors\BehaviorInstanceSave.cs" />
 		<Compile Include="..\GumDataTypes\Behaviors\BehaviorReference.cs" Link="Behaviors\BehaviorReference.cs" />
 		<Compile Include="..\GumDataTypes\Behaviors\BehaviorSave.cs" Link="Behaviors\BehaviorSave.cs" />

--- a/GumCommon/ILLink.Descriptors.xml
+++ b/GumCommon/ILLink.Descriptors.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="GumCommon">
+    <type fullname="Gum.DataTypes.*" preserve="all" />
+    <type fullname="Gum.StateAnimation.SaveClasses.*" preserve="all" />
+  </assembly>
+</linker>

--- a/GumDataTypes/GumDataTypesNet6.csproj
+++ b/GumDataTypes/GumDataTypesNet6.csproj
@@ -43,6 +43,12 @@
 		<Folder Include="Properties\" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 	<ItemGroup>
 	  <PackageReference Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
 	  <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/GumDataTypes/ILLink.Descriptors.xml
+++ b/GumDataTypes/ILLink.Descriptors.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="GumDataTypesNet6" preserve="all" />
+</linker>

--- a/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
@@ -543,4 +543,23 @@ public class GumProjectSaveTests : BaseTestClass
         project.ScreenReferences.Count.ShouldBe(1);
         project.ScreenReferences[0].Name.ShouldBe("MainMenu");
     }
+
+    [Fact]
+    public void ContainingAssembly_EmbedsIlLinkDescriptor_PreservingSaveClassesForTrimmedPublish()
+    {
+        // Pins the fix for #4104: PublishTrimmed console/game builds crashed on GumProjectSave.Load
+        // with "cannot be serialized because it does not have a parameterless constructor", because
+        // the trimmer can't see the reflection-based construction XmlSerializer does internally.
+        // This embedded resource tells the .NET trimmer to keep every save-class member instead.
+        var assembly = typeof(GumProjectSave).Assembly;
+
+        assembly.GetManifestResourceNames().ShouldContain("ILLink.Descriptors.xml");
+
+        using var stream = assembly.GetManifestResourceStream("ILLink.Descriptors.xml")!;
+        using var reader = new StreamReader(stream);
+        string descriptorXml = reader.ReadToEnd();
+
+        descriptorXml.ShouldContain($"assembly fullname=\"{assembly.GetName().Name}\"");
+        descriptorXml.ShouldContain("preserve=\"all\"");
+    }
 }


### PR DESCRIPTION
Closes #4104

## Problem
`PublishTrimmed=true` games crashed in `GumService.Initialize` with `GumProjectSave cannot be serialized because it does not have a parameterless constructor`. `XmlSerializer(Type)` resolves constructors reflectively, which the trimmer can't see through, so it strips them.

## Fix
Embed an `ILLink.Descriptors.xml` root descriptor (the sanctioned library-author trimming mechanism) preserving `Gum.DataTypes.*` / `Gum.StateAnimation.SaveClasses.*` in **GumCommon** — the assembly real games actually link `GumProjectSave` into via `<Compile Include>` (not the separately-packaged `GumDataTypesNet6`, which turned out to be a different compiled copy consumed only by the little-used `GumRuntimeNet6`). Applied the same fix there too for consistency, since it's cheap and closes the same defect for that package's own consumers.

Zero consumer-side configuration needed — the trimmer auto-discovers the embedded descriptor for any referencing assembly.

## Why not sgen
The issue suggested `Microsoft.XmlSerializer.Generator` (sgen) pre-generated serializers as the primary option. Spiked it first: it doesn't work on the current .NET SDK's tool-resolution model — repro'd the failure even against Microsoft's own official tutorial verbatim, matching several long-standing open `dotnet/runtime` issues. Not viable today.

## Verification
- New unit test pins the embedded descriptor's presence/content on the assembly containing `GumProjectSave`.
- Manually reproduced the exact reported crash via a scratch `PublishTrimmed=true SelfContained=true` console publish referencing `GumCommon` directly (the real runtime path) — crashed identically without the fix, loaded and round-tripped a real sample `.gumx` (5 screens, 43 components, 9 standards) with byte-identical (SHA256) output to the non-trimmed baseline with the fix.
- Full `MonoGameGum.Tests` suite (1967 tests) green.
- `KniGum`, `RaylibGum`, `SkiaGum` all build clean against the updated `GumCommon`.

FRB canary: not needed — no `.cs` behavior changed, only project-file/embedded-resource plumbing not consumed by FRB1's own `GumCoreShared.projitems`.
