### PR TITLE
Audit and fix remaining trim-unsafe reflection sites

### DIFF
--- a/.claude/skills/gum-unit-tests/SKILL.md
+++ b/.claude/skills/gum-unit-tests/SKILL.md
@@ -32,6 +32,7 @@ description: Writing unit tests in the Gum repo. Triggers: tests in Gum.ProjectS
 - A test asserting on an absolute path must not use a Windows-style `"C:\..."` literal — `Path.IsPathRooted` doesn't recognize a drive letter as rooted on Unix, so macOS/Linux CI treats it as relative and silently prepends the runner's real working directory, corrupting the path. Use a leading-slash literal (e.g. `"/game/Content/"`) instead — rooted on both platforms.
   - If the assertion compares against `ToolsUtilities.FilePath.FullPath`, a bare leading-slash literal still isn't safe: `FilePath` normalizes slashes to `Path.DirectorySeparatorChar`, so `fullPath == "/ProjectA.gumx"` passes on Unix but fails on Windows. Route the literal through `new FilePath(...).FullPath` on both sides of the comparison instead.
 - Use named parameters for boolean literals.
+- Don't name a test namespace after an existing Gum type (e.g. `MonoGameGum.Tests.Binding` collides with `Gum.Forms.Data.Binding`) — an unrelated file elsewhere in the same test project that references the type unqualified can suddenly fail to compile (`CS0118: '...' is a namespace but is used like a type`).
 
 ## Test at production defaults
 

