### PR TITLE
Spatial (any-angle) gamepad/stick focus navigation

### DIFF
--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -288,6 +288,7 @@
 		<Compile Include="..\MonoGameGum\Forms\Controls\FrameworkElementExt.cs" Link="Forms\Controls\FrameworkElementExt.cs" />
 		<Compile Include="..\MonoGameGum\Forms\FrameworkElementTemplate.cs" Link="Forms\FrameworkElementTemplate.cs" />
 		<Compile Include="..\MonoGameGum\Forms\FrameworkElementTreeExtensions.cs" Link="Forms\FrameworkElementTreeExtensions.cs" />
+		<Compile Include="..\MonoGameGum\Forms\SpatialNavigationService.cs" Link="Forms\SpatialNavigationService.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\Button.cs" Link="Forms\Controls\Button.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\CheckBox.cs" Link="Forms\Controls\CheckBox.cs" />
 		<Compile Include="..\MonoGameGum\Forms\Controls\ColorPicker.cs" Link="Forms\Controls\ColorPicker.cs" />

--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -1,0 +1,135 @@
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Input;
+using Gum.Wireframe;
+
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+/// <summary>
+/// Tests for direction-agnostic ("spatial") gamepad focus navigation — the issue #4129 spike.
+/// Exercises <see cref="FrameworkElement.HandleGamepadSpatialNavigation"/>, driven by a real
+/// <see cref="GamePad"/> data holder. Mirrors the harness approach in
+/// <see cref="RaylibGum.Tests.Forms.ControllerTabNavigationTests"/> for the index-based counterpart.
+/// </summary>
+public class ControllerSpatialNavigationTests : BaseTestClass
+{
+    private sealed class SpatialNavHarness : FrameworkElement, IInputReceiver
+    {
+        public SpatialNavHarness(InteractiveGue visual) : base(visual) { }
+
+        public void InvokeHandleGamepadSpatialNavigation(IGamePad gamepad, GraphicalUiElement navigationRoot) =>
+            HandleGamepadSpatialNavigation(gamepad, navigationRoot);
+
+        public IInputReceiver? ParentInputReceiver => null;
+
+        public void OnGainFocus() { }
+
+        public void OnLoseFocus() { }
+
+        public void OnFocusUpdate() { }
+
+        public void OnFocusUpdatePreview(RoutedEventArgs args) { }
+
+        public void DoKeyboardAction(IInputReceiverKeyboard keyboard) { }
+    }
+
+    private static SpatialNavHarness CreateHarness(ContainerRuntime parent, float x, float y)
+    {
+        ContainerRuntime visual = new ContainerRuntime();
+        visual.Parent = parent;
+        SpatialNavHarness harness = new SpatialNavHarness(visual);
+        harness.X = x;
+        harness.Y = y;
+        return harness;
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_DiagonalDPadHeld_MovesFocusToDiagonalCandidate()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness right = CreateHarness(root, 150, 0);
+        SpatialNavHarness downRight = CreateHarness(root, 100, 100);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeFalse();
+        downRight.IsFocused.ShouldBeTrue();
+        right.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_DPadRightPushed_MovesFocusToCandidateOnRight()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness right = CreateHarness(root, 150, 0);
+        SpatialNavHarness above = CreateHarness(root, 0, -150);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeFalse();
+        right.IsFocused.ShouldBeTrue();
+        above.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_NoInput_DoesNotChangeFocus()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness other = CreateHarness(root, 150, 0);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeTrue();
+        other.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_StickPushedOffAxis_MovesFocusUsingContinuousAngle()
+    {
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness downRight = CreateHarness(root, 100, 100);
+        SpatialNavHarness right = CreateHarness(root, 150, 0);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        // AnalogStick.Y is +1 = up, so pushing down-right on screen is (positive X, negative Y).
+        gamepad.SetLeftStickPosition(0.7f, -0.7f);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeFalse();
+        downRight.IsFocused.ShouldBeTrue();
+        right.IsFocused.ShouldBeFalse();
+    }
+}

--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -46,6 +46,22 @@ public class ControllerSpatialNavigationTests : BaseTestClass
         return harness;
     }
 
