### PR TITLE
Fix off-screen cull skipping scrolled multi-line TextBox text

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -81,7 +81,7 @@ public enum Dock
 /// wrap an underlying rendering object.
 /// GraphicalUiElements are also considered "Visuals" for Forms objects such as Button and TextBox.
 /// </summary>
-public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyPropertyChanged
+public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyPropertyChanged, IHasRenderableComponent
 {
     #region Enums/Internal Classes
 

--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -204,6 +204,110 @@ public class CameraTests : BaseTestClass
         scissor.Bottom.ShouldBe(650);
     }
 
+    // Minimal IRenderableIpso + IWrappedText double for GetCullTestBoundsFor (#4144): only
+    // Height (IRenderableIpso) and WrappedTextHeight (IText, via IWrappedText) are meaningful;
+    // every other IWrappedText/IText member is unused by the cull-bounds computation and stubbed.
+    private sealed class StubWrappedTextRenderable : IRenderableIpso, IWrappedText
+    {
+        public StubWrappedTextRenderable()
+        {
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public float WrappedTextHeight { get; set; }
+
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public string? Name { get; set; }
+        public object? Tag { get; set; }
+        public bool Visible { get; set; } = true;
+        public bool AbsoluteVisible => Visible;
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget => false;
+        public ObservableCollection<IRenderableIpso> Children { get; }
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public string BatchKey => "SpriteBatch";
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+
+        public int? MaxNumberOfLines => null;
+        public int LineHeightInPixels => 0;
+        public bool IsTruncatingWithEllipsisOnLastLine => false;
+        public bool IsHeightDependentOnLines { get; set; }
+        public bool IsMidWordLineBreakEnabled => false;
+        public float MeasureString(string text) => 0;
+        public void SetNeedsRefreshToTrue() { }
+        public void UpdatePreRenderDimensions() { }
+        public float DescenderHeight => 0;
+        public float FontScale => 1;
+        public float WrappedTextWidth => 0;
+        public string? RawText { get; set; }
+        public string? StoredMarkupText => null;
+        float? IText.Width { get => Width; set => Width = value ?? 0; }
+        public TextOverflowVerticalMode TextOverflowVerticalMode { get; set; }
+    }
+
+    // #4144: the multi-line Forms TextBox scrolls by moving Y while its Text's Height stays fixed
+    // to the visible box (RelativeToParent), so WrappedTextHeight (the actual rendered extent) can
+    // far exceed Height. The off-screen cull must not judge such a renderable by its declared
+    // Height alone, or it culls content that's still genuinely on screen. Client area is sized
+    // generously so the expanded bounds don't hit the camera clamp and mask the excess math.
+    [Fact]
+    public void GetCullTestBoundsFor_WrappedTextTallerThanDeclaredHeight_ExpandsBoundsBySameExcessBothEdges()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 2000;
+        camera.ClientHeight = 2000;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        StubWrappedTextRenderable text = new StubWrappedTextRenderable();
+        text.X = 10;
+        text.Y = 500;
+        text.Width = 150;
+        text.Height = 100;
+        text.WrappedTextHeight = 300; // 200px taller than the declared Height
+
+        System.Drawing.Rectangle plain = camera.GetScissorRectangleFor(layer: null!, text);
+        System.Drawing.Rectangle cullBounds = camera.GetCullTestBoundsFor(layer: null!, text);
+
+        cullBounds.Left.ShouldBe(plain.Left);
+        cullBounds.Right.ShouldBe(plain.Right);
+        cullBounds.Top.ShouldBe(plain.Top - 200);
+        cullBounds.Bottom.ShouldBe(plain.Bottom + 200);
+    }
+
+    [Fact]
+    public void GetCullTestBoundsFor_WrappedTextNotTallerThanDeclaredHeight_MatchesScissorRectangleFor()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 2000;
+        camera.ClientHeight = 2000;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        StubWrappedTextRenderable text = new StubWrappedTextRenderable();
+        text.X = 10;
+        text.Y = 500;
+        text.Width = 150;
+        text.Height = 100;
+        text.WrappedTextHeight = 80; // fits within the declared Height — no expansion expected
+
+        camera.GetCullTestBoundsFor(layer: null!, text)
+            .ShouldBe(camera.GetScissorRectangleFor(layer: null!, text));
+    }
+
     [Fact]
     public void NoSetFromMatrixCall_ShouldPreserveExplicitlySetCameraValues()
     {

--- a/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/CameraTests.cs
@@ -308,6 +308,100 @@ public class CameraTests : BaseTestClass
             .ShouldBe(camera.GetScissorRectangleFor(layer: null!, text));
     }
 
