### PR TITLE
Support drag-and-drop from Project window search results onto the Wireframe view

### DIFF
--- a/Gum/Managers/SearchResultDragPayload.cs
+++ b/Gum/Managers/SearchResultDragPayload.cs
@@ -1,0 +1,13 @@
+namespace Gum.Managers;
+
+// Issue #4123: FlatSearchListBox (WPF) drags a TreeNode tagged with the search result's backing
+// object onto the Wireframe canvas (WinForms). TreeNode.Tag does not survive that WPF -> WinForms
+// drag boundary when its type isn't [Serializable] -- Gum's *Save types aren't, and TreeNode's own
+// serialization silently drops Tag in that case (confirmed empirically: Tag comes back null under
+// every format). DragDrop.DoDragDrop is synchronous -- only one drag can be in flight at a time --
+// so a single static slot set immediately before the call and cleared in a finally is sufficient to
+// carry the real object across in-process instead.
+internal static class SearchResultDragPayload
+{
+    public static object? Current { get; set; }
+}

--- a/Gum/Plugins/InternalPlugins/TreeView/FlatSearchListBox.xaml
+++ b/Gum/Plugins/InternalPlugins/TreeView/FlatSearchListBox.xaml
@@ -20,7 +20,11 @@
     </UserControl.Resources>
     <Grid>
 
-        <ListBox x:Name="FlatList" PreviewMouseLeftButtonUp="FlatList_MouseLeftButtonUp">
+        <ListBox
+            x:Name="FlatList"
+            PreviewMouseLeftButtonDown="FlatList_PreviewMouseLeftButtonDown"
+            PreviewMouseLeftButtonUp="FlatList_MouseLeftButtonUp"
+            PreviewMouseMove="FlatList_PreviewMouseMove">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">

--- a/Gum/Plugins/InternalPlugins/TreeView/FlatSearchListBox.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/FlatSearchListBox.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
+using Gum.Managers;
 using Gum.Plugins.InternalPlugins.TreeView.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -20,6 +21,9 @@ namespace Gum.Plugins.InternalPlugins.TreeView
 
         public event Action<SearchItemViewModel> SelectSearchNode;
 
+        private Point _mouseDownPoint;
+        private SearchItemViewModel? _dragCandidate;
+
         public FlatSearchListBox()
         {
             InitializeComponent();
@@ -27,6 +31,8 @@ namespace Gum.Plugins.InternalPlugins.TreeView
 
         private void FlatList_MouseLeftButtonUp(object? sender, MouseButtonEventArgs e)
         {
+            _dragCandidate = null;
+
             var objectPushed = e.OriginalSource;
             var frameworkElementPushed = (objectPushed as FrameworkElement);
 
@@ -34,6 +40,57 @@ namespace Gum.Plugins.InternalPlugins.TreeView
             SelectSearchNode(searchNodePushed);
             e.Handled = true;
         }
+
+        private void FlatList_PreviewMouseLeftButtonDown(object? sender, MouseButtonEventArgs e)
+        {
+            _mouseDownPoint = e.GetPosition(null);
+            _dragCandidate = (e.OriginalSource as FrameworkElement)?.DataContext as SearchItemViewModel;
+        }
+
+        private void FlatList_PreviewMouseMove(object? sender, MouseEventArgs e)
+        {
+            if (e.LeftButton != MouseButtonState.Pressed || _dragCandidate == null)
+            {
+                return;
+            }
+
+            Point current = e.GetPosition(null);
+            if (Math.Abs(current.X - _mouseDownPoint.X) < SystemParameters.MinimumHorizontalDragDistance &&
+                Math.Abs(current.Y - _mouseDownPoint.Y) < SystemParameters.MinimumVerticalDragDistance)
+            {
+                return;
+            }
+
+            SearchItemViewModel dragged = _dragCandidate;
+            _dragCandidate = null;
+
+            var data = new DataObject(CreateDragNode(dragged));
+            // TreeNode.Tag does not survive the WPF -> WinForms drag boundary when its type isn't
+            // [Serializable] (Gum's *Save types aren't) -- SearchResultDragPayload carries the real
+            // object across in-process instead; MainEditorTabPlugin.OnWireframeDrop falls back to it
+            // when Tag comes back null.
+            SearchResultDragPayload.Current = dragged.BackingObject;
+            try
+            {
+                DragDrop.DoDragDrop(FlatList, data, DragDropEffects.Copy);
+            }
+            catch
+            {
+                // Swallow, mirroring MultiSelectTreeView.Theming's own drag-start guard so a
+                // failed/canceled OLE drag never destabilizes the host app.
+            }
+            finally
+            {
+                SearchResultDragPayload.Current = null;
+            }
+        }
+
+        // Produces the same drag payload shape a real tree node does (a TreeNode tagged with the
+        // underlying element/instance/behavior), so the Wireframe drop side
+        // (MultiSelectTreeView.ExtractDraggedNodes, which reads TreeNode.Tag) handles a dragged
+        // search result the same way it handles a dragged tree node.
+        internal static System.Windows.Forms.TreeNode CreateDragNode(SearchItemViewModel item) =>
+            new System.Windows.Forms.TreeNode { Tag = item.BackingObject };
     }
 
     public class ObjectToFluentIconConverter : IValueConverter

