### PR TITLE
Add TextRuntime.LocalizeText: per-instance opt-out from translation

### DIFF
--- a/.claude/skills/gum-property-assignment/SKILL.md
+++ b/.claude/skills/gum-property-assignment/SKILL.md
@@ -70,6 +70,18 @@ branches, and which one a property takes isn't obvious from this pipeline alone 
 
 ---
 
+## Combining Variables
+
+Several independent variables can combine into one derived value — X/XUnits into position,
+Font+FontSize+IsBold+... into a loaded `BitmapFont` (below), or a boolean opt-out flag alongside
+a text/state value into the final displayed string. `SetProperty` never peeks across variables to
+sequence or dedupe this: each contributing setter independently recomputes the full derived value
+from whatever is currently live on the object, so any application order converges to the same
+result, at the cost of tolerated redundant recomputation (e.g. re-deriving a font twice if both
+`Font` and `FontSize` land in the same batch).
+
+---
+
 ## Font Deferred-Loading System
 
 Loading a `.fnt` file is expensive. A text element has ~6 font-related properties (Font,

--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -169,17 +169,8 @@ public class StandardElementsManager
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "Hello", Name = "Text", Category = "Text" });
 
-            // Okay so here's some info on this value.
-            // It would be nice to be able to select whether 
-            // a Text should or should not be localized in Gum.
-            // The problem is that when we do the localization, we
-            // only have access to the GraphicalUiElement, not the InstanceSave.
-            // Sure, we could get the reference, but what about at runtime in a game?
-            // We ultimately want this value to be saved in the GraphicalUiElement so it
-            // can be applied at runtime too. This is a pain to do, since it would require
-            // changes to SkiaGum and possibly to FRB plugins. It's a bigger project, so until
-            // then, we'll leave this out and put it back in when it's time.
-            //stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "Apply Localization", Category = "Text" });
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "LocalizeText", Category = "Text" });
+
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "HorizontalAlignment", Value = HorizontalAlignment.Left, Name = "HorizontalAlignment", Category = "Text" });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "VerticalAlignment", Value = VerticalAlignment.Top, Name = "VerticalAlignment", Category = "Text" });
 

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -900,7 +900,16 @@ public partial class CustomSetPropertyOnRenderable
         {
             textRenderable.StoredMarkupText = null;
             var rawText = valueAsString;
-            if(LocalizationService != null && propertyName == "Text")
+#if !FRB
+            // TextRuntime doesn't exist under FRB (see Guard symmetry in coder.md), so a bare
+            // GraphicalUiElement(Text) - not possible outside FRB per TrySetPropertyOnText above -
+            // is treated as translatable, matching pre-LocalizeText behavior.
+            var shouldTranslate = graphicalUiElement is not Gum.GueDeriving.TextRuntime textRuntimeForLocalization
+                || textRuntimeForLocalization.LocalizeText;
+#else
+            var shouldTranslate = true;
+#endif
+            if(LocalizationService != null && propertyName == "Text" && shouldTranslate)
             {
                 rawText = LocalizationService.Translate(rawText);
             }
@@ -957,9 +966,12 @@ public partial class CustomSetPropertyOnRenderable
 #else
             // Runtime-type-first: delegate to TextRuntime.Text/SetTextNoTranslate, which own the
             // logic via the shared SetText helper. Matches the shape dispatcher's pattern (#3706).
-            // Unlike Font/FontScale/etc. below, a bare GraphicalUiElement(Text) with no TextRuntime
-            // is a real, supported combination (e.g. the tool's WireframeObjectManager), so fall
-            // back to calling SetText directly rather than silently no-op'ing.
+            // Every current runtime (MonoGame, Raylib, Skia, Sokol) registers "Text" as a
+            // TextRuntime via RegisterGueInstantiation, so textRuntime is non-null everywhere
+            // except FRB (handled separately above via #if FRB). New Text functionality can
+            // assume TextRuntime exists and skip FRB - FRB gets no new functionality unless
+            // skipping it would break FRB outright. The else below is just a defensive fallback
+            // for a registration gap, not a normal path.
             if (textRuntime != null)
             {
                 if (propertyName == "Text")
@@ -974,6 +986,18 @@ public partial class CustomSetPropertyOnRenderable
             else
             {
                 SetText(textRenderable, graphicalUiElement, propertyName, value);
+            }
+#endif
+            handled = true;
+        }
+        else if (propertyName == "LocalizeText")
+        {
+#if !FRB
+            // No TextRuntime under FRB (see Guard symmetry in coder.md) - FRB gets no new
+            // functionality here, so this is a no-op there rather than a compile error.
+            if (textRuntime != null)
+            {
+                textRuntime.LocalizeText = (bool)value;
             }
 #endif
             handled = true;

--- a/MonoGameGum.Tests/Localization/LocalizeTextTests.cs
+++ b/MonoGameGum.Tests/Localization/LocalizeTextTests.cs
@@ -1,0 +1,103 @@
+using Gum.Localization;
+using Gum.Wireframe;
+using Gum.GueDeriving;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MonoGameGum.Tests.Localization;
+
+/// <summary>
+/// Tests <see cref="TextRuntime.LocalizeText"/>, the per-instance opt-out from translation -
+/// distinct from <see cref="TextRuntime.SetTextNoTranslate"/>, which bypasses translation for a
+/// single assignment rather than persisting on the instance.
+/// </summary>
+public class LocalizeTextTests : BaseTestClass
+{
+    private LocalizationService _localizationService = null!;
+
+    public LocalizeTextTests() : base()
+    {
+        _localizationService = new LocalizationService();
+        Dictionary<string, string[]> entries = new()
+        {
+            { "Greeting", new[] { "Hello", "Hola" } },
+        };
+        List<string> headers = new() { "English", "Spanish" };
+        _localizationService.AddDatabase(entries, headers);
+        _localizationService.CurrentLanguage = 0;
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+    }
+
+    [Fact]
+    public void LocalizeText_ShouldDefaultToTrue()
+    {
+        TextRuntime text = new();
+
+        text.LocalizeText.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SettingLocalizeTextToFalse_ShouldUntranslateAlreadyAssignedText()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.Text = "Greeting";
+        text.Text.ShouldBe("Hello");
+
+        text.LocalizeText = false;
+
+        text.Text.ShouldBe("Greeting");
+    }
+
+    [Fact]
+    public void SettingLocalizeTextToTrue_ShouldRetranslateText_AfterHavingBeenFalse()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.LocalizeText = false;
+        text.Text = "Greeting";
+        text.Text.ShouldBe("Greeting");
+
+        text.LocalizeText = true;
+
+        text.Text.ShouldBe("Hello");
+    }
+
+    [Fact]
+    public void Text_ShouldNotBeTranslated_WhenLocalizeTextIsFalse()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.LocalizeText = false;
+
+        text.Text = "Greeting";
+
+        text.Text.ShouldBe("Greeting");
+    }
+
+    [Fact]
+    public void SetPropertyLocalizeText_ShouldSetLocalizeTextProperty()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+
+        text.SetProperty("LocalizeText", false);
+
+        text.LocalizeText.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RefreshLocalization_ShouldNotTranslate_WhenLocalizeTextIsFalse()
+    {
+        TextRuntime text = new();
+        text.AddToRoot();
+        text.LocalizeText = false;
+        text.Text = "Greeting";
+
+        _localizationService.CurrentLanguage = 1;
+        GumService.Default.RefreshLocalization();
+
+        text.Text.ShouldBe("Greeting");
+    }
+}

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -10,6 +10,7 @@ using CustomSetPropertyOnRenderableType = RaylibGum.Renderables.CustomSetPropert
 using SkiaGum;
 using SkiaGum.Helpers;
 using SkiaSharp;
