### PR TITLE
Raise Slider.ValueChangedByUi for keyboard and gamepad input

### DIFF
--- a/MonoGameGum.Tests/Forms/SliderTests.cs
+++ b/MonoGameGum.Tests/Forms/SliderTests.cs
@@ -3,7 +3,9 @@ using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals.V3;
 using Gum.Wireframe;
 using Gum.GueDeriving;
+using Microsoft.Xna.Framework.Input;
 using MonoGameGum.Input;
+using MonoGameGum.Tests.Input;
 using Gum.Input;
 using Moq;
 using Shouldly;
@@ -13,6 +15,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using GamePad = Gum.Input.GamePad;
 
 namespace MonoGameGum.Tests.Forms;
 public class SliderTests : BaseTestClass
@@ -156,5 +159,69 @@ public class SliderTests : BaseTestClass
         slider.OnFocusUpdate();
 
         slider.Value.ShouldBe(55);
+    }
+
+    [Fact]
+    public void Slider_RightArrowPressed_RaisesValueChangedByUi()
+    {
+        Slider slider = new()
+        {
+            Minimum = 0,
+            Maximum = 100,
+            SmallChange = 5,
+            Value = 50
+        };
+
+        Mock<IInputReceiverKeyboardMonoGame> keyboard = new Mock<IInputReceiverKeyboardMonoGame>();
+        keyboard.As<IInputReceiverKeyboard>()
+            .Setup(k => k.KeyTyped(Gum.Forms.Input.Keys.Right)).Returns(true);
+        keyboard.As<IInputReceiverKeyboard>()
+            .Setup(k => k.KeysTyped).Returns(new List<Gum.Forms.Input.Keys>());
+        FrameworkElement.KeyboardsForUiControl.Add(keyboard.Object);
+
+        bool wasRaised = false;
+        slider.ValueChangedByUi += (_, _) => wasRaised = true;
+
+        slider.OnFocusUpdate();
+
+        wasRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Slider_DPadRightPressed_RaisesValueChangedByUi()
+    {
+        Slider slider = new()
+        {
+            Minimum = 0,
+            Maximum = 100,
+            SmallChange = 5,
+            Value = 50
+        };
+        slider.IsFocused = true;
+
+        GamePad gamepad = new();
+        GamePadState pressedState = new GamePadState(
+            new GamePadThumbSticks(new Microsoft.Xna.Framework.Vector2(0, 0), new Microsoft.Xna.Framework.Vector2(0, 0)),
+            new GamePadTriggers(0, 0),
+            new GamePadButtons(0),
+            new GamePadDPad(
+                ButtonState.Released,
+                ButtonState.Released,
+                ButtonState.Released,
+                ButtonState.Pressed));
+
+        InteractiveGue.CurrentGameTime = 0;
+        gamepad.Activity(new GamePadState(), 0);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        bool wasRaised = false;
+        slider.ValueChangedByUi += (_, _) => wasRaised = true;
+
+        InteractiveGue.CurrentGameTime = 1;
+        gamepad.Activity(pressedState, 1);
+        slider.OnFocusUpdate();
+
+        slider.Value.ShouldBe(55);
+        wasRaised.ShouldBeTrue();
     }
 }

--- a/MonoGameGum/Forms/Controls/Slider.cs
+++ b/MonoGameGum/Forms/Controls/Slider.cs
@@ -424,6 +424,7 @@ public class Slider : RangeBase, IInputReceiver
 
             HandleGamepadNavigation(gamepad);
 
+            var valueBeforeGamepad = Value;
 
             if (gamepad.ButtonRepeatRate(GamepadButton.DPadLeft) ||
                 gamepad.LeftStick.AsDPadPushedRepeatRate(DPadDirection.Left))
@@ -436,6 +437,10 @@ public class Slider : RangeBase, IInputReceiver
                 this.Value += this.SmallChange;
             }
 
+            if (valueBeforeGamepad != Value)
+            {
+                RaiseValueChangedByUi();
+            }
 
             void RaiseIfPushedAndEnabled(GamepadButton button)
             {
@@ -464,6 +469,8 @@ public class Slider : RangeBase, IInputReceiver
                 ? gamepad.AnalogSticks[0]
                 : null;
 
+            var valueBeforeGamepad = Value;
+
             if (gamepad.DPadRepeatRate(FlatRedBall.Input.Xbox360GamePad.DPadDirection.Left) ||
                 leftStick?.AsDPadPushedRepeatRate(FlatRedBall.Input.Xbox360GamePad.DPadDirection.Left) == true)
             {
@@ -473,6 +480,11 @@ public class Slider : RangeBase, IInputReceiver
                 leftStick?.AsDPadPushedRepeatRate(FlatRedBall.Input.Xbox360GamePad.DPadDirection.Right) == true)
             {
                 this.Value += this.SmallChange;
+            }
+
+            if (valueBeforeGamepad != Value)
+            {
+                RaiseValueChangedByUi();
             }
 
             if (IsEnabled)
@@ -492,6 +504,8 @@ public class Slider : RangeBase, IInputReceiver
 
         foreach (var keyboard in KeyboardsForUiControl)
         {
+            var valueBeforeKeyboard = Value;
+
             // Fully qualified so this compiles regardless of the file-level `using Keys = ...` alias.
             if(keyboard.KeyTyped(Gum.Forms.Input.Keys.Right) == true)
             {
@@ -500,6 +514,11 @@ public class Slider : RangeBase, IInputReceiver
             if(keyboard.KeyTyped(Gum.Forms.Input.Keys.Left) == true)
             {
                 this.Value -= SmallChange;
+            }
+
+            if (valueBeforeKeyboard != Value)
+            {
+                RaiseValueChangedByUi();
             }
         }
 


### PR DESCRIPTION
## Summary
Keyboard Left/Right and gamepad D-pad/left-stick input on `Slider` changed `Value` directly instead of going through `RaiseValueChangedByUi()`, unlike the mouse-drag/track-click paths. Per docs, `ValueChangedByUi` should fire for any input-hardware-driven change, so this was a contract violation.

Fixes #4126.

## Changes
- `Slider.OnFocusUpdate()`: raise `ValueChangedByUi` after the value actually changes in the gamepad D-pad/stick branch, the FRB generic-gamepad branch (same bug, mirrored fix for symmetry), and the keyboard branch.
- Added `Slider_RightArrowPressed_RaisesValueChangedByUi` and `Slider_DPadRightPressed_RaisesValueChangedByUi` tests, both red before the fix.

## Test plan
- [x] New tests fail before the fix, pass after
- [x] Full `MonoGameGum.Tests` suite green (1975/1975)
- FRB canary: not run — the `#if FRB` generic-gamepad branch mirrors the exact fix already verified on the tested MonoGame gamepad branch; running the canary would require checking out this branch in the primary Gum checkout, which currently has unrelated uncommitted WIP I didn't want to disturb.

Manual test: not needed — behavior is fully covered by the new unit tests exercising the real `OnFocusUpdate` keyboard/gamepad input path.
