### PR TITLE
Collapse matching Red/Green/Blue VariableReferences to Color/FillColor/StrokeColor

### DIFF
--- a/.claude/skills/gum-forms-theme-import/SKILL.md
+++ b/.claude/skills/gum-forms-theme-import/SKILL.md
@@ -238,6 +238,13 @@ instances yourself, `--fix` already writes it into every state. This only works 
 missing outright, though; see "Recoloring after a clone" above for the stale-but-present case it
 can't touch.
 
+**A `Red`/`Green`/`Blue` triple only collapses to `Color`/`FillColor`/`StrokeColor` when both sides
+use the identical channel name** — `VariableReferenceLogic.TryGetCompositeExpansion` requires the
+RHS to end with `.` + the LHS. A plain-color instance borrowing a Rectangle swatch's fill
+(`Red = X.FillRed`, common for `Text` instances) doesn't qualify - collapsing it would reference a
+`Color` composite the swatch doesn't have. `FormsTemplate` (Standard)'s own instances use this
+mismatched-name pattern exclusively, so none of its `VariableReferences` triples are eligible.
+
 One more staged-output-specific gotcha, beyond the postbuild simply not rerunning (item 7 /
 "the staged build, not the source" above): `xcopy` never deletes, so a rename or removal in the
 template leaves the stale old file sitting in an already-built output even when the postbuild

--- a/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
@@ -227,8 +227,24 @@ public class BubblegumTemplateTests
                         }
 
                         string left = referenceString.Substring(0, equalsIndex).Trim();
-                        string effectiveLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
-                        wired.Add(effectiveLeft);
+
+                        // A collapsed composite reference (e.g. "FillColor = Other.FillColor", #4153)
+                        // wires all 3 of its channel scalars at apply time (GumRuntime.ElementSaveExtensions),
+                        // not a literal "FillColor" scalar - so it must mark Red/Green/Blue as wired here too.
+                        if (left.EndsWith("Color", StringComparison.Ordinal))
+                        {
+                            string colorPrefix = left.Substring(0, left.Length - "Color".Length);
+                            foreach (string channelToken in new[] { "Red", "Green", "Blue" })
+                            {
+                                string channelLeft = colorPrefix + channelToken;
+                                wired.Add(string.IsNullOrEmpty(sourceObject) ? channelLeft : $"{sourceObject}.{channelLeft}");
+                            }
+                        }
+                        else
+                        {
+                            string effectiveLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
+                            wired.Add(effectiveLeft);
+                        }
                     }
                 }
 

--- a/Tests/Gum.ProjectServices.Tests/HazardTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HazardTemplateTests.cs
@@ -224,8 +224,24 @@ public class HazardTemplateTests
                         }
 
                         string left = referenceString.Substring(0, equalsIndex).Trim();
