### PR TITLE
Add direction-agnostic RadialPushedRepeatRate to AnalogStick

### DIFF
--- a/GumRuntime/Input/GamePad.cs
+++ b/GumRuntime/Input/GamePad.cs
@@ -329,6 +329,11 @@ public class AnalogStick : IAnalogStick
     double[] _lastDPadPush;
     double[] _lastDPadRepeatRate;
 
+    bool _lastRadialDown;
+    // Start at -1 (not 0) so the first frame at time 0 is not mistaken for a repeat.
+    double _lastRadialPush = -1;
+    double _lastRadialRepeatRate = -1;
+
     /// <summary>
     /// Creates a new analog stick in its neutral (centered) state.
     /// </summary>
@@ -380,7 +385,8 @@ public class AnalogStick : IAnalogStick
             return true;
         }
 
-        bool repeatedThisFrame = _currentTime > 0 && _lastDPadPush[(int)direction] == _currentTime;
+        // If called multiple times in one frame, keep returning true for the rest of the frame.
+        bool repeatedThisFrame = _currentTime > 0 && _lastDPadRepeatRate[(int)direction] == _currentTime;
 
         if (repeatedThisFrame ||
             (AsDPadDown(direction) &&
@@ -393,6 +399,50 @@ public class AnalogStick : IAnalogStick
 
         return false;
     }
+
+    /// <inheritdoc/>
+    public bool RadialPushedRepeatRate() =>
+        RadialPushedRepeatRate(DefaultTimeAfterPush, DefaultTimeBetweenRepeating);
+
+    /// <summary>
+    /// Returns whether the stick's radial magnitude (sqrt(x²+y²)) was pushed past the on-threshold
+    /// this frame, or has been held past the off-threshold long enough to trigger a key-repeat with
+    /// the supplied timing. Unlike <see cref="AsDPadPushedRepeatRate(DPadDirection)"/>, this is
+    /// direction-agnostic — it fires at any angle, not just the four DPad directions. Read
+    /// <see cref="X"/>/<see cref="Y"/> after this returns true to get the angle the stick is pointing.
+    /// </summary>
+    public bool RadialPushedRepeatRate(double timeAfterPush, double timeBetweenRepeating)
+    {
+        if (RadialPushed())
+        {
+            return true;
+        }
+
+        // If called multiple times in one frame, keep returning true for the rest of the frame.
+        bool repeatedThisFrame = _currentTime > 0 && _lastRadialRepeatRate == _currentTime;
+
+        if (repeatedThisFrame ||
+            (RadialDown() &&
+             _currentTime - _lastRadialPush > timeAfterPush &&
+             _currentTime - _lastRadialRepeatRate > timeBetweenRepeating))
+        {
+            _lastRadialRepeatRate = _currentTime;
+            return true;
+        }
+
+        return false;
+    }
+
+    // Radial equivalent of AsDPadDown: gated on magnitude instead of a per-axis threshold, with
+    // the same on/off hysteresis band so a push doesn't chatter near the threshold.
+    bool RadialDown()
+    {
+        float magnitudeSquared = (_x * _x) + (_y * _y);
+        float threshold = _lastRadialDown ? DPadOffValue : DPadOnValue;
+        return magnitudeSquared > threshold * threshold;
+    }
+
+    bool RadialPushed() => !_lastRadialDown && RadialDown();
 
     /// <summary>
     /// Commits the stick position for the current frame. Called by <see cref="GamePad.Activity"/>.
@@ -421,11 +471,12 @@ public class AnalogStick : IAnalogStick
         }
 
         // Capture the previous down-state (using the previous position) before moving to the
-        // new position, so AsDPadPushed can detect the off-to-on transition this frame.
+        // new position, so AsDPadPushed/RadialPushed can detect the off-to-on transition this frame.
         _lastDPadDown[(int)DPadDirection.Up] = AsDPadDown(DPadDirection.Up);
         _lastDPadDown[(int)DPadDirection.Down] = AsDPadDown(DPadDirection.Down);
         _lastDPadDown[(int)DPadDirection.Left] = AsDPadDown(DPadDirection.Left);
         _lastDPadDown[(int)DPadDirection.Right] = AsDPadDown(DPadDirection.Right);
+        _lastRadialDown = RadialDown();
 
         _x = x;
         _y = y;
@@ -436,6 +487,10 @@ public class AnalogStick : IAnalogStick
             {
                 _lastDPadPush[i] = time;
             }
+        }
+        if (RadialPushed())
+        {
+            _lastRadialPush = time;
         }
     }
 
@@ -543,6 +598,10 @@ public class AnalogStick : IAnalogStick
             _lastDPadPush[i] = -1;
             _lastDPadRepeatRate[i] = -1;
         }
+
+        _lastRadialDown = false;
+        _lastRadialPush = -1;
+        _lastRadialRepeatRate = -1;
     }
 }
 

--- a/GumRuntime/Input/IGamePad.cs
+++ b/GumRuntime/Input/IGamePad.cs
@@ -61,6 +61,14 @@ public interface IAnalogStick
     bool AsDPadPushedRepeatRate(DPadDirection direction);
 
     /// <summary>
