### PR TITLE
Merge fill+border circles onto one CircleRuntime in code themes

### DIFF
--- a/Tests/Gum.Themes.Tests/CircleSeamTests.cs
+++ b/Tests/Gum.Themes.Tests/CircleSeamTests.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Shouldly;
+
+namespace Gum.Themes.Tests;
+
+/// <summary>
+/// Two <see cref="CircleRuntime"/> children sized and positioned identically — one filled,
+/// one stroked — render as two independently-antialiased edges at the same nominal radius,
+/// producing a visible seam. <see cref="CircleRuntime"/> supports fill + stroke simultaneously
+/// on a single instance (see <c>FillRadiusInset</c>, issue #2834), so any circle needing both
+/// should merge onto one runtime rather than stacking two.
+/// </summary>
+public class CircleSeamTests
+{
+    public static IEnumerable<object[]> CircleVisualTypes()
+    {
+        yield return new object[] { typeof(Bubblegum.SliderThumbVisual), "Bubblegum.SliderThumbVisual" };
+        yield return new object[] { typeof(Neon.SliderThumbVisual), "Neon.SliderThumbVisual" };
+        yield return new object[] { typeof(ForestGlade.SliderThumbVisual), "ForestGlade.SliderThumbVisual" };
+        yield return new object[] { typeof(Retro95.RadioButtonVisual), "Retro95.RadioButtonVisual" };
+        yield return new object[] { typeof(Neon.RadioButtonVisual), "Neon.RadioButtonVisual" };
+        yield return new object[] { typeof(Meadow.RadioButtonVisual), "Meadow.RadioButtonVisual" };
+        yield return new object[] { typeof(Hazard.RadioButtonVisual), "Hazard.RadioButtonVisual" };
+        yield return new object[] { typeof(Bubblegum.RadioButtonVisual), "Bubblegum.RadioButtonVisual" };
+        yield return new object[] { typeof(ForestGlade.RadioButtonVisual), "ForestGlade.RadioButtonVisual" };
+        yield return new object[] { typeof(DarkPro.RadioButtonVisual), "DarkPro.RadioButtonVisual" };
+        yield return new object[] { typeof(Template.RadioButtonVisual), "Template.RadioButtonVisual" };
+        yield return new object[] { typeof(Template.Variants.RadioButtonVisual), "Template.Variants.RadioButtonVisual" };
+    }
+
+    [Theory]
+    [MemberData(nameof(CircleVisualTypes))]
+    public void Visual_HasNoTwoCirclesSharingIdenticalBounds(Type visualType, string name)
+    {
+        GraphicalUiElement visual = (GraphicalUiElement)CreateWithDefaults(visualType);
+        List<CircleRuntime> circles = visual.Children
+            .OfType<CircleRuntime>()
+            .ToList();
+
+        var seams = circles
+            .GroupBy(c => (c.X, c.XUnits, c.Y, c.YUnits, c.Width, c.WidthUnits, c.Height, c.HeightUnits, c.XOrigin, c.YOrigin))
+            .Where(g => g.Count() > 1)
+            .ToList();
+
+        seams.ShouldBeEmpty(
+            $"{name} has {(seams.Count > 0 ? seams[0].Count() : 0)} CircleRuntime children sharing identical bounds — " +
+            "two independently-antialiased circles at the same radius render a visible seam. Merge fill + stroke onto one CircleRuntime.");
+    }
+
+    // Activator.CreateInstance(Type) requires a true zero-arg constructor; C# optional
+    // parameters (the RadioButtonVisual ctors' `bool fullInstantiation = true, ...`) don't
+    // qualify. Resolve the constructor and supply each parameter's default value instead.
+    private static object CreateWithDefaults(Type type)
+    {
+        ConstructorInfo ctor = type.GetConstructors().OrderByDescending(c => c.GetParameters().Length).First();
+        object?[] args = ctor.GetParameters()
+            .Select(p => p.HasDefaultValue ? p.DefaultValue : null)
+            .ToArray();
+        return ctor.Invoke(args);
+    }
+}

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/RadioButtonVisual.cs
@@ -28,7 +28,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -46,9 +45,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -57,6 +53,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime c = new CircleRuntime();
         c.Name = "BubblegumRadioOuterFill";
         c.X = 0;
