### PR TITLE
Annotate MVVM binding reflection with RequiresUnreferencedCode; add GUE lambda SetBinding

### DIFF
--- a/GumCommon/Mvvm/PropertyPathObserver.cs
+++ b/GumCommon/Mvvm/PropertyPathObserver.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 #if FRB
@@ -71,6 +72,9 @@ public class PropertyPathObserver : IDisposable
     /// <summary>
     /// Start observing on a new root object (detaches from the old).
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Walks the path on newRoot's own type, resolving each segment by name (GetProperty). Those " +
+        "members may be removed under PublishTrimmed if nothing else in the app references them.")]
     public void Attach(object newRoot)
     {
         ArgumentNullException.ThrowIfNull(newRoot);
@@ -124,6 +128,7 @@ public class PropertyPathObserver : IDisposable
     /// Walks the path on the current root and returns the leaf value, or null if any
     /// intermediate is null. Returns null if no root is attached.
     /// </summary>
+    [RequiresUnreferencedCode("Calls " + nameof(WalkSegments) + ".")]
     public object? GetCurrentValue()
     {
         if (_currentRoot is null)
@@ -137,6 +142,9 @@ public class PropertyPathObserver : IDisposable
     /// Walks the first <paramref name="count"/> segments starting from <paramref name="root"/>
     /// and returns the resulting object, or null if any intermediate is null.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Walks the path on root's own type, resolving each segment by name (GetProperty). Those " +
+        "members may be removed under PublishTrimmed if nothing else in the app references them.")]
     public static object? WalkSegments(object? root, PathSegment[] segments, int count)
     {
         object? cursor = root;
@@ -153,6 +161,10 @@ public class PropertyPathObserver : IDisposable
         return cursor;
     }
 
+    [RequiresUnreferencedCode(
+        "Re-walks the path from the changed segment, resolving each by name (GetProperty) on the " +
+        "runtime type. Those members may be removed under PublishTrimmed if nothing else in the app " +
+        "references them.")]
     private void OnSegmentChanged(int level, string propName)
     {
         // only react if the changed property matches the segment
@@ -209,6 +221,10 @@ public class PropertyPathObserver : IDisposable
         OnValueChanged();
     }
 
+    [RequiresUnreferencedCode(
+        "Walks the path from the root, resolving each segment by name (GetProperty) on the runtime " +
+        "type. Those members may be removed under PublishTrimmed if nothing else in the app references " +
+        "them.")]
     private object? WalkTo(int level)
     {
         object? cursor = _currentRoot;
@@ -226,6 +242,9 @@ public class PropertyPathObserver : IDisposable
         return cursor;
     }
 