+    /// Returns whether the stick's radial magnitude (sqrt(x²+y²)) was pushed past the on-threshold
+    /// this frame, or has held there long enough to trigger key-repeat semantics. Unlike
+    /// <see cref="AsDPadPushedRepeatRate(DPadDirection)"/>, this is direction-agnostic — it fires
+    /// at any angle. Read <see cref="X"/>/<see cref="Y"/> after this returns true for the angle.
+    /// </summary>
+    bool RadialPushedRepeatRate();
+
+    /// <summary>
     /// The stick's horizontal position after deadzone processing, from -1 (left) to +1 (right).
     /// </summary>
     float X { get; }

--- a/Tests/RaylibGum.Tests/Inputs/AnalogStickTests.cs
+++ b/Tests/RaylibGum.Tests/Inputs/AnalogStickTests.cs
@@ -80,4 +80,84 @@ public class AnalogStickTests : BaseTestClass
 
         sut.AsDPadDown(DPadDirection.Right).ShouldBeFalse();
     }
+
+    // ---- RadialPushedRepeatRate (issue #4128) ----
+
+    [Fact]
+    public void RadialPushedRepeatRate_ReturnsFalse_WhenMagnitudeBelowOnThreshold()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        // Magnitude sqrt(0.3^2 + 0.3^2) = 0.424 < 0.55 on-threshold.
+        sut.Update(0.3f, 0.3f, 1);
+
+        sut.RadialPushedRepeatRate().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RadialPushedRepeatRate_ReturnsTrue_OnInitialPush_AtDiagonalAngle()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        // Magnitude sqrt(0.45^2 + 0.45^2) = 0.636 > 0.55 on-threshold, even though neither
+        // axis alone (0.45) crosses the per-axis DPad on-threshold - the motivating case.
+        sut.Update(0.45f, 0.45f, 1);
+
+        sut.RadialPushedRepeatRate().ShouldBeTrue();
+        sut.AsDPadDown(DPadDirection.Up).ShouldBeFalse();
+        sut.AsDPadDown(DPadDirection.Right).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RadialPushedRepeatRate_ReturnsFalse_WhenHeldButBeforeRepeatDelay()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        sut.Update(0, 1, 0);
+        sut.Update(0, 1, 0.1); // Still within the default 0.35s initial delay.
+
+        sut.RadialPushedRepeatRate().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RadialPushedRepeatRate_ReturnsTrue_AfterRepeatDelay()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        sut.Update(0, 1, 0);
+        sut.Update(0, 1, 0.4); // Past the default 0.35s initial delay.
+
+        sut.RadialPushedRepeatRate().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RadialPushedRepeatRate_UsesCustomTimings()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        sut.Update(0, 1, 0);
+
+        sut.Update(0, 1, 0.4);
+        sut.RadialPushedRepeatRate(timeAfterPush: 0.5, timeBetweenRepeating: 0.2).ShouldBeFalse();
+
+        sut.Update(0, 1, 0.6);
+        sut.RadialPushedRepeatRate(timeAfterPush: 0.5, timeBetweenRepeating: 0.2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RadialPushedRepeatRate_ReturnsTrueConsistently_WhenCalledMultipleTimesInSameFrame()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        sut.Update(0, 1, 0);
+        sut.Update(0, 1, 0.4); // Triggers the first repeat.
+
+        sut.RadialPushedRepeatRate().ShouldBeTrue();
+        sut.RadialPushedRepeatRate().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AsDPadPushedRepeatRate_ReturnsTrueConsistently_WhenCalledMultipleTimesInSameFrame()
+    {
+        AnalogStick sut = new AnalogStick { Deadzone = 0 };
+        sut.Update(1, 0, 0);
+        sut.Update(1, 0, 0.4); // Triggers the first repeat.
+
+        sut.AsDPadPushedRepeatRate(DPadDirection.Right).ShouldBeTrue();
+        sut.AsDPadPushedRepeatRate(DPadDirection.Right).ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
Closes #4128

Adds `AnalogStick.RadialPushedRepeatRate()` / `(timeAfterPush, timeBetweenRepeating)`, gated on radial magnitude (sqrt(x²+y²)) instead of per-axis thresholds — so a diagonal stick push registers even when neither individual axis crosses the DPad on-threshold. Reuses the same 0.55/0.45 hysteresis band and push/hold-repeat timing shape as `AsDPadPushedRepeatRate`. Parameterless overload added to `IAnalogStick` (matching the existing `AsDPadPushedRepeatRate(direction)` precedent — the custom-timing overload stays class-only, same as the DPad version).

Also fixes a latent bug in `AsDPadPushedRepeatRate`: its same-frame re-entry check compared against `_lastDPadPush` instead of `_lastDPadRepeatRate`, so a second call in the same frame after a repeat fired could return `false` when it should stay `true` (matches the comment/intent, and how `GamePad.ButtonRepeatRate` already does it correctly). Pinned with a new test.

Not wiring this into navigation yet — that's the follow-up spike per the issue.

## Test plan
- New unit tests in `AnalogStickTests` covering: below on-threshold, diagonal push above threshold (motivating case), pre-delay, post-delay, custom timings, and same-frame multi-call consistency (both the new radial method and the DPad bugfix).
- `dotnet test Tests/RaylibGum.Tests` and `dotnet test MonoGameGum.Tests` — full suites green.
- `dotnet build` on `KniGum.csproj` and `SkiaGum.csproj` — clean, confirming the `IAnalogStick` interface addition doesn't break other consumers.
