### PR TITLE
Flush pending LostFocus-triggered edit before a binding source swap

### DIFF
--- a/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
+++ b/MonoGameGum.Tests/Forms/FrameworkElementBindingTests.cs
@@ -387,6 +387,35 @@ public class FrameworkElementBindingTests : BaseTestClass
             "so setting IsFocused to false should not update the source value");
     }
 
+    /// <summary>
+    /// Issue #4139: a master-detail list rebinding its detail panel to a new item
+    /// (e.g. clicking weapon2 right after editing weapon1's damage field) never fires
+    /// the TextBox's real LostFocus event, so a LostFocus-triggered edit was silently
+    /// discarded instead of committed to the outgoing source.
+    /// </summary>
+    [Fact]
+    public void UpdateSourceTrigger_LostFocus_FlushesPendingEdit_WhenBindingContextChanges()
+    {
+        // Arrange
+        TestViewModel weapon1 = new() { Text = "Initial1" };
+        TestViewModel weapon2 = new() { Text = "Initial2" };
+
+        TextBox element = new() { BindingContext = weapon1 };
+        Binding binding = new(nameof(TestViewModel.Text))
+        {
+            UpdateSourceTrigger = UpdateSourceTrigger.LostFocus
+        };
+        element.SetBinding(nameof(TextBox.Text), binding);
+
+        // Act - edit without ever losing real focus, then swap to a different source
+        element.Text = "EditedButNotBlurred";
+        element.BindingContext = weapon2;
+
+        // Assert - the pending edit should have been committed to weapon1 before the swap
+        weapon1.Text.ShouldBe("EditedButNotBlurred");
+        element.Text.ShouldBe("Initial2");
+    }
+
     [Fact]
     public void DefaultUpdateTrigger_Registered_AppliesAsLostFocus()
     {

--- a/MonoGameGum/Forms/Data/NpcBindingExpression.cs
+++ b/MonoGameGum/Forms/Data/NpcBindingExpression.cs
@@ -22,6 +22,7 @@ internal class NpcBindingExpression : UntypedBindingExpression
     private object? LastTargetValue { get; set; }
     private bool _isUpdatingTarget;
     private bool _isUpdatingSource;
+    private bool _isLostFocusTrigger;
     
     public NpcBindingExpression(
         FrameworkElement target,
@@ -83,13 +84,21 @@ internal class NpcBindingExpression : UntypedBindingExpression
                 break;
 
             case UpdateSourceTrigger.LostFocus when ShouldUpdateSource:
+                _isLostFocusTrigger = true;
                 TargetElement.LostFocus += OnLostFocus;
                 break;
         }
     }
 
-    private void OnLostFocus(object? s, EventArgs e)
+    private void OnLostFocus(object? s, EventArgs e) => FlushPendingTargetValue();
+
+    protected override void FlushPendingTargetValue()
     {
+        if (!_isLostFocusTrigger || !ShouldUpdateSource)
+        {
+            return;
+        }
+
         object? targetValue = TargetProperty.GetValue(TargetElement);
         if (targetValue != LastTargetValue)
         {

--- a/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
+++ b/MonoGameGum/Forms/Data/UntypedBindingExpressionBase.cs
@@ -52,6 +52,15 @@ internal abstract class UntypedBindingExpression : BindingExpressionBase
 
     protected bool SuppressAttach { get; set; }
 
+    /// <summary>
+    /// Commits any pending edit to the outgoing source before <see cref="AttachToSource"/> repoints
+    /// this binding at a new one. A source swap (e.g. a master-detail panel's BindingContext changing)
+    /// is an implicit end-of-edit, since the control is about to display a different object entirely -
+    /// so a deferred-commit trigger (like <see cref="UpdateSourceTrigger.LostFocus"/>) must flush here
+    /// even when the target never raised its real focus-lost event.
+    /// </summary>
+    protected virtual void FlushPendingTargetValue() { }
+
     [RequiresUnreferencedCode(
         "Resolves the binding path by name against newSource's own type (PropertyPathObserver.Attach, " +
         "BinderHelpers.BuildGetter/BuildSetter). Those members may be removed under PublishTrimmed if " +
@@ -62,6 +71,8 @@ internal abstract class UntypedBindingExpression : BindingExpressionBase
         {
             return;
         }
+
+        FlushPendingTargetValue();
 
         PathObserver.Detach();
         SourceGetter = null;


### PR DESCRIPTION
## Summary
- A master-detail panel's TextBox never loses real UI focus when you click a different list item, so a `UpdateSourceTrigger.LostFocus` TwoWay edit was silently discarded when `BindingContext` swapped out from under it before that blur event fired.
- `AttachToSource` now flushes any pending target value to the outgoing source (reusing `NpcBindingExpression`'s existing LostFocus commit path, including its parse-failure-safe fallback) before detaching, gated so `PropertyChanged`-trigger bindings (always already in sync) get no extra write.

## Test plan
- [x] `UpdateSourceTrigger_LostFocus_FlushesPendingEdit_WhenBindingContextChanges` reproduces the bug (red before, green after)
- [x] Full `MonoGameGum.Tests` suite: 2004 passed, no regressions
- [x] FRB canary (FlatRedBall.Forms.DesktopGlNet6): 0 errors, same as baseline

Manual test: not needed — pure binding-logic change, fully covered by the unit test asserting the exact same VM-property observable a manual TextBox/click check would only approximate by eye.

Closes #4139