-                        string effectiveLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
-                        wired.Add(effectiveLeft);
+
+                        // A collapsed composite reference (e.g. "FillColor = Other.FillColor", #4153)
+                        // wires all 3 of its channel scalars at apply time (GumRuntime.ElementSaveExtensions),
+                        // not a literal "FillColor" scalar - so it must mark Red/Green/Blue as wired here too.
+                        if (left.EndsWith("Color", StringComparison.Ordinal))
+                        {
+                            string colorPrefix = left.Substring(0, left.Length - "Color".Length);
+                            foreach (string channelToken in new[] { "Red", "Green", "Blue" })
+                            {
+                                string channelLeft = colorPrefix + channelToken;
+                                wired.Add(string.IsNullOrEmpty(sourceObject) ? channelLeft : $"{sourceObject}.{channelLeft}");
+                            }
+                        }
+                        else
+                        {
+                            string effectiveLeft = string.IsNullOrEmpty(sourceObject) ? left : $"{sourceObject}.{left}";
+                            wired.Add(effectiveLeft);
+                        }
                     }
                 }
 

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
@@ -217,9 +217,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -273,9 +271,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -324,9 +320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -375,9 +369,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -426,9 +418,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -477,9 +467,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -528,9 +516,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -579,9 +565,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ButtonIcon.gucx
@@ -204,9 +204,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -260,9 +258,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -311,9 +307,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -362,9 +356,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -413,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -464,9 +454,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -515,9 +503,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -566,9 +552,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
@@ -353,9 +353,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -377,9 +375,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -478,9 +474,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -553,9 +547,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -628,9 +620,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -703,9 +693,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -778,9 +766,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -853,9 +839,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -928,9 +912,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1024,9 +1006,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1120,9 +1100,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1216,9 +1194,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1312,9 +1288,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1408,9 +1382,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1504,9 +1476,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1600,9 +1570,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1675,9 +1643,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1750,9 +1716,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1825,9 +1789,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1900,9 +1862,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1975,9 +1935,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -2050,9 +2008,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -2125,9 +2081,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
@@ -348,9 +348,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -428,9 +426,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -518,9 +514,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -608,9 +602,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -698,9 +690,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -788,9 +778,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -878,9 +866,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -968,9 +954,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
@@ -200,9 +200,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
@@ -281,9 +281,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBox.gucx
@@ -323,9 +323,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -385,9 +383,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -433,9 +429,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -481,9 +475,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -529,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -577,9 +567,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -625,9 +613,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -673,9 +659,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
@@ -215,9 +215,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.HoverRow.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.HoverRow.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.HoverRow.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.HoverRow.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -251,9 +249,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -299,9 +295,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Menu.gucx
@@ -176,9 +176,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -188,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
@@ -394,9 +394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.HoverOption.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.HoverOption.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.HoverOption.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.HoverOption.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -451,9 +449,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -532,9 +528,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.HoverOption.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.HoverOption.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.HoverOption.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.HoverOption.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
@@ -460,9 +460,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -472,9 +470,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -484,9 +480,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -585,9 +579,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -597,9 +589,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -696,9 +686,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -708,9 +696,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -807,9 +793,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -819,9 +803,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -918,9 +900,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -930,9 +910,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
@@ -250,9 +250,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -262,9 +260,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
         <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
         <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
@@ -324,9 +320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -351,9 +345,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -408,9 +400,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
@@ -435,9 +425,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -492,9 +480,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -519,9 +505,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -576,9 +560,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -603,9 +585,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -660,9 +640,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -687,9 +665,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -744,9 +720,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -771,9 +745,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -828,9 +800,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
@@ -855,9 +825,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -912,9 +880,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
@@ -939,9 +905,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -996,9 +960,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -1023,9 +985,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1080,9 +1040,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -1107,9 +1065,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1164,9 +1120,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -1191,9 +1145,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1248,9 +1200,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -1275,9 +1225,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1332,9 +1280,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -1359,9 +1305,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1416,9 +1360,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -1443,9 +1385,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ScrollViewer.gucx
@@ -268,9 +268,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Slider.gucx
@@ -122,9 +122,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -157,9 +155,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -184,9 +180,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
@@ -157,9 +157,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -216,9 +214,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -258,9 +254,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -300,9 +294,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
@@ -342,9 +334,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -384,9 +374,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
@@ -426,9 +414,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
@@ -468,9 +454,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
           <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
           <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Splitter.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Splitter.gucx