@@ -71,25 +71,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
         c.FillColor = BubblegumStyling.ActiveStyle.Colors.Surface1;
-        c.StrokeWidth = 0;
-        return c;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime c = new CircleRuntime();
-        c.Name = "BubblegumRadioOuterBorder";
-        c.X = 0;
-        c.Y = 0;
-        c.XUnits = GeneralUnitType.PixelsFromSmall;
-        c.YUnits = GeneralUnitType.PixelsFromMiddle;
-        c.XOrigin = HorizontalAlignment.Left;
-        c.YOrigin = VerticalAlignment.Center;
-        c.Width = OuterSize;
-        c.Height = OuterSize;
-        c.WidthUnits = DimensionUnitType.Absolute;
-        c.HeightUnits = DimensionUnitType.Absolute;
-        c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
         c.StrokeColor = BubblegumStyling.ActiveStyle.Colors.Border;
@@ -210,7 +191,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.Bubblegum.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.Bubblegum.MonoGame/SliderThumbVisual.cs
@@ -41,7 +41,6 @@ public class SliderThumbVisual : InteractiveGue
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _body;
-    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -60,6 +59,10 @@ public class SliderThumbVisual : InteractiveGue
             name: "BubblegumSliderThumbFocusRing");
         AddChild(_focusRing);
 
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         _body = BubblegumShapes.FilledCircleWithDropshadow(
             color: BubblegumStyling.ActiveStyle.Colors.White,
             shadowColor: ShadowColor,
@@ -67,13 +70,10 @@ public class SliderThumbVisual : InteractiveGue
             offsetY: ShadowOffsetY,
             blur: ShadowBlur,
             name: "BubblegumSliderThumbBody");
+        _body.StrokeWidth = BorderThickness;
+        _body.StrokeWidthUnits = DimensionUnitType.Absolute;
+        _body.StrokeColor = BubblegumStyling.ActiveStyle.Colors.Accent;
         AddChild(_body);
-
-        _border = BubblegumShapes.CircleBorder(
-            color: BubblegumStyling.ActiveStyle.Colors.Accent,
-            thickness: BorderThickness,
-            name: "BubblegumSliderThumbBorder");
-        AddChild(_border);
 
         WireStates();
     }
@@ -117,7 +117,7 @@ public class SliderThumbVisual : InteractiveGue
     {
         _body.FillColor = body;
         _body.HasDropshadow = showShadow;
-        _border.StrokeColor = border;
+        _body.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.DarkPro.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.DarkPro.MonoGame/RadioButtonVisual.cs
@@ -31,7 +31,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -52,9 +51,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -63,6 +59,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime circle = new CircleRuntime();
         circle.Name = "DarkProRadioOuterFill";
         circle.X = 0;
@@ -77,25 +77,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.IsFilled = true;
         circle.FillColor = DarkProStyling.ActiveStyle.Colors.Surface1;
-        circle.StrokeWidth = 0;
-        return circle;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime circle = new CircleRuntime();
-        circle.Name = "DarkProRadioOuterBorder";
-        circle.X = 0;
-        circle.Y = 0;
-        circle.XUnits = GeneralUnitType.PixelsFromSmall;
-        circle.YUnits = GeneralUnitType.PixelsFromMiddle;
-        circle.XOrigin = HorizontalAlignment.Left;
-        circle.YOrigin = VerticalAlignment.Center;
-        circle.Width = OuterSize;
-        circle.Height = OuterSize;
-        circle.WidthUnits = DimensionUnitType.Absolute;
-        circle.HeightUnits = DimensionUnitType.Absolute;
-        circle.IsFilled = false;
         circle.StrokeWidth = BorderThickness;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
         circle.StrokeColor = DarkProStyling.ActiveStyle.Colors.Border;
@@ -231,7 +212,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/RadioButtonVisual.cs
@@ -31,7 +31,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -49,9 +48,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -60,6 +56,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime c = new CircleRuntime();
         c.Name = "ForestGladeRadioOuterFill";
         c.X = 0;
@@ -74,25 +74,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
         c.FillColor = new Color(3, 28, 32);
-        c.StrokeWidth = 0;
-        return c;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime c = new CircleRuntime();
-        c.Name = "ForestGladeRadioOuterBorder";
-        c.X = 0;
-        c.Y = 0;
-        c.XUnits = GeneralUnitType.PixelsFromSmall;
-        c.YUnits = GeneralUnitType.PixelsFromMiddle;
-        c.XOrigin = HorizontalAlignment.Left;
-        c.YOrigin = VerticalAlignment.Center;
-        c.Width = OuterSize;
-        c.Height = OuterSize;
-        c.WidthUnits = DimensionUnitType.Absolute;
-        c.HeightUnits = DimensionUnitType.Absolute;
-        c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
         c.StrokeColor = new Color(232, 255, 117, 76);
@@ -222,7 +203,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.ForestGlade.MonoGame/SliderThumbVisual.cs
@@ -32,7 +32,6 @@ public class SliderThumbVisual : InteractiveGue
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _body;
-    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -50,9 +49,6 @@ public class SliderThumbVisual : InteractiveGue
         _body = CreateBody();
         AddChild(_body);
 
-        _border = CreateBorder();
-        AddChild(_border);
-
         WireStates();
     }
 