+using CustomSetPropertyOnRenderableType = SkiaGum.CustomSetPropertyOnRenderable;
 #else
 using Gum.Graphics;
 using Gum.RenderingLibrary;
@@ -808,6 +809,35 @@ public class TextRuntime : InteractiveGue
         CustomSetPropertyOnRenderableType.SetText(ContainedText, this, "TextNoTranslate", value);
         NotifyPropertyChanged(nameof(Text));
 #endif
+    }
+
+    bool _localizeText = true;
+
+    /// <summary>
+    /// Whether this instance's <see cref="Text"/> is translated through the active
+    /// <see cref="Gum.Localization.LocalizationService"/>. Defaults to true.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="SetTextNoTranslate"/>, which bypasses translation for a single assignment,
+    /// this is a persistent, per-instance setting - useful for elements whose text is never
+    /// translatable (e.g. numeric readouts). Toggling it re-derives the currently assigned text
+    /// under the new setting; it does not affect text assigned via <see cref="SetTextNoTranslate"/>.
+    /// </remarks>
+    public bool LocalizeText
+    {
+        get => _localizeText;
+        set
+        {
+            if (_localizeText != value)
+            {
+                _localizeText = value;
+                string? originalText = CustomSetPropertyOnRenderableType.TryGetLocalizationKey(this);
+                if (originalText != null)
+                {
+                    this.Text = originalText;
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1557,7 +1557,9 @@ public partial class CustomSetPropertyOnRenderable
             }
 
             var rawText = valueAsString;
-            if (LocalizationService != null && propertyName == "Text")
+            var shouldTranslate = gue is not Gum.GueDeriving.TextRuntime textRuntimeForLocalization
+                || textRuntimeForLocalization.LocalizeText;
+            if (LocalizationService != null && propertyName == "Text" && shouldTranslate)
             {
                 rawText = LocalizationService.Translate(rawText);
             }
@@ -1574,6 +1576,14 @@ public partial class CustomSetPropertyOnRenderable
                 gue.HeightUnits == DimensionUnitType.RelativeToChildren)
             {
                 gue.UpdateLayout();
+            }
+            handled = true;
+        }
+        else if (propertyName == "LocalizeText")
+        {
+            if (gueAsTextRuntime != null)
+            {
+                gueAsTextRuntime.LocalizeText = (bool)value;
             }
             handled = true;
         }

--- a/Tests/CodeGen_Maui_FullCodegen/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/StandardElements.Generated.cs
@@ -1621,6 +1621,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/StandardElements.Generated.cs
@@ -1894,6 +1894,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/StandardElements.Generated.cs
@@ -2286,6 +2286,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/StandardElements.Generated.cs
@@ -1891,6 +1891,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGame_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/StandardElements.Generated.cs
@@ -1894,6 +1894,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_Raylib_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Raylib_ByReference/StandardElements.Generated.cs
@@ -888,6 +888,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_Skia_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Skia_ByReference/StandardElements.Generated.cs
@@ -888,6 +888,9 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
+      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
+        <Value xsi:type=""xsd:boolean"">true</Value>
+      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorLocalizeTextTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorLocalizeTextTests.cs
@@ -1,0 +1,103 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+using System.Linq;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// LocalizeText (issue #4133) is a plain bool property on TextRuntime, not a method-mapped
+/// dispatch name like TextNoTranslate, so codegen needs no special-casing - a set value emits a
+/// plain bool assignment the same as any other property.
+/// </summary>
+public class CodeGeneratorLocalizeTextTests : BaseTestClass
+{
+    private static CodeGenerator CreateCodeGenerator()
+    {
+        Mock<INameVerifier> mockNameVerifier = new Mock<INameVerifier>();
+        string whyNotValid;
+        CommonValidationError error;
+        mockNameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+        CodeGenerationNameVerifier codeGenNameVerifier = new CodeGenerationNameVerifier(mockNameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new FixedProjectDirectoryProvider(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+        LocalizationService localizationService = new LocalizationService();
+
+        return new CodeGenerator(
+            codeGenNameVerifier,
+            localizationService,
+            elementSettingsManager,
+            directoryProvider);
+    }
+
+    private static CodeOutputProjectSettings CreateMonoGame() => new CodeOutputProjectSettings
+    {
+        OutputLibrary = OutputLibrary.MonoGame,
+        RootNamespace = "MyGame",
+    };
+
+    private static ComponentSave CreateComponent(string name, string baseType)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = baseType };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(defaultState);
+        return component;
+    }
+
+    private static void AddVariable(ElementSave element, string name, object? value, string type) =>
+        element.DefaultState.Variables.Add(new VariableSave
+        {
+            Name = name,
+            Value = value,
+            SetsValue = true,
+            Type = type,
+        });
+
+    /// <summary>
+    /// Mirrors StandardElementsManager defining LocalizeText on the Text standard element.
+    /// Codegen only emits an instance variable whose root is defined on the base element.
+    /// </summary>
+    private void RegisterTextLocalizeTextVariable()
+    {
+        StandardElementSave text = Project.StandardElements.First(item => item.Name == "Text");
+        AddVariable(text, "LocalizeText", true, "bool");
+    }
+
+    [Fact]
+    public void GetCodeForInstance_LocalizeTextFalse_EmitsPlainBoolAssignment()
+    {
+        GumProjectSave project = Project;
+        RegisterTextLocalizeTextVariable();
+
+        ComponentSave main = CreateComponent("MainComponent", "Container");
+
+        InstanceSave textInstance = new InstanceSave
+        {
+            Name = "MyText",
+            BaseType = "Text",
+            ParentContainer = main,
+        };
+        main.Instances.Add(textInstance);
+        AddVariable(main, "MyText.LocalizeText", false, "bool");
+
+        project.Components.Add(main);
+
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            string code = CreateCodeGenerator().GetCodeForInstance(textInstance, main, CreateMonoGame());
+
+            code.ShouldContain("this.MyText.LocalizeText = false;");
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+}

--- a/Tests/SkiaGum.Tests/Localization/LocalizeTextTests.cs
+++ b/Tests/SkiaGum.Tests/Localization/LocalizeTextTests.cs
@@ -1,0 +1,73 @@
+using Gum.Localization;
+using Gum.Wireframe;
+using Shouldly;
+using SkiaGum;
+using SkiaGum.GueDeriving;
+using System;
+using System.Collections.Generic;
+
+namespace SkiaGum.Tests.Localization;
+
+/// <summary>
+/// Tests <see cref="TextRuntime.LocalizeText"/> on SkiaGum's own <see cref="CustomSetPropertyOnRenderable"/>
+/// copy - the per-instance opt-out from translation, distinct from <see cref="TextRuntime.SetTextNoTranslate"/>,
+/// which bypasses translation for a single assignment rather than persisting on the instance.
+/// </summary>
+public class LocalizeTextTests : IDisposable
+{
+    private readonly LocalizationService _localizationService;
+
+    public LocalizeTextTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+
+        _localizationService = new LocalizationService();
+        Dictionary<string, string[]> entries = new()
+        {
+            { "Greeting", new[] { "Hello", "Hola" } },
+        };
+        List<string> headers = new() { "English", "Spanish" };
+        _localizationService.AddDatabase(entries, headers);
+        _localizationService.CurrentLanguage = 1;
+        CustomSetPropertyOnRenderable.LocalizationService = _localizationService;
+    }
+
+    public void Dispose()
+    {
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+    }
+
+    [Fact]
+    public void Text_ShouldNotBeTranslated_WhenLocalizeTextIsFalse()
+    {
+        TextRuntime sut = new();
+        sut.LocalizeText = false;
+
+        sut.Text = "Greeting";
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.RawText.ShouldBe("Greeting");
+    }
+
+    [Fact]
+    public void SetPropertyLocalizeText_ShouldSetLocalizeTextProperty()
+    {
+        TextRuntime sut = new();
+
+        sut.SetProperty("LocalizeText", false);
+
+        sut.LocalizeText.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SettingLocalizeTextToFalse_ShouldUntranslateAlreadyAssignedText()
+    {
+        TextRuntime sut = new();
+        sut.Text = "Greeting";
+        ((Text)sut.RenderableComponent).RawText.ShouldBe("Hola");
+
+        sut.LocalizeText = false;
+
+        ((Text)sut.RenderableComponent).RawText.ShouldBe("Greeting");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/StandardElementsManagerTests.cs
@@ -114,6 +114,16 @@ public class StandardElementsManagerTests : BaseTestClass
         state.Variables.Any(v => v.Name == "DropshadowBlue").ShouldBeTrue();
     }
 
+    [Fact]
+    public void DefaultState_ExposesLocalizeTextVariable_DefaultingTrue()
+    {
+        var state = StandardElementsManager.Self.DefaultStates["Text"];
+
+        var variable = state.Variables.First(v => v.Name == "LocalizeText");
+        variable.Type.ShouldBe("bool");
+        variable.Value.ShouldBe(true);
+    }
+
     [Theory]
     [InlineData("Circle")]
     [InlineData("Rectangle")]

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerApplyLocalizationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeObjectManagerApplyLocalizationTests.cs
@@ -94,4 +94,17 @@ public class WireframeObjectManagerApplyLocalizationTests : BaseTestClass
         Text containedText = (Text)gue.RenderableComponent;
         containedText.RawText.ShouldBe("Hello(loc)");
     }
+
+    [Fact]
+    public void ApplyLocalization_ShouldNotTranslate_WhenLocalizeTextIsFalse()
+    {
+        Gum.GueDeriving.TextRuntime textRuntime = new();
+        textRuntime.LocalizeText = false;
+        textRuntime.SetProperty("Text", "Hello");
+
+        _wireframeObjectManager.ApplyLocalization(textRuntime);
+
+        Text containedText = (Text)textRuntime.RenderableComponent;
+        containedText.RawText.ShouldBe("Hello");
+    }
 }

--- a/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/WireframeObjectManager.cs
@@ -318,13 +318,6 @@ public partial class WireframeObjectManager : IWireframeObjectManager
     public void ApplyLocalization(GraphicalUiElement gue, string forcedId = null)
     {
         var shouldLocalize = _projectState.GumProjectSave.ShowLocalizationInGum;
-        //if(gue.Tag is InstanceSave instance)
-        //{
-        //    var rfv = new RecursiveVariableFinder(_selectedState.SelectedStateSave);
-
-        //    var value = rfv.GetValue<bool>(instance.Name + ".Apply Localization");
-        //    isLocalized = value;
-        //}
 
         if(shouldLocalize)
         {


### PR DESCRIPTION
## Summary
- Adds `TextRuntime.LocalizeText` (bool, default `true`) - a persisted per-instance opt-out from translation, distinct from `SetTextNoTranslate` (a one-off bypass for dynamic assignments).
- Wired as a combining-variable pair with `Text` in the shared `SetText` translation check (`Gum/Wireframe/CustomSetPropertyOnRenderable.cs`, covers MonoGame + Raylib) and Skia's separate copy.
- Exposed as a standard `"Text"` variable (`StandardElementsManager.cs`), so it shows in the tool's Variables tab as a plain checkbox, flows through codegen with no special-casing, and the wireframe preview already honors it via the existing `SetProperty("Text", ...)` call.
- Sokol and FRB are intentionally out of scope: Sokol has no real `ILocalizationService` plumbing to gate (just a bare delegate), and FRB gets no new functionality per its build-verification policy (no-op there).
- Boyscout: removed the stale `WireframeObjectManager.ApplyLocalization` comment/stub this feature was blocked on, and corrected a stale comment in `CustomSetPropertyOnRenderable.cs` claiming a bare `GraphicalUiElement(Text)` (no `TextRuntime`) is a normal tool code path - confirmed all four current backends register `Text` → `TextRuntime` via the primary path, so that's FRB-only today.
- Added a general "Combining Variables" note to the `gum-property-assignment` skill (X/XUnits, Font+FontSize, and this flag+text pair all follow the same no-peeking, order-independent-convergence rule).

## Test plan
- [x] `MonoGameGum.Tests` (2003/2003), `RaylibGum.Tests` (554/554), `SkiaGum.Tests` (419/419), `GumToolUnitTests` (1166/1168, 2 pre-existing skips), `Gum.ProjectServices.Tests` (413/415, 2 pre-existing skips) - all green.
- [x] `GumFull.sln` builds clean, 0 errors, no new warnings.
- [x] FRB canary: pass (built `GumCore.DesktopGlNet6.csproj` from the primary checkout with this branch's `GumCoreShared.projitems`-listed files overlaid; 0 errors, same as `main` baseline).
- Manual test: needed (new tool-UI checkbox + preview-visible translation behavior). Steps:
  1. Open the Gum tool, load or create a project, and load a localization file (Project Properties → Localization Files) with "Show Localization" enabled.
  2. Add a Text instance whose string ID isn't in the localization database - confirm it renders with the `(loc)` suffix as before.
  3. In the Variables tab, Text category, find the new **Localize Text** checkbox (default checked). Uncheck it.
  4. Confirm the `(loc)` suffix disappears and the raw text renders as typed, with no other behavior change.

Closes #4133