@@ -77,9 +77,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
@@ -459,9 +459,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -471,9 +469,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +479,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.AccentLight.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.AccentLight.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.AccentLight.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -584,9 +578,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -596,9 +588,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -695,9 +685,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -707,9 +695,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -806,9 +792,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -818,9 +802,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -917,9 +899,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -929,9 +909,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>FillGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>FillBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>FillColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
@@ -187,9 +187,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/UserControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/UserControl.gucx
@@ -63,9 +63,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Background.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Background.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Background.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Background.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Window.gucx
@@ -485,9 +485,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -497,9 +495,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -509,9 +505,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Elements/Divider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Elements/Divider.gucx
@@ -302,9 +302,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Placeholder.Red</string>
-        <string>Green = Components/Bubblegum/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Bubblegum/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Bubblegum/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -314,9 +312,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Placeholder.Red</string>
-        <string>Green = Components/Bubblegum/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Bubblegum/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Bubblegum/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -326,9 +322,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Placeholder.Red</string>
-        <string>Green = Components/Bubblegum/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Bubblegum/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Bubblegum/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Button.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Button.gucx
@@ -217,9 +217,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         <string>DropshadowRed = Components/Hazard/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Hazard/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -273,9 +271,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -324,9 +320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -375,9 +369,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -426,9 +418,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -477,9 +467,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -528,9 +516,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -579,9 +565,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ButtonIcon.gucx
@@ -204,9 +204,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         <string>DropshadowRed = Components/Hazard/Styles.Accent.FillRed</string>
         <string>DropshadowGreen = Components/Hazard/Styles.Accent.FillGreen</string>
         <string>DropshadowBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -260,9 +258,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -311,9 +307,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -362,9 +356,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -413,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -464,9 +454,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -515,9 +503,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -566,9 +552,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/CheckBox.gucx
@@ -353,9 +353,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -377,9 +375,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -478,9 +474,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -553,9 +547,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -628,9 +620,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -703,9 +693,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -778,9 +766,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -853,9 +839,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -928,9 +912,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1024,9 +1006,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1120,9 +1100,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1216,9 +1194,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1312,9 +1288,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1408,9 +1382,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1504,9 +1476,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1600,9 +1570,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1675,9 +1643,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1750,9 +1716,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1825,9 +1789,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1900,9 +1862,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1975,9 +1935,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -2050,9 +2008,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -2125,9 +2081,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ComboBox.gucx
@@ -348,9 +348,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -428,9 +426,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -518,9 +514,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -608,9 +602,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -698,9 +690,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -788,9 +778,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -878,9 +866,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -968,9 +954,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/DialogBox.gucx
@@ -200,9 +200,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ItemsControl.gucx
@@ -281,9 +281,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBox.gucx
@@ -323,9 +323,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -385,9 +383,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -433,9 +429,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -481,9 +475,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -529,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -577,9 +567,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -625,9 +613,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -673,9 +659,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBoxItem.gucx
@@ -215,9 +215,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface2.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface2.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface2.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface2.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -251,9 +249,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -299,9 +295,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Menu.gucx
@@ -176,9 +176,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -188,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/MenuItem.gucx
@@ -394,9 +394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface2.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface2.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface2.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface2.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -451,9 +449,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -532,9 +528,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface2.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface2.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface2.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface2.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/PasswordBox.gucx
@@ -460,9 +460,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -472,9 +470,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -484,9 +480,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -585,9 +579,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -597,9 +589,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -696,9 +686,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -708,9 +696,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -807,9 +793,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -819,9 +803,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -918,9 +900,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -930,9 +910,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
@@ -250,9 +250,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -262,9 +260,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
         <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
         <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
@@ -324,9 +320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -351,9 +345,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -408,9 +400,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
@@ -435,9 +425,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -492,9 +480,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
@@ -519,9 +505,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -576,9 +560,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
@@ -603,9 +585,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -660,9 +640,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -687,9 +665,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -744,9 +720,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -771,9 +745,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -828,9 +800,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
@@ -855,9 +825,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -912,9 +880,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
@@ -939,9 +905,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -996,9 +960,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -1023,9 +985,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1080,9 +1040,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -1107,9 +1065,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1164,9 +1120,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -1191,9 +1145,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1248,9 +1200,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
@@ -1275,9 +1225,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1332,9 +1280,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
@@ -1359,9 +1305,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1416,9 +1360,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
           <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
           <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
           <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
