### PR TITLE
Merge fill+border circles onto one CircleRuntime in Add Forms theme content

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
@@ -59,52 +59,6 @@
     <Variable Type="float" Name="Height" SetsValue="true">
       <Value xsi:type="xsd:float">24</Value>
     </Variable>
-    <Variable Type="float" Name="OuterBorder.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">20</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="OuterBorder.HeightUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="bool" Name="OuterBorder.IsFilled" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
-    </Variable>
-    <Variable Type="string" Name="OuterBorder.Parent" SetsValue="true" />
-    <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-      <Value xsi:type="xsd:int">204</Value>
-    </Variable>
-    <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-      <Value xsi:type="xsd:int">170</Value>
-    </Variable>
-    <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-      <Value xsi:type="xsd:int">240</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">2</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">20</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="OuterBorder.WidthUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.X" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="HorizontalAlignment" Name="OuterBorder.XOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="OuterBorder.XUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.Y" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="VerticalAlignment" Name="OuterBorder.YOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="OuterBorder.YUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
-    </Variable>
     <Variable Type="bool" Name="Radio.ExposeChildrenEvents" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -180,8 +134,17 @@
     <Variable Type="bool" Name="RadioBackground.IsFilled" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">204</Value>
+    </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">170</Value>
+    </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">240</Value>
+    </Variable>
     <Variable Type="float" Name="RadioBackground.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">2</Value>
     </Variable>
     <Variable Type="float" Name="RadioBackground.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
@@ -302,15 +265,6 @@
         <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
         <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
         <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
-      </Value>
-    </VariableList>
-    <VariableList xsi:type="VariableListSaveOfString">
-      <Type>string</Type>
-      <Name>OuterBorder.VariableReferences</Name>
-      <Category>References</Category>
-      <IsFile>false</IsFile>
-      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-      <Value>
         <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
         <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
         <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
@@ -323,15 +277,6 @@
       <Name>EnabledOn</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
@@ -354,6 +299,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -373,6 +327,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -385,18 +342,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -417,15 +362,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">204</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">170</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">240</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -447,6 +383,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">204</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">170</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">240</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -466,6 +411,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -478,18 +426,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -510,15 +446,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">221</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">174</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">205</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -540,6 +467,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">245</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">221</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">174</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">205</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">217</Value>
       </Variable>
@@ -559,6 +495,9 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -571,18 +510,6 @@
           <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -603,15 +530,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">221</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">174</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">205</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -633,6 +551,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">245</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">221</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">174</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">205</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">217</Value>
       </Variable>
@@ -652,6 +579,9 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -664,18 +594,6 @@
           <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -696,15 +614,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -726,6 +635,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -745,6 +663,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -757,18 +678,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -789,15 +698,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -819,6 +719,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -838,6 +747,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -850,18 +762,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -882,15 +782,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">117</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">68</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">204</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">117</Value>
       </Variable>
@@ -912,6 +803,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">117</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">68</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">204</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -931,6 +831,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -943,18 +846,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -975,15 +866,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">117</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">68</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">204</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -1005,6 +887,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">117</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">68</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">204</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -1024,6 +915,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1036,18 +930,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1068,15 +950,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -1098,6 +971,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -1117,6 +999,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1129,18 +1014,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1161,15 +1034,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -1191,6 +1055,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -1210,6 +1083,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1222,18 +1098,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1254,15 +1118,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -1284,6 +1139,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">85</Value>
       </Variable>
@@ -1303,6 +1167,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1315,18 +1182,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1347,15 +1202,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">157</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">107</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">255</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
@@ -1375,6 +1221,15 @@
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
+        <Value xsi:type="xsd:int">255</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">157</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">107</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
@@ -1396,6 +1251,9 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1408,18 +1266,6 @@
           <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1439,15 +1285,6 @@
       <Name>DisabledFocusedOn</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">221</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">174</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">205</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
@@ -1470,6 +1307,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">245</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">221</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">174</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">205</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">217</Value>
       </Variable>
@@ -1489,6 +1335,9 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1501,18 +1350,6 @@
           <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1532,15 +1369,6 @@
       <Name>DisabledFocusedOff</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">221</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">174</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">205</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