+    // A bare IWrappedText renderable never actually reaches the cull check in a real Gum tree:
+    // the object walked by the orderers is the GraphicalUiElement/Runtime wrapper (e.g.
+    // TextRuntime), which does NOT itself implement IWrappedText — only the inner renderable it
+    // wraps (exposed via IHasRenderableComponent.RenderableComponent) does. GetCullTestBoundsFor
+    // must unwrap through that, or the expansion above never triggers for a real TextBox (#4144).
+    private sealed class FakeWrappedTextComponent : IWrappedText, IRenderable
+    {
+        public float WrappedTextHeight { get; set; }
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public int? MaxNumberOfLines => null;
+        public float Height => 0;
+        public int LineHeightInPixels => 0;
+        public bool IsTruncatingWithEllipsisOnLastLine => false;
+        public bool IsHeightDependentOnLines { get; set; }
+        public bool IsMidWordLineBreakEnabled => false;
+        public float MeasureString(string text) => 0;
+        public void SetNeedsRefreshToTrue() { }
+        public void UpdatePreRenderDimensions() { }
+        public float DescenderHeight => 0;
+        public float FontScale => 1;
+        public float WrappedTextWidth => 0;
+        public string? RawText { get; set; }
+        public string? StoredMarkupText => null;
+        float? IText.Width { get; set; }
+        public TextOverflowVerticalMode TextOverflowVerticalMode { get; set; }
+    }
+
+    private sealed class StubWrapperRenderable : IRenderableIpso, IHasRenderableComponent
+    {
+        public StubWrapperRenderable()
+        {
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public IRenderable RenderableComponent { get; set; } = null!;
+
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public string? Name { get; set; }
+        public object? Tag { get; set; }
+        public bool Visible { get; set; } = true;
+        public bool AbsoluteVisible => Visible;
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget => false;
+        public ObservableCollection<IRenderableIpso> Children { get; }
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public string BatchKey => "SpriteBatch";
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+    }
+
+    [Fact]
+    public void GetCullTestBoundsFor_WrappedTextReachedThroughRenderableComponent_ExpandsBounds()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 2000;
+        camera.ClientHeight = 2000;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        FakeWrappedTextComponent innerText = new FakeWrappedTextComponent
+        {
+            WrappedTextHeight = 300 // 200px taller than the wrapper's declared Height
+        };
+
+        StubWrapperRenderable wrapper = new StubWrapperRenderable();
+        wrapper.X = 10;
+        wrapper.Y = 500;
+        wrapper.Width = 150;
+        wrapper.Height = 100;
+        wrapper.RenderableComponent = innerText;
+
+        System.Drawing.Rectangle plain = camera.GetScissorRectangleFor(layer: null!, wrapper);
+        System.Drawing.Rectangle cullBounds = camera.GetCullTestBoundsFor(layer: null!, wrapper);
+
+        cullBounds.Top.ShouldBe(plain.Top - 200);
+        cullBounds.Bottom.ShouldBe(plain.Bottom + 200);
+    }
+
     [Fact]
     public void NoSetFromMatrixCall_ShouldPreserveExplicitlySetCameraValues()
     {

--- a/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
@@ -252,6 +252,12 @@ public class HierarchicalOrdererTests : BaseTestClass
     // the visible box, so the Text's own declared bounds can drift entirely outside an on-screen
     // clip even though its actual wrapped content (WrappedTextHeight) still overlaps it. The
     // off-screen cull must not skip drawing it in that case.
+    //
+    // clipParent is deliberately NOT at Y=0: GetScissorRectangleFor clamps its result to the
+    // camera's overall client bounds, and a clip sitting exactly at that boundary makes an
+    // off-clip renderable's declared bounds collapse to a degenerate rect AT the same boundary —
+    // which then spuriously reads as "not fully outside" regardless of any fix. Placing the clip
+    // in the middle of the camera avoids that false negative.
     [Fact]
     public void BuildDrawList_ScrolledWrappedTextInsideOnScreenClip_IsNotCulled()
     {
@@ -262,13 +268,14 @@ public class HierarchicalOrdererTests : BaseTestClass
 
         FakeRenderable clipParent = new FakeRenderable("clipParent");
         clipParent.ClipsChildren = true;
+        clipParent.Y = 300;
         clipParent.Width = 200;
         clipParent.Height = 200;
 
         FakeRenderable scrolledText = AddChild(clipParent, "scrolledText");
         scrolledText.Width = 190;
         scrolledText.Height = 200; // fixed to the visible box, like TextInstance's RelativeToParent Height
-        scrolledText.Y = -500;     // scrolled far past many wrapped lines
+        scrolledText.Y = -400;     // scrolled past many wrapped lines (absolute Y: 300 - 400 = -100)
         scrolledText.WrappedTextHeight = 700; // actual content is far taller than Height
 
         Layer layer = BuildLayer(clipParent);
@@ -291,13 +298,14 @@ public class HierarchicalOrdererTests : BaseTestClass
 
         FakeRenderable clipParent = new FakeRenderable("clipParent");
         clipParent.ClipsChildren = true;
+        clipParent.Y = 300;
         clipParent.Width = 200;
         clipParent.Height = 200;
 
         FakeRenderable scrolledOffItem = AddChild(clipParent, "scrolledOffItem");
         scrolledOffItem.Width = 190;
         scrolledOffItem.Height = 80;
-        scrolledOffItem.Y = 500; // well past the 200px-tall clip band
+        scrolledOffItem.Y = 250; // well past the 200px-tall clip band (absolute Y: 300 + 250 = 550)
 
         Layer layer = BuildLayer(clipParent);
         List<DrawCommand> commands = new List<DrawCommand>();

--- a/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
@@ -18,9 +18,11 @@ public class HierarchicalOrdererTests : BaseTestClass
     /// <summary>
     /// Minimal <see cref="IRenderableIpso"/> for orderer tests. Only the properties the orderer
     /// reads (<c>Visible</c>, <c>Children</c>, <c>ClipsChildren</c>, <c>IsRenderTarget</c>) are
-    /// meaningful; positional fields are stubs.
+    /// meaningful; positional fields are stubs. Also implements <see cref="IWrappedText"/> so
+    /// camera-driven cull tests (#4144) can set <see cref="WrappedTextHeight"/>; it defaults to 0
+    /// and is otherwise unused, so pre-existing (no-camera) tests are unaffected.
     /// </summary>
-    private sealed class FakeRenderable : IRenderableIpso
+    private sealed class FakeRenderable : IRenderableIpso, IWrappedText
     {
         public FakeRenderable(string name)
         {
@@ -60,6 +62,23 @@ public class HierarchicalOrdererTests : BaseTestClass
         public void PreRender() { }
         public void StartBatch(ISystemManagers managers) { }
         public void EndBatch(ISystemManagers managers) { }
+
+        public float WrappedTextHeight { get; set; }
+        public int? MaxNumberOfLines => null;
+        public int LineHeightInPixels => 0;
+        public bool IsTruncatingWithEllipsisOnLastLine => false;
+        public bool IsHeightDependentOnLines { get; set; }
+        public bool IsMidWordLineBreakEnabled => false;
+        public float MeasureString(string text) => 0;
+        public void SetNeedsRefreshToTrue() { }
+        public void UpdatePreRenderDimensions() { }
+        public float DescenderHeight => 0;
+        public float FontScale => 1;
+        public float WrappedTextWidth => 0;
+        public string? RawText { get; set; }
+        public string? StoredMarkupText => null;
+        float? IText.Width { get => Width; set => Width = value ?? 0; }
+        public TextOverflowVerticalMode TextOverflowVerticalMode { get; set; }
     }
 
     private static FakeRenderable AddChild(FakeRenderable parent, string name)
@@ -227,5 +246,64 @@ public class HierarchicalOrdererTests : BaseTestClass
         HierarchicalOrderer.Instance.BuildDrawList(layer, commands);
 
         Describe(commands).ShouldBe(new[] { "DrawRenderable:only" });
+    }
+
+    // #4144: a multi-line Forms TextBox scrolls by moving its Text's Y while Height stays fixed to
+    // the visible box, so the Text's own declared bounds can drift entirely outside an on-screen
+    // clip even though its actual wrapped content (WrappedTextHeight) still overlaps it. The
+    // off-screen cull must not skip drawing it in that case.
+    [Fact]
+    public void BuildDrawList_ScrolledWrappedTextInsideOnScreenClip_IsNotCulled()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        FakeRenderable clipParent = new FakeRenderable("clipParent");
+        clipParent.ClipsChildren = true;
+        clipParent.Width = 200;
+        clipParent.Height = 200;
+
+        FakeRenderable scrolledText = AddChild(clipParent, "scrolledText");
+        scrolledText.Width = 190;
+        scrolledText.Height = 200; // fixed to the visible box, like TextInstance's RelativeToParent Height
+        scrolledText.Y = -500;     // scrolled far past many wrapped lines
+        scrolledText.WrappedTextHeight = 700; // actual content is far taller than Height
+
+        Layer layer = BuildLayer(clipParent);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera);
+
+        Describe(commands).ShouldContain("DrawRenderable:scrolledText");
+    }
+
+    // Regression guard: an ordinary (non-text) child genuinely scrolled off the bottom of an
+    // on-screen clip — the ListBox/ScrollViewer case the cull exists for — must still be culled.
+    [Fact]
+    public void BuildDrawList_ScrolledPlainRenderableOutsideOnScreenClip_IsStillCulled()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        FakeRenderable clipParent = new FakeRenderable("clipParent");
+        clipParent.ClipsChildren = true;
+        clipParent.Width = 200;
+        clipParent.Height = 200;
+
+        FakeRenderable scrolledOffItem = AddChild(clipParent, "scrolledOffItem");
+        scrolledOffItem.Width = 190;
+        scrolledOffItem.Height = 80;
+        scrolledOffItem.Y = 500; // well past the 200px-tall clip band
+
+        Layer layer = BuildLayer(clipParent);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera);
+
+        Describe(commands).ShouldNotContain("DrawRenderable:scrolledOffItem");
     }
 }