--- a/Gum/DataTypes/VariableListSaveExtensionMethods.cs
+++ b/Gum/DataTypes/VariableListSaveExtensionMethods.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Gum.DataTypes.Variables;
 
 namespace Gum.DataTypes
 {
     public static class VariableListSaveExtensionMethods
     {
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "typeof(List<string>) is a closed, compile-time-constant BCL type, " +
+                "not data-dependent -- its default TypeConverter needs no additional preserved members.")]
         public static TypeConverter GetTypeConverter(this VariableListSave variableListSave)
         {
             return TypeDescriptor.GetConverter(typeof(List<string>));

--- a/GumCommon/ILLink.Descriptors.xml
+++ b/GumCommon/ILLink.Descriptors.xml
@@ -3,5 +3,6 @@
     <type fullname="Gum.DataTypes.*" preserve="all" />
     <type fullname="Gum.StateAnimation.SaveClasses.*" preserve="all" />
     <type fullname="Gum.Forms.Controls.*" preserve="all" />
+    <type fullname="Gum.Wireframe.GraphicalUiElement" preserve="all" />
   </assembly>
 </linker>

--- a/MonoGameGum.Tests/Binding/GraphicalUiElementBindingTrimSafetyTests.cs
+++ b/MonoGameGum.Tests/Binding/GraphicalUiElementBindingTrimSafetyTests.cs
@@ -1,0 +1,49 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace MonoGameGum.Tests.BindingTrimSafety;
+
+public class GraphicalUiElementBindingTrimSafetyTests
+{
+    private static string ReadDescriptorXml(Assembly assembly)
+    {
+        assembly.GetManifestResourceNames().ShouldContain("ILLink.Descriptors.xml");
+
+        using Stream stream = assembly.GetManifestResourceStream("ILLink.Descriptors.xml")!;
+        using StreamReader reader = new(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public void GumCommon_IlLinkDescriptor_PreservesGraphicalUiElementForTrimmedPublish()
+    {
+        // Pins part of the #4116 audit: ApplyVmValueToUi/BindEvent (GraphicalUiElement.Binding.cs)
+        // resolve SetBinding's UI-side target via thisType.GetProperty(name)/GetType().GetMethod
+        // for Delegate.CreateDelegate, invisible to the trimmer. Properties/methods declared
+        // directly on the GraphicalUiElement base (X, Y, Width, etc., compiled into GumCommon)
+        // need preserving separately from concrete runtime subclasses (MonoGameGum etc.).
+        string descriptorXml = ReadDescriptorXml(typeof(GraphicalUiElement).Assembly);
+
+        descriptorXml.ShouldContain("Gum.Wireframe.GraphicalUiElement");
+    }
+
+    [Fact]
+    public void MonoGameGum_IlLinkDescriptor_PreservesRuntimesAndRenderablesForTrimmedPublish()
+    {
+        // Pins part of the #4116 audit: the same SetBinding/SetPropertyThroughReflection
+        // reflection also targets concrete runtime wrapper types (TextRuntime, ButtonRuntime,
+        // etc. -- Gum.GueDeriving.*) and the renderables they wrap (RenderingLibrary.Graphics.*,
+        // RenderingLibrary.Math.Geometry.*), all compiled directly into MonoGameGum rather than
+        // GumCommon, so they need their own descriptor.
+        string descriptorXml = ReadDescriptorXml(typeof(TextRuntime).Assembly);
+
+        descriptorXml.ShouldContain("Gum.GueDeriving.*");
+        descriptorXml.ShouldContain("RenderingLibrary.Graphics.*");
+        descriptorXml.ShouldContain("RenderingLibrary.Math.Geometry.*");
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -218,4 +218,10 @@
 		<PackageReference Include="TextCopy" Version="6.2.1" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 </Project>

--- a/MonoGameGum/FnaGum/ILLink.Descriptors.xml
+++ b/MonoGameGum/FnaGum/ILLink.Descriptors.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="FnaGum">
+    <type fullname="Gum.GueDeriving.*" preserve="all" />
+    <type fullname="MonoGameGum.GueDeriving.*" preserve="all" />
+    <type fullname="SkiaGum.GueDeriving.*" preserve="all" />
+    <type fullname="RenderingLibrary.Graphics.*" preserve="all" />
+    <type fullname="RenderingLibrary.Math.Geometry.*" preserve="all" />
+  </assembly>
+</linker>

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -637,6 +637,12 @@ public class FrameworkElement : INotifyPropertyChanged
             // whether to create a forms object. Yes, this is less convenient for the user who is manually
             // creating runtimes, but it's worth it for the standard behavior of the user creating instances
             // of Gum objects, and to be able to create Forms objects in Gum tool
+            //
+            // Trim-unsafe (#4116 audit): gumType is an arbitrary caller-supplied type (the value side
+            // of the obsolete DefaultFormsComponents dictionary), so Gum has no way to preserve its
+            // members via its own ILLink.Descriptors.xml. Not fixed: this is the deprecated legacy
+            // path (superseded by DefaultFormsTemplates above), so the trim-safety cost of a caller
+            // still using it is accepted rather than invested in.
             var boolBoolConstructor = gumType.GetConstructor(new[] { typeof(bool), typeof(bool) });
             if(boolBoolConstructor != null)
             {

--- a/MonoGameGum/ILLink.Descriptors.xml
+++ b/MonoGameGum/ILLink.Descriptors.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="MonoGameGum">
+    <type fullname="Gum.GueDeriving.*" preserve="all" />
+    <type fullname="MonoGameGum.GueDeriving.*" preserve="all" />
+    <type fullname="SkiaGum.GueDeriving.*" preserve="all" />
+    <type fullname="RenderingLibrary.Graphics.*" preserve="all" />
+    <type fullname="RenderingLibrary.Math.Geometry.*" preserve="all" />
+  </assembly>
+</linker>

--- a/MonoGameGum/KniGum/ILLink.Descriptors.xml
+++ b/MonoGameGum/KniGum/ILLink.Descriptors.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="KniGum">
+    <type fullname="Gum.GueDeriving.*" preserve="all" />
+    <type fullname="MonoGameGum.GueDeriving.*" preserve="all" />
+    <type fullname="SkiaGum.GueDeriving.*" preserve="all" />
+    <type fullname="RenderingLibrary.Graphics.*" preserve="all" />
+    <type fullname="RenderingLibrary.Math.Geometry.*" preserve="all" />
+  </assembly>
+</linker>

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -265,4 +265,10 @@
     <Compile Remove="..\**\obj\**\*.*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Descriptors.xml">
+      <LogicalName>ILLink.Descriptors.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -317,4 +317,10 @@
 		<PackageReference Include="TextCopy" Version="6.2.1" Condition="!$(TargetFramework.Contains('ios'))" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/RaylibGum/ILLink.Descriptors.xml
+++ b/Runtimes/RaylibGum/ILLink.Descriptors.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="RaylibGum">
+    <type fullname="Gum.GueDeriving.*" preserve="all" />
+    <type fullname="MonoGameGum.GueDeriving.*" preserve="all" />
+    <type fullname="SkiaGum.GueDeriving.*" preserve="all" />
+    <type fullname="RenderingLibrary.Graphics.*" preserve="all" />
+    <type fullname="RenderingLibrary.Math.Geometry.*" preserve="all" />
+  </assembly>
+</linker>

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -280,4 +280,10 @@
 	  <Compile Update="..\..\MonoGameGum\Forms\Controls\TextBoxBase.cs" Link="Forms\Controls\TextBoxBase.cs" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/SkiaGum/ILLink.Descriptors.xml
+++ b/Runtimes/SkiaGum/ILLink.Descriptors.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="SkiaGum">
+    <type fullname="Gum.GueDeriving.*" preserve="all" />
+    <type fullname="MonoGameGum.GueDeriving.*" preserve="all" />
+    <type fullname="SkiaGum.GueDeriving.*" preserve="all" />
+    <type fullname="RenderingLibrary.Graphics.*" preserve="all" />
+    <type fullname="RenderingLibrary.Math.Geometry.*" preserve="all" />
+  </assembly>
+</linker>

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -198,4 +198,10 @@
 		<Folder Include="Xna\" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="ILLink.Descriptors.xml">
+			<LogicalName>ILLink.Descriptors.xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 </Project>

--- a/Tests/RaylibGum.Tests/TrimSafetyTests.cs
+++ b/Tests/RaylibGum.Tests/TrimSafetyTests.cs
@@ -1,0 +1,32 @@
+using Gum.GueDeriving;
+using Shouldly;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace RaylibGum.Tests;
+
+public class TrimSafetyTests
+{
+    [Fact]
+    public void IlLinkDescriptor_PreservesRuntimesAndRenderablesForTrimmedPublish()
+    {
+        // Pins part of the #4116 audit: GraphicalUiElement.Binding.cs's SetBinding-family
+        // reflection (ApplyVmValueToUi/BindEvent) and SetPropertyThroughReflection target
+        // concrete runtime wrapper types (Gum.GueDeriving.*) and the renderables they wrap
+        // (RenderingLibrary.Graphics.*/.Math.Geometry.*), which the .NET trimmer can't see
+        // through via Type.GetProperty(string)/Delegate.CreateDelegate(string). These are
+        // compiled directly into RaylibGum (not GumCommon), so they need their own descriptor.
+        Assembly assembly = typeof(TextRuntime).Assembly;
+
+        assembly.GetManifestResourceNames().ShouldContain("ILLink.Descriptors.xml");
+
+        using Stream stream = assembly.GetManifestResourceStream("ILLink.Descriptors.xml")!;
+        using StreamReader reader = new(stream);
+        string descriptorXml = reader.ReadToEnd();
+
+        descriptorXml.ShouldContain("Gum.GueDeriving.*");
+        descriptorXml.ShouldContain("RenderingLibrary.Graphics.*");
+        descriptorXml.ShouldContain("RenderingLibrary.Math.Geometry.*");
+    }
+}

--- a/Tests/SkiaGum.Tests/TrimSafetyTests.cs
+++ b/Tests/SkiaGum.Tests/TrimSafetyTests.cs
@@ -1,0 +1,33 @@
+using Shouldly;
+using SkiaGum.GueDeriving;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace SkiaGum.Tests;
+
+public class TrimSafetyTests
+{
+    [Fact]
+    public void IlLinkDescriptor_PreservesRuntimesAndRenderablesForTrimmedPublish()
+    {
+        // Pins part of the #4116 audit: GraphicalUiElement.Binding.cs's SetBinding-family
+        // reflection (ApplyVmValueToUi/BindEvent) and SetPropertyThroughReflection target
+        // concrete runtime wrapper types (Gum.GueDeriving.*/SkiaGum.GueDeriving.* shims) and
+        // the renderables they wrap (RenderingLibrary.Graphics.*), which the .NET trimmer
+        // can't see through via Type.GetProperty(string)/Delegate.CreateDelegate(string).
+        // These are compiled directly into SkiaGum (not GumCommon), so they need their own
+        // descriptor.
+        Assembly assembly = typeof(TextRuntime).Assembly;
+
+        assembly.GetManifestResourceNames().ShouldContain("ILLink.Descriptors.xml");
+
+        using Stream stream = assembly.GetManifestResourceStream("ILLink.Descriptors.xml")!;
+        using StreamReader reader = new(stream);
+        string descriptorXml = reader.ReadToEnd();
+
+        descriptorXml.ShouldContain("Gum.GueDeriving.*");
+        descriptorXml.ShouldContain("SkiaGum.GueDeriving.*");
+        descriptorXml.ShouldContain("RenderingLibrary.Graphics.*");
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up audit from #4116, extending the #4115 fix pattern. Confirmed the flagged reflection sites split into two categories:

**Fixable (this PR)** -- reflection into Gum's own types, same pattern as #4115:
- `GraphicalUiElement.Binding.cs`'s `ApplyVmValueToUi`/`BindEvent` (UI-side of data binding) and `SetPropertyThroughReflection` target concrete runtime wrappers (`Gum.GueDeriving.*`) and renderables (`RenderingLibrary.Graphics.*`/`.Math.Geometry.*`), compiled per-platform (not GumCommon) -- new `ILLink.Descriptors.xml` added to MonoGameGum, KniGum, FnaGum, RaylibGum, SkiaGum.
- Base `GraphicalUiElement` properties (X/Y/Width/etc.) -- extended GumCommon's existing descriptor.
- `VariableListSaveExtensionMethods.GetTypeConverter` -- suppressed with justification (reflects on a compile-time-constant `typeof(List<string>)`, not data-dependent -- a false-positive warning).
- `FrameworkElement.cs`'s obsolete `DefaultFormsComponents` legacy path -- documented as trim-unsafe rather than fixed (arbitrary caller type, and superseded by `DefaultFormsTemplates`).

**Not fixable from Gum's side** -- reflection into arbitrary caller-supplied ViewModel types (`UpdateToVmProperty`, `UnsubscribeEventsOnOldViewModel`, `IsDottedPathTargetingEvent`, all of `PropertyPathObserver.cs`). Gum can't preserve types it doesn't know about via its own descriptor. Filed as #4118 to annotate the call chain with `RequiresUnreferencedCode` instead, so trimmed builds get an actionable warning rather than a silent no-op.

## Verification
- New pinning tests for each new/extended descriptor (GumCommon, MonoGameGum, RaylibGum, SkiaGum).
- 1969/1969 `MonoGameGum.Tests`, 547/547 `RaylibGum.Tests`, 416/416 `SkiaGum.Tests` green.
- `KniGum` sanity-built clean.
- `FnaGum` descriptor added by the same mechanical pattern without building it (no FNA submodule init needed for a static XML/csproj change -- FnaGum is the same XNALIKE compile family as MonoGameGum/KniGum, both of which build clean with this change).
- Also added a `gum-unit-tests` skill note: a test namespace matching an existing Gum type name (e.g. `MonoGameGum.Tests.Binding` vs. `Gum.Forms.Data.Binding`) can break compilation elsewhere in the same test project -- hit this while naming the new pin test file.

Manual test: not needed -- same reasoning as #4115: the bug only manifests under `PublishTrimmed`, which a debug-mode tool/sample run never exercises.

FRB canary: not needed -- change is `ILLink.Descriptors.xml`/csproj plumbing plus one suppression attribute and one comment; no FRB1-shared source touched.

Closes #4116