+    private sealed class SpatialNavButton : Button
+    {
+        public void InvokeHandleGamepadSpatialNavigation(IGamePad gamepad, GraphicalUiElement navigationRoot) =>
+            HandleGamepadSpatialNavigation(gamepad, navigationRoot);
+    }
+
+    private static SpatialNavButton CreateButton(string name, float x, float y)
+    {
+        SpatialNavButton button = new SpatialNavButton();
+        button.Name = name;
+        button.X = x;
+        button.Y = y;
+        button.AddToRoot();
+        return button;
+    }
+
     [Fact]
     public void HandleGamepadSpatialNavigation_DiagonalDPadHeld_MovesFocusToDiagonalCandidate()
     {
@@ -67,6 +83,39 @@ public class ControllerSpatialNavigationTests : BaseTestClass
         origin.IsFocused.ShouldBeFalse();
         downRight.IsFocused.ShouldBeTrue();
         right.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_DiagonalDPadPressedSequentially_MovesFocusToDiagonalCandidate()
+    {
+        // Realistic controller use: Up is held first, then Right is pressed afterward while Up is
+        // still down — not both pushed on the exact same frame. ButtonRepeatRate(Up) only pulses
+        // on its own push/repeat schedule, so it is false on the frame Right is first pressed;
+        // direction must come from which buttons are currently held (ButtonDown), not from which
+        // ones' own repeat-rate happened to fire this frame. pureRight sits exactly where a
+        // (buggy) Up-dropped, Right-only angle of 0 degrees would send focus; diagonal sits
+        // exactly where the correct -45 degree (up-right) angle should send it instead.
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness pureRight = CreateHarness(root, 150, 0);
+        SpatialNavHarness diagonal = CreateHarness(root, 100, -100);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadUp, true);
+        gamepad.Activity(0);
+
+        gamepad.SetButtonState(GamepadButton.DPadUp, true);
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(0.1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeFalse();
+        diagonal.IsFocused.ShouldBeTrue();
+        pureRight.IsFocused.ShouldBeFalse();
     }
 
     [Fact]
@@ -108,6 +157,32 @@ public class ControllerSpatialNavigationTests : BaseTestClass
 
         origin.IsFocused.ShouldBeTrue();
         other.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_SkillTreeLayoutDPadDown_MovesFocusToNearestDownwardCandidate()
+    {
+        // Reproduces the manual-test demo's scattered 6-button layout reported in issue #4129:
+        // pressing Down from TopLeft was observed to jump straight to FarRightMid instead of
+        // BottomLeft/Middle. Real Button (not the bare-visual harness) via AddToRoot, matching
+        // the demo's own setup exactly, to see whether this test path agrees with the app.
+        SpatialNavButton topLeft = CreateButton("TopLeft", 80, 60);
+        CreateButton("TopRight", 500, 90);
+        SpatialNavButton middle = CreateButton("Middle", 280, 260);
+        SpatialNavButton bottomLeft = CreateButton("BottomLeft", 60, 420);
+        CreateButton("BottomRight", 560, 440);
+        SpatialNavButton farRightMid = CreateButton("FarRightMid", 650, 250);
+
+        topLeft.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+
+        topLeft.InvokeHandleGamepadSpatialNavigation(gamepad, GumService.Default.Root);
+
+        farRightMid.IsFocused.ShouldBeFalse();
+        (bottomLeft.IsFocused || middle.IsFocused).ShouldBeTrue();
     }
 
     [Fact]

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -56,6 +56,79 @@ public class GamepadNavigationModeTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadNavigation_SliderDPadDownPressed_NavigatesAwayWithoutChangingValue()
+    {
+        // Companion to the DPadRight test below: Up/Down aren't gated by
+        // IsUsingLeftAndRightGamepadDirectionsForNavigation, and Slider has no competing Up/Down
+        // handling of its own, so Down should navigate (now spatially) exactly like any other
+        // control, leaving Value untouched.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Slider slider = new Slider();
+        panel.AddChild(slider);
+        slider.X = 0;
+        slider.Y = 0;
+        slider.Value = 50;
+
+        Button below = new Button();
+        panel.AddChild(below);
+        below.X = 0;
+        below.Y = 150;
+
+        slider.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        slider.OnFocusUpdate();
+
+        slider.Value.ShouldBe(50);
+        slider.IsFocused.ShouldBeFalse();
+        below.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_SliderDPadRightPressed_AdjustsValueAndDoesNotNavigate()
+    {
+        // Slider disables Left/Right-as-navigation in its own constructor (Slider.cs:101),
+        // predating this feature — confirms that pre-existing guard also protects the new Spatial
+        // path, since GamepadNavigationMode is resolved inside the same shared
+        // HandleGamepadNavigation method Slider already calls. Without it, DPadRight would both
+        // adjust Value and try to navigate away using the same press.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Slider slider = new Slider();
+        panel.AddChild(slider);
+        slider.X = 0;
+        slider.Y = 0;
+        slider.Value = 50;
+
+        Button right = new Button();
+        panel.AddChild(right);
+        right.X = 150;
+        right.Y = 0;
+
+        slider.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        slider.OnFocusUpdate();
+
+        slider.Value.ShouldBeGreaterThan(50);
+        slider.IsFocused.ShouldBeTrue();
+        right.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadNavigation_ExplicitOverrideSet_TakesPrecedenceOverScoring()
     {
         Panel panel = new Panel();

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -1,0 +1,197 @@
+using Gum.Forms.Controls;
+using Gum.Input;
+
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+/// <summary>
+/// Tests for the real (non-spike) integration of issue #4129: <see cref="FrameworkElement.GamepadNavigationMode"/>
+/// lets a container opt a subtree into spatial navigation declaratively, so stock controls (plain
+/// <see cref="Button"/> here, no subclass) get it automatically through the existing
+/// <see cref="FrameworkElement.HandleGamepadNavigation(GamePadForNavigation)"/> call every control's
+/// own <c>OnFocusUpdate</c> already makes — unlike PR #4132's spike, which required a custom
+/// subclass and a manually-driven gamepad kept out of <see cref="FrameworkElement.GamePadsForUiControl"/>.
+/// </summary>
+public class GamepadNavigationModeTests : BaseTestClass
+{
+    [Fact]
+    public void HandleGamepadNavigation_DiagonalPress_IgnoresSingleDirectionOverride()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button overrideRightTarget = new Button();
+        panel.AddChild(overrideRightTarget);
+        overrideRightTarget.X = 500;
+        overrideRightTarget.Y = 0;
+
+        Button diagonalCandidate = new Button();
+        panel.AddChild(diagonalCandidate);
+        diagonalCandidate.X = 100;
+        diagonalCandidate.Y = 100;
+
+        // Set, but the press below is diagonal (Right+Down), not a clean single direction, so the
+        // override must be ignored and scoring must run instead.
+        origin.SpatialNavigationRight = overrideRightTarget;
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        origin.OnFocusUpdate();
+
+        diagonalCandidate.IsFocused.ShouldBeTrue();
+        overrideRightTarget.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_ExplicitOverrideSet_TakesPrecedenceOverScoring()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button nearestByScore = new Button();
+        panel.AddChild(nearestByScore);
+        nearestByScore.X = 50;
+        nearestByScore.Y = 0;
+
+        Button overrideTarget = new Button();
+        panel.AddChild(overrideTarget);
+        overrideTarget.X = 500;
+        overrideTarget.Y = 0;
+
+        origin.SpatialNavigationRight = overrideTarget;
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        origin.OnFocusUpdate();
+
+        overrideTarget.IsFocused.ShouldBeTrue();
+        nearestByScore.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_NestedPanelExplicitTabOrder_OptsOutOfOuterSpatialZone()
+    {
+        Panel outer = new Panel();
+        outer.AddToRoot();
+        outer.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Panel inner = new Panel();
+        outer.AddChild(inner);
+        inner.GamepadNavigationMode = GamepadNavigationMode.TabOrder;
+
+        Button first = new Button();
+        inner.AddChild(first);
+        first.X = 0;
+        first.Y = 0;
+
+        // Directly opposite ("up") of the Down press below — if spatial scoring wrongly ran here,
+        // this candidate would be excluded by the direction cone and nothing would be focused,
+        // proving second.IsFocused below can only be true via tab order.
+        Button second = new Button();
+        inner.AddChild(second);
+        second.X = 0;
+        second.Y = -150;
+
+        first.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        first.OnFocusUpdate();
+
+        first.IsFocused.ShouldBeFalse();
+        second.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_NoModeSet_UsesExistingIndexBasedNavigation()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        // GamepadNavigationMode left unset (null) on every ancestor — must default to TabOrder,
+        // exactly matching every existing consumer's behavior before this feature existed.
+
+        Button first = new Button();
+        panel.AddChild(first);
+        first.X = 0;
+        first.Y = 0;
+
+        Button second = new Button();
+        panel.AddChild(second);
+        second.X = -150;
+        second.Y = 0;
+
+        first.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        first.OnFocusUpdate();
+
+        first.IsFocused.ShouldBeFalse();
+        second.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleGamepadNavigation_PanelMarkedSpatial_StockButtonNavigatesSpatially()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button right = new Button();
+        panel.AddChild(right);
+        right.X = 150;
+        right.Y = 0;
+
+        Button above = new Button();
+        panel.AddChild(above);
+        above.X = 0;
+        above.Y = -150;
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        origin.OnFocusUpdate();
+
+        origin.IsFocused.ShouldBeFalse();
+        right.IsFocused.ShouldBeTrue();
+        above.IsFocused.ShouldBeFalse();
+    }
+}

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -165,6 +165,46 @@ public class GamepadNavigationModeTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadNavigation_ListBoxItemsHaveInternalFocus_DoesNotTriggerTopLevelNavigation()
+    {
+        // ListBox.OnFocusUpdate branches: DoListItemsHaveFocus routes to DoListItemFocusUpdate
+        // (moves selection between rows), which never calls HandleGamepadNavigation at all --
+        // only the else branch (DoTopLevelFocusUpdate, top-level list focus) does. So a Down
+        // press while an item has internal focus should stay entirely within the list, not also
+        // trigger spatial navigation away to a sibling control.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        ListBox listBox = new ListBox();
+        panel.AddChild(listBox);
+        listBox.X = 0;
+        listBox.Y = 0;
+        listBox.Items!.Add("A");
+        listBox.Items!.Add("B");
+        listBox.Items!.Add("C");
+        listBox.SelectedIndex = 0;
+        listBox.DoListItemsHaveFocus = true;
+
+        Button below = new Button();
+        panel.AddChild(below);
+        below.X = 0;
+        below.Y = 300;
+
+        listBox.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        listBox.OnFocusUpdate();
+
+        listBox.IsFocused.ShouldBeTrue();
+        below.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadNavigation_NestedPanelExplicitTabOrder_OptsOutOfOuterSpatialZone()
     {
         Panel outer = new Panel();

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -205,6 +205,62 @@ public class GamepadNavigationModeTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadNavigation_ScrollViewerItemHasInternalFocus_ChildNavigatesLikeAnyOtherFocusedControl()
+    {
+        // ScrollViewer.DoItemsHaveFocus is NOT the same shape as ListBox.DoListItemsHaveFocus --
+        // ListBox's is a virtual/internal flag (the ListBox itself stays the real IsFocused /
+        // CurrentInputReceiver throughout), but ScrollViewer.DoItemsHaveFocus hands REAL focus to
+        // the child element (confirmed: scrollViewer.IsFocused goes false, item.IsFocused goes
+        // true, matching the existing ScrollViewerTests precedent). Once that happens, it's the
+        // child's own OnFocusUpdate that runs each frame (per InteractiveGue.CurrentInputReceiver
+        // dispatch), not ScrollViewer.DoTopLevelFocusUpdate -- so a plain Button child under a
+        // Spatial-marked ancestor navigates exactly like any other focused Button.
+        //
+        // This originally exposed a real bug: ScrollViewer itself is also a focusable candidate,
+        // and (being a large container wrapping `item` near its top edge) its own center scored
+        // better than the true sibling `below`, so Down navigated back to the ScrollViewer itself
+        // instead of escaping to `below`. Fixed in SpatialNavigationService by excluding ancestors
+        // of the origin, not just the origin, from the candidate set (see
+        // SpatialNavigationServiceTests.FindBestCandidate_ExcludesAncestorsOfOrigin...).
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        ScrollViewer scrollViewer = new ScrollViewer();
+        panel.AddChild(scrollViewer);
+        scrollViewer.X = 0;
+        scrollViewer.Y = 0;
+
+        Button item = new Button();
+        scrollViewer.AddChild(item);
+
+        Button below = new Button();
+        panel.AddChild(below);
+        below.X = 0;
+        below.Y = 300;
+
+        scrollViewer.IsFocused = true;
+        scrollViewer.DoItemsHaveFocus = true;
+
+        item.IsFocused.ShouldBeTrue();
+        scrollViewer.IsFocused.ShouldBeFalse();
+        item.ParentFrameworkElement.ShouldBe(scrollViewer);
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        // The real per-frame dispatch would call OnFocusUpdate on whichever element is actually
+        // CurrentInputReceiver -- that's now `item`, not scrollViewer.
+        item.OnFocusUpdate();
+
+        below.IsFocused.ShouldBeTrue();
+        item.IsFocused.ShouldBeFalse();
+        scrollViewer.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadNavigation_NestedPanelExplicitTabOrder_OptsOutOfOuterSpatialZone()
     {
         Panel outer = new Panel();

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -1,0 +1,105 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class SpatialNavigationServiceTests : BaseTestClass
+{
+    private static Button CreatePositionedButton(float x, float y)
+    {
+        Button button = new();
+        button.AddToRoot();
+        button.X = x;
+        button.Y = y;
+        return button;
+    }
+
+    [Fact]
+    public void FindBestCandidate_DiagonalRequest_PicksDiagonallyPlacedCandidate()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        Button rightOnAxis = CreatePositionedButton(150, 0);
+        Button downRightDiagonal = CreatePositionedButton(100, 100);
+
+        List<FrameworkElement> candidates = new() { rightOnAxis, downRightDiagonal };
+
+        float fortyFiveDegrees = MathF.PI / 4f;
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, fortyFiveDegrees, candidates);
+
+        result.ShouldBe(downRightDiagonal);
+    }
+
+    [Fact]
+    public void FindBestCandidate_ExcludesCandidateOutsideDirectionCone_EvenWhenClosest()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        Button behind = CreatePositionedButton(-50, 0);
+        Button ahead = CreatePositionedButton(200, 0);
+
+        List<FrameworkElement> candidates = new() { behind, ahead };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBe(ahead);
+    }
+
+    [Fact]
+    public void FindBestCandidate_NeverReturnsOrigin_EvenIfPresentInCandidates()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        Button only = CreatePositionedButton(100, 0);
+
+        List<FrameworkElement> candidates = new() { origin, only };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBe(only);
+    }
+
+    [Fact]
+    public void FindBestCandidate_PicksNearerOnAxisCandidate_OverFartherOne()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        Button near = CreatePositionedButton(100, 0);
+        Button far = CreatePositionedButton(300, 0);
+
+        List<FrameworkElement> candidates = new() { near, far };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBe(near);
+    }
+
+    [Fact]
+    public void FindBestCandidate_PrefersWellAlignedFartherCandidate_OverCloserOffAxisCandidate()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        // Close, but nearly perpendicular to the rightward request:
+        Button closeOffAxis = CreatePositionedButton(20, 100);
+        // Farther, but exactly aligned with the rightward request:
+        Button farOnAxis = CreatePositionedButton(150, 0);
+
+        List<FrameworkElement> candidates = new() { closeOffAxis, farOnAxis };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBe(farOnAxis);
+    }
+
+    [Fact]
+    public void FindBestCandidate_ReturnsNull_WhenNoCandidatesQualify()
+    {
+        Button origin = CreatePositionedButton(0, 0);
+        Button behind = CreatePositionedButton(-50, 0);
+
+        List<FrameworkElement> candidates = new() { behind };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBeNull();
+    }
+}

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -48,6 +48,41 @@ public class SpatialNavigationServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void FindBestCandidate_ExcludesAncestorsOfOrigin_EvenWhenGeometricallyBestScored()
+    {
+        // Reproduces a real finding: a large focusable container wrapping the origin near its top
+        // edge has its own center positioned "downward" relative to the origin, and close by (the
+        // origin is inside it) -- so without this exclusion, pressing Down from an item near the
+        // top of a container can navigate back to that same container instead of a true sibling.
+        Panel container = new();
+        container.AddToRoot();
+        container.X = 0;
+        container.Y = 0;
+        container.Width = 150;
+        container.Height = 200;
+
+        Button origin = new();
+        container.AddChild(origin);
+        origin.X = 2;
+        origin.Y = 2;
+        origin.Width = 10;
+        origin.Height = 10;
+
+        Button sibling = new();
+        sibling.AddToRoot();
+        sibling.X = 0;
+        sibling.Y = 300;
+        sibling.Width = 10;
+        sibling.Height = 10;
+
+        List<FrameworkElement> candidates = new() { container, sibling };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, MathF.PI / 2f, candidates);
+
+        result.ShouldBe(sibling);
+    }
+
+    [Fact]
     public void FindBestCandidate_NeverReturnsOrigin_EvenIfPresentInCandidates()
     {
         Button origin = CreatePositionedButton(0, 0);

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -165,6 +165,7 @@
 		<Compile Remove="..\Forms\Controls\UserControl.cs" />
 		<Compile Remove="..\Forms\FrameworkElementTemplate.cs" />
 		<Compile Remove="..\Forms\FrameworkElementTreeExtensions.cs" />
+		<Compile Remove="..\Forms\SpatialNavigationService.cs" />
 		<Compile Remove="..\Forms\Controls\Tooltip.cs" />
 		<Compile Remove="..\Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="..\Forms\GraphicalUiElementFormsExtensions.cs" />

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1524,14 +1524,32 @@ public class FrameworkElement : INotifyPropertyChanged
 #if !FRB
     /// <summary>
     /// Direction-agnostic ("spatial") focus navigation spike (issue #4129): reads the requested
-    /// direction from the gamepad's DPad — including diagonals, from two simultaneously-held
-    /// buttons — or left analog stick, then moves focus to whichever focusable candidate under
+    /// direction from the gamepad's DPad — including diagonals, from two currently-held buttons —
+    /// or left analog stick, then moves focus to whichever focusable candidate under
     /// <paramref name="navigationRoot"/> best matches that direction by on-screen position (see
     /// <see cref="Gum.Forms.SpatialNavigationService"/>), rather than by tab order. This is a
     /// parallel, opt-in path — it does not call and is not called by
     /// <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>; a control/screen chooses one or
     /// the other.
     /// </summary>
+    /// <remarks>
+    /// Call this at most once per frame, for whichever single element currently has focus (e.g.
+    /// from that element's own per-frame update, mirroring where <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>
+    /// is normally called from). Do not call it from a loop over every candidate that checks
+    /// <see cref="IsFocused"/> per iteration — a candidate this call just focused can still be
+    /// visited later in that same loop, re-triggering navigation against the same held input and
+    /// chaining multiple hops into a single press.
+    ///
+    /// Also do not add the same gamepad to <see cref="GamePadsForUiControl"/> (what
+    /// <c>GumService.UseGamepadDefaults()</c> does) for a control that also drives this method:
+    /// every stock control's own <c>OnFocusUpdate</c> (e.g. <c>ButtonBase</c>) already reads that
+    /// list and runs the existing index-based <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>
+    /// off it. If both are wired to the same gamepad, one Down press moves focus via tab order
+    /// first, then this method fires again from the new position using the same still-held press —
+    /// two navigation systems compounding into one input. Read the gamepad directly (e.g. from
+    /// <c>GumService.Default.Gamepads</c>) instead, without registering it in
+    /// <see cref="GamePadsForUiControl"/>, for a control that should use spatial nav exclusively.
+    /// </remarks>
     /// <param name="gamepad">The gamepad to read directional input from.</param>
     /// <param name="navigationRoot">The visual subtree to search for focusable candidates.</param>
     protected void HandleGamepadSpatialNavigation(IGamePad gamepad, GraphicalUiElement navigationRoot)
@@ -1553,35 +1571,27 @@ public class FrameworkElement : INotifyPropertyChanged
         }
     }
 
