### PR TITLE
Fix Behavior FormsProperty silently failing under PublishTrimmed

### DIFF
--- a/GumCommon/ILLink.Descriptors.xml
+++ b/GumCommon/ILLink.Descriptors.xml
@@ -2,5 +2,6 @@
   <assembly fullname="GumCommon">
     <type fullname="Gum.DataTypes.*" preserve="all" />
     <type fullname="Gum.StateAnimation.SaveClasses.*" preserve="all" />
+    <type fullname="Gum.Forms.Controls.*" preserve="all" />
   </assembly>
 </linker>

--- a/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
+++ b/MonoGameGum.Tests/Forms/BehaviorFormsPropertyApplyTests.cs
@@ -526,4 +526,22 @@ public class BehaviorFormsPropertyApplyTests : BaseTestClass
 
         scrollViewer.VerticalScrollBarVisibility.ShouldBe(ScrollBarVisibility.Hidden);
     }
+
+    [Fact]
+    public void ContainingAssembly_IlLinkDescriptor_PreservesFormsControlsForTrimmedPublish()
+    {
+        // Pins the fix for #4115: Apply resolves formsControl.GetType().GetProperty(name)
+        // reflectively, which the .NET trimmer can't see through, so a PublishTrimmed game
+        // silently dropped Behavior-declared FormsProperties like Splitter.ResizeBehavior.
+        // This embedded resource tells the trimmer to keep every Gum.Forms.Controls member.
+        System.Reflection.Assembly assembly = typeof(FrameworkElement).Assembly;
+
+        assembly.GetManifestResourceNames().ShouldContain("ILLink.Descriptors.xml");
+
+        using System.IO.Stream stream = assembly.GetManifestResourceStream("ILLink.Descriptors.xml")!;
+        using System.IO.StreamReader reader = new(stream);
+        string descriptorXml = reader.ReadToEnd();
+
+        descriptorXml.ShouldContain("Gum.Forms.Controls.*");
+    }
 }


### PR DESCRIPTION
## Summary
`BehaviorFormsPropertyApplier.Apply` resolves the target `FrameworkElement` property via `Type.GetProperty(string)`, invisible to the .NET trimmer, so `PublishTrimmed` games silently dropped Behavior-declared FormsProperties (e.g. `Splitter.ResizeBehavior`, `TextBox.TextWrapping`) with no exception.

Extends the `GumCommon/ILLink.Descriptors.xml` root descriptor added for #4104 to also preserve `Gum.Forms.Controls.*` — the single-home namespace every `FrameworkElement`-derived control compiles into (every platform runtime references these types via `GumCommon` rather than recompiling them).

## Verification
- New pinning test (`ContainingAssembly_IlLinkDescriptor_PreservesFormsControlsForTrimmedPublish`) + full `BehaviorFormsPropertyApplyTests` suite green (16/16); full `MonoGameGum.Tests` green (1968/1968).
- Scratch `PublishTrimmed=true` + `SelfContained` console spike against `MonoGameGum`, exercising the real production call path (`FormsUtilities.RegisterFromFileFormRuntimeDefaults`'s `InitialStateAppliedNotifier`, not reflection-only invocation): reproduced the exact silent no-op (`ResizeBehavior` stayed `null`) without the descriptor entry, confirmed correct `Columns` with it.
- Sanity-built `RaylibGum` and `SkiaGum` (also consume `GumCommon`'s Forms controls) clean.

Manual test: not needed — the bug only manifests under `PublishTrimmed`, which a normal debug-mode tool/sample run never exercises; the trim-publish spike above is the actual repro and proof, stronger than a UI click-through would be.

FRB canary: not needed — change is a `GumCommon` trimmer-descriptor XML file (not FRB1-shared source) plus a test.

Closes #4115