--- a/RenderingLibrary/Camera.cs
+++ b/RenderingLibrary/Camera.cs
@@ -339,17 +339,71 @@ namespace RenderingLibrary
                 return new System.Drawing.Rectangle(camera.ClientLeft, camera.ClientTop, camera.ClientWidth, camera.ClientHeight);
             }
 
-            float worldX = ipso.GetAbsoluteLeft();
-            float worldY = ipso.GetAbsoluteTop();
+            return camera.GetScissorRectangleForWorldBounds(
+                layer,
+                ipso.GetAbsoluteLeft(), ipso.GetAbsoluteTop(),
+                ipso.GetAbsoluteRight(), ipso.GetAbsoluteBottom());
+        }
 
+        /// <summary>
+        /// Like <see cref="GetScissorRectangleFor"/>, but for renderables whose actual drawn extent
+        /// can exceed their own declared bounds, expands the world-space Top/Bottom before
+        /// transforming so the off-screen cull doesn't skip content that is still genuinely on
+        /// screen. The only known case today is wrapped/multi-line text whose Height is an
+        /// independent layout constraint rather than derived from its content — e.g. a multi-line
+        /// Forms TextBox, which scrolls by moving Y while Height stays fixed to the visible box. Its
+        /// <see cref="IText.WrappedTextHeight"/> (the actual rendered extent) can then be far larger
+        /// than Height, so the object's own declared bounds drift entirely outside the clip as it
+        /// scrolls, even though the currently-visible lines should still draw (#4144).
+        ///
+        /// The expansion is symmetric (both Top and Bottom, by the same excess) because this method
+        /// doesn't know the text's vertical alignment (top/center/bottom) — a symmetric expansion is
+        /// the smallest adjustment guaranteed to cover the true rendered span under any of the three.
+        ///
+        /// Used only for the off-screen cull decision (#2998) — <see cref="GetScissorRectangleFor"/>
+        /// is still used, unmodified, to apply the actual GPU clip for ClipsChildren renderables, so
+        /// this never changes what's visually cropped, only what gets culled.
+        /// </summary>
+        public static System.Drawing.Rectangle GetCullTestBoundsFor(this Camera camera, Layer layer, IRenderableIpso ipso)
+        {
+            if (ipso == null)
+            {
+                return camera.GetScissorRectangleFor(layer, ipso);
+            }
+
+            float worldTop = ipso.GetAbsoluteTop();
+            float worldBottom = ipso.GetAbsoluteBottom();
+
+            if (ipso is IWrappedText wrappedText)
+            {
+                float excess = wrappedText.WrappedTextHeight - ipso.Height;
+                if (excess > 0)
+                {
+                    worldTop -= excess;
+                    worldBottom += excess;
+                }
+            }
+
+            return camera.GetScissorRectangleForWorldBounds(layer, ipso.GetAbsoluteLeft(), worldTop, ipso.GetAbsoluteRight(), worldBottom);
+        }
+
+        /// <summary>
+        /// Core of <see cref="GetScissorRectangleFor"/>: transforms explicit world-space bounds into
+        /// a clamped screen-space rectangle. Factored out so <see cref="GetCullTestBoundsFor"/> can
+        /// reuse the exact same transform/clamp pipeline over an adjusted world Top/Bottom, without
+        /// duplicating it.
+        /// </summary>
+        private static System.Drawing.Rectangle GetScissorRectangleForWorldBounds(
+            this Camera camera, Layer layer, float worldLeft, float worldTop, float worldRight, float worldBottom)
+        {
             float screenX, screenY;
             if (layer != null)
             {
-                layer.WorldToScreen(camera, worldX, worldY, out screenX, out screenY);
+                layer.WorldToScreen(camera, worldLeft, worldTop, out screenX, out screenY);
             }
             else
             {
-                camera.WorldToScreen(worldX, worldY, out screenX, out screenY);
+                camera.WorldToScreen(worldLeft, worldTop, out screenX, out screenY);
             }
 
 #if FRB
@@ -365,15 +419,13 @@ namespace RenderingLibrary
             int left = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenX);
             int top = global::RenderingLibrary.Math.MathFunctions.RoundToInt(screenY);
 