+    // Direction comes from which buttons are currently held (ButtonDown), so a diagonal is just
+    // "both held right now" — it doesn't require two buttons to be pushed on the exact same frame.
+    // Firing (returning non-null) is still gated on ButtonRepeatRate, so a held direction only
+    // triggers on its own push/repeat pulses rather than every single frame.
     private static float? TryGetRequestedDirectionAngle(IGamePad gamepad)
     {
-        float x = 0f;
-        float y = 0f;
-        bool anyDigital = false;
+        bool right = gamepad.ButtonDown(GamepadButton.DPadRight);
+        bool left = gamepad.ButtonDown(GamepadButton.DPadLeft);
+        bool down = gamepad.ButtonDown(GamepadButton.DPadDown);
+        bool up = gamepad.ButtonDown(GamepadButton.DPadUp);
 
-        if (gamepad.ButtonRepeatRate(GamepadButton.DPadRight))
-        {
-            x += 1f;
-            anyDigital = true;
-        }
-        if (gamepad.ButtonRepeatRate(GamepadButton.DPadLeft))
-        {
-            x -= 1f;
-            anyDigital = true;
-        }
-        if (gamepad.ButtonRepeatRate(GamepadButton.DPadDown))
-        {
-            y += 1f;
-            anyDigital = true;
-        }
-        if (gamepad.ButtonRepeatRate(GamepadButton.DPadUp))
-        {
-            y -= 1f;
-            anyDigital = true;
-        }
+        bool shouldFireDigital =
+            (right && gamepad.ButtonRepeatRate(GamepadButton.DPadRight)) ||
+            (left && gamepad.ButtonRepeatRate(GamepadButton.DPadLeft)) ||
+            (down && gamepad.ButtonRepeatRate(GamepadButton.DPadDown)) ||
+            (up && gamepad.ButtonRepeatRate(GamepadButton.DPadUp));
 
-        if (anyDigital)
+        if (shouldFireDigital)
         {
+            float x = (right ? 1f : 0f) - (left ? 1f : 0f);
+            float y = (down ? 1f : 0f) - (up ? 1f : 0f);
             return MathF.Atan2(y, x);
         }
 

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -75,6 +75,19 @@ public enum SizeMode
     Auto
 }
 