@@ -1563,6 +1391,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">245</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">221</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">174</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">205</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">217</Value>
       </Variable>
@@ -1582,6 +1419,9 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
+          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
+          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1594,18 +1434,6 @@
           <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1623,7 +1451,6 @@
     </State>
   </Category>
   <Instance Name="RadioBackground" BaseType="Circle" />
-  <Instance Name="OuterBorder" BaseType="Circle" />
   <Instance Name="Radio" BaseType="Circle" />
   <Instance Name="TextInstance" BaseType="Text" />
   <Instance Name="FocusedIndicator" BaseType="Circle" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
@@ -49,8 +49,17 @@
     <Variable Type="bool" Name="Body.IsFilled" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
+    <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">157</Value>
+    </Variable>
+    <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">107</Value>
+    </Variable>
+    <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
     <Variable Type="float" Name="Body.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">2</Value>
     </Variable>
     <Variable Type="float" Name="Body.Width" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
@@ -74,51 +83,6 @@
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="PositionUnitType" Name="Body.YUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="BorderInstance.HeightUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
-    </Variable>
-    <Variable Type="bool" Name="BorderInstance.IsFilled" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-      <Value xsi:type="xsd:int">157</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-      <Value xsi:type="xsd:int">107</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-      <Value xsi:type="xsd:int">255</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">2</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="BorderInstance.WidthUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.X" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="HorizontalAlignment" Name="BorderInstance.XOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="BorderInstance.XUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">6</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Y" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="VerticalAlignment" Name="BorderInstance.YOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="BorderInstance.YUnits" SetsValue="true">
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="ButtonCategory" Name="ButtonCategoryState" SetsValue="false" />
@@ -199,15 +163,6 @@
         <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
-      </Value>
-    </VariableList>
-    <VariableList xsi:type="VariableListSaveOfString">
-      <Type>string</Type>
-      <Name>BorderInstance.VariableReferences</Name>
-      <Category>References</Category>
-      <IsFile>false</IsFile>
-      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-      <Value>
         <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
         <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
         <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -242,13 +197,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">107</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -264,15 +219,6 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -293,13 +239,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">107</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -315,15 +261,6 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -344,13 +281,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">117</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">68</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">204</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -366,15 +303,6 @@
           <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
@@ -395,13 +323,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">107</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -417,15 +345,6 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -446,13 +365,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">157</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">107</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">255</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -468,15 +387,6 @@
           <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -497,13 +407,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">221</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">174</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">205</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -519,15 +429,6 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -548,13 +449,13 @@
       <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">221</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeGreen" SetsValue="true">
         <Value xsi:type="xsd:int">174</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.StrokeRed" SetsValue="true">
         <Value xsi:type="xsd:int">205</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -570,15 +471,6 @@
           <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -587,7 +479,6 @@
     </State>
   </Category>
   <Instance Name="Body" BaseType="Circle" />
-  <Instance Name="BorderInstance" BaseType="Circle" />
   <Instance Name="FocusedIndicator" BaseType="Circle" />
   <Behaviors>
     <ElementBehaviorReference>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
@@ -59,52 +59,6 @@
     <Variable Type="float" Name="Height" SetsValue="true">
       <Value xsi:type="xsd:float">24</Value>
     </Variable>
-    <Variable Type="float" Name="OuterBorder.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">20</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="OuterBorder.HeightUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="bool" Name="OuterBorder.IsFilled" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
-    </Variable>
-    <Variable Type="string" Name="OuterBorder.Parent" SetsValue="true" />
-    <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-      <Value xsi:type="xsd:int">22</Value>
-    </Variable>
-    <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-      <Value xsi:type="xsd:int">63</Value>
-    </Variable>
-    <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-      <Value xsi:type="xsd:int">74</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">2</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">20</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="OuterBorder.WidthUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.X" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="HorizontalAlignment" Name="OuterBorder.XOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="OuterBorder.XUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">0</Value>
-    </Variable>
-    <Variable Type="float" Name="OuterBorder.Y" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="VerticalAlignment" Name="OuterBorder.YOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="OuterBorder.YUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
-    </Variable>
     <Variable Type="bool" Name="Radio.ExposeChildrenEvents" SetsValue="true">
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
@@ -180,8 +134,17 @@
     <Variable Type="bool" Name="RadioBackground.IsFilled" SetsValue="true">
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">22</Value>
+    </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">63</Value>
+    </Variable>
+    <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">74</Value>
+    </Variable>
     <Variable Type="float" Name="RadioBackground.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">2</Value>
     </Variable>
     <Variable Type="float" Name="RadioBackground.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
