### PR TITLE
Add OutputLibrary.Silk to codegen for Gum.SilkNet

### DIFF
--- a/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
+++ b/Gum/CodeOutputPlugin/Views/CodeWindow.xaml.cs
@@ -236,7 +236,8 @@ public partial class CodeWindow : UserControl, ICodeOutputTabView
             {OutputLibrary.MonoGameForms, "MonoGame + Forms" },
             {OutputLibrary.Skia, "SkiaSharp" },
             {OutputLibrary.MonoGame, "MonoGame (no forms, deprecated)" },
-            {OutputLibrary.Raylib, "Raylib" }
+            {OutputLibrary.Raylib, "Raylib" },
+            {OutputLibrary.Silk, "Silk.NET" }
         };
         var StringToLibrary = LibraryToString.ToDictionary((i) => i.Value, (i) => i.Key);
 
@@ -279,6 +280,7 @@ public partial class CodeWindow : UserControl, ICodeOutputTabView
         options.Add(LibraryToString[OutputLibrary.Skia]);
         options.Add(LibraryToString[OutputLibrary.MonoGame]);
         options.Add(LibraryToString[OutputLibrary.Raylib]);
+        options.Add(LibraryToString[OutputLibrary.Silk]);
 
         member.CustomOptions = options;
 
@@ -504,6 +506,13 @@ public partial class CodeWindow : UserControl, ICodeOutputTabView
                 if (CodeOutputProjectSettings?.ObjectInstantiationType == ObjectInstantiationType.FullyInCode)
                 {
                     detailText = "Raylib code generation only supports \"Reference loaded Gum Project\" (Fully in Code is not yet supported)";
+                }
+            }
+            else if (CodeOutputProjectSettings?.OutputLibrary == OutputLibrary.Silk)
+            {
+                if (CodeOutputProjectSettings?.ObjectInstantiationType == ObjectInstantiationType.FullyInCode)
+                {
+                    detailText = "Silk.NET code generation only supports \"Reference loaded Gum Project\" (Fully in Code is not yet supported)";
                 }
             }
 

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorSilkSupportTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorSilkSupportTests.cs
@@ -1,0 +1,74 @@
+using Gum.ProjectServices.CodeGeneration;
+using Shouldly;
+using System;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="CodeGenerator.UsesUnifiedGumRuntime"/> and
+/// <see cref="CodeGenerator.AssertSupportedCombination"/> — the guard that keeps Silk.NET
+/// (<c>Gum.SilkNet</c>) codegen scoped to <see cref="ObjectInstantiationType.FindByName"/> for now,
+/// mirroring Raylib's #3430 rollout (see #3573).
+/// </summary>
+public class CodeGeneratorSilkSupportTests
+{
+    [Fact]
+    public void UsesUnifiedGumRuntime_Silk_ReturnsTrue()
+    {
+        CodeGenerator.UsesUnifiedGumRuntime(OutputLibrary.Silk).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AssertSupportedCombination_SilkWithFullyInCode_Throws()
+    {
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Silk,
+            ObjectInstantiationType = ObjectInstantiationType.FullyInCode
+        };
+
+        Should.Throw<NotSupportedException>(() => CodeGenerator.AssertSupportedCombination(settings));
+    }
+
+    [Fact]
+    public void AssertSupportedCombination_SilkWithFindByName_DoesNotThrow()
+    {
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Silk,
+            ObjectInstantiationType = ObjectInstantiationType.FindByName
+        };
+
+        Should.NotThrow(() => CodeGenerator.AssertSupportedCombination(settings));
+    }
+
+    [Fact]
+    public void CoerceToSupportedCombination_SilkWithFullyInCode_ChangesToFindByName()
+    {
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Silk,
+            ObjectInstantiationType = ObjectInstantiationType.FullyInCode
+        };
+
+        bool changed = CodeGenerator.CoerceToSupportedCombination(settings);
+
+        changed.ShouldBeTrue();
+        settings.ObjectInstantiationType.ShouldBe(ObjectInstantiationType.FindByName);
+    }
+
+    [Fact]
+    public void CoerceToSupportedCombination_SilkWithFindByName_LeavesUnchanged()
+    {
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Silk,
+            ObjectInstantiationType = ObjectInstantiationType.FindByName
+        };
+
+        bool changed = CodeGenerator.CoerceToSupportedCombination(settings);
+
+        changed.ShouldBeFalse();
+        settings.ObjectInstantiationType.ShouldBe(ObjectInstantiationType.FindByName);
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorSyntaxVersionNamespaceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorSyntaxVersionNamespaceTests.cs
@@ -265,6 +265,34 @@ public class CodeGeneratorSyntaxVersionNamespaceTests
     }
 
     [Fact]