+    [RequiresUnreferencedCode(
+        "Searches collectionType's own properties by reflection for an int indexer. That indexer may " +
+        "be removed under PublishTrimmed if nothing else in the app references it.")]
     private static Type GetElementTypeForLeaf(Type collectionType)
     {
         if (collectionType.IsArray)
@@ -251,6 +270,10 @@ public class PropertyPathObserver : IDisposable
     /// path references an index that doesn't yet exist (e.g. empty collection) or has
     /// been removed. The binding will re-evaluate when the collection changes.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Falls back to searching collection's own properties by reflection for an int indexer when " +
+        "it isn't an array or IList. That indexer may be removed under PublishTrimmed if nothing else " +
+        "in the app references it.")]
     private static object? GetIndexedValue(object collection, int index)
     {
         Type type = collection.GetType();
@@ -341,6 +364,9 @@ public class PropertyPathObserver : IDisposable
             Detached = true;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Automatic relay for an already-attached path observer's INotifyPropertyChanged " +
+                "subscription. The trim risk is already surfaced wherever Attach was actually called.")]
         private void OnChanged(object? _, PropertyChangedEventArgs e)
         {
             if (_weakObs.TryGetTarget(out PropertyPathObserver? obs))

--- a/GumRuntime/GraphicalUiElement.Binding.cs
+++ b/GumRuntime/GraphicalUiElement.Binding.cs
@@ -1,10 +1,13 @@
+using Gum.Forms.Data;
 using Gum.Mvvm;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -81,6 +84,10 @@ public partial class GraphicalUiElement
         RemoveBindingContextRecursively();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic parent-to-child BindingContext propagation, always wired regardless " +
+            "of whether binding is used. The trim risk is already surfaced wherever an ancestor's " +
+            "BindingContext/SetBinding was actually called by the app.")]
     private void HandleBindingParentChanged(object? sender, ParentChangedEventArgs args)
     {
         if (args.OldValue is GraphicalUiElement old)
@@ -98,6 +105,10 @@ public partial class GraphicalUiElement
         InheritedBindingContext = newParent?.BindingContext;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic parent-to-child BindingContext propagation, always wired regardless " +
+            "of whether binding is used. The trim risk is already surfaced wherever an ancestor's " +
+            "BindingContext/SetBinding was actually called by the app.")]
     void ParentBindingContextChanged(object? s, BindingContextChangedEventArgs e)
     {
         InheritedBindingContext = EffectiveParentGue?.BindingContext;
@@ -105,6 +116,10 @@ public partial class GraphicalUiElement
 
     public event EventHandler<BindingContextChangedEventArgs>? InheritedBindingContextChanged;
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic teardown clearing BindingContext when this element is removed from " +
+            "managers. The trim risk this unwinds was already surfaced wherever BindingContext/SetBinding " +
+            "was actually called by the app to set up the binding in the first place.")]
     private void RemoveBindingContextRecursively()
     {
         this.BindingContext = null;
@@ -131,6 +146,10 @@ public partial class GraphicalUiElement
     internal object? InheritedBindingContext
     {
         get => mInheritedBindingContext;
+        [RequiresUnreferencedCode(
+            "Propagates a new BindingContext down from a parent, which re-resolves every existing " +
+            "binding's VM member by name on the new context's type. Those members may be removed " +
+            "under PublishTrimmed if nothing else in the app references them.")]
         set
         {
             var oldInherited = mInheritedBindingContext;
@@ -158,6 +177,10 @@ public partial class GraphicalUiElement
     public object? BindingContext
     {
         get => mBindingContext ?? mInheritedBindingContext;
+        [RequiresUnreferencedCode(
+            "Assigning a new BindingContext re-resolves every existing binding's VM member by name " +
+            "on the new context's type. Those members may be removed under PublishTrimmed if nothing " +
+            "else in the app references them.")]
         set
         {
             var oldEffectiveBindingContext = BindingContext;
@@ -171,6 +194,10 @@ public partial class GraphicalUiElement
     }
 
     bool _isSubscribedToViewModelPropertyChanged = false;
+    [RequiresUnreferencedCode(
+        "Unsubscribes VM events and resolves each bound VM property/field/event by name on the new " +
+        "context's own type. Those members may be removed under PublishTrimmed if nothing else in the " +
+        "app references them.")]
     private void HandleBindingContextChangedInternal(object? oldContext, object? newContext)
     {
         if (oldContext is INotifyPropertyChanged oldViewModel)
@@ -225,6 +252,9 @@ public partial class GraphicalUiElement
     public static int PropertyUnsubscribeCallCount = 0;
     public static int GetTypeCallCount = 0;
 
+    [RequiresUnreferencedCode(
+        "Looks up an event on the VM's own type by name (GetEvent). That member may be removed " +
+        "under PublishTrimmed if nothing else in the app references it.")]
     private void UnsubscribeEventsOnOldViewModel(INotifyPropertyChanged oldViewModel)
     {
         if (_isSubscribedToViewModelPropertyChanged)
@@ -250,6 +280,10 @@ public partial class GraphicalUiElement
 
     object? EffectiveBindingContext => mBindingContext ?? InheritedBindingContext;
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic relay for an already-active flat binding's INotifyPropertyChanged " +
+            "subscription. The trim risk is already surfaced at the SetBinding/BindingContext call that " +
+            "set this binding up.")]
     private void HandleViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName is null)
@@ -286,6 +320,9 @@ public partial class GraphicalUiElement
     /// assigned. Returns true if the path was confirmed to target an event and
     /// should throw.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Walks the dotted path on the VM's own type and looks up the leaf event by name (GetEvent). " +
+        "Those members may be removed under PublishTrimmed if nothing else in the app references them.")]
     private bool IsDottedPathTargetingEvent(string vmProperty)
     {
         var context = BindingContext;
@@ -305,6 +342,7 @@ public partial class GraphicalUiElement
         return parent.GetType().GetEvent(leafName) != null;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(IsDottedPathTargetingEvent) + ".")]
     private void ThrowIfDottedPathTargetsEvent(string vmProperty)
     {
         if (IsDottedPathTargetingEvent(vmProperty))
@@ -326,6 +364,17 @@ public partial class GraphicalUiElement
         }
     }
 
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> to the VM member named by <paramref name="vmProperty"/>,
+    /// resolved by reflection at bind time. Under <c>PublishTrimmed</c>, that member survives only if
+    /// something else in the app references it directly -- prefer the
+    /// <see cref="SetBinding{TVm}(string, Expression{Func{TVm, object}}, string?)"/> overload, whose
+    /// expression argument keeps the member from being trimmed.
+    /// </summary>
+    [RequiresUnreferencedCode(
+        "vmProperty is resolved by name against the BindingContext's own type. That member may be " +
+        "removed under PublishTrimmed if nothing else in the app references it. Prefer the " +
+        "SetBinding<TVm> overload that takes an expression instead of a string.")]
     public void SetBinding(string uiProperty, string vmProperty, string? toStringFormat = null)
     {
         if (uiProperty == nameof(BindingContext))
@@ -392,6 +441,23 @@ public partial class GraphicalUiElement
         }
     }
 
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> to the VM member referenced by <paramref name="vmPropertyExpression"/>.
+    /// Prefer this over the string-path overload: the expression is a compile-time reference to the VM
+    /// member, which keeps that member from being removed under <c>PublishTrimmed</c>. See
+    /// <see cref="SetBinding(string, string, string?)"/> for the trim-safety caveat this avoids.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "vmPropertyExpression is a compiler-built expression tree that references the " +
+            "VM member directly, which keeps the trimmer from removing it. The string-path overload this " +
+            "forwards to can therefore always resolve that member by name at runtime.")]
+    public void SetBinding<TVm>(string uiProperty, Expression<Func<TVm, object?>> vmPropertyExpression, string? toStringFormat = null) =>
+        SetBinding(uiProperty, BinderHelpers.ExtractPath(vmPropertyExpression), toStringFormat);
+
+    [RequiresUnreferencedCode(
+        "Resolves the bound VM property/field/event by name on the BindingContext's own type " +
+        "(GetProperty/GetField/GetEvent). That member may be removed under PublishTrimmed if nothing " +
+        "else in the app references it.")]
     private bool UpdateToVmProperty(string vmPropertyName)
     {
         var updated = false;
@@ -569,6 +635,10 @@ public partial class GraphicalUiElement
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic descendant notification when a BindingContext-bound VM property " +
+            "changes. The trim risk is already surfaced wherever SetBinding was actually called to set " +
+            "up this binding.")]
     private void MatchAndPushBindingContextChange(string vmPropertyName, object? rootContext)
     {
         if (BindingContextBinding == vmPropertyName && BindingContextBindingPropertyOwner == rootContext)
@@ -578,6 +648,15 @@ public partial class GraphicalUiElement
         PushBindingContextChangeToDescendents(vmPropertyName, rootContext);
     }
 
