### PR TITLE
Keep composite variable references (Color = X.Color) collapsed on disk

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberRegistry.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/CompositeMemberRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using GumRuntime;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
@@ -24,8 +25,10 @@ public class CompositeMemberRegistry : ICompositeMemberRegistry
     {
         // Alpha is deliberately excluded: it stays an independent row so it can be animated separately
         // from color. Compose builds an opaque color; Decompose writes only R/G/B.
+        // Channel names are sourced from ElementSaveExtensions' composite-reference table (GumRuntime)
+        // so this UI-facing registry and apply-time reference expansion can't drift apart.
         return new CompositeMemberDescriptor(
-            ChannelRootNames: new[] { "Red", "Green", "Blue" },
+            ChannelRootNames: ElementSaveExtensions.GetCompositeChannelRootNames("Color")!,
             CompositeNameFormat: "{prefix}Color{suffix}",
             Displayer: typeof(Gum.Controls.DataUi.ColorDisplay),
             CompositeType: typeof(Color),
@@ -58,11 +61,7 @@ public class CompositeMemberRegistry : ICompositeMemberRegistry
         // Rectangle only - no affixed variants (no StrokeCornerRadius / CornerRadius2), so the
         // composite name format has no prefix/suffix content beyond the token itself.
         return new CompositeMemberDescriptor(
-            ChannelRootNames: new[]
-            {
-                "CornerRadius", "CustomRadiusTopLeft", "CustomRadiusTopRight",
-                "CustomRadiusBottomLeft", "CustomRadiusBottomRight"
-            },
+            ChannelRootNames: ElementSaveExtensions.GetCompositeChannelRootNames("CornerRadius")!,
             CompositeNameFormat: "{prefix}CornerRadius{suffix}",
             Displayer: typeof(Gum.Controls.DataUi.CornerRadiusDisplay),
             CompositeType: typeof(CornerRadiusComposite),

--- a/GumRuntime/ElementSaveExtensions.GumRuntime.cs
+++ b/GumRuntime/ElementSaveExtensions.GumRuntime.cs
@@ -586,7 +586,7 @@ namespace GumRuntime
         /// are not materialized into the state's <see cref="StateSave.Variables"/>. This
         /// indicates the state was authored by something other than the Gum tool's normal
         /// reference-edit path (AI agent, hand edit, programmatic creation, partial delete)
-        /// and that running <see cref="ApplyVariableReferences"/> on each returned state
+        /// and that running <c>ApplyVariableReferences</c> on each returned state
         /// would restore consistency. Commented-out (<c>//</c>) and unparseable lines are
         /// skipped; they are not treated as missing materializations.
         /// </summary>
@@ -615,6 +615,7 @@ namespace GumRuntime
                 }
 
                 var sourceObject = variableList.SourceObject;
+                ElementSave? channelOwner = ResolveChannelOwner(state, sourceObject);
 
                 foreach (string referenceString in variableList.ValueAsIList)
                 {
@@ -623,28 +624,50 @@ namespace GumRuntime
                         continue;
                     }
 
-                    var split = referenceString
-                        .Split(equalsArray, 2, StringSplitOptions.RemoveEmptyEntries);
-                    if (split.Length != 2)
+                    foreach (string expandedReferenceString in ExpandCompositeReferenceLine(referenceString, channelOwner))
                     {
-                        continue;
-                    }
+                        var split = expandedReferenceString
+                            .Split(equalsArray, 2, StringSplitOptions.RemoveEmptyEntries);
+                        if (split.Length != 2)
+                        {
+                            continue;
+                        }
 
-                    var left = split[0].Trim();
-                    var effectiveLeft = string.IsNullOrEmpty(sourceObject)
-                        ? left
-                        : $"{sourceObject}.{left}";
+                        var left = split[0].Trim();
+                        var effectiveLeft = string.IsNullOrEmpty(sourceObject)
+                            ? left
+                            : $"{sourceObject}.{left}";
 
-                    var hasMaterialized = state.Variables
-                        .Any(v => v.Name == effectiveLeft);
-                    if (!hasMaterialized)
-                    {
-                        return true;
+                        var hasMaterialized = state.Variables
+                            .Any(v => v.Name == effectiveLeft);
+                        if (!hasMaterialized)
+                        {
+                            return true;
+                        }
                     }
                 }
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="ElementSave"/> whose declared root variables determine whether a
+        /// composite reference's channels (e.g. Red/Green/Blue for <c>Color</c>) are real for the
+        /// object a <c>VariableReferences</c> row applies to - the row's own state's element when
+        /// unqualified, or the qualified instance's type when <paramref name="sourceObject"/> is set.
+        /// Public for the same reason as <see cref="ExpandCompositeReferenceLine"/>.
+        /// </summary>
+        public static ElementSave? ResolveChannelOwner(StateSave state, string? sourceObject)
+        {
+            ElementSave? element = state.ParentContainer;
+            if (string.IsNullOrEmpty(sourceObject) || element == null)
+            {
+                return element;
+            }
+
+            InstanceSave? instance = element.GetInstance(sourceObject);
+            return instance != null ? ObjectFinder.Self.GetElementSave(instance) : null;
         }
 
         /// <summary>
@@ -753,25 +776,29 @@ namespace GumRuntime
                         instance = element.GetInstance(variableList.SourceObject);
                     }
 