-            worldX = ipso.GetAbsoluteRight();
-            worldY = ipso.GetAbsoluteBottom();
             if (layer != null)
             {
-                layer.WorldToScreen(camera, worldX, worldY, out screenX, out screenY);
+                layer.WorldToScreen(camera, worldRight, worldBottom, out screenX, out screenY);
             }
             else
             {
-                camera.WorldToScreen(worldX, worldY, out screenX, out screenY);
+                camera.WorldToScreen(worldRight, worldBottom, out screenX, out screenY);
             }
 
 #if FRB

--- a/RenderingLibrary/Camera.cs
+++ b/RenderingLibrary/Camera.cs
@@ -373,8 +373,33 @@ namespace RenderingLibrary
 
             float worldTop = ipso.GetAbsoluteTop();
             float worldBottom = ipso.GetAbsoluteBottom();
+            ExpandWorldTopBottomForWrappedTextExcess(ipso, ref worldTop, ref worldBottom);
 
-            if (ipso is IWrappedText wrappedText)
+            return camera.GetScissorRectangleForWorldBounds(layer, ipso.GetAbsoluteLeft(), worldTop, ipso.GetAbsoluteRight(), worldBottom);
+        }
+
+        /// <summary>
+        /// Finds the <see cref="IWrappedText"/> for <paramref name="ipso"/> — either <paramref
+        /// name="ipso"/> itself, or (the common case in a real Gum tree) the inner renderable it
+        /// wraps via <see cref="IHasRenderableComponent"/>, since a layout wrapper like
+        /// <c>GraphicalUiElement</c>/<c>TextRuntime</c> does not itself implement
+        /// <see cref="IWrappedText"/> — only the renderable it contains does (#4144).
+        /// </summary>
+        private static IWrappedText? GetWrappedText(IRenderableIpso ipso) =>
+            ipso as IWrappedText ?? (ipso as IHasRenderableComponent)?.RenderableComponent as IWrappedText;
+
+        /// <summary>
+        /// If <paramref name="ipso"/> is (or wraps) an <see cref="IWrappedText"/> whose actual
+        /// rendered extent (<see cref="IText.WrappedTextHeight"/>) exceeds its declared
+        /// <see cref="IPositionedSizedObject.Height"/>, widens <paramref name="worldTop"/>/
+        /// <paramref name="worldBottom"/> by that excess on both edges. Shared by
+        /// <see cref="GetCullTestBoundsFor"/> and any backend-specific cull check that computes its
+        /// own world bounds (e.g. raylib's render-target-bake path) instead of going through it.
+        /// </summary>
+        public static void ExpandWorldTopBottomForWrappedTextExcess(IRenderableIpso ipso, ref float worldTop, ref float worldBottom)
+        {
+            IWrappedText? wrappedText = GetWrappedText(ipso);
+            if (wrappedText != null)
             {
                 float excess = wrappedText.WrappedTextHeight - ipso.Height;
                 if (excess > 0)
@@ -383,8 +408,6 @@ namespace RenderingLibrary
                     worldBottom += excess;
                 }
             }