@@ -302,15 +265,6 @@
         <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
         <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
         <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-      </Value>
-    </VariableList>
-    <VariableList xsi:type="VariableListSaveOfString">
-      <Type>string</Type>
-      <Name>OuterBorder.VariableReferences</Name>
-      <Category>References</Category>
-      <IsFile>false</IsFile>
-      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-      <Value>
         <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
         <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
         <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
@@ -323,15 +277,6 @@
       <Name>EnabledOn</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
@@ -354,6 +299,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -373,6 +327,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -385,18 +342,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -417,15 +362,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">22</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">63</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">74</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -447,6 +383,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">22</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">63</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">74</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -466,6 +411,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -478,18 +426,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -510,15 +446,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -540,6 +467,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">16</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">16</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">36</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">42</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">38</Value>
       </Variable>
@@ -559,6 +495,9 @@
           <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -571,18 +510,6 @@
           <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -603,15 +530,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -633,6 +551,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">16</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">16</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">36</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">42</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">38</Value>
       </Variable>
@@ -652,6 +579,9 @@
           <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -664,18 +594,6 @@
           <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -696,15 +614,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -726,6 +635,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -745,6 +663,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -757,18 +678,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -789,15 +698,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -819,6 +719,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -838,6 +747,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -850,18 +762,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -882,15 +782,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">12</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">163</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">201</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">12</Value>
       </Variable>
@@ -912,6 +803,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">12</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">163</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -931,6 +831,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -943,18 +846,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -975,15 +866,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">12</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">163</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">201</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -1005,6 +887,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">12</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">163</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -1024,6 +915,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1036,18 +930,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1068,15 +950,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -1098,6 +971,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -1117,6 +999,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1129,18 +1014,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1161,15 +1034,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -1191,6 +1055,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -1210,6 +1083,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1222,18 +1098,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1254,15 +1118,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -1284,6 +1139,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -1303,6 +1167,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1315,18 +1182,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1347,15 +1202,6 @@
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
       </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
@@ -1377,6 +1223,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">18</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">200</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">244</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">40</Value>
       </Variable>
@@ -1396,6 +1251,9 @@
           <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1408,18 +1266,6 @@
           <string>Red = Components/Hazard/Styles.Text.FillRed</string>
           <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1439,15 +1285,6 @@
       <Name>DisabledFocusedOn</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
@@ -1470,6 +1307,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">16</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">16</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">36</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">42</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">38</Value>
       </Variable>
@@ -1489,6 +1335,9 @@
           <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1501,18 +1350,6 @@
           <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1532,15 +1369,6 @@
       <Name>DisabledFocusedOff</Name>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="OuterBorder.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
       </Variable>
       <Variable Type="int" Name="Radio.FillBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
@@ -1563,6 +1391,15 @@
       <Variable Type="int" Name="RadioBackground.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">16</Value>
       </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeBlue" SetsValue="true">
+        <Value xsi:type="xsd:int">16</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeGreen" SetsValue="true">
+        <Value xsi:type="xsd:int">36</Value>
+      </Variable>
+      <Variable Type="int" Name="RadioBackground.StrokeRed" SetsValue="true">
+        <Value xsi:type="xsd:int">42</Value>
+      </Variable>
       <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
         <Value xsi:type="xsd:int">38</Value>
       </Variable>
@@ -1582,6 +1419,9 @@
           <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
           <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
           <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
+          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
+          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1594,18 +1434,6 @@
           <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
           <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
           <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>OuterBorder.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1623,7 +1451,6 @@
     </State>
   </Category>
   <Instance Name="RadioBackground" BaseType="Circle" />