@@ -69,7 +65,13 @@ public class SliderThumbVisual : InteractiveGue
         body.WidthUnits = DimensionUnitType.RelativeToParent;
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
-        body.StrokeWidth = 0;
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
+        body.StrokeWidth = BorderThickness;
+        body.StrokeWidthUnits = DimensionUnitType.Absolute;
+        body.StrokeColor = new Color(232, 255, 117, 128); // sun-pale .5 alpha
         // CSS radial-gradient(circle at 35% 30%, sun-pale, leaf-bright 65%, #008c2e).
         // 2-stop approximation: sun-pale centre → canopy-lit edge. Offset of
         // 35%/30% is implemented by nudging the gradient origin off-centre
@@ -93,25 +95,6 @@ public class SliderThumbVisual : InteractiveGue
         body.DropshadowOffsetY = 0f;
         body.DropshadowBlur = ShadowBlur;
         return body;
-    }
-
-    private static CircleRuntime CreateBorder()
-    {
-        CircleRuntime border = new CircleRuntime();
-        border.Name = "ForestGladeSliderThumbBorder";
-        border.XUnits = GeneralUnitType.PixelsFromMiddle;
-        border.YUnits = GeneralUnitType.PixelsFromMiddle;
-        border.XOrigin = HorizontalAlignment.Center;
-        border.YOrigin = VerticalAlignment.Center;
-        border.Width = 0;
-        border.Height = 0;
-        border.WidthUnits = DimensionUnitType.RelativeToParent;
-        border.HeightUnits = DimensionUnitType.RelativeToParent;
-        border.IsFilled = false;
-        border.StrokeWidth = BorderThickness;
-        border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.StrokeColor = new Color(232, 255, 117, 128); // sun-pale .5 alpha
-        return border;
     }
 
     private static CircleRuntime CreateFocusRing()
@@ -189,7 +172,7 @@ public class SliderThumbVisual : InteractiveGue
         _body.FillColor = centre;
         _body.HasDropshadow = showShadow;
         _body.DropshadowBlur = blur;
-        _border.StrokeColor = border;
+        _body.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.Hazard.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Hazard.MonoGame/RadioButtonVisual.cs
@@ -36,7 +36,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -57,9 +56,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -68,6 +64,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime circle = new CircleRuntime();
         circle.Name = "HazardRadioOuterFill";
         circle.X = 0;
@@ -82,25 +82,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.IsFilled = true;
         circle.FillColor = HazardStyling.ActiveStyle.Colors.Surface1;
-        circle.StrokeWidth = 0;
-        return circle;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime circle = new CircleRuntime();
-        circle.Name = "HazardRadioOuterBorder";
-        circle.X = 0;
-        circle.Y = 0;
-        circle.XUnits = GeneralUnitType.PixelsFromSmall;
-        circle.YUnits = GeneralUnitType.PixelsFromMiddle;
-        circle.XOrigin = HorizontalAlignment.Left;
-        circle.YOrigin = VerticalAlignment.Center;
-        circle.Width = OuterSize;
-        circle.Height = OuterSize;
-        circle.WidthUnits = DimensionUnitType.Absolute;
-        circle.HeightUnits = DimensionUnitType.Absolute;
-        circle.IsFilled = false;
         circle.StrokeWidth = BorderThickness;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
         circle.StrokeColor = HazardStyling.ActiveStyle.Colors.Border;