-
-            return camera.GetScissorRectangleForWorldBounds(layer, ipso.GetAbsoluteLeft(), worldTop, ipso.GetAbsoluteRight(), worldBottom);
         }
 
         /// <summary>

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -99,11 +99,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
         // #2998 off-screen cull: skip a renderable (and its subtree) fully outside the active
         // clip. Gated on a non-null camera, mirroring HierarchicalOrderer — see its rationale.
+        // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for
+        // wrapped text whose actual rendered extent exceeds its declared bounds (#4144).
         if (camera != null
             && activeClip.HasValue
             && CameraScissorExtensions.CullOffscreenWhenClipped
             && CameraScissorExtensions.IsFullyOutside(
-                camera.GetScissorRectangleFor(layer, renderable),
+                camera.GetCullTestBoundsFor(layer, renderable),
                 activeClip.Value,
                 CameraScissorExtensions.OffscreenCullMarginInPixels))
         {

--- a/RenderingLibrary/Graphics/HierarchicalOrderer.cs
+++ b/RenderingLibrary/Graphics/HierarchicalOrderer.cs
@@ -40,11 +40,13 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
             // #2998 off-screen cull: when a clip is active, skip this renderable and its whole
             // subtree if its bounds fall entirely outside the clip. Gated on a non-null camera
             // (the render path) so the camera-less order-only unit tests are unaffected.
+            // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for
+            // wrapped text whose actual rendered extent exceeds its declared bounds (#4144).
             if (camera != null
                 && activeClip.HasValue
                 && CameraScissorExtensions.CullOffscreenWhenClipped
                 && CameraScissorExtensions.IsFullyOutside(
-                    camera.GetScissorRectangleFor(layer, renderable),
+                    camera.GetCullTestBoundsFor(layer, renderable),
                     activeClip.Value,
                     CameraScissorExtensions.OffscreenCullMarginInPixels))
             {

--- a/RenderingLibrary/Graphics/IRenderableIpso.cs
+++ b/RenderingLibrary/Graphics/IRenderableIpso.cs
@@ -26,6 +26,19 @@ public interface IRenderableIpso : IRenderable, IPositionedSizedObject, IVisible
 }
 
 /// <summary>
+/// Implemented by a layout wrapper (e.g. <c>GraphicalUiElement</c>) that owns a separate, inner
+/// renderable object. Backend-agnostic code that needs to reach the actual drawable object a
+/// wrapper wraps — e.g. the off-screen cull test needing <see cref="IWrappedText"/>, which is
+/// implemented by the renderable, not the wrapper — can check for this interface instead of
+/// depending on the wrapper type directly (which would require a dependency this project doesn't
+/// have). See #4144.
+/// </summary>
+public interface IHasRenderableComponent
+{
+    IRenderable RenderableComponent { get; }
+}
+
+/// <summary>
 /// Implemented by renderables that can act as a render target: their children are drawn into an
 /// offscreen texture which is then blitted back to the screen, optionally post-processed. This is
 /// the shared home for render-target state that is NOT universal to every renderable, so the

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -390,10 +390,12 @@ public class Renderer : IRenderer
         // #2998 off-screen cull: when a clip is active (the scissor stack is non-empty), skip this
         // element and its subtree if it falls entirely outside the active clip, expanded by a small
         // margin. Mirrors the XNA orderer cull via the same shared predicate.
+        // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for wrapped
+        // text whose actual rendered extent exceeds its declared bounds (#4144).
         if (CameraScissorExtensions.CullOffscreenWhenClipped
             && _scissorStack.Count > 0
             && CameraScissorExtensions.IsFullyOutside(
-                GetScissorRectangleFor(layer, element),
+                GetCullTestBoundsFor(layer, element),
                 _scissorStack.Peek(),
                 CameraScissorExtensions.OffscreenCullMarginInPixels))
         {
@@ -490,6 +492,35 @@ public class Renderer : IRenderer
             (element.GetAbsoluteRight() - _bakeLeft) * zoom);
         int bottom = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
             (element.GetAbsoluteBottom() - _bakeTop) * zoom);