@@ -1443,9 +1385,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ScrollViewer.gucx
@@ -268,9 +268,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Slider.gucx
@@ -122,9 +122,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -157,9 +155,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -184,9 +180,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
@@ -121,9 +121,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -162,9 +160,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -189,9 +185,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -216,9 +210,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -243,9 +235,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -270,9 +260,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.AccentHover.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.AccentHover.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.AccentHover.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.AccentHover.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -297,9 +285,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledAccent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledAccent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledAccent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledAccent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -324,9 +310,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledAccent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledAccent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledAccent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledAccent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Splitter.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Splitter.gucx
@@ -77,9 +77,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/TextBox.gucx
@@ -459,9 +459,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -471,9 +469,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +479,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Selection.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Selection.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Selection.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Selection.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -584,9 +578,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -596,9 +588,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -695,9 +685,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -707,9 +695,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -806,9 +792,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -818,9 +802,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -917,9 +899,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -929,9 +909,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>FillRed = Components/Hazard/Styles.DisabledFill.FillRed</string>
-          <string>FillGreen = Components/Hazard/Styles.DisabledFill.FillGreen</string>
-          <string>FillBlue = Components/Hazard/Styles.DisabledFill.FillBlue</string>
+          <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Toast.gucx
@@ -187,9 +187,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/UserControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/UserControl.gucx
@@ -63,9 +63,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Background.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Background.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Background.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Background.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Window.gucx
@@ -485,9 +485,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -497,9 +495,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -509,9 +505,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Elements/Divider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Elements/Divider.gucx
@@ -302,9 +302,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Placeholder.Red</string>
-        <string>Green = Components/Hazard/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Hazard/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Hazard/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -314,9 +312,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Placeholder.Red</string>
-        <string>Green = Components/Hazard/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Hazard/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Hazard/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -326,9 +322,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Placeholder.Red</string>
-        <string>Green = Components/Hazard/Styles.Placeholder.Green</string>
-        <string>Blue = Components/Hazard/Styles.Placeholder.Blue</string>
+        <string>Color = Components/Hazard/Styles.Placeholder.Color</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Screens/Hazard/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Screens/Hazard/DemoScreenGum.gusx
@@ -699,9 +699,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -711,9 +709,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>FillRed = Components/Hazard/Styles.Surface1.FillRed</string>
-        <string>FillGreen = Components/Hazard/Styles.Surface1.FillGreen</string>
-        <string>FillBlue = Components/Hazard/Styles.Surface1.FillBlue</string>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">


### PR DESCRIPTION
## Summary
- Collapses matching `FillRed/FillGreen/FillBlue` -> `FillColor` (and `Red/Green/Blue` -> `Color`, `Stroke*` -> `StrokeColor`) `VariableReferences` triples in the Bubblegum and Hazard themes, per #4149/#4151's composite-reference support.
- 278 triples collapsed across 43 files (21 Bubblegum, 22 Hazard). `gumcli check`/`check-references`/`diff-standards` output is byte-identical before and after for all 3 theme projects.
- Fixes `BubblegumTemplateTests`/`HazardTemplateTests.AllColorVariables_ShouldBeStylesWired`, which only recognized per-channel wiring, to expand a collapsed composite reference into its Red/Green/Blue channels before checking.
- Documents the collapse-eligibility rule (and the FormsTemplate finding below) in the `gum-forms-theme-import` skill.

## FormsTemplate (Standard) is untouched — not eligible
Its instances use bare `Red`/`Green`/`Blue` while their target Style swatches expose `FillRed`/`FillGreen`/`FillBlue` (a `Text`-like instance borrowing a `Rectangle` swatch's fill). The composite reference requires the RHS to end in `.` + the LHS (e.g. `FillColor = X.FillColor`), so a channel-name mismatch like `Red = X.FillRed` can't collapse — none of FormsTemplate's ~400 triples qualify. This is a pre-existing authoring difference, not something this PR changes.

Closes #4153

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests` — 426 passed, 3 skipped
- [x] `gumcli check` / `check-references` / `diff-standards` on all 3 theme projects — identical output before/after, exit 0
- [x] `gumcli check-references --fix` — no additional changes (nothing unpropagated)
- [x] `dotnet build GumFull.sln` — 0 errors (exercises the plugin postbuild copy path)
- [x] Manual: Add Forms import (Bubblegum + Hazard) and wireframe check in the tool