@@ -237,7 +218,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.Meadow.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Meadow.MonoGame/RadioButtonVisual.cs
@@ -28,7 +28,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -46,9 +45,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -57,6 +53,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime c = new CircleRuntime();
         c.Name = "MeadowRadioOuterFill";
         c.X = 0;
@@ -71,25 +71,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
         c.FillColor = MeadowStyling.ActiveStyle.Colors.White;
-        c.StrokeWidth = 0;
-        return c;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime c = new CircleRuntime();
-        c.Name = "MeadowRadioOuterBorder";
-        c.X = 0;
-        c.Y = 0;
-        c.XUnits = GeneralUnitType.PixelsFromSmall;
-        c.YUnits = GeneralUnitType.PixelsFromMiddle;
-        c.XOrigin = HorizontalAlignment.Left;
-        c.YOrigin = VerticalAlignment.Center;
-        c.Width = OuterSize;
-        c.Height = OuterSize;
-        c.WidthUnits = DimensionUnitType.Absolute;
-        c.HeightUnits = DimensionUnitType.Absolute;
-        c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
         c.StrokeColor = MeadowStyling.ActiveStyle.Colors.PeachDark;
@@ -211,7 +192,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.Neon.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/RadioButtonVisual.cs
@@ -28,7 +28,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -46,9 +45,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -57,6 +53,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime c = new CircleRuntime();
         c.Name = "NeonRadioOuterFill";
         c.X = 0;
@@ -71,25 +71,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         c.HeightUnits = DimensionUnitType.Absolute;
         c.IsFilled = true;
         c.FillColor = NeonStyling.ActiveStyle.Colors.Surface1;
-        c.StrokeWidth = 0;
-        return c;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime c = new CircleRuntime();
-        c.Name = "NeonRadioOuterBorder";
-        c.X = 0;
-        c.Y = 0;
-        c.XUnits = GeneralUnitType.PixelsFromSmall;
-        c.YUnits = GeneralUnitType.PixelsFromMiddle;
-        c.XOrigin = HorizontalAlignment.Left;
-        c.YOrigin = VerticalAlignment.Center;
-        c.Width = OuterSize;
-        c.Height = OuterSize;
-        c.WidthUnits = DimensionUnitType.Absolute;
-        c.HeightUnits = DimensionUnitType.Absolute;
-        c.IsFilled = false;
         c.StrokeWidth = BorderThickness;
         c.StrokeWidthUnits = DimensionUnitType.Absolute;
         c.StrokeColor = NeonStyling.ActiveStyle.Colors.Border;
@@ -210,7 +191,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.Neon.MonoGame/SliderThumbVisual.cs
+++ b/Themes/Gum.Themes.Neon.MonoGame/SliderThumbVisual.cs
@@ -38,7 +38,6 @@ public class SliderThumbVisual : InteractiveGue
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _body;
-    private readonly CircleRuntime _border;
 
     private StateSaveCategory _buttonCategory = null!;
 
@@ -56,14 +55,15 @@ public class SliderThumbVisual : InteractiveGue
         _body = CreateBody();
         AddChild(_body);
 
-        _border = CreateBorder();
-        AddChild(_border);
-
         WireStates();
     }
 
     private static CircleRuntime CreateBody()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime body = new CircleRuntime();
         body.Name = "NeonSliderThumbBody";
         body.X = 0;
@@ -78,7 +78,9 @@ public class SliderThumbVisual : InteractiveGue
         body.HeightUnits = DimensionUnitType.RelativeToParent;
         body.IsFilled = true;
         body.FillColor = NeonStyling.ActiveStyle.Colors.Surface1;
-        body.StrokeWidth = 0;
+        body.StrokeWidth = BorderThickness;
+        body.StrokeWidthUnits = DimensionUnitType.Absolute;
+        body.StrokeColor = NeonStyling.ActiveStyle.Colors.Accent;
         // Native Gaussian drop shadow under the thumb — replaces the prior
         // single-circle approximation. Toggled per state via WireStates.
         body.HasDropshadow = true;
@@ -87,27 +89,6 @@ public class SliderThumbVisual : InteractiveGue
         body.DropshadowOffsetY = ShadowOffsetY;
         body.DropshadowBlur = ShadowBlur;
         return body;