+    /// <summary>
+    /// Writes this UI property's current value back to its bound VM member, resolved by name on the
+    /// BindingContext's own type. That member may be removed under <c>PublishTrimmed</c> if nothing
+    /// else in the app references it -- see <see cref="SetBinding(string, string, string?)"/>.
+    /// </summary>
+    [RequiresUnreferencedCode(
+        "Resolves the bound VM property by name on the BindingContext's own type (or an intermediate " +
+        "segment's type for dotted paths). That member may be removed under PublishTrimmed if nothing " +
+        "else in the app references it.")]
     protected void PushValueToViewModel([CallerMemberName] string? uiPropertyName = null)
     {
         if (uiPropertyName == null)

--- a/MonoGameGum.Tests/Binding/GraphicalUiElementLambdaBindingTests.cs
+++ b/MonoGameGum.Tests/Binding/GraphicalUiElementLambdaBindingTests.cs
@@ -1,0 +1,99 @@
+using Gum.GueDeriving;
+using Gum.Mvvm;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.LambdaBinding;
+
+public class GraphicalUiElementLambdaBindingTests
+{
+    [Fact]
+    public void SetBinding_LambdaExpression_DottedPath_ResolvesNestedValue()
+    {
+        // Arrange
+        TextRuntime sut = new();
+        ParentViewModel viewModel = new();
+        viewModel.Child!.Name = "nested-value";
+
+        // Act
+        sut.SetBinding<ParentViewModel>(nameof(sut.Text), vm => vm.Child!.Name);
+        sut.BindingContext = viewModel;
+
+        // Assert
+        sut.Text.ShouldBe("nested-value");
+    }
+
+    [Fact]
+    public void SetBinding_LambdaExpression_FlatPath_ResolvesValue()
+    {
+        // Arrange
+        TextRuntime sut = new();
+        TestViewModel viewModel = new() { StringValue = "hello" };
+
+        // Act
+        sut.SetBinding<TestViewModel>(nameof(sut.Text), vm => vm.StringValue);
+        sut.BindingContext = viewModel;
+
+        // Assert
+        sut.Text.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void SetBinding_LambdaExpression_ToStringFormat_IsApplied()
+    {
+        // Arrange
+        TextRuntime sut = new();
+        TestViewModel viewModel = new() { IntValue = 5 };
+
+        // Act
+        sut.SetBinding<TestViewModel>(nameof(sut.Text), vm => vm.IntValue, "N2");
+        sut.BindingContext = viewModel;
+
+        // Assert
+        sut.Text.ShouldBe("5.00");
+    }
+
+    #region View models
+
+    private class TestViewModel : ViewModel
+    {
+        public string StringValue
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+
+        public int IntValue
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
+    }
+
+    private class NamedChild : ViewModel
+    {
+        public string Name
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+    }
+
+    private class ParentViewModel : ViewModel
+    {
+        public NamedChild? Child
+        {
+            get => Get<NamedChild?>();
+            set => Set(value);
+        }
+
+        public ParentViewModel()
+        {
+            Child = new NamedChild();
+        }
+    }
+
+    #endregion
+}

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -211,6 +212,10 @@ public class FrameworkElement : INotifyPropertyChanged
     public object BindingContext
     {
         get => Visual?.BindingContext;
+        [RequiresUnreferencedCode(
+            "Assigning a new BindingContext re-resolves every existing binding's VM member by name on " +
+            "the new context's type. Those members may be removed under PublishTrimmed if nothing else " +
+            "in the app references them.")]
         set
         {
             if (Visual != null)
@@ -1102,8 +1107,30 @@ public class FrameworkElement : INotifyPropertyChanged
 
     #region Binding/ViewModel
 
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> to the VM member named by <paramref name="vmProperty"/>,
+    /// resolved by reflection at bind time. Under <c>PublishTrimmed</c>, that member survives only if
+    /// something else in the app references it directly -- prefer the lambda <c>SetBinding</c>
+    /// overload (see <see cref="FrameworkElementExt"/>), whose expression argument keeps the member
+    /// from being trimmed.
+    /// </summary>
+    [RequiresUnreferencedCode(
+        "vmProperty is resolved by name against the BindingContext's own type. That member may be " +
+        "removed under PublishTrimmed if nothing else in the app references it. Prefer the lambda " +
+        "SetBinding overload that takes an expression instead of a string.")]
     public void SetBinding(string uiProperty, string vmProperty) => SetBinding(uiProperty, new Binding(vmProperty));
 
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> using <paramref name="binding"/>'s <see cref="Binding.Path"/>,
+    /// resolved by reflection at bind time. Under <c>PublishTrimmed</c>, the bound VM member survives
+    /// only if something else in the app references it directly -- prefer the lambda <c>SetBinding</c>
+    /// overload (see <see cref="FrameworkElementExt"/>), whose expression argument keeps the member
+    /// from being trimmed.
+    /// </summary>
+    [RequiresUnreferencedCode(
+        "binding.Path is resolved by name against the BindingContext's own type. That member may be " +
+        "removed under PublishTrimmed if nothing else in the app references it. Prefer the lambda " +
+        "SetBinding overload that takes an expression instead of a string.")]
     public void SetBinding(string uiProperty, Binding binding)
     {
         PropertyRegistry.SetBinding(uiProperty, binding);

--- a/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElementExt.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using Gum.Wireframe;
 using RenderingLibrary;
 using System;
@@ -23,9 +24,27 @@ namespace Gum.Forms.Controls;
 
 public static class FrameworkElementExt
 {
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> to the VM member referenced by <paramref name="propertyExpression"/>.
+    /// Prefer this over the string-path overload: the expression is a compile-time reference to the VM
+    /// member, which keeps that member from being removed under <c>PublishTrimmed</c>.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "propertyExpression is a compiler-built expression tree that references the VM " +
+            "member directly, which keeps the trimmer from removing it. The string-path overload this " +
+            "forwards to can therefore always resolve that member by name at runtime.")]
     public static void SetBinding(this FrameworkElement element, string uiProperty, LambdaExpression propertyExpression) =>
         element.SetBinding(uiProperty, BinderHelpers.ExtractPath(propertyExpression));
-    
+
+    /// <summary>
+    /// Binds <paramref name="uiProperty"/> to the VM member referenced by <paramref name="propertyExpression"/>.
+    /// Prefer this over the string-path overload: the expression is a compile-time reference to the VM
+    /// member, which keeps that member from being removed under <c>PublishTrimmed</c>.
+    /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "propertyExpression is a compiler-built expression tree that references the VM " +
+            "member directly, which keeps the trimmer from removing it. The string-path overload this " +
+            "forwards to can therefore always resolve that member by name at runtime.")]
     public static void SetBinding<T>(this FrameworkElement element, string uiProperty, Expression<Func<T, object?>> propertyExpression) =>
         element.SetBinding(uiProperty, BinderHelpers.ExtractPath(propertyExpression));
 

--- a/MonoGameGum/Forms/Controls/ItemsControl.cs
+++ b/MonoGameGum/Forms/Controls/ItemsControl.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 #if FRB
@@ -235,6 +236,10 @@ public class ItemsControl : ScrollViewer
 
     #region Create New Item
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic per-item BindingContext assignment when populating from a bound " +
+            "collection. Any by-name VM member resolution happens in the item template's own bindings, " +
+            "which already carry this warning at the SetBinding call that created them.")]
     protected virtual FrameworkElement CreateNewItemFrameworkElement(object o)
     {
         if(FrameworkElementTemplate != null)
@@ -666,6 +671,10 @@ public class ItemsControl : ScrollViewer
 
     #region Event Handler methods
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic per-item BindingContext assignment when populating from a bound " +
+            "collection. Any by-name VM member resolution happens in the item template's own bindings, " +
+            "which already carry this warning at the SetBinding call that created them.")]
     protected virtual void HandleItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
     {
         switch (e.Action)

--- a/MonoGameGum/Forms/Controls/ListBox.cs
+++ b/MonoGameGum/Forms/Controls/ListBox.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using RenderingLibrary;
 using System.Collections.ObjectModel;
 using System.Reflection;
@@ -576,6 +577,10 @@ public class ListBox : ItemsControl, IInputReceiver
 
     #region Item Creation
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic per-item BindingContext assignment when populating from a bound " +
+            "collection. Any by-name VM member resolution happens in the item template's own bindings, " +
+            "which already carry this warning at the SetBinding call that created them.")]
     protected override FrameworkElement CreateNewItemFrameworkElement(object o)
     {
         ListBoxItem? item = null;

--- a/MonoGameGum/Forms/Controls/Menu.cs
+++ b/MonoGameGum/Forms/Controls/Menu.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -89,6 +90,10 @@ public class Menu : ItemsControl
 
     #region Item Creation
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic per-item BindingContext assignment when populating from a bound " +
+            "collection. Any by-name VM member resolution happens in the item template's own bindings, " +
+            "which already carry this warning at the SetBinding call that created them.")]
     protected override FrameworkElement CreateNewItemFrameworkElement(object o)
     {
         MenuItem menuItem;

--- a/MonoGameGum/Forms/Controls/MenuItem.cs
+++ b/MonoGameGum/Forms/Controls/MenuItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.SymbolStore;
 using System.Linq;
 using System.Text;
@@ -453,6 +454,10 @@ public class MenuItem : ItemsControl
 
     #region Popup ListBox (sub-items)
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic per-item BindingContext assignment when populating sub-items from a " +
+            "bound collection. Any by-name VM member resolution happens in the item template's own " +
+            "bindings, which already carry this warning at the SetBinding call that created them.")]
     internal void TryShowPopup()
     {
         if (this.Items?.Count > 0 && itemsPopup == null)

--- a/MonoGameGum/Forms/Data/BinderHelpers.cs
+++ b/MonoGameGum/Forms/Data/BinderHelpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -34,6 +35,9 @@ internal static class BinderHelpers
     /// </summary>
     public static PathSegment[] ParseSegments(string path) => PathSegmentParser.ParseSegments(path);
 
+    [RequiresUnreferencedCode(
+        "Walks the path on targetType by name (GetProperty/GetField). Those members may be removed " +
+        "under PublishTrimmed if nothing else in the app references them.")]
     public static bool CanWritePath(Type targetType, string path)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -88,6 +92,9 @@ internal static class BinderHelpers
         };
     }
 
