### PR TITLE
Fix flaky TextRuntimeBbCodeHasDropshadowTagTests (RaylibGum.Tests font cache leak)

### DIFF
--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -21,7 +21,12 @@ namespace RaylibGum.Tests.Renderables;
 /// styling (Color / FontScale runs) when text is assigned through the property pipeline,
 /// mirroring the MonoGame runtime's behavior. Issue #3471.
 /// </summary>
-public class TextMarkupTests
+// #4142: must inherit BaseTestClass. Text_WithBoldWrappingFontSize_AppliesNestedResolvedRuns_WhenFontCreatorWired
+// below rasterizes a real font (Bold=true, FontSize=20, Arial) via KernSmithRaylibFontCreator and caches it in
+// the process-wide LoaderManager.Self singleton. Without BaseTestClass's Dispose (which clears that cache via
+// the CacheTextures false/true toggle), the cached entry leaks into whichever later test in the same process
+// happens to request the same font signature, poisoning it with a cache hit that skips its own font creator.
+public class TextMarkupTests : BaseTestClass
 {
     // Issue #3532: the font-aware wrap seam MeasureString(string, int) must fall back to the base
     // MeasureString when the line carries no inline runs, so plain-text wrapping stays byte-identical.


### PR DESCRIPTION
Closes #4142

## Root cause (corrects the issue's diagnosis)

The actual CI failure (PR #4140, attempt 1, Build-and-Test windows-latest) was in **`RaylibGum.Tests`**, not `MonoGameGum.Tests` - a same-named/mirrored test class, easy to conflate. It's also not xUnit parallelism: both assemblies already have `[assembly: CollectionBehavior(DisableTestParallelization = true)]`, and `InMemoryFontCreator` itself is correctly saved/restored via try/finally in every test.

The real leak: `TextMarkupTests` (RaylibGum.Tests) didn't inherit `BaseTestClass`. Its `Text_WithBoldWrappingFontSize_AppliesNestedResolvedRuns_WhenFontCreatorWired` test wires a *real* `KernSmithRaylibFontCreator` and rasterizes a font for (Bold=true, FontSize=20, Arial) - which the Raylib font-resolution path (`CustomSetPropertyOnRenderable.GetAndCreateFontIfNecessary`) caches into the process-wide `LoaderManager.Self` singleton, keyed by that exact signature. Every other test class clears that cache in `Dispose()` (`LoaderManager.Self.CacheTextures = false; = true;`), but `TextMarkupTests` has no `Dispose`, so its cached font persists for the rest of the process. Whenever `TextRuntimeBbCodeHasDropshadowTagTests` (which requests the same Bold+no-dropshadow Arial-20 signature) happened to run *after* it - xUnit's execution order isn't guaranteed stable across runs - it got a cache hit and its own `RecordingRaylibFontCreator` was never invoked, so the assertion on `Requests` failed.

## Fix

`TextMarkupTests : BaseTestClass`, matching every other test class in the project.

## Verification

Reproduced locally by filtering just these two classes together and running repeatedly: failed ~4/6 tries before the fix. After the fix: 15/15 clean on the same filter, plus 10/10 clean full-suite runs (554 tests each).

Manual test: not needed - test-infrastructure-only fix, no production behavior change.
FRB canary: not needed - no FRB-shared source touched.