+                    ElementSave? channelOwner = instance != null ? ObjectFinder.Self.GetElementSave(instance) : element;
 
                     foreach (string referenceString in variableList.ValueAsIList)
                     {
-                        // this applies the variable and returns info about the application:
-                        var result = ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave, liveRoot);
-                        // In the gum tool, we need to check if the applicatoin actually changed the value
-                        // If so, we notify plugins that the variable was changed in case any additional changes
-                        // need to happen
-                        if (!string.IsNullOrEmpty(result.VariableName))
+                        foreach (string expandedReferenceString in ExpandCompositeReferenceLine(referenceString, channelOwner))
                         {
-                            var unqualified = result.VariableName;
-                            if (unqualified?.Contains(".") == true)
+                            // this applies the variable and returns info about the application:
+                            var result = ApplyVariableReferencesOnSpecificOwner(instance, expandedReferenceString, stateSave, liveRoot);
+                            // In the gum tool, we need to check if the applicatoin actually changed the value
+                            // If so, we notify plugins that the variable was changed in case any additional changes
+                            // need to happen
+                            if (!string.IsNullOrEmpty(result.VariableName))
                             {
-                                unqualified = unqualified.Substring(unqualified.IndexOf(".") + 1);
-                            }
-                            if (!ValueEquality(result.OldValue, result.NewValue))
-                            {
-                                VariableChangedThroughReference?.Invoke(
-                                    element, null, unqualified, result.OldValue);
+                                var unqualified = result.VariableName;
+                                if (unqualified?.Contains(".") == true)
+                                {
+                                    unqualified = unqualified.Substring(unqualified.IndexOf(".") + 1);
+                                }
+                                if (!ValueEquality(result.OldValue, result.NewValue))
+                                {
+                                    VariableChangedThroughReference?.Invoke(
+                                        element, null, unqualified, result.OldValue);
+                                }
                             }
                         }
                     }
@@ -793,9 +820,13 @@ namespace GumRuntime
                 {
                     if (variableList.SourceObject == null)
                     {
+                        ElementSave? channelOwner = stateSave.ParentContainer;
                         foreach (string referenceString in variableList.ValueAsIList)
                         {
-                            ApplyVariableReferencesOnSpecificOwner(graphicalElement, referenceString, stateSave, graphicalElement);
+                            foreach (string expandedReferenceString in ExpandCompositeReferenceLine(referenceString, channelOwner))
+                            {
+                                ApplyVariableReferencesOnSpecificOwner(graphicalElement, expandedReferenceString, stateSave, graphicalElement);
+                            }
                         }
                     }
                     else
@@ -815,9 +846,15 @@ namespace GumRuntime
 
                         if (instance != null)
                         {
+                            ElementSave? channelOwner = instance.Tag is InstanceSave instanceSave
+                                ? ObjectFinder.Self.GetElementSave(instanceSave)
+                                : null;
                             foreach (string referenceString in variableList.ValueAsIList)
                             {
-                                ApplyVariableReferencesOnSpecificOwner(instance, referenceString, stateSave, graphicalElement);
+                                foreach (string expandedReferenceString in ExpandCompositeReferenceLine(referenceString, channelOwner))
+                                {
+                                    ApplyVariableReferencesOnSpecificOwner(instance, expandedReferenceString, stateSave, graphicalElement);
+                                }
                             }
                         }
                     }
@@ -826,6 +863,160 @@ namespace GumRuntime
         }
 
         static char[] equalsArray = new char[] { '=' };