-  <Instance Name="OuterBorder" BaseType="Circle" />
   <Instance Name="Radio" BaseType="Circle" />
   <Instance Name="TextInstance" BaseType="Text" />
   <Instance Name="FocusedIndicator" BaseType="Circle" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
@@ -4,41 +4,14 @@
   <BaseType>Container</BaseType>
   <State>
     <Name>Default</Name>
-    <Variable Type="int" Name="Body.DropshadowAlpha" SetsValue="true">
-      <Value xsi:type="xsd:int">160</Value>
-    </Variable>
-    <Variable Type="int" Name="Body.DropshadowBlue" SetsValue="true">
+    <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">26</Value>
     </Variable>
-    <Variable Type="float" Name="Body.DropshadowBlurX" SetsValue="true">
-      <Value xsi:type="xsd:float">10</Value>
-    </Variable>
-    <Variable Type="float" Name="Body.DropshadowBlurY" SetsValue="true">
-      <Value xsi:type="xsd:float">10</Value>
-    </Variable>
-    <Variable Type="int" Name="Body.DropshadowGreen" SetsValue="true">
+    <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
       <Value xsi:type="xsd:int">200</Value>
     </Variable>
-    <Variable Type="float" Name="Body.DropshadowOffsetX" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="float" Name="Body.DropshadowOffsetY" SetsValue="true">
-      <Value xsi:type="xsd:float">2</Value>
-    </Variable>
-    <Variable Type="int" Name="Body.DropshadowRed" SetsValue="true">
-      <Value xsi:type="xsd:int">244</Value>
-    </Variable>
-    <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
-    </Variable>
-    <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-      <Value xsi:type="xsd:int">16</Value>
-    </Variable>
     <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-      <Value xsi:type="xsd:int">18</Value>
-    </Variable>
-    <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
+      <Value xsi:type="xsd:int">244</Value>
     </Variable>
     <Variable Type="float" Name="Body.Height" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>
@@ -74,51 +47,6 @@
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="PositionUnitType" Name="Body.YUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">7</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="BorderInstance.HeightUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
-    </Variable>
-    <Variable Type="bool" Name="BorderInstance.IsFilled" SetsValue="true">
-      <Value xsi:type="xsd:boolean">false</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-      <Value xsi:type="xsd:int">26</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-      <Value xsi:type="xsd:int">200</Value>
-    </Variable>
-    <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-      <Value xsi:type="xsd:int">244</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.StrokeWidth" SetsValue="true">
-      <Value xsi:type="xsd:float">2</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="DimensionUnitType" Name="BorderInstance.WidthUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">2</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.X" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="HorizontalAlignment" Name="BorderInstance.XOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="BorderInstance.XUnits" SetsValue="true">
-      <Value xsi:type="xsd:int">6</Value>
-    </Variable>
-    <Variable Type="float" Name="BorderInstance.Y" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
-    </Variable>
-    <Variable Type="VerticalAlignment" Name="BorderInstance.YOrigin" SetsValue="true">
-      <Value xsi:type="xsd:int">1</Value>
-    </Variable>
-    <Variable Type="PositionUnitType" Name="BorderInstance.YUnits" SetsValue="true">
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="ButtonCategory" Name="ButtonCategoryState" SetsValue="false" />
@@ -193,24 +121,9 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-        <string>DropshadowRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Hazard/Styles.Accent.FillBlue</string>
-      </Value>
-    </VariableList>
-    <VariableList xsi:type="VariableListSaveOfString">
-      <Type>string</Type>
-      <Name>BorderInstance.VariableReferences</Name>
-      <Category>References</Category>
-      <IsFile>false</IsFile>
-      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-      <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
+        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -231,24 +144,12 @@
     <State>
       <Name>Enabled</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">18</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
         <Value xsi:type="xsd:int">200</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">244</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -261,46 +162,22 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>Highlighted</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
+        <Value xsi:type="xsd:int">60</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
+        <Value xsi:type="xsd:int">208</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">18</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
+        <Value xsi:type="xsd:int">245</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
@@ -312,45 +189,21 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>Pushed</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">12</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
         <Value xsi:type="xsd:int">163</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">201</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -363,45 +216,21 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>Focused</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">18</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
         <Value xsi:type="xsd:int">26</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
         <Value xsi:type="xsd:int">200</Value>
       </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Variable Type="int" Name="Body.FillRed" SetsValue="true">
         <Value xsi:type="xsd:int">244</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