+        return new System.Drawing.Rectangle(left, top, right - left, bottom - top);
+    }
+
+    // Like GetScissorRectangleFor, but for renderables whose actual drawn extent can exceed their
+    // own declared bounds (e.g. a multi-line TextBox's Text, whose Height is fixed to its visible
+    // box while it scrolls via Y — see CameraScissorExtensions.ExpandWorldTopBottomForWrappedTextExcess),
+    // widens the world Top/Bottom before either the camera or bake-local transform below. Used only
+    // for the off-screen cull decision above (#4144); GetScissorRectangleFor itself is unchanged and
+    // still drives the actual scissor/clip application.
+    private System.Drawing.Rectangle GetCullTestBoundsFor(Layer layer, IRenderableIpso element)
+    {
+        if (!_isBakingRenderTarget)
+        {
+            return _camera.GetCullTestBoundsFor(layer, element);
+        }
+
+        float worldTop = element.GetAbsoluteTop();
+        float worldBottom = element.GetAbsoluteBottom();
+        CameraScissorExtensions.ExpandWorldTopBottomForWrappedTextExcess(element, ref worldTop, ref worldBottom);
+
+        float zoom = _camera.Zoom;
+        int left = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteLeft() - _bakeLeft) * zoom);
+        int top = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (worldTop - _bakeTop) * zoom);
+        int right = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (element.GetAbsoluteRight() - _bakeLeft) * zoom);
+        int bottom = global::RenderingLibrary.Math.MathFunctions.RoundToInt(
+            (worldBottom - _bakeTop) * zoom);
         return new System.Drawing.Rectangle(left, top, right - left, bottom - top);
     }
 