+
+        /// <summary>
+        /// A composite reference property (e.g. <c>Color</c>) backed by several sibling "channel"
+        /// variables (e.g. Red/Green/Blue) that must stay in sync when the composite is referenced
+        /// as a whole (<c>Color = Other.Color</c>). Mirrors the tool-side
+        /// <c>CompositeMemberDescriptor</c> used for the Variables-tab swatch, minus the WPF-only
+        /// compose/decompose/display concerns - this half only needs to expand a reference line
+        /// into one line per channel at apply time.
+        /// </summary>
+        private readonly struct CompositeReferenceDescriptor
+        {
+            public string CompositeToken { get; }
+            public string[] ChannelRootNames { get; }
+
+            public CompositeReferenceDescriptor(string compositeToken, string[] channelRootNames)
+            {
+                CompositeToken = compositeToken;
+                ChannelRootNames = channelRootNames;
+            }
+
+            /// <summary>
+            /// If <paramref name="compositeName"/> contains this descriptor's token surrounded by
+            /// some prefix/suffix (e.g. <c>StrokeColor</c>, <c>Color2</c>), outputs the matching
+            /// channel variable names (e.g. <c>StrokeColor</c> -&gt; StrokeRed/StrokeGreen/StrokeBlue).
+            /// </summary>
+            public bool TryGetChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
+            {
+                int index = compositeName.IndexOf(CompositeToken, StringComparison.Ordinal);
+                if (index < 0)
+                {
+                    channelNames = Array.Empty<string>();
+                    return false;
+                }
+
+                string prefix = compositeName.Substring(0, index);
+                string suffix = compositeName.Substring(index + CompositeToken.Length);
+
+                channelNames = ChannelRootNames.Select(token => prefix + token + suffix).ToArray();
+                return true;
+            }
+        }
+
+        private static readonly CompositeReferenceDescriptor[] CompositeReferenceDescriptors = new[]
+        {
+            new CompositeReferenceDescriptor("Color", new[] { "Red", "Green", "Blue" }),
+            new CompositeReferenceDescriptor("CornerRadius", new[]
+            {
+                "CornerRadius", "CustomRadiusTopLeft", "CustomRadiusTopRight",
+                "CustomRadiusBottomLeft", "CustomRadiusBottomRight"
+            }),
+        };
+
+        /// <summary>
+        /// Returns the channel root names for a known composite token (e.g. <c>"Color"</c> -&gt;
+        /// Red/Green/Blue), or null if the token isn't registered. Exposed so other
+        /// composite-aware consumers - e.g. the tool's <c>CompositeMemberRegistry</c>, which adds
+        /// WPF display/compose concerns on top - can source the channel list from one place
+        /// instead of duplicating it.
+        /// </summary>
+        public static string[]? GetCompositeChannelRootNames(string compositeToken)
+        {
+            foreach (CompositeReferenceDescriptor descriptor in CompositeReferenceDescriptors)
+            {
+                if (descriptor.CompositeToken == compositeToken)
+                {
+                    return descriptor.ChannelRootNames;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryGetCompositeChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
+        {
+            foreach (CompositeReferenceDescriptor descriptor in CompositeReferenceDescriptors)
+            {
+                if (descriptor.TryGetChannelNames(compositeName, out channelNames))
+                {
+                    return true;
+                }
+            }
+
+            channelNames = Array.Empty<string>();
+            return false;
+        }
+
+        /// <summary>
+        /// True only if <paramref name="channelOwner"/> declares a root variable for every channel -
+        /// i.e. the composite name really is backed by real channels on this element, not just a
+        /// coincidental name match (e.g. a literal "BackgroundColor" scalar with no
+        /// BackgroundRed/Green/Blue).
+        /// </summary>
+        private static bool OwnerHasAllCompositeChannels(IReadOnlyList<string> channelNames, ElementSave? channelOwner)
+        {
+            if (channelOwner == null)
+            {
+                return false;
+            }
+
+            foreach (string channelName in channelNames)
+            {
+                if (ObjectFinder.Self.GetRootVariable(channelName, channelOwner) == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Expands a single reference line into one line per channel when its left side is a
+        /// composite property directly referencing the same composite on another object (e.g.
+        /// <c>Color = Other.Color</c> -&gt; <c>Red = Other.Red</c>, <c>Green = Other.Green</c>,
+        /// <c>Blue = Other.Blue</c>). Returns the line unchanged (as a single-item sequence) when it
+        /// isn't a composite reference. This is what lets the collapsed form stay on disk while
+        /// every apply/evaluate/validate path downstream only ever sees plain single-channel lines.
+        /// Public so other GumCommon-tier consumers of raw <c>VariableReferences</c> line text
+        /// (e.g. <c>HeadlessErrorChecker</c>'s reference-conflict check) can expand consistently
+        /// with how references are actually applied, instead of duplicating the channel table.
+        /// </summary>
+        public static IEnumerable<string> ExpandCompositeReferenceLine(string referenceString, ElementSave? channelOwner)
+        {
+            if (string.IsNullOrEmpty(referenceString) || referenceString.StartsWith("//"))
+            {
+                yield return referenceString;
+                yield break;
+            }
+
+            string[] split = referenceString
+                .Split(equalsArray, 2, StringSplitOptions.RemoveEmptyEntries)
+                .Select(item => item.Trim())
+                .ToArray();
+
+            if (split.Length == 2)
+            {
+                string left = split[0];
+                string right = split[1];
+
+                if (right.EndsWith("." + left, StringComparison.Ordinal) &&
+                    TryGetCompositeChannelNames(left, out IReadOnlyList<string> channelNames) &&
+                    OwnerHasAllCompositeChannels(channelNames, channelOwner))
+                {
+                    string withoutVariable = right.Substring(0, right.Length - (1 + left.Length));
+                    foreach (string channelName in channelNames)
+                    {
+                        yield return $"{channelName} = {withoutVariable}.{channelName}";
+                    }
+                    yield break;
+                }
+            }
+
+            yield return referenceString;
+        }
 
         /// <summary>
         /// Evaluates the reference string (such as X = SomeOtherItem.X), applying the right side to the left side.

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -158,6 +158,37 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
 
     #endregion
 
+    #region CompositeColorExpansion
+
+    [Fact]
+    public void ApplyVariableReferences_CollapsedColorReference_ExpandsToAllChannels()
+    {
+        // "Color = Source.Color" must expand to Red/Green/Blue at apply time even though
+        // it stays a single collapsed line in VariableReferences.
+        ColoredRectangleRuntime parent = new ColoredRectangleRuntime();
+        parent.Red = 0;
+        parent.Green = 0;
+        parent.Blue = 0;
+
+        StateSave state = BuildStateWithVariableReference(
+            "Color = Source.Color",
+            null,
+            ("Red", 0, "int"),
+            ("Green", 0, "int"),
+            ("Blue", 0, "int"),
+            ("Source.Red", 10, "int"),
+            ("Source.Green", 20, "int"),
+            ("Source.Blue", 30, "int"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.Red.ShouldBe(10);
+        parent.Green.ShouldBe(20);
+        parent.Blue.ShouldBe(30);
+    }
+
+    #endregion
+
     #region SimpleAssignment
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
@@ -110,37 +110,33 @@ public class VariableReferenceLogicTests : BaseTestClass
     #region ReactIfChangedMemberIsVariableReference
 
     [Fact]
-    public void ReactIfChangedMemberIsVariableReference_ColorAssignment_ExpandsToThreeEntries()
+    public void ReactIfChangedMemberIsVariableReference_ColorAssignment_StaysCollapsed()
     {
         // "Background.Color" has no explicit left side, so AddImpliedLeftSide runs first,
-        // converting it to "Color = Background.Color", then the composite expansion splits it.
+        // converting it to "Color = Background.Color" - but composite expansion no longer runs
+        // at authoring time, so the line stays collapsed on disk. Expansion happens at apply
+        // time instead (GumRuntime.ElementSaveExtensions.ApplyVariableReferences).
         (StateSave defaultState, VariableListSave<string> varList) =
             BuildOwnerWithChannelsAndReference("Background.Color", "Red", "Green", "Blue");
 
         _sut.ReactIfChangedMemberIsVariableReference(
             instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        varList.Value.Count.ShouldBe(3);
-        varList.Value.ShouldContain("Red = Background.Red");
-        varList.Value.ShouldContain("Green = Background.Green");
-        varList.Value.ShouldContain("Blue = Background.Blue");
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("Color = Background.Color");
     }
 
     [Fact]
-    public void ReactIfChangedMemberIsVariableReference_FillColorAssignment_ExpandsToFillChannels()
+    public void ReactIfChangedMemberIsVariableReference_FillColorAssignment_StaysCollapsed()
     {
-        // Affixed colors expand to their affixed channels, the inverse of how CompositeMemberLogic
-        // collapses FillRed/FillGreen/FillBlue into a single "FillColor" swatch.
         (StateSave defaultState, VariableListSave<string> varList) =
-            BuildOwnerWithChannelsAndReference("Background.FillColor", "FillRed", "FillGreen", "FillBlue");
+            BuildOwnerWithChannelsAndReference("FillColor = Background.FillColor", "FillRed", "FillGreen", "FillBlue");
 
         _sut.ReactIfChangedMemberIsVariableReference(
             instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        varList.Value.Count.ShouldBe(3);
-        varList.Value.ShouldContain("FillRed = Background.FillRed");
-        varList.Value.ShouldContain("FillGreen = Background.FillGreen");
-        varList.Value.ShouldContain("FillBlue = Background.FillBlue");
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("FillColor = Background.FillColor");
     }
 
     [Fact]
@@ -160,7 +156,7 @@ public class VariableReferenceLogicTests : BaseTestClass
     }
 
     [Fact]
-    public void ReactIfChangedMemberIsVariableReference_StrokeColorAssignment_ExpandsToStrokeChannels()
+    public void ReactIfChangedMemberIsVariableReference_StrokeColorAssignment_StaysCollapsed()
     {
         (StateSave defaultState, VariableListSave<string> varList) =
             BuildOwnerWithChannelsAndReference("Background.StrokeColor", "StrokeRed", "StrokeGreen", "StrokeBlue");
@@ -168,14 +164,12 @@ public class VariableReferenceLogicTests : BaseTestClass
         _sut.ReactIfChangedMemberIsVariableReference(
             instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        varList.Value.Count.ShouldBe(3);
-        varList.Value.ShouldContain("StrokeRed = Background.StrokeRed");
-        varList.Value.ShouldContain("StrokeGreen = Background.StrokeGreen");
-        varList.Value.ShouldContain("StrokeBlue = Background.StrokeBlue");
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("StrokeColor = Background.StrokeColor");
     }
 
     [Fact]
-    public void ReactIfChangedMemberIsVariableReference_SuffixedColorAssignment_ExpandsToSuffixedChannels()
+    public void ReactIfChangedMemberIsVariableReference_SuffixedColorAssignment_StaysCollapsed()
     {
         // Gradient channels carry a numeric suffix (e.g. Color2 -> Red2/Green2/Blue2).
         (StateSave defaultState, VariableListSave<string> varList) =
@@ -184,10 +178,8 @@ public class VariableReferenceLogicTests : BaseTestClass
         _sut.ReactIfChangedMemberIsVariableReference(
             instance: null, defaultState, changedMember: "VariableReferences", oldValue: null);
 
-        varList.Value.Count.ShouldBe(3);
-        varList.Value.ShouldContain("Red2 = Background.Red2");
-        varList.Value.ShouldContain("Green2 = Background.Green2");
-        varList.Value.ShouldContain("Blue2 = Background.Blue2");
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("Color2 = Background.Color2");
     }
 
     [Fact]
@@ -617,6 +609,45 @@ public class VariableReferenceLogicTests : BaseTestClass
             trySave: false);
 
         varList.Value[0].ShouldBe("ButtonCategoryState = \"Disabled\"");
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_CollapsedColorReference_AcceptsLineAndAppliesAllChannels()
+    {
+        // "Color = Source.Color" is not a real StateSave variable on either side, so validation
+        // must special-case it rather than reporting "Could not find variable [Color]". The line
+        // stays collapsed on disk; Red/Green/Blue are materialized via the same apply-time
+        // expansion GumRuntime.ElementSaveExtensions.ApplyVariableReferences performs.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "Color = Source.Color",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        defaultState.Variables.Add(new VariableSave { Name = "Red", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Green", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Blue", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.Red", Value = 10, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.Green", Value = 20, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.Blue", Value = 30, Type = "int", SetsValue = true });
+
+        project.Screens.Add(screen);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("Color = Source.Color");
+        defaultState.GetValue("Red").ShouldBe(10);
+        defaultState.GetValue("Green").ShouldBe(20);
+        defaultState.GetValue("Blue").ShouldBe(30);
     }
 
     #endregion

--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -647,6 +647,42 @@ public class HeadlessErrorCheckerTests : BaseTestClass
     }
 
     [Fact]
+    public void GetErrorsFor_ShouldReportGum0002_WhenCollapsedColorReferenceChannelDisagreesWithMaterializedScalar()
+    {
+        // "Color = Source.Color" is a collapsed composite reference - Red/Green/Blue are the real
+        // channels. An explicit Red=14 that disagrees with the reference's evaluated Red (100)
+        // must still be flagged, even though "Color" itself is never a materialized scalar to
+        // compare directly against.
+        ComponentSave component = new ComponentSave { Name = "BadColorComponent", BaseType = "Container" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(state);
+
+        state.Variables.Add(new VariableSave { Name = "Source.Red", Type = "int", Value = 100, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Source.Green", Type = "int", Value = 20, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Source.Blue", Type = "int", Value = 30, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Red", Type = "int", Value = 14, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Green", Type = "int", Value = 20, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Blue", Type = "int", Value = 30, SetsValue = true });
+
+        VariableListSave<string> refs = new VariableListSave<string>
+        {
+            Name = "VariableReferences",
+            Type = "string"
+        };
+        refs.Value.Add("Color = Source.Color");
+        state.VariableLists.Add(refs);
+
+        Project.Components.Add(component);
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+        ErrorResult error = errors.ShouldHaveSingleItem();
+        error.Code.ShouldBe("GUM0002");
+        error.ElementName.ShouldBe("BadColorComponent");
+        error.Message.ShouldContain("Red");
+    }
+
+    [Fact]
     public void GetErrorsFor_ShouldNotReportGum0002_WhenScalarMatchesEvaluatedReference()
     {
         // Regression guard: when the materialized scalar matches the evaluated

--- a/Tests/Gum.ProjectServices.Tests/ReferencePropagationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ReferencePropagationServiceTests.cs
@@ -63,6 +63,53 @@ public class ReferencePropagationServiceTests : IDisposable
         return component;
     }
 
+    // The type Red/Green/Blue-composite components derive from. Its own DefaultState is what
+    // tells the composite-channel guard the channels are real - a real ColoredRectangle-derived
+    // component normally doesn't redeclare inherited scalars on its own state unless overridden,
+    // so the schema (channel existence) and the materialized value live on different states.
+    private static ComponentSave BuildColorTypeComponent()
+    {
+        ComponentSave colorType = new ComponentSave { Name = "ColorType" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = colorType };
+        state.Variables.Add(new VariableSave { Name = "Red", Type = "int", Value = 0, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Green", Type = "int", Value = 0, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Blue", Type = "int", Value = 0, SetsValue = true });
+        colorType.States.Add(state);
+        return colorType;
+    }
+
+    // "Color = Source.Color" is a collapsed composite reference - Red/Green/Blue are the real
+    // materialized scalars. materializeChannels controls whether this component's OWN state
+    // already records them (simulating post-propagation) or not (pre-propagation); either way
+    // BuildColorTypeComponent (added separately via BaseType) is what makes the channels real.
+    private static ComponentSave BuildComponentWithCollapsedColorReference(string componentName, bool materializeChannels)
+    {
+        ComponentSave component = new ComponentSave { Name = componentName, BaseType = "ColorType" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = component };
+        component.States.Add(state);
+
+        if (materializeChannels)
+        {
+            state.Variables.Add(new VariableSave { Name = "Red", Type = "int", Value = 10, SetsValue = true });
+            state.Variables.Add(new VariableSave { Name = "Green", Type = "int", Value = 20, SetsValue = true });
+            state.Variables.Add(new VariableSave { Name = "Blue", Type = "int", Value = 30, SetsValue = true });
+        }
+
+        state.Variables.Add(new VariableSave { Name = "Source.Red", Type = "int", Value = 10, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Source.Green", Type = "int", Value = 20, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Source.Blue", Type = "int", Value = 30, SetsValue = true });
+
+        VariableListSave<string> refs = new VariableListSave<string>
+        {
+            Name = "VariableReferences",
+            Type = "string"
+        };
+        refs.Value.Add("Color = Source.Color");
+        state.VariableLists.Add(refs);
+
+        return component;
+    }
+
     [Fact]
     public void Detect_ProjectWithUnpropagatedComponent_ReportsThatComponent()
     {
@@ -136,5 +183,38 @@ public class ReferencePropagationServiceTests : IDisposable
         IReadOnlyList<ElementSave> modified = _sut.PropagateReferences(project);
 
         modified.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Detect_ComponentWithMaterializedCollapsedColorReference_ReportsClean()
+    {
+        // Red/Green/Blue are already materialized (10/20/30) - the collapsed "Color = ..."
+        // row must not be treated as unpropagated just because no literal "Color" scalar exists.
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(BuildColorTypeComponent());
+        ComponentSave component = BuildComponentWithCollapsedColorReference("ColorComponent", materializeChannels: true);
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        DetectUnpropagatedReferencesResult result = _sut.Detect(project);
+
+        result.HasUnpropagatedReferences.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PropagateReferences_CollapsedColorReference_MaterializesAllThreeChannels()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.Components.Add(BuildColorTypeComponent());
+        ComponentSave component = BuildComponentWithCollapsedColorReference("ColorComponent", materializeChannels: false);
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        IReadOnlyList<ElementSave> modified = _sut.PropagateReferences(project);
+
+        modified.Count.ShouldBe(1);
+        component.DefaultState.GetValue("Red").ShouldBe(10);
+        component.DefaultState.GetValue("Green").ShouldBe(20);
+        component.DefaultState.GetValue("Blue").ShouldBe(30);
     }
 }

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/DetectUnpropagatedReferencesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/DetectUnpropagatedReferencesTests.cs
@@ -178,6 +178,50 @@ public class DetectUnpropagatedReferencesTests : BaseTestClass
     }
 
     [Fact]
+    public void GetStatesWithUnpropagatedReferences_TunneledCollapsedColorReferenceWithMaterializedScalars_DoesNotReport()
+    {
+        // "Color = Source.Color" on an instance's VariableReferences row must expand to
+        // RectangleInstance.Red/Green/Blue for the materialized-scalar check - the instance's
+        // type (ColorType) is what tells the detector the composite's channels are real.
+        // Without the fix, the detector looks for a literal "RectangleInstance.Color" scalar,
+        // which never exists, and always false-positives as unpropagated.
+        ComponentSave colorType = new ComponentSave { Name = "ColorType" };
+        StateSave colorTypeDefault = new StateSave { Name = "Default", ParentContainer = colorType };
+        colorTypeDefault.Variables.Add(new VariableSave { Name = "Red", Type = "int", Value = 0, SetsValue = true });
+        colorTypeDefault.Variables.Add(new VariableSave { Name = "Green", Type = "int", Value = 0, SetsValue = true });
+        colorTypeDefault.Variables.Add(new VariableSave { Name = "Blue", Type = "int", Value = 0, SetsValue = true });
+        colorType.States.Add(colorTypeDefault);
+
+        ScreenSave screen = new ScreenSave { Name = "ScreenWithTunneledCollapsedColorGood" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(state);
+
+        InstanceSave instance = new InstanceSave { Name = "RectangleInstance", BaseType = "ColorType", ParentContainer = screen };
+        screen.Instances.Add(instance);
+
+        state.Variables.Add(new VariableSave { Name = "RectangleInstance.Red", Type = "int", Value = 10, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "RectangleInstance.Green", Type = "int", Value = 20, SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "RectangleInstance.Blue", Type = "int", Value = 30, SetsValue = true });
+
+        VariableListSave<string> refs = new VariableListSave<string>
+        {
+            Name = "RectangleInstance.VariableReferences",
+            Type = "string"
+        };
+        refs.Value.Add("Color = Source.Color");
+        state.VariableLists.Add(refs);
+
+        GumProjectSave project = new GumProjectSave();
+        project.Screens.Add(screen);
+        project.Components.Add(colorType);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        var result = screen.GetStatesWithUnpropagatedReferences();
+
+        result.ShouldNotContain(state);
+    }
+
+    [Fact]
     public void GetStatesWithUnpropagatedReferences_StateHasReferenceAndMaterializedScalar_DoesNotReport()
     {
         // Regression guard: a properly authored state (reference row + materialized

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -108,6 +108,25 @@ public class VariableReferenceLogic : IVariableReferenceLogic
             return;
         }
 
+        if (TryGetCompositeExpansion(parentElement, leftSideInstance, line, out var expandedLines))
+        {
+            // Composite reference (e.g. "Color = Other.Color") - "Color" is never a real
+            // StateSave variable on either side, so validate each underlying channel line
+            // independently instead. Report a single failure against the original collapsed
+            // line (so CommentFailures can find and comment it out) if any channel is invalid.
+            foreach (string expandedLine in expandedLines)
+            {
+                var channelFailures = new List<(string, GeneralResponse)>();
+                AddFailureForLine(parentElement, leftSideInstance, channelFailures, expandedLine, liveRoot);
+                if (channelFailures.Count > 0)
+                {
+                    failures.Add((line, channelFailures[0].Item2));
+                    return;
+                }
+            }
+            return;
+        }
+
         var assignmentSyntax = GetAssignmentSyntax(line);
 
         GeneralResponse response = GeneralResponse.SuccessfulResponse;
@@ -731,23 +750,6 @@ public class VariableReferenceLogic : IVariableReferenceLogic
                     }
                 }
 
-                if (split.Length == 2)
-                {
-                    var leftSide = split[0];
-                    var rightSide = split[1];
-                    // A composite reference (e.g. "Color = X.Color", "StrokeColor = X.StrokeColor") expands into
-                    // one assignment per underlying channel. The registry knows which names are composites and
-                    // what channels they map to, so any registered composite (color today, others later) expands
-                    // with no extra control flow here. We only expand when the reference owner actually has those
-                    // channels - otherwise a non-composite name that merely contains the token (e.g. a literal
-                    // "BackgroundColor" variable) would be mangled into BackgroundRed/Green/Blue.
-                    if (rightSide.EndsWith("." + leftSide) &&
-                        TryGetCompositeChannelNames(leftSide, out var channelNames) &&
-                        OwnerHasAllChannels(channelNames, selectedInstance, ownerElement))
-                    {
-                        ExpandCompositeToChannels(newValueAsList, i, rightSide, leftSide, channelNames);
-                    }
-                }
             }
         }
 
@@ -866,19 +868,38 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         return true;
     }
 
-    private static void ExpandCompositeToChannels(List<string> asList, int i, string rightSide,
-        string compositeName, IReadOnlyList<string> channelNames)
+    /// <summary>
+    /// If <paramref name="line"/> is a composite reference directly assigning the same composite
+    /// from another object (e.g. <c>Color = Other.Color</c>), outputs the equivalent per-channel
+    /// lines (e.g. <c>Red = Other.Red</c>, <c>Green = Other.Green</c>, <c>Blue = Other.Blue</c>)
+    /// and returns true. Used by validation only - the collapsed line itself is what gets
+    /// persisted; expansion happens again at apply time in <c>GumRuntime.ElementSaveExtensions</c>.
+    /// </summary>
+    private bool TryGetCompositeExpansion(ElementSave parentElement, InstanceSave? leftSideInstance, string line,
+        out IReadOnlyList<string> expandedLines)
     {
-        // rightSide ends with "." + compositeName (e.g. "X.StrokeColor"); strip that to get the referenced
-        // object path ("X"), then re-attach each channel name on both sides.
-        var withoutVariable = rightSide.Substring(0, rightSide.Length - ("." + compositeName).Length);
+        string[] split = line
+            .Split(equalsArray, 2, StringSplitOptions.RemoveEmptyEntries)
+            .Select(item => item.Trim())
+            .ToArray();
 
-        asList.RemoveAt(i);
-
-        foreach (var channelName in channelNames)
+        if (split.Length == 2)
         {
-            asList.Add($"{channelName} = {withoutVariable}.{channelName}");
+            var leftSide = split[0];
+            var rightSide = split[1];
+
+            if (rightSide.EndsWith("." + leftSide) &&
+                TryGetCompositeChannelNames(leftSide, out var channelNames) &&
+                OwnerHasAllChannels(channelNames, leftSideInstance, parentElement))
+            {
+                var withoutVariable = rightSide.Substring(0, rightSide.Length - ("." + leftSide).Length);
+                expandedLines = channelNames.Select(channelName => $"{channelName} = {withoutVariable}.{channelName}").ToArray();
+                return true;
+            }
         }
+
+        expandedLines = Array.Empty<string>();
+        return false;
     }
 
     private static string[] AddImpliedLeftSide(List<string> asList, int i, string[] split)

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -141,11 +141,18 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
                 continue;
             }
             string? sourceObject = variableList.SourceObject;
+            ElementSave? channelOwner = ElementSaveExtensions.ResolveChannelOwner(state, sourceObject);
             foreach (string referenceString in variableList.ValueAsIList)
             {
-                if (TryParseReference(referenceString, sourceObject, out string qualifiedLeft, out string right))
+                // A collapsed composite line (e.g. "Color = Other.Color") never materializes a
+                // literal "Color" scalar - only Red/Green/Blue do - so expand to the underlying
+                // channels first, the same way ApplyVariableReferences does at apply time.
+                foreach (string expandedReferenceString in ElementSaveExtensions.ExpandCompositeReferenceLine(referenceString, channelOwner))
                 {
-                    EmitConflictIfPresent(element, state, state, qualifiedLeft, right, errors);
+                    if (TryParseReference(expandedReferenceString, sourceObject, out string qualifiedLeft, out string right))
+                    {
+                        EmitConflictIfPresent(element, state, state, qualifiedLeft, right, errors);
+                    }
                 }
             }
         }
@@ -187,12 +194,16 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
                 {
                     continue;
                 }
+                ElementSave? channelOwner = ElementSaveExtensions.ResolveChannelOwner(matchedState, sourceObject: null);
                 foreach (string referenceString in variableList.ValueAsIList)
                 {
-                    if (TryParseReference(referenceString, sourceObject: null, out string leftOnInstance, out string right))
+                    foreach (string expandedReferenceString in ElementSaveExtensions.ExpandCompositeReferenceLine(referenceString, channelOwner))
                     {
-                        string qualifiedLeft = $"{variable.SourceObject}.{leftOnInstance}";
-                        EmitConflictIfPresent(element, state, matchedState, qualifiedLeft, right, errors);
+                        if (TryParseReference(expandedReferenceString, sourceObject: null, out string leftOnInstance, out string right))
+                        {
+                            string qualifiedLeft = $"{variable.SourceObject}.{leftOnInstance}";
+                            EmitConflictIfPresent(element, state, matchedState, qualifiedLeft, right, errors);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

`Color = Other.Color` no longer expands into `Red`/`Green`/`Blue` lines when saved - the collapsed line is expanded at apply time instead, in `ElementSaveExtensions.ApplyVariableReferences` (`GumRuntime`), the single choke point already shared by tool materialization, wireframe preview, `gumcli check-references`, and game-runtime `ApplyAllVariableReferences`. The Roslyn expression evaluator and its no-Roslyn runtime fallback need no changes - expansion happens before either ever sees the line.

Also fixes two bugs the collapsed form exposed:
- `StateHasUnpropagatedReferences` looked for a literal `"Color"` scalar (never materialized) and always false-positived any collapsed composite reference as unpropagated.
- `HeadlessErrorChecker`'s GUM0002 conflict check had the same gap - it silently no-op'd on collapsed composite references instead of comparing their expanded channels.

Tool-side, `VariableReferenceLogic.ModifyLines` no longer eagerly expands the line at authoring time, and `GetIndividualFailures`/`AddFailureForLine` validate a composite LHS by validating its expanded channel lines instead of rejecting it as an unknown variable. `CompositeMemberRegistry`'s channel-name arrays (Color, CornerRadius) now source from the same `GumRuntime` table instead of duplicating it.

## Test plan
- [x] Unit tests: `MonoGameGum.Tests`, `Gum.Presentation.Tests`, `Gum.ProjectServices.Tests`, `GumToolUnitTests` - all green, new tests added for the collapsed form at every layer (runtime apply, CLI detect/propagate, tool validation, GUM0002 conflict detection).
- [x] `GumFull.sln` builds clean.
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`): 0 errors, no new warnings.
- [x] Manual: edit a `Color` variable reference in the Gum tool, confirm the saved XML has one `Color = ...` line and the wireframe preview still updates.

Closes #4149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