-    }
-
-    private static CircleRuntime CreateBorder()
-    {
-        CircleRuntime border = new CircleRuntime();
-        border.Name = "NeonSliderThumbBorder";
-        border.X = 0;
-        border.Y = 0;
-        border.XUnits = GeneralUnitType.PixelsFromMiddle;
-        border.YUnits = GeneralUnitType.PixelsFromMiddle;
-        border.XOrigin = HorizontalAlignment.Center;
-        border.YOrigin = VerticalAlignment.Center;
-        border.Width = 0;
-        border.Height = 0;
-        border.WidthUnits = DimensionUnitType.RelativeToParent;
-        border.HeightUnits = DimensionUnitType.RelativeToParent;
-        border.IsFilled = false;
-        border.StrokeWidth = BorderThickness;
-        border.StrokeWidthUnits = DimensionUnitType.Absolute;
-        border.StrokeColor = NeonStyling.ActiveStyle.Colors.Accent;
-        return border;
     }
 
     private static CircleRuntime CreateFocusRing()
@@ -174,7 +155,7 @@ public class SliderThumbVisual : InteractiveGue
     {
         _body.FillColor = body;
         _body.HasDropshadow = showShadow;
-        _border.StrokeColor = border;
+        _body.StrokeColor = border;
         _focusRing.Visible = ring;
     }
 }

--- a/Themes/Gum.Themes.Retro95.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Retro95.MonoGame/RadioButtonVisual.cs
@@ -28,7 +28,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
     private const float BoxToLabelGap = 6f;
 
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
     private readonly Retro95DottedFocusRect _focusRect;
 
@@ -45,13 +44,15 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         TextInstance.X = OuterSize + BoxToLabelGap;
         TextInstance.Width = -(OuterSize + BoxToLabelGap);
 
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         _outerFill = CreateCircle("Retro95RadioFill", OuterSize, filled: true, color: Retro95Styling.ActiveStyle.Colors.WhiteFill);
+        _outerFill.StrokeWidth = BorderThickness;
+        _outerFill.StrokeWidthUnits = DimensionUnitType.Absolute;
+        _outerFill.StrokeColor = Retro95Styling.ActiveStyle.Colors.ShadowOuter;
         AddChild(_outerFill);
-
-        _outerBorder = CreateCircle("Retro95RadioBorder", OuterSize, filled: false, color: Retro95Styling.ActiveStyle.Colors.ShadowOuter);
-        _outerBorder.StrokeWidth = BorderThickness;
-        _outerBorder.StrokeWidthUnits = DimensionUnitType.Absolute;
-        AddChild(_outerBorder);
 
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);

--- a/Themes/Gum.Themes.Template.MonoGame/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Template.MonoGame/RadioButtonVisual.cs
@@ -34,7 +34,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -55,9 +54,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -66,6 +62,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime circle = new CircleRuntime();
         circle.Name = "RadioOuterFill";
         circle.X = 0;
@@ -80,25 +80,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.IsFilled = true;
         circle.FillColor = TemplateStyling.ActiveStyle.Colors.Surface1;
-        circle.StrokeWidth = 0;
-        return circle;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime circle = new CircleRuntime();
-        circle.Name = "RadioOuterBorder";
-        circle.X = 0;
-        circle.Y = 0;
-        circle.XUnits = GeneralUnitType.PixelsFromSmall;
-        circle.YUnits = GeneralUnitType.PixelsFromMiddle;
-        circle.XOrigin = HorizontalAlignment.Left;
-        circle.YOrigin = VerticalAlignment.Center;
-        circle.Width = OuterSize;
-        circle.Height = OuterSize;
-        circle.WidthUnits = DimensionUnitType.Absolute;
-        circle.HeightUnits = DimensionUnitType.Absolute;
-        circle.IsFilled = false;
         circle.StrokeWidth = BorderThickness;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
         circle.StrokeColor = TemplateStyling.ActiveStyle.Colors.Border;
@@ -234,7 +215,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)

--- a/Themes/Gum.Themes.Template.MonoGame/Variants/RadioButtonVisual.cs
+++ b/Themes/Gum.Themes.Template.MonoGame/Variants/RadioButtonVisual.cs
@@ -44,7 +44,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private readonly CircleRuntime _focusRing;
     private readonly CircleRuntime _outerFill;