+    public void ResolveSyntaxVersion_Silk_WithExplicitLegacyVersion_FloorsToVersion3()
+    {
+        // Gum.SilkNet, like Raylib, never existed at any legacy (pre-unification) namespace
+        // scheme, so it floors to version 3 regardless of an explicit lower SyntaxVersion setting.
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        Gum.Localization.LocalizationService localizationService = new Gum.Localization.LocalizationService();
+
+        CodeGenerator generator = new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.Silk,
+            SyntaxVersion = "2"
+        };
+
+        int result = generator.ResolveSyntaxVersion(settings);
+
+        result.ShouldBe(3);
+    }
+
+    [Fact]
     public void ResolveSyntaxVersion_MonoGame_WithNoExplicitVersion_StaysAtVersion0()
     {
         // Pin existing MonoGame behavior: no detection service + auto-detect "*" still resolves to 0.

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -328,37 +328,46 @@ public class CodeGenerator
     /// <summary>
     /// True for the <see cref="OutputLibrary"/> values whose generated code targets Gum's
     /// unified <c>Gum.GueDeriving</c>/<c>GumService</c> runtime surface the same way MonoGame
-    /// does (currently <see cref="OutputLibrary.MonoGame"/> and <see cref="OutputLibrary.Raylib"/>).
+    /// does (currently <see cref="OutputLibrary.MonoGame"/>, <see cref="OutputLibrary.Raylib"/>,
+    /// and <see cref="OutputLibrary.Silk"/> — <c>Gum.SilkNet</c>).
     /// This is not "behaves like MonoGame" — Gum owns the unified API and MonoGame is simply the
-    /// platform that has led its rollout — so sites that need identical codegen behavior for both
-    /// should check this instead of duplicating <c>|| OutputLibrary.Raylib</c> at every call site.
+    /// platform that has led its rollout — so sites that need identical codegen behavior for all
+    /// three should check this instead of duplicating <c>|| OutputLibrary.Raylib || OutputLibrary.Silk</c>
+    /// at every call site.
     /// </summary>
     internal static bool UsesUnifiedGumRuntime(OutputLibrary outputLibrary) =>
-        outputLibrary == OutputLibrary.MonoGame || outputLibrary == OutputLibrary.Raylib;
+        outputLibrary == OutputLibrary.MonoGame ||
+        outputLibrary == OutputLibrary.Raylib ||
+        outputLibrary == OutputLibrary.Silk;
+
+    /// <summary>
+    /// True for the <see cref="OutputLibrary"/> values whose codegen is scoped to
+    /// <see cref="ObjectInstantiationType.FindByName"/> only — <see cref="ObjectInstantiationType.FullyInCode"/>
+    /// is a deferred follow-up for these targets (Raylib: issue #3430; Silk: issue #3573), not
+    /// implemented, and must fail loudly rather than silently emit broken code.
+    /// </summary>
+    private static bool IsFindByNameOnly(OutputLibrary outputLibrary) =>
+        outputLibrary == OutputLibrary.Raylib || outputLibrary == OutputLibrary.Silk;
 
     /// <summary>
     /// Throws if the project settings request a combination code generation does not support yet.
-    /// Currently: <see cref="OutputLibrary.Raylib"/> only supports
-    /// <see cref="ObjectInstantiationType.FindByName"/> — <see cref="ObjectInstantiationType.FullyInCode"/>
-    /// for Raylib is a deferred follow-up (see issue #3430), not implemented, and must fail loudly
-    /// rather than silently emit broken code.
+    /// See <see cref="IsFindByNameOnly"/> for which <see cref="OutputLibrary"/> values this applies to.
     /// </summary>
     public static void AssertSupportedCombination(CodeOutputProjectSettings projectSettings)
     {
-        if (projectSettings.OutputLibrary == OutputLibrary.Raylib &&
+        if (IsFindByNameOnly(projectSettings.OutputLibrary) &&
             projectSettings.ObjectInstantiationType == ObjectInstantiationType.FullyInCode)
         {
             throw new NotSupportedException(
-                "Raylib code generation currently only supports ObjectInstantiationType.FindByName. " +
-                "Set ObjectInstantiationType to FindByName in ProjectCodeSettings.codsj (FullyInCode support for Raylib is not implemented yet).");
+                $"{projectSettings.OutputLibrary} code generation currently only supports ObjectInstantiationType.FindByName. " +
+                "Set ObjectInstantiationType to FindByName in ProjectCodeSettings.codsj (FullyInCode support is not implemented yet).");
         }
     }
 
     /// <summary>
     /// Adjusts <paramref name="projectSettings"/> in place to the nearest combination code generation
-    /// supports, so callers never reach the <see cref="AssertSupportedCombination"/> throw. Currently
-    /// forces <see cref="OutputLibrary.Raylib"/> to <see cref="ObjectInstantiationType.FindByName"/>
-    /// (FullyInCode for Raylib is not implemented yet — see issue #3430).
+    /// supports, so callers never reach the <see cref="AssertSupportedCombination"/> throw. See
+    /// <see cref="IsFindByNameOnly"/> for which <see cref="OutputLibrary"/> values this applies to.
     /// </summary>
     /// <remarks>
     /// This is the smooth-UX counterpart to <see cref="AssertSupportedCombination"/>: the interactive
@@ -369,7 +378,7 @@ public class CodeGenerator
     /// <returns><c>true</c> if a setting was changed, otherwise <c>false</c>.</returns>
     public static bool CoerceToSupportedCombination(CodeOutputProjectSettings projectSettings)
     {
-        if (projectSettings.OutputLibrary == OutputLibrary.Raylib &&
+        if (IsFindByNameOnly(projectSettings.OutputLibrary) &&
             projectSettings.ObjectInstantiationType == ObjectInstantiationType.FullyInCode)
         {
             projectSettings.ObjectInstantiationType = ObjectInstantiationType.FindByName;
@@ -385,14 +394,14 @@ public class CodeGenerator
     /// parsing <see cref="CodeOutputProjectSettings.SyntaxVersion"/> directly (treating
     /// auto-detect <c>"*"</c> as version 0) when no detection service is wired in.
     /// <para>
-    /// Raylib codegen never existed at any legacy (pre-unification) namespace scheme — the
-    /// Raylib runtime only ever exposed the fully unified <c>Gum.GueDeriving</c>/<c>GumService</c>
+    /// Raylib and Silk codegen never existed at any legacy (pre-unification) namespace scheme —
+    /// both runtimes only ever exposed the fully unified <c>Gum.GueDeriving</c>/<c>GumService</c>
     /// surface — so this floors the resolved version at 3 (the highest namespace-unification
-    /// threshold any generator check uses) for <see cref="OutputLibrary.Raylib"/> regardless of
-    /// what auto-detection or an explicit (legacy) <see cref="CodeOutputProjectSettings.SyntaxVersion"/>
-    /// would otherwise report. Flooring at the max threshold rather than the minimum needed (1)
-    /// means Raylib never takes any legacy branch anywhere in the generator, so those branches
-    /// never need Raylib-specific handling.
+    /// threshold any generator check uses) for those two <see cref="OutputLibrary"/> values
+    /// regardless of what auto-detection or an explicit (legacy)
+    /// <see cref="CodeOutputProjectSettings.SyntaxVersion"/> would otherwise report. Flooring at
+    /// the max threshold rather than the minimum needed (1) means neither ever takes any legacy
+    /// branch anywhere in the generator, so those branches never need platform-specific handling.
     /// </para>
     /// </summary>
     internal int ResolveSyntaxVersion(CodeOutputProjectSettings projectSettings)
@@ -414,7 +423,10 @@ public class CodeGenerator
             version = 0;
         }
 
-        if (projectSettings.OutputLibrary == OutputLibrary.Raylib && version < 3)
+        bool neverHadLegacyNamespace = projectSettings.OutputLibrary == OutputLibrary.Raylib ||
+            projectSettings.OutputLibrary == OutputLibrary.Silk;
+
+        if (neverHadLegacyNamespace && version < 3)
         {
             version = 3;
         }

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputProjectSettings.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputProjectSettings.cs
@@ -14,7 +14,8 @@ public enum OutputLibrary
     Maui = 3,
     MonoGame = 4,
     MonoGameForms = 5,
-    Raylib = 6
+    Raylib = 6,
+    Silk = 7
 }
 
 public enum ObjectInstantiationType

--- a/docs/gum-tool/code-tab/README.md
+++ b/docs/gum-tool/code-tab/README.md
@@ -78,11 +78,12 @@ Select the desired Output Library, such as **MonoGame + Forms**. This should mat
 
 * **MonoGame + Forms** is the recommended code generation if your project is using MonoGame. This code generation generates code with classes containing properties which inherit from FrameworkElement such as Button and Textbox wherever possible. If a non-forms instance (such as a Sprite or Text instance) is added to a screen or component, then code will _fall back_ to generating non-forms properties (such as SpriteRuntime or TextRuntime).
 * **MonoGame (no forms, deprecated)** generates code without creating forms controls. Use this if your game does not use Forms, or if your game predates Forms support in MonoGame.
-* **SkiaSharp** generates code for runtimes which use SkiaSharp for graphics, such as WPF, .NET Maui, and Silk.NET
+* **SkiaSharp** generates code for runtimes which use SkiaSharp for graphics, such as WPF and .NET Maui
 * **Raylib** generates code for projects using the Raylib runtime. Raylib code generation currently supports only the **Reference Loaded Gum Project** instantiation type (see below); the **Fully in Code** type is not yet supported and Gum displays a warning if you select it.
+* **Silk.NET** generates code for projects using the Gum.SilkNet runtime. Like Raylib, it currently supports only the **Reference Loaded Gum Project** instantiation type; the **Fully in Code** type is not yet supported and Gum displays a warning if you select it.
 
 {% hint style="info" %}
-The **Raylib** Output Library is available in the Gum July 2026 release and newer.
+The **Raylib** Output Library is available in the Gum July 2026 release and newer. The **Silk.NET** Output Library is available in the Gum [RELEASE MONTH/YEAR TODO] release and newer.
 {% endhint %}
 
 Additional libraries may be added in the future. If your project needs support for code generation and you are using a library that is not supported, please contact the Gum team on Discord or GitHub.


### PR DESCRIPTION
## Summary

Adds `OutputLibrary.Silk` so the Gum tool's codegen can target `Gum.SilkNet` (`Runtimes/SilkNetGum`).

Issue #3573 was gated on "Gum.SilkNet's namespace convention settling" — that's already done: `SilkNetGum` file-links `MonoGameGum`'s `GueDeriving`/`GumService`/Forms source directly (taking the `#if SKIA` branch), so it already compiles into the same unified `Gum.GueDeriving` namespace MonoGame and Raylib use. No mapping work was needed; see the issue comment for the full audit.

Mirrors #3430's Raylib rollout:
- `OutputLibrary.Silk` added to the enum
- Wired into `CodeGenerator.UsesUnifiedGumRuntime` (namespace/constructor codegen) and the syntax-version floor (`ResolveSyntaxVersion`)
- Scoped to `ObjectInstantiationType.FindByName` only for now via a new shared `IsFindByNameOnly` check (both `AssertSupportedCombination` and `CoerceToSupportedCombination` previously duplicated the Raylib-only condition; factored out now that a second library shares it) — `FullyInCode` is a deferred follow-up, same as Raylib
- Added to the tool's Output Library picker (`CodeWindow.xaml.cs`) with the same "Fully in Code not yet supported" warning text Raylib gets
- Doc update: `docs/gum-tool/code-tab/README.md` gains a Silk.NET bullet; the release-month hint needs the actual release filled in before publishing (marked with a `[RELEASE MONTH/YEAR TODO]` placeholder)

Auto-detection (`CodeGenerationAutoSetupService`, which sets `OutputLibrary.Raylib` on seeing a `Raylib-cs` PackageReference) intentionally does **not** get a Silk equivalent here — Silk.NET consumers reference varying window-backend packages (`Silk.NET.Windowing.Sdl`, `.Glfw`, etc.), so there's no single unambiguous package name to sniff the way `Raylib-cs` gives Raylib. Flagging as a follow-up rather than guessing.

Closes #3573

## Test plan

- [x] New unit tests in `Tests/Gum.ProjectServices.Tests/CodeGeneratorSilkSupportTests.cs` (mirrors `CodeGeneratorRaylibSupportTests.cs`) plus a `ResolveSyntaxVersion_Silk_...` case in `CodeGeneratorSyntaxVersionNamespaceTests.cs`, all TDD'd red-then-green against the missing enum member
- [x] Full `Gum.ProjectServices.Tests` suite: 412 passed, 0 failed
- [x] `dotnet build GumFull.sln`: 0 errors
- [ ] Manual: open the tool, Code tab → Output Library dropdown shows "Silk.NET"; selecting it + Fully in Code shows the new warning and generated code compiles against `Gum.GueDeriving`

Manual test: needed (tool UI is runtime-visible) — steps handed off separately.
FRB canary: not needed — no `GumCoreShared.projitems`/`FlatRedBall.Forms.Shared.projitems`-covered source touched (this is `Tools/Gum.ProjectServices/` + `Gum/CodeOutputPlugin/`, tool-only).