+    [RequiresUnreferencedCode(
+        "Looks up a property or field on declaringType by name. That member may be removed under " +
+        "PublishTrimmed if nothing else in the app references it.")]
     private static bool TryGetMember(Type declaringType, string memberName, out MemberInfo? member, out Type memberType)
     {
         member = declaringType.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public);
@@ -111,6 +118,9 @@ internal static class BinderHelpers
     /// <summary>
     /// Null-safe getter: returns DependencyProperty.UnsetValue if any intermediate is null.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Walks the path on targetType by name (Expression.PropertyOrField). Those members may be " +
+        "removed under PublishTrimmed if nothing else in the app references them.")]
     public static Func<object, object?> BuildGetter(Type targetType, string path)
     {
         //parameter: the incoming object
@@ -174,6 +184,9 @@ internal static class BinderHelpers
     /// <summary>
     /// Null-safe setter: no-op if any intermediate is null.
     /// </summary>
+    [RequiresUnreferencedCode(
+        "Walks the path on targetType by name (Expression.PropertyOrField). Those members may be " +
+        "removed under PublishTrimmed if nothing else in the app references them.")]
     public static Action<object, object?> BuildSetter(Type targetType, string path)
     {
         // parameters: (object instance, object? value)
@@ -392,6 +405,7 @@ internal static class BinderHelpers
     /// Builds an expression that accesses an element by integer index, with null propagation
     /// on the collection. If the collection is null, the result is default(elementType).
     /// </summary>
+    [RequiresUnreferencedCode("Calls " + nameof(FindIntIndexer) + " for non-array collections.")]
     private static Expression BuildIndexAccess(Expression collection, int index)
     {
         Type collectionType = collection.Type;
@@ -428,6 +442,7 @@ internal static class BinderHelpers
         return rawAccess;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(FindIntIndexer) + " for non-array collections.")]
     private static Expression BuildIndexAccessWithNullPropagation(Expression collection, int index)
     {
         Type collectionType = collection.Type;
@@ -464,6 +479,7 @@ internal static class BinderHelpers
         return rawAccess;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(FindIntIndexer) + " for non-array collections.")]
     private static Expression BuildIndexSetExpression(Expression collection, int index, Expression value)
     {
         Type collectionType = collection.Type;
@@ -509,6 +525,9 @@ internal static class BinderHelpers
         }
     }
 