--- a/Gum/Properties/AssemblyInfo.cs
+++ b/Gum/Properties/AssemblyInfo.cs
@@ -35,3 +35,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("2026.07.22")]
 [assembly: AssemblyFileVersion("2026.07.22")]
 [assembly: InternalsVisibleTo("GumToolUnitTests")]
+[assembly: InternalsVisibleTo("EditorTabPlugin_XNA")]

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -968,7 +968,9 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         if (droppedNodes.Length > 0)
         {
-            foreach (var draggedObject in droppedNodes.Select(x => x.Tag))
+            // A search-result drag's TreeNode.Tag doesn't survive the WPF -> WinForms boundary
+            // (see SearchResultDragPayload); fall back to it when Tag comes back null.
+            foreach (var draggedObject in droppedNodes.Select(x => x.Tag ?? SearchResultDragPayload.Current))
             {
                 _dragDropManager.OnNodeObjectDroppedInWireframe(draggedObject);
             }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/MainEditorTabPluginDragDropTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/MainEditorTabPluginDragDropTests.cs
@@ -92,6 +92,34 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
         dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(draggedTag), Times.Once);
     }
 
+    [Fact]
+    public void OnWireframeDrop_DraggedNodeTagIsNull_FallsBackToSearchResultDragPayload()
+    {
+        // Issue #4123: a search-result drag (FlatSearchListBox) boxes its backing object into
+        // TreeNode.Tag, but Tag comes back null after crossing the WPF -> WinForms drag boundary
+        // (confirmed empirically: ComponentSave/ElementSave aren't [Serializable], and TreeNode's
+        // own serialization only carries Tag across when its type is). SearchResultDragPayload is
+        // the in-process fallback that carries the real object instead.
+        MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
+
+        object backingObject = new();
+        SearchResultDragPayload.Current = backingObject;
+        try
+        {
+            GumTreeNode draggedNode = new GumTreeNode("Circle1") { Tag = null };
+            DataObject dataObject = new DataObject((object)draggedNode);
+            DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.Copy);
+
+            plugin.OnWireframeDrop(null, args);
+
+            dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(backingObject), Times.Once);
+        }
+        finally
+        {
+            SearchResultDragPayload.Current = null;
+        }
+    }
+
     // Stubs MainEditorTabPlugin headlessly without running its ~20-argument constructor (which stands
     // up a WireframeEditorFactory, SelectionManager, ScreenshotService, etc.) - see the
     // "Plugin/DI composition tests" entry in the gum-unit-tests skill. OnWireframeDragEnter/

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/FlatSearchListBoxDragTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/FlatSearchListBoxDragTests.cs
@@ -1,0 +1,25 @@
+using Gum.DataTypes;
+using Gum.Plugins.InternalPlugins.TreeView;
+using Gum.Plugins.InternalPlugins.TreeView.ViewModels;
+using Shouldly;
+using System.Windows.Forms;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+// Issue #4123: dragging a Project-panel search result must produce the same drag payload shape a
+// real tree node does, so the Wireframe drop side (MultiSelectTreeView.ExtractDraggedNodes, which
+// reads TreeNode.Tag) handles it identically with no drop-side changes.
+public class FlatSearchListBoxDragTests : BaseTestClass
+{
+    [Fact]
+    public void CreateDragNode_ReturnsTreeNodeTaggedWithBackingObject()
+    {
+        ComponentSave backingObject = new ComponentSave { Name = "MyComponent" };
+        SearchItemViewModel item = new SearchItemViewModel { BackingObject = backingObject };
+
+        TreeNode dragNode = FlatSearchListBox.CreateDragNode(item);
+
+        dragNode.Tag.ShouldBeSameAs(backingObject);
+    }
+}


### PR DESCRIPTION
## Summary
- Search-result drag from the Project panel now works the same as a tree-node drag: dropping a Component/Screen/Standard-element search result onto the Wireframe canvas creates an instance, same as dragging it from the tree.
- No changes to the drop side (`MultiSelectTreeView.ExtractDraggedNodes`) - the search list produces the same TreeNode-shaped payload a tree drag already does.
- Found and fixed along the way: TreeNode.Tag doesn't survive the WPF -> WinForms drag boundary for non-`[Serializable]` types (Gum's `*Save` types aren't), so the tagged backing object came back null on drop. `SearchResultDragPayload` carries it across in-process instead.

## Test plan
- [x] Unit tests: `FlatSearchListBoxDragTests`, `MainEditorTabPluginDragDropTests` (new fallback case), full TreeView/EditorTab suite green.
- [x] Manual: dragged a Component search result onto an open Screen's canvas in a real project, confirmed instance created.

Fixes #4123