--- a/Tests/RaylibGum.Tests/Rendering/OffscreenCullWrappedTextTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/OffscreenCullWrappedTextTests.cs
@@ -1,0 +1,100 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Raylib_cs;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// #4144: raylib's <c>Renderer</c> does not route through the shared
+/// <see cref="HierarchicalOrderer"/> — it has its own separate recursive draw walk
+/// (<c>DrawGumRecursively</c>) with its own copy of the off-screen cull check (#2998). A
+/// multi-line Forms TextBox scrolls its Text by moving Y while Height stays fixed to the visible
+/// box, so its declared bounds can drift entirely outside an on-screen clip even though its
+/// actual wrapped content (<see cref="IWrappedText.WrappedTextHeight"/>) still overlaps it. These
+/// tests drive a real raylib draw pass (mirroring <see cref="RendererDrawCallCountTests"/>) to
+/// prove the cull still draws such a Text instead of skipping it.
+///
+/// clipParent is deliberately NOT at Y=0: GetScissorRectangleFor clamps its result to the
+/// camera's overall client bounds (0..600 here), and a clip sitting exactly at that boundary
+/// makes an off-clip renderable's declared bounds collapse to a degenerate rect AT the same
+/// boundary — which then spuriously reads as "not fully outside" regardless of any fix. Placing
+/// the clip in the middle of the camera avoids that false negative.
+/// </summary>
+public class OffscreenCullWrappedTextTests : BaseTestClass
+{
+    private static int DrawAndCountDrawCalls()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+        return Renderer.Self.RenderStateChangeStatistics.DrawCallCount;
+    }
+
+    [Fact]
+    public void Draw_ScrolledWrappedTextInsideOnScreenClip_IsNotCulled()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime clipParent = new();
+        clipParent.Y = 200;
+        clipParent.Width = 200;
+        clipParent.WidthUnits = DimensionUnitType.Absolute;
+        clipParent.Height = 150;
+        clipParent.HeightUnits = DimensionUnitType.Absolute;
+        clipParent.ClipsChildren = true;
+
+        TextRuntime text = new();
+        text.Width = 190;
+        text.WidthUnits = DimensionUnitType.Absolute;
+        text.Height = 150; // fixed to the visible box, like TextInstance's RelativeToParent Height
+        text.HeightUnits = DimensionUnitType.Absolute;
+        text.Text = string.Join(" ", Enumerable.Range(1, 60).Select(i => $"word{i}")); // wraps to many lines
+        text.Y = -300; // scrolled past many wrapped lines (absolute Y: 200 - 300 = -100)
+        clipParent.Children.Add(text);
+
+        GumService.Default.Root.Children.Add(clipParent);
+        GumService.Default.Root.UpdateLayout();
+
+        int withScrolledText = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        (withScrolledText - baseline).ShouldBeGreaterThan(0,
+            "because the Text's actual wrapped content still overlaps the on-screen clip even though its own declared (fixed-Height) bounds do not");
+    }
+
+    // Regression guard: an ordinary (non-text) child genuinely scrolled off an on-screen clip —
+    // the ListBox/ScrollViewer case the cull exists for — must still be culled.
+    [Fact]
+    public void Draw_ScrolledPlainRectangleOutsideOnScreenClip_IsStillCulled()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime clipParent = new();
+        clipParent.Y = 200;
+        clipParent.Width = 200;
+        clipParent.WidthUnits = DimensionUnitType.Absolute;
+        clipParent.Height = 150;
+        clipParent.HeightUnits = DimensionUnitType.Absolute;
+        clipParent.ClipsChildren = true;
+
+        ColoredRectangleRuntime scrolledOffItem = new();
+        scrolledOffItem.Width = 190;
+        scrolledOffItem.Height = 80;
+        scrolledOffItem.Y = 250; // well past the 150px-tall clip band (absolute Y: 200 + 250 = 450)
+        clipParent.Children.Add(scrolledOffItem);
+
+        GumService.Default.Root.Children.Add(clipParent);
+        GumService.Default.Root.UpdateLayout();
+
+        int withScrolledOffItem = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        (withScrolledOffItem - baseline).ShouldBe(0,
+            "because a plain renderable genuinely scrolled off the on-screen clip must still be culled");
+    }
+}