+    [RequiresUnreferencedCode(
+        "Searches type's own properties by reflection for an int indexer. That indexer may be removed " +
+        "under PublishTrimmed if nothing else in the app references it.")]
     private static PropertyInfo? FindIntIndexer(Type type)
     {
         // Look for a property with an int index parameter (the standard C# indexer named "Item")
@@ -524,6 +543,7 @@ internal static class BinderHelpers
         return null;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(FindIntIndexer) + ".")]
     private static Type GetElementType(Type collectionType)
     {
         if (collectionType.IsArray)

--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Gum.Wireframe;
 
@@ -53,6 +54,10 @@ internal class NpcBindingExpression : UntypedBindingExpression
         Binding.Mode is not BindingMode.OneWay &&
         TargetProperty.Name is not nameof(FrameworkElement.BindingContext);
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic relay when an inherited BindingContext changes further up the visual " +
+            "tree. The trim risk is already surfaced wherever SetBinding was actually called to create " +
+            "this binding.")]
     private void OnInheritedBindingContextChanged(object? sender, BindingContextChangedEventArgs e)
     {
         if (CurrentRoot != null)

--- a/MonoGameGum/Forms/Data/PropertyRegistry.cs
+++ b/MonoGameGum/Forms/Data/PropertyRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 
@@ -32,6 +33,7 @@ internal class PropertyRegistry
         return npcExpression;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(NpcBindingExpression) + "." + nameof(NpcBindingExpression.Start) + ".")]
     public void SetBinding(string uiPropertyName, Binding binding)
     {
         NpcBindingExpression npcExpression = new (Owner, uiPropertyName, binding);

--- a/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
+++ b/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Gum.Wireframe;
 
 #if !FRB
@@ -38,8 +39,12 @@ internal abstract class UntypedBindingExpression : BindingExpressionBase
         PathObserver.ValueChanged += UpdateTarget;
     }
 