-    private readonly CircleRuntime _outerBorder;
     private readonly CircleRuntime _innerDot;
 
     public RadioButtonVisual(bool fullInstantiation = true, bool tryCreateFormsObject = true)
@@ -65,9 +64,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         _outerFill = CreateOuterFill();
         AddChild(_outerFill);
 
-        _outerBorder = CreateOuterBorder();
-        AddChild(_outerBorder);
-
         _innerDot = CreateInnerDot();
         AddChild(_innerDot);
 
@@ -76,6 +72,10 @@ public class RadioButtonVisual : BaseRadioButtonVisual
 
     private static CircleRuntime CreateOuterFill()
     {
+        // Fill + border merged onto one CircleRuntime (not two stacked circles): the
+        // runtime insets the fill's AA halo under the stroke's opaque band when both are
+        // set on the same instance, avoiding the seam two independently-antialiased
+        // circles at identical bounds would produce.
         CircleRuntime circle = new CircleRuntime();
         circle.Name = "RadioOuterFill";
         circle.X = 0;
@@ -90,25 +90,6 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         circle.HeightUnits = DimensionUnitType.Absolute;
         circle.IsFilled = true;
         circle.FillColor = TemplateStyling.ActiveStyle.Colors.Surface1;
-        circle.StrokeWidth = 0;
-        return circle;
-    }
-
-    private static CircleRuntime CreateOuterBorder()
-    {
-        CircleRuntime circle = new CircleRuntime();
-        circle.Name = "RadioOuterBorder";
-        circle.X = 0;
-        circle.Y = 0;
-        circle.XUnits = GeneralUnitType.PixelsFromSmall;
-        circle.YUnits = GeneralUnitType.PixelsFromMiddle;
-        circle.XOrigin = HorizontalAlignment.Left;
-        circle.YOrigin = VerticalAlignment.Center;
-        circle.Width = OuterSize;
-        circle.Height = OuterSize;
-        circle.WidthUnits = DimensionUnitType.Absolute;
-        circle.HeightUnits = DimensionUnitType.Absolute;
-        circle.IsFilled = false;
         circle.StrokeWidth = BorderThickness;
         circle.StrokeWidthUnits = DimensionUnitType.Absolute;
         circle.StrokeColor = TemplateStyling.ActiveStyle.Colors.Border;
@@ -244,7 +225,7 @@ public class RadioButtonVisual : BaseRadioButtonVisual
         Color? innerColor = null)
     {
         _outerFill.FillColor = fill;
-        _outerBorder.StrokeColor = border;
+        _outerFill.StrokeColor = border;
         TextInstance.Color = text;
         _innerDot.Visible = innerVisible;
         if (innerColor.HasValue)


### PR DESCRIPTION
## Summary
Several code-theme `SliderThumbVisual`/`RadioButtonVisual`s built their circle "fill" and "border" as two separate `CircleRuntime` instances stacked at identical bounds. Two independently-antialiased circles at the same nominal radius produce a visible seam. `CircleRuntime` already supports fill + stroke simultaneously on one instance (`FillRadiusInset`, issue #2834) — this merges each pair onto a single `CircleRuntime`, removing the redundant second instance.

Fixed:
- `SliderThumbVisual`: Bubblegum, Neon, ForestGlade
- `RadioButtonVisual`: Retro95, Neon, Meadow, Hazard, Bubblegum, ForestGlade, DarkPro, Template, Template/Variants

Scoped to code themes only, per this pass — the `.gucx` tool-template themes are out of scope.

Added `Tests/Gum.Themes.Tests/CircleSeamTests.cs`: a parameterized test across all 12 affected visual types asserting no two `CircleRuntime` children share identical bounds. Confirmed red before the fix (all 12 failed for the expected reason), green after.

Closes #4146

## Test plan
- [x] `dotnet test Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj` — 30/30 green
- [x] `Themes/Gum.Themes.Bubblegum.Raylib` builds clean (cross-platform sanity check)
- [x] Manual: `Samples/MonoGameGumThemesShowcase` built; VS opened. Press 1–9 to cycle themes (F1 screen shows all controls) and zoom in on the Slider thumb / RadioButton dot for Forest Glade(1), Neon(2), Dark Pro(3), Bubblegum(4), Retro 95(6), Hazard(7), Meadow(8), Template(9) — confirm the faint seam is gone. Template's `Variants` gallery isn't wired into this showcase; it's covered by the unit test only.