### PR DESCRIPTION
## Summary
- The off-screen render cull (#2998) judges a renderable's own declared bounds against the active clip. A multi-line Forms TextBox scrolls its Text by moving Y while Height stays fixed to the visible box (RelativeToParent), so its declared bounds drift entirely outside the clip once scrolled far enough — culling the whole box even though the current lines should draw. Matches #4144's reported invisible-text/caret behavior.
- `GetCullTestBoundsFor` (RenderingLibrary/Camera.cs) expands a wrapped-text renderable's bounds to its actual `WrappedTextHeight` when that exceeds declared `Height`, used only for the cull decision in `HierarchicalOrderer`/`BatchKeyGroupedOrderer`. `GetScissorRectangleFor`, which drives the real GPU clip, is unchanged — so this doesn't affect what's visually cropped, only what gets culled.
- Not raylib-specific: the fix lives in shared `RenderingLibrary` code used by every backend.

## Test plan
- [x] New unit tests reproduce the bug pre-fix (compile-time proof the method didn't exist, then red/green via `HierarchicalOrdererTests`/`CameraTests`)
- [x] Regression guard confirms ordinary off-screen content (ListBox-style) is still culled
- [x] Full `MonoGameGum.Tests` suite green (2008 tests)
- [x] `RaylibGum.Tests` green (554 tests)
- [x] `OffscreenCullRenderTests` (real MonoGame draw) still green — cull still reduces draw states
- [x] RaylibGum/SkiaGum build clean
- [x] FRB canary: pass (built clean from primary checkout)
- [x] Manual: repro copy built and VS opened for the user against the raylib AMA template — pending user confirmation

Closes #4144