+    [RequiresUnreferencedCode("Calls " + nameof(AttachToSource) + ".")]
     public void Start() => AttachToSource(TargetElement.BindingContext);
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Automatic relay when an already-bound target's BindingContext changes. The " +
+            "trim risk is already surfaced wherever SetBinding was actually called to create this binding.")]
     private void OnTargetBindingContextChanged(object? sender, BindingContextChangedEventArgs e)
     {
         AttachToSource(e.NewBindingContext);
@@ -47,6 +52,10 @@ internal abstract class UntypedBindingExpression : BindingExpressionBase
 
     protected bool SuppressAttach { get; set; }
 
+    [RequiresUnreferencedCode(
+        "Resolves the binding path by name against newSource's own type (PropertyPathObserver.Attach, " +
+        "BinderHelpers.BuildGetter/BuildSetter). Those members may be removed under PublishTrimmed if " +
+        "nothing else in the app references them.")]
     protected void AttachToSource(object? newSource)
     {
         if (SuppressAttach)

--- a/docs/code/binding-viewmodels/advanced-binding-options.md
+++ b/docs/code/binding-viewmodels/advanced-binding-options.md
@@ -4,9 +4,35 @@
 
 Gum provides multiple options to control how binding behaves using the `Binding` type.
 
+## Lambda Binding
+
+The recommended way to set up a binding is with a lambda expression, which provides compile-time checking, refactoring support, and (unlike a string path) safety under `PublishTrimmed` -- see the hint below. Lambda expressions are extension methods available on `FrameworkElement`.
+
+A typed lambda specifies the ViewModel type explicitly:
+
+```csharp
+// Initialize
+textBox.SetBinding<MyViewModel>(
+    nameof(TextBox.Text),
+    vm => vm.PlayerName);
+```
+
+A parameterless lambda captures the ViewModel from a local variable:
+
+```csharp
+// Initialize
+MyViewModel vm = new();
+textBox.BindingContext = vm;
+textBox.SetBinding(
+    nameof(TextBox.Text),
+    () => vm.PlayerName);
+```
+
+Both approaches extract the property path from the expression at call time. The resulting binding behaves identically to a string-based binding.
+
 ## Using the Binding Class
 
-The fastest way to set up binding is to use the name of the properties being bound, as shown in the following code example:
+A binding can also be set up using the name of the properties being bound:
 
 ```csharp
 // Initialize
@@ -17,6 +43,10 @@ label.SetBinding(
     // ViewModel property:
     nameof(MyViewModel.LabelText));
 ```
+
+{% hint style="warning" %}
+This string-path overload resolves `LabelText` by reflection when the binding is applied. Under `PublishTrimmed`, a VM member reached *only* through a string-path binding can be removed by the trimmer if nothing else in your code references it directly -- the binding then silently stops updating instead of throwing. The lambda overloads above avoid this: writing `vm => vm.LabelText` gives the compiler a direct reference to the property, which keeps the trimmer from removing it. Prefer lambda binding for any project that publishes with `PublishTrimmed` enabled.
+{% endhint %}
 
 The SetBinding call shown above is a shortcut for creating a `Binding` object. The following code is functionally identical:
 
@@ -43,32 +73,6 @@ label.SetBinding(
     nameof(label.Text),
     binding);
 ```
-
-## Lambda Binding
-
-Binding can also be created using lambda expressions, which provide compile-time checking and refactoring support. Lambda expressions are extension methods available on `FrameworkElement`.
-
-A typed lambda specifies the ViewModel type explicitly:
-
-```csharp
-// Initialize
-textBox.SetBinding<MyViewModel>(
-    nameof(TextBox.Text),
-    vm => vm.PlayerName);
-```
-
-A parameterless lambda captures the ViewModel from a local variable:
-
-```csharp
-// Initialize
-MyViewModel vm = new();
-textBox.BindingContext = vm;
-textBox.SetBinding(
-    nameof(TextBox.Text),
-    () => vm.PlayerName);
-```
-
-Both approaches extract the property path from the expression at call time. The resulting binding behaves identically to a string-based binding.
 
 ## Nested Property Paths
 

--- a/docs/code/binding-viewmodels/binding-deep-dive.md
+++ b/docs/code/binding-viewmodels/binding-deep-dive.md
@@ -10,16 +10,30 @@ Although typical ViewModels do not include view-specific properties such as colo
 
 ### Binding Visual Properties Directly
 
-Visual properties can be bound directly. For example, the following code shows how to bind the width of a Button to a ButtonWidth property on a ViewModel.
+Visual properties can be bound directly. For example, the following code shows how to bind the width of a Button to a ButtonWidth property on a ViewModel using a lambda expression:
 
 ```csharp
 // Initialize
 // assume MyButton is a valid button
 var buttonVisual = MyButton.Visual;
+buttonVisual.SetBinding<ViewModel>(
+    nameof(buttonVisual.Width),
+    vm => vm.ButtonWidth);
+```
+
+A visual can also be bound using a string property name:
+
+```csharp
+// Initialize
+var buttonVisual = MyButton.Visual;
 buttonVisual.SetBinding(
     nameof(buttonVisual.Width),
     nameof(ViewModel.ButtonWidth));
 ```
+
+{% hint style="warning" %}
+The string-path overload resolves `ButtonWidth` by reflection when the binding is applied. Under `PublishTrimmed`, a VM member reached *only* through a string-path binding can be removed by the trimmer if nothing else in your code references it directly -- the binding then silently stops updating instead of throwing. The lambda overload above avoids this: writing `vm => vm.ButtonWidth` gives the compiler a direct reference to the property, which keeps the trimmer from removing it. Prefer lambda binding for any project that publishes with `PublishTrimmed` enabled.
+{% endhint %}
 
 If the property requires a specific type, then the Visual can be casted to access type-specific properties, as shown in the following code block:
 
@@ -28,9 +42,9 @@ If the property requires a specific type, then the Visual can be casted to acces
 // This assumes the project is code-only
 var buttonVisual = (ButtonVisual)MyButton.Visual;
 var text = buttonVisual.TextInstance;
-text.SetBinding(
+text.SetBinding<ViewModel>(
     nameof(Text.FontScale),
-    nameof(ViewModel.ButtonFontScale));
+    vm => vm.ButtonFontScale);
 ```
 
 ### Binding Converter Properties (Code Generation)

--- a/docs/code/binding-viewmodels/binding-deep-dive.md
+++ b/docs/code/binding-viewmodels/binding-deep-dive.md
@@ -16,7 +16,7 @@ Visual properties can be bound directly. For example, the following code shows h
 // Initialize
 // assume MyButton is a valid button
 var buttonVisual = MyButton.Visual;
-buttonVisual.SetBinding<ViewModel>(
+buttonVisual.SetBinding<MyViewModel>(
     nameof(buttonVisual.Width),
     vm => vm.ButtonWidth);
 ```
@@ -28,7 +28,7 @@ A visual can also be bound using a string property name:
 var buttonVisual = MyButton.Visual;
 buttonVisual.SetBinding(
     nameof(buttonVisual.Width),
-    nameof(ViewModel.ButtonWidth));
+    nameof(MyViewModel.ButtonWidth));
 ```
 
 {% hint style="warning" %}
@@ -42,7 +42,7 @@ If the property requires a specific type, then the Visual can be casted to acces
 // This assumes the project is code-only
 var buttonVisual = (ButtonVisual)MyButton.Visual;
 var text = buttonVisual.TextInstance;
-text.SetBinding<ViewModel>(
+text.SetBinding<MyViewModel>(
     nameof(Text.FontScale),
     vm => vm.ButtonFontScale);
 ```


### PR DESCRIPTION
## Summary
- Annotates the trim-unsafe MVVM binding reflection sites (arbitrary caller VM types) with `[RequiresUnreferencedCode]`, cascaded through their real call chains: `GraphicalUiElement.SetBinding`/`BindingContext`, `FrameworkElement.SetBinding`/`BindingContext`, `PropertyPathObserver`, `BinderHelpers`.
- Automatic/internal-relay call sites (parent-child BindingContext propagation, per-item container binding in `ItemsControl`/`ListBox`/`Menu`/`MenuItem`, event-driven re-attachment) are suppressed with justification instead of propagated -- that risk already surfaced at the `SetBinding`/`BindingContext` call that set the binding up.
- Adds a lambda-expression `SetBinding<TVm>` overload to `GraphicalUiElement`, matching the existing `FrameworkElement` one. It's a thin wrapper -- extracts the path via the already-shared `BinderHelpers.ExtractPath` and forwards to the string-path overload -- but the expression itself gives the compiler a direct reference to the VM member, which keeps the trimmer from removing it. Both lambda overloads (GUE's new one and Forms' existing one) carry `[UnconditionalSuppressMessage]` since they forward into the now-annotated string path.
- Updates `docs/code/binding-viewmodels/advanced-binding-options.md` and `binding-deep-dive.md` to lead with lambda binding and add a `PublishTrimmed` warning callout on the string-path overloads.

## Verification
- New tests: `MonoGameGum.Tests/Binding/GraphicalUiElementLambdaBindingTests.cs` (flat path, nested path, `toStringFormat`).
- 1973/1973 `MonoGameGum.Tests` green. `GumCommon`, `KniGum`, `RaylibGum`, `SkiaGum` build clean.
- Validated the annotation cascade empirically by building with `-p:EnableTrimAnalyzer=true` and iterating until zero unaccounted IL2026 warnings remained (spot-checked by temporarily removing one suppression and confirming the warning reappears).

Manual test: not needed -- the new overload's runtime behavior is covered by the new unit tests (real `TextRuntime`/ViewModel property resolution, not mocked); the `[RequiresUnreferencedCode]`/suppression attributes are build-time-only metadata with no runtime effect outside `PublishTrimmed`.

FRB canary: pass -- built `FlatRedBall.Forms.DesktopGlNet6.csproj` from the primary checkout against this branch's commit (detached, since the branch was already checked out in this worktree); 0 errors, same as the `main` baseline.

Closes #4118