@@ -414,46 +243,22 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>HighlightedFocused</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
+        <Value xsi:type="xsd:int">60</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
+        <Value xsi:type="xsd:int">208</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">18</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">26</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">200</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">244</Value>
+        <Value xsi:type="xsd:int">245</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
@@ -465,46 +270,22 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>Disabled</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
+        <Value xsi:type="xsd:int">26</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">14</Value>
+        <Value xsi:type="xsd:int">57</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
+        <Value xsi:type="xsd:int">69</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">false</Value>
@@ -516,46 +297,22 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.DisabledAccent.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.DisabledAccent.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.DisabledAccent.FillBlue</string>
         </Value>
       </VariableList>
     </State>
     <State>
       <Name>DisabledFocused</Name>
       <Variable Type="int" Name="Body.FillBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">7</Value>
+        <Value xsi:type="xsd:int">26</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">14</Value>
+        <Value xsi:type="xsd:int">57</Value>
       </Variable>
       <Variable Type="int" Name="Body.FillRed" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="bool" Name="Body.HasDropshadow" SetsValue="true">
-        <Value xsi:type="xsd:boolean">false</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
-        <Value xsi:type="xsd:int">16</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
-        <Value xsi:type="xsd:int">36</Value>
-      </Variable>
-      <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
-        <Value xsi:type="xsd:int">42</Value>
+        <Value xsi:type="xsd:int">69</Value>
       </Variable>
       <Variable Type="bool" Name="FocusedIndicator.Visible" SetsValue="true">
         <Value xsi:type="xsd:boolean">true</Value>
@@ -567,27 +324,14 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
-        </Value>
-      </VariableList>
-      <VariableList xsi:type="VariableListSaveOfString">
-        <Type>string</Type>
-        <Name>BorderInstance.VariableReferences</Name>
-        <Category>References</Category>
-        <IsFile>false</IsFile>
-        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
-        <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>FillRed = Components/Hazard/Styles.DisabledAccent.FillRed</string>
+          <string>FillGreen = Components/Hazard/Styles.DisabledAccent.FillGreen</string>
+          <string>FillBlue = Components/Hazard/Styles.DisabledAccent.FillBlue</string>
         </Value>
       </VariableList>
     </State>
   </Category>
   <Instance Name="Body" BaseType="Circle" />
-  <Instance Name="BorderInstance" BaseType="Circle" />
   <Instance Name="FocusedIndicator" BaseType="Circle" />
   <Behaviors>
     <ElementBehaviorReference>


### PR DESCRIPTION
## Summary
Follow-up to #4147 (which fixed the code-only Bubblegum/Hazard themes). The Gum tool's Add Forms importable theme content (`.gucx`) still had the old two-circle fill+border shape for **SliderThumb** and **RadioButton** in both themes — never updated when the code themes were fixed.

- Bubblegum SliderThumb/RadioButton: merged `Body`/`RadioBackground`'s separate fill+border circles onto one `Circle` instance carrying both `Fill*` and `Stroke*`.
- Hazard SliderThumb: removed the separate border circle entirely and recolored `Body` to the solid Accent fill the code theme actually uses (the old content was a leftover Bubblegum-style dark-fill-plus-border pair that never matched Hazard's own code theme — Hazard's thumb has no border at all).
- Hazard RadioButton: kept its border, merged onto one circle the same way as Bubblegum's.

Found via a requested comparison pass between the two themes' tool content and their code-theme counterparts — RadioButton had the identical bug pattern the user flagged for SliderThumb.

## Test plan
- [x] `gumcli check` / `check-references` / `diff-standards` clean on both themes
- [x] `BubblegumTemplateTests` / `HazardTemplateTests` all pass
- [x] Deployed `Gum/bin/Debug/Content/FormsThemes/**` confirmed to carry the fix (postbuild copy path)
- [ ] Manual: Add Forms import both themes into a project and visually confirm the Slider thumb and RadioButton render as a single seamless circle each (no double-edge, no unwanted border ring on Hazard's slider thumb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