+#if !FRB
+/// <summary>
+/// How gamepad D-pad/stick input navigates focus among a <see cref="FrameworkElement"/>'s
+/// focusable descendants. See <see cref="FrameworkElement.GamepadNavigationMode"/>.
+/// </summary>
+public enum GamepadNavigationMode
+{
+    /// <summary>Index-based navigation (<see cref="FrameworkElement.HandleTab"/>) — the default.</summary>
+    TabOrder,
+    /// <summary>On-screen-position-based navigation (<see cref="Gum.Forms.SpatialNavigationService"/>).</summary>
+    Spatial
+}
+#endif
 
 #endregion
 
@@ -1161,8 +1174,66 @@ public class FrameworkElement : INotifyPropertyChanged
     /// </summary>
     public bool IsUsingLeftAndRightGamepadDirectionsForNavigation { get; set; } = true;
 
+#if !FRB
+    /// <summary>
+    /// Explicitly sets (or clears, if null) how gamepad D-pad/stick input navigates focus among
+    /// this element's focusable descendants — <see cref="Controls.GamepadNavigationMode.TabOrder"/>
+    /// (index-based, the default) or <see cref="Controls.GamepadNavigationMode.Spatial"/>
+    /// (nearest-in-direction by on-screen position, see <see cref="Gum.Forms.SpatialNavigationService"/>).
+    /// An unset element inherits the nearest ancestor's value (an explicit
+    /// <see cref="Controls.GamepadNavigationMode.TabOrder"/> on a nested element opts back out of an
+    /// outer <see cref="Controls.GamepadNavigationMode.Spatial"/> zone); the root default is TabOrder.
+    /// Does not affect keyboard Tab, which is always index-based.
+    /// </summary>
+    public GamepadNavigationMode? GamepadNavigationMode { get; set; }
+
+    /// <summary>
+    /// Explicit per-direction focus overrides (Unity/UWP-style escape hatch): if set, a clean
+    /// single-direction D-pad press in that direction moves focus straight to the assigned element,
+    /// skipping <see cref="Gum.Forms.SpatialNavigationService"/> scoring entirely. Not consulted for
+    /// diagonal presses or analog stick input, which have no single well-defined cardinal to key off.
+    /// Only meaningful while resolved <see cref="GamepadNavigationMode"/> is
+    /// <see cref="Controls.GamepadNavigationMode.Spatial"/>.
+    /// </summary>
+    public FrameworkElement? SpatialNavigationUp { get; set; }
+
+    /// <inheritdoc cref="SpatialNavigationUp"/>
+    public FrameworkElement? SpatialNavigationDown { get; set; }
+
+    /// <inheritdoc cref="SpatialNavigationUp"/>
+    public FrameworkElement? SpatialNavigationLeft { get; set; }
+
+    /// <inheritdoc cref="SpatialNavigationUp"/>
+    public FrameworkElement? SpatialNavigationRight { get; set; }
+
+    private (GamepadNavigationMode Mode, GraphicalUiElement? SpatialRoot) ResolveGamepadNavigationMode()
+    {
+        for (FrameworkElement? current = this; current != null; current = current.ParentFrameworkElement)
+        {
+            if (current.GamepadNavigationMode == Controls.GamepadNavigationMode.Spatial)
+            {
+                return (Controls.GamepadNavigationMode.Spatial, current.Visual);
+            }
+            if (current.GamepadNavigationMode == Controls.GamepadNavigationMode.TabOrder)
+            {
+                // Explicit opt-out wins even when nested under an outer Spatial-marked ancestor.
+                return (Controls.GamepadNavigationMode.TabOrder, null);
+            }
+        }
+        return (Controls.GamepadNavigationMode.TabOrder, null);
+    }
+#endif
+
     protected void HandleGamepadNavigation(GamePadForNavigation gamepad)
     {
+#if !FRB
+        (GamepadNavigationMode mode, GraphicalUiElement? spatialRoot) = ResolveGamepadNavigationMode();
+        if (mode == Controls.GamepadNavigationMode.Spatial && spatialRoot != null)
+        {
+            HandleGamepadSpatialNavigation(gamepad, spatialRoot);
+            return;
+        }
+#endif
         if (gamepad.ButtonRepeatRate(GamepadButton.DPadDown) ||
             (IsUsingLeftAndRightGamepadDirectionsForNavigation && gamepad.ButtonRepeatRate(GamepadButton.DPadRight)) ||
             gamepad.LeftStick.AsDPadPushedRepeatRate(DPadDirection.Down) ||
@@ -1523,37 +1594,36 @@ public class FrameworkElement : INotifyPropertyChanged
 
 #if !FRB
     /// <summary>
-    /// Direction-agnostic ("spatial") focus navigation spike (issue #4129): reads the requested
-    /// direction from the gamepad's DPad — including diagonals, from two currently-held buttons —
-    /// or left analog stick, then moves focus to whichever focusable candidate under
+    /// Direction-agnostic ("spatial") focus navigation (issue #4129): reads the requested direction
+    /// from the gamepad's DPad — including diagonals, from two currently-held buttons — or left
+    /// analog stick, then moves focus to whichever focusable candidate under
     /// <paramref name="navigationRoot"/> best matches that direction by on-screen position (see
-    /// <see cref="Gum.Forms.SpatialNavigationService"/>), rather than by tab order. This is a
-    /// parallel, opt-in path — it does not call and is not called by
-    /// <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>; a control/screen chooses one or
-    /// the other.
+    /// <see cref="Gum.Forms.SpatialNavigationService"/>), rather than by tab order. An explicit
+    /// per-direction override (<see cref="SpatialNavigationUp"/> etc.) on this element takes
+    /// precedence over scoring for a clean single-direction D-pad press.
     /// </summary>
     /// <remarks>
-    /// Call this at most once per frame, for whichever single element currently has focus (e.g.
-    /// from that element's own per-frame update, mirroring where <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>
-    /// is normally called from). Do not call it from a loop over every candidate that checks
-    /// <see cref="IsFocused"/> per iteration — a candidate this call just focused can still be
+    /// Prefer setting <see cref="GamepadNavigationMode"/> on a container instead of calling this
+    /// directly — every stock control already calls <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>
+    /// from its own per-frame update, which resolves the mode automatically and dispatches here.
+    /// If calling this directly, call it at most once per frame, for whichever single element
+    /// currently has focus — do not call it from a loop over every candidate that checks
+    /// <see cref="IsFocused"/> per iteration, since a candidate this call just focused can still be
     /// visited later in that same loop, re-triggering navigation against the same held input and
     /// chaining multiple hops into a single press.
-    ///
-    /// Also do not add the same gamepad to <see cref="GamePadsForUiControl"/> (what
-    /// <c>GumService.UseGamepadDefaults()</c> does) for a control that also drives this method:
-    /// every stock control's own <c>OnFocusUpdate</c> (e.g. <c>ButtonBase</c>) already reads that
-    /// list and runs the existing index-based <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>
-    /// off it. If both are wired to the same gamepad, one Down press moves focus via tab order
-    /// first, then this method fires again from the new position using the same still-held press —
-    /// two navigation systems compounding into one input. Read the gamepad directly (e.g. from
-    /// <c>GumService.Default.Gamepads</c>) instead, without registering it in
-    /// <see cref="GamePadsForUiControl"/>, for a control that should use spatial nav exclusively.
     /// </remarks>
     /// <param name="gamepad">The gamepad to read directional input from.</param>
     /// <param name="navigationRoot">The visual subtree to search for focusable candidates.</param>
     protected void HandleGamepadSpatialNavigation(IGamePad gamepad, GraphicalUiElement navigationRoot)
     {
+        FrameworkElement? explicitOverride = TryGetExplicitDirectionOverride(gamepad);
+        if (explicitOverride != null)
+        {
+            explicitOverride.IsFocused = true;
+            this.IsFocused = false;
+            return;
+        }
+
         float? angle = TryGetRequestedDirectionAngle(gamepad);
         if (angle == null)
         {
@@ -1571,27 +1641,86 @@ public class FrameworkElement : INotifyPropertyChanged
         }
     }
 
+    private readonly struct DigitalDirectionState
+    {
+        public bool Right { get; }
+        public bool Left { get; }
+        public bool Down { get; }
+        public bool Up { get; }
+        public bool ShouldFire { get; }
+
+        public DigitalDirectionState(bool right, bool left, bool down, bool up, bool shouldFire)
+        {
+            Right = right;
+            Left = left;
+            Down = down;
+            Up = up;
+            ShouldFire = shouldFire;
+        }
+    }
+
     // Direction comes from which buttons are currently held (ButtonDown), so a diagonal is just
     // "both held right now" — it doesn't require two buttons to be pushed on the exact same frame.
-    // Firing (returning non-null) is still gated on ButtonRepeatRate, so a held direction only
-    // triggers on its own push/repeat pulses rather than every single frame.
-    private static float? TryGetRequestedDirectionAngle(IGamePad gamepad)
+    // Firing is still gated on ButtonRepeatRate, so a held direction only triggers on its own
+    // push/repeat pulses rather than every single frame.
+    private static DigitalDirectionState GetDigitalDirectionState(IGamePad gamepad)
     {
         bool right = gamepad.ButtonDown(GamepadButton.DPadRight);
         bool left = gamepad.ButtonDown(GamepadButton.DPadLeft);
         bool down = gamepad.ButtonDown(GamepadButton.DPadDown);
         bool up = gamepad.ButtonDown(GamepadButton.DPadUp);
 
-        bool shouldFireDigital =
+        bool shouldFire =
             (right && gamepad.ButtonRepeatRate(GamepadButton.DPadRight)) ||
             (left && gamepad.ButtonRepeatRate(GamepadButton.DPadLeft)) ||
             (down && gamepad.ButtonRepeatRate(GamepadButton.DPadDown)) ||
             (up && gamepad.ButtonRepeatRate(GamepadButton.DPadUp));
 
-        if (shouldFireDigital)
+        return new DigitalDirectionState(right, left, down, up, shouldFire);
+    }
+
+    // Only a clean single held direction has one well-defined cardinal to key an override off of —
+    // a diagonal (two held) or stick-driven request falls through to SpatialNavigationService instead.
+    private FrameworkElement? TryGetExplicitDirectionOverride(IGamePad gamepad)
+    {
+        DigitalDirectionState state = GetDigitalDirectionState(gamepad);
+        if (!state.ShouldFire)
         {
-            float x = (right ? 1f : 0f) - (left ? 1f : 0f);
-            float y = (down ? 1f : 0f) - (up ? 1f : 0f);
+            return null;
+        }
+
+        int heldCount = (state.Right ? 1 : 0) + (state.Left ? 1 : 0) + (state.Down ? 1 : 0) + (state.Up ? 1 : 0);
+        if (heldCount != 1)
+        {
+            return null;
+        }
+
+        if (state.Right)
+        {
+            return SpatialNavigationRight;
+        }
+        if (state.Left)
+        {
+            return SpatialNavigationLeft;
+        }
+        if (state.Down)
+        {
+            return SpatialNavigationDown;
+        }
+        if (state.Up)
+        {
+            return SpatialNavigationUp;
+        }
+        return null;
+    }
+
+    private static float? TryGetRequestedDirectionAngle(IGamePad gamepad)
+    {
+        DigitalDirectionState state = GetDigitalDirectionState(gamepad);
+        if (state.ShouldFire)
+        {
+            float x = (state.Right ? 1f : 0f) - (state.Left ? 1f : 0f);
+            float y = (state.Down ? 1f : 0f) - (state.Up ? 1f : 0f);
             return MathF.Atan2(y, x);
         }
 

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1663,10 +1663,14 @@ public class FrameworkElement : INotifyPropertyChanged
     // "both held right now" — it doesn't require two buttons to be pushed on the exact same frame.
     // Firing is still gated on ButtonRepeatRate, so a held direction only triggers on its own
     // push/repeat pulses rather than every single frame.
-    private static DigitalDirectionState GetDigitalDirectionState(IGamePad gamepad)
+    // Right/Left are gated on IsUsingLeftAndRightGamepadDirectionsForNavigation, matching the
+    // existing index-based path (HandleGamepadNavigation above) — a control that disables it
+    // (e.g. Slider, which uses Left/Right for its own value adjustment) must keep that exclusion
+    // under spatial navigation too, or the same press would both navigate and act on the control.
+    private DigitalDirectionState GetDigitalDirectionState(IGamePad gamepad)
     {
-        bool right = gamepad.ButtonDown(GamepadButton.DPadRight);
-        bool left = gamepad.ButtonDown(GamepadButton.DPadLeft);
+        bool right = IsUsingLeftAndRightGamepadDirectionsForNavigation && gamepad.ButtonDown(GamepadButton.DPadRight);
+        bool left = IsUsingLeftAndRightGamepadDirectionsForNavigation && gamepad.ButtonDown(GamepadButton.DPadLeft);
         bool down = gamepad.ButtonDown(GamepadButton.DPadDown);
         bool up = gamepad.ButtonDown(GamepadButton.DPadUp);
 
@@ -1714,7 +1718,7 @@ public class FrameworkElement : INotifyPropertyChanged
         return null;
     }
 
-    private static float? TryGetRequestedDirectionAngle(IGamePad gamepad)
+    private float? TryGetRequestedDirectionAngle(IGamePad gamepad)
     {
         DigitalDirectionState state = GetDigitalDirectionState(gamepad);
         if (state.ShouldFire)

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1512,7 +1512,7 @@ public class FrameworkElement : INotifyPropertyChanged
         return didChildHandle;
     }
 
-    static bool CanElementBeFocused(FrameworkElement? element)
+    internal static bool CanElementBeFocused(FrameworkElement? element)
     {
         return element is IInputReceiver &&
                     ((IVisible)element.Visual).AbsoluteVisible == true &&
@@ -1520,6 +1520,80 @@ public class FrameworkElement : INotifyPropertyChanged
                     element.Visual.HasEvents &&
                     element.GamepadTabbingFocusBehavior == TabbingFocusBehavior.FocusableIfInputReceiver;
     }
+
+#if !FRB
+    /// <summary>
+    /// Direction-agnostic ("spatial") focus navigation spike (issue #4129): reads the requested
+    /// direction from the gamepad's DPad — including diagonals, from two simultaneously-held
+    /// buttons — or left analog stick, then moves focus to whichever focusable candidate under
+    /// <paramref name="navigationRoot"/> best matches that direction by on-screen position (see
+    /// <see cref="Gum.Forms.SpatialNavigationService"/>), rather than by tab order. This is a
+    /// parallel, opt-in path — it does not call and is not called by
+    /// <see cref="HandleGamepadNavigation(GamePadForNavigation)"/>; a control/screen chooses one or
+    /// the other.
+    /// </summary>
+    /// <param name="gamepad">The gamepad to read directional input from.</param>
+    /// <param name="navigationRoot">The visual subtree to search for focusable candidates.</param>
+    protected void HandleGamepadSpatialNavigation(IGamePad gamepad, GraphicalUiElement navigationRoot)
+    {
+        float? angle = TryGetRequestedDirectionAngle(gamepad);
+        if (angle == null)
+        {
+            return;
+        }
+
+        var candidates = Gum.Forms.FrameworkElementTreeExtensions.ProjectToFrameworkElements(navigationRoot.Descendants())
+            .Where(CanElementBeFocused);
+
+        FrameworkElement? best = Gum.Forms.SpatialNavigationService.FindBestCandidate(this, angle.Value, candidates);
+        if (best != null)
+        {
+            best.IsFocused = true;
+            this.IsFocused = false;
+        }
+    }
+
+    private static float? TryGetRequestedDirectionAngle(IGamePad gamepad)
+    {
+        float x = 0f;
+        float y = 0f;
+        bool anyDigital = false;
+
+        if (gamepad.ButtonRepeatRate(GamepadButton.DPadRight))
+        {
+            x += 1f;
+            anyDigital = true;
+        }
+        if (gamepad.ButtonRepeatRate(GamepadButton.DPadLeft))
+        {
+            x -= 1f;
+            anyDigital = true;
+        }
+        if (gamepad.ButtonRepeatRate(GamepadButton.DPadDown))
+        {
+            y += 1f;
+            anyDigital = true;
+        }
+        if (gamepad.ButtonRepeatRate(GamepadButton.DPadUp))
+        {
+            y -= 1f;
+            anyDigital = true;
+        }
+
+        if (anyDigital)
+        {
+            return MathF.Atan2(y, x);
+        }
+
+        if (gamepad.LeftStick.RadialPushedRepeatRate())
+        {
+            // AnalogStick.Y is math-convention (+1 = up); screen space is Y-down, so flip the sign.
+            return MathF.Atan2(-gamepad.LeftStick.Y, gamepad.LeftStick.X);
+        }
+
+        return null;
+    }
+#endif
 
 #if !FRB
     /// <summary>

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -1,0 +1,104 @@
+using Gum.Forms.Controls;
+using System;
+using System.Collections.Generic;
+
+namespace Gum.Forms;
+
+/// <summary>
+/// Scores focusable <see cref="FrameworkElement"/> candidates by on-screen distance and angular
+/// alignment to a requested direction, and picks the best match — the geometric core of
+/// direction-agnostic ("spatial") focus navigation (issue #4129). Stateless and read-only: it only
+/// reads already-resolved absolute (screen-space) bounds off the visual tree and does not mutate
+/// focus itself; callers (see <see cref="FrameworkElement"/>'s gamepad navigation methods) apply
+/// the result.
+/// </summary>
+public static class SpatialNavigationService
+{
+    /// <summary>
+    /// Returns whichever <paramref name="candidates"/> element best matches
+    /// <paramref name="directionAngleRadians"/> from <paramref name="origin"/>'s center, or null if
+    /// none qualify. Candidates outside the direction cone (<paramref name="maxAngleRadians"/> either
+    /// side of the requested angle) are excluded so navigation never moves backwards; among the rest,
+    /// the lowest <c>distance * (1 + angleWeight * angleDiff / maxAngleRadians)</c> score wins.
+    /// </summary>
+    /// <param name="origin">The currently-focused element navigation is relative to.</param>
+    /// <param name="directionAngleRadians">
+    /// The requested direction in screen space: 0 = right, increasing clockwise (Y grows downward).
+    /// </param>
+    /// <param name="candidates">
+    /// The focusable elements to consider. <paramref name="origin"/> is skipped if present.
+    /// </param>
+    /// <param name="maxAngleRadians">Half-width of the direction cone; candidates outside are excluded.</param>
+    /// <param name="angleWeight">How strongly angular misalignment penalizes an otherwise-close candidate.</param>
+    public static FrameworkElement? FindBestCandidate(
+        FrameworkElement origin,
+        float directionAngleRadians,
+        IEnumerable<FrameworkElement> candidates,
+        float maxAngleRadians = MathF.PI / 2f,
+        float angleWeight = 2f)
+    {
+        (float originX, float originY) = GetCenter(origin);
+
+        FrameworkElement? best = null;
+        float bestScore = float.MaxValue;
+
+        foreach (FrameworkElement candidate in candidates)
+        {
+            if (candidate == origin)
+            {
+                continue;
+            }
+
+            (float candidateX, float candidateY) = GetCenter(candidate);
+            float dx = candidateX - originX;
+            float dy = candidateY - originY;
+            float distance = MathF.Sqrt(dx * dx + dy * dy);
+
+            if (distance == 0f)
+            {
+                continue;
+            }
+
+            float candidateAngle = MathF.Atan2(dy, dx);
+            float angleDiff = MathF.Abs(NormalizeAngle(candidateAngle - directionAngleRadians));
+
+            if (angleDiff > maxAngleRadians)
+            {
+                continue;
+            }
+
+            float score = distance * (1f + angleWeight * (angleDiff / maxAngleRadians));
+
+            if (score < bestScore)
+            {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    private static (float x, float y) GetCenter(FrameworkElement element)
+    {
+        float x = (element.Visual.AbsoluteLeft + element.Visual.AbsoluteRight) / 2f;
+        float y = (element.Visual.AbsoluteTop + element.Visual.AbsoluteBottom) / 2f;
+        return (x, y);
+    }
+
+    // Wraps to (-π, π] so the angular difference between two directions is always the shorter way around.
+    private static float NormalizeAngle(float angleRadians)
+    {
+        float twoPi = MathF.PI * 2f;
+        float normalized = angleRadians % twoPi;
+        if (normalized > MathF.PI)
+        {
+            normalized -= twoPi;
+        }
+        else if (normalized < -MathF.PI)
+        {
+            normalized += twoPi;
+        }
+        return normalized;
+    }
+}

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -26,7 +26,11 @@ public static class SpatialNavigationService
     /// The requested direction in screen space: 0 = right, increasing clockwise (Y grows downward).
     /// </param>
     /// <param name="candidates">
-    /// The focusable elements to consider. <paramref name="origin"/> is skipped if present.
+    /// The focusable elements to consider. <paramref name="origin"/>, and any ancestor of
+    /// <paramref name="origin"/> (e.g. a large focusable container the origin sits near the edge
+    /// of), are skipped if present — an ancestor's own center can otherwise score better than a
+    /// true sibling simply by virtue of containing the origin, sending focus "backwards" into a
+    /// container the origin is already inside instead of to something actually in that direction.
     /// </param>
     /// <param name="maxAngleRadians">Half-width of the direction cone; candidates outside are excluded.</param>
     /// <param name="angleWeight">How strongly angular misalignment penalizes an otherwise-close candidate.</param>
@@ -44,7 +48,7 @@ public static class SpatialNavigationService
 
         foreach (FrameworkElement candidate in candidates)
         {
-            if (candidate == origin)
+            if (candidate == origin || origin.Visual.IsInParentChain(candidate.Visual))
             {
                 continue;
             }

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -198,6 +198,7 @@
 		<Compile Remove="..\Forms\Controls\UserControl.cs" />
 		<Compile Remove="..\Forms\FrameworkElementTemplate.cs" />
 		<Compile Remove="..\Forms\FrameworkElementTreeExtensions.cs" />
+		<Compile Remove="..\Forms\SpatialNavigationService.cs" />
 		<Compile Remove="..\Forms\Controls\Tooltip.cs" />
 		<Compile Remove="..\Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="..\Forms\GraphicalUiElementFormsExtensions.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -177,6 +177,7 @@
 		<Compile Remove="Threading\DeferredActionQueue.cs" />
 		<Compile Remove="Forms\FrameworkElementTemplate.cs" />
 		<Compile Remove="Forms\FrameworkElementTreeExtensions.cs" />
+		<Compile Remove="Forms\SpatialNavigationService.cs" />
 		<Compile Remove="Forms\Controls\Tooltip.cs" />
 		<Compile Remove="Forms\Controls\ToolTipService.cs" />
 		<Compile Remove="Forms\GraphicalUiElementFormsExtensions.cs" />

--- a/docs/code/events-and-interactivity/tabbing-moving-focus.md
+++ b/docs/code/events-and-interactivity/tabbing-moving-focus.md
@@ -114,6 +114,45 @@ button.IsUsingLeftAndRightGamepadDirectionsForNavigation = false;
 
 `IsUsingLeftAndRightGamepadDirectionsForNavigation` is set to true on all controls except on `Sliders`, which use left/right input for changing the `Slider`'s `Value`.
 
+## Spatial (Any-Angle) Gamepad Navigation
+
+For scattered layouts where controls aren't arranged in a single row, column, or stack, such as a skill tree, radial menu, or free-form HUD, tab order navigation doesn't produce a natural or predictable path between controls. Spatial navigation instead moves focus to whichever focusable control is nearest in the direction the player presses, based on each control's on-screen position.
+
+This section assumes you have already followed the gamepad setup above (adding a gamepad to `GamePadsForUiControl` and giving a control initial focus).
+
+To opt a group of controls into spatial navigation, set `GamepadNavigationMode` on a container that wraps them:
+
+```csharp
+// Initialize
+Panel skillTreePanel = new();
+skillTreePanel.AddToRoot();
+skillTreePanel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+```
+
+Every focusable descendant of `skillTreePanel`, including controls nested inside further sub-containers, automatically uses spatial navigation for DPad and left stick input. No changes are needed on the controls themselves. `GamepadNavigationMode` is inherited: a control with the property unset walks up to the nearest ancestor that has it set, so you only need to set it once on the container that groups the scattered controls.
+
+Setting `GamepadNavigationMode` to `TabOrder` on a nested container opts that container back out of an outer `Spatial` zone. For example, a linear list of items inside an otherwise scattered screen can keep tab order navigation for its own items:
+
+```csharp
+// Initialize
+StackPanel linearList = new();
+skillTreePanel.AddChild(linearList);
+linearList.GamepadNavigationMode = GamepadNavigationMode.TabOrder;
+```
+
+Keyboard Tab navigation always uses tab order, regardless of `GamepadNavigationMode`. Spatial navigation only affects gamepad DPad and left stick input.
+
+### Explicit Direction Overrides
+
+Spatial navigation scores candidates by distance and angle, which can occasionally pick a control other than the one you expect for an unusual layout. To force a specific direction to a specific control, set `SpatialNavigationUp`, `SpatialNavigationDown`, `SpatialNavigationLeft`, or `SpatialNavigationRight` on the control:
+
+```csharp
+// Initialize
+myButton.SpatialNavigationRight = otherButton;
+```
+
+An explicit override only applies to a single-direction DPad press. It is not consulted for a diagonal press or for left stick input, since neither has one well-defined cardinal direction to match against.
+
 ## Modal Tab Trapping
 
 When you show an element modally by adding it to `GumService.Default.ModalRoot`, tab focus is confined to the controls inside that modal element. Tabbing forward past the last focusable control wraps back to the first, and Shift+Tabbing before the first control wraps to the last. Focus never escapes to the controls behind the modal under the regular `Root`.


### PR DESCRIPTION
Closes #4129

Real, integrated spatial (any-angle) focus navigation for gamepad/stick input on scattered UI layouts, per the follow-up discussion after the initial spike validated the approach.

**`FrameworkElement.GamepadNavigationMode`** (`TabOrder`/`Spatial`, inherited via the existing `ParentFrameworkElement` walk, nearest-ancestor-wins with explicit `TabOrder` opt-out) — set once on a container, every stock control (Button, ComboBox, ListBox, ScrollViewer, Slider, TextBox) gets spatial nav automatically through the same `HandleGamepadNavigation` call it already makes. No subclassing or manual gamepad wiring needed.

**`SpatialNavigationService`** — distance + angular-alignment scoring (Unity-style, not WICG's vertex decomposition) over on-screen candidate positions. Excludes the origin and any ancestor of the origin (a large focusable container wrapping the origin near an edge would otherwise win by proximity).

**Explicit per-direction override escape hatch** — `SpatialNavigationUp/Down/Left/Right`, checked before scoring for a clean single-direction D-pad press.

Keyboard Tab and FRB are both untouched.

Bugs found and fixed while testing against every control that calls `HandleGamepadNavigation`:
- Diagonal D-pad detection required both directions pushed on the exact same frame.
- Spatial mode ignored `IsUsingLeftAndRightGamepadDirectionsForNavigation` (Slider disables it so Left/Right can adjust `Value` instead of navigating).
- Ancestor-container-wins-by-proximity (found via `ScrollViewer.DoItemsHaveFocus`, which hands real focus to the child, unlike `ListBox.DoListItemsHaveFocus`'s virtual flag).

## Test plan
- Full `MonoGameGum.Tests` suite green (1997), FRB canary clean (checked after each `FrameworkElement.cs` change).
- Unit tests for: stock Button+Panel integration, no-mode regression guard, nested TabOrder opt-out, explicit override precedence/non-application on diagonal, Slider's Left/Right dual-purpose input, ListBox/ScrollViewer internal-item-focus isolation, ancestor-exclusion in scoring.
- Docs added to `tabbing-moving-focus.md`.
- Manual: scattered 12-button demo with a real gamepad, still in progress.