### PR TITLE
Fix raylib cull/clip-walk divergences from HierarchicalOrderer; add conformance tests

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -361,32 +361,21 @@ public class Renderer : IRenderer
         _scissorStack.Clear();
         for(int i = 0; i < renderables.Count; i++)
         {
-            IRenderableIpso renderable = renderables[i];
-
-            DrawGumRecursively(renderable, layer);
-
-            //if (renderable is GraphicalUiElement graphicalUiElement)
-            //{
-            //    DrawGumRecursively(graphicalUiElement);
-
-            //    //if (RenderUsingHierarchy)
-            //    //{
-            //    //    DrawGumRecursively(graphicalUiElement);
-            //    //}
-            //    //else
-            //    //{
-            //    //    graphicalUiElement.Render(null);
-            //    //}
-            //}
-            //else
-            //{
-            //    renderable.Render(null);
-            //}
+            DrawGumRecursively(renderables[i], layer);
         }
     }
 
     private void DrawGumRecursively(IRenderableIpso element, Layer layer)
     {
+        // Mirrors HierarchicalOrderer's own top-of-node check: an invisible renderable and its whole
+        // subtree are skipped. Covers both top-level layer renderables (Render's loop above has no
+        // Visible check of its own) and children (the loop below no longer filters on Visible either,
+        // relying on this single check — #4155).
+        if (!element.Visible)
+        {
+            return;
+        }
+
         // #2998 off-screen cull: when a clip is active (the scissor stack is non-empty), skip this
         // element and its subtree if it falls entirely outside the active clip, expanded by a small
         // margin. Mirrors the XNA orderer cull via the same shared predicate.
@@ -410,14 +399,6 @@ public class Renderer : IRenderer
         // to draw its children directly.
         if (element.IsRenderTarget)
         {
-            // A hidden RT container draws nothing (its bake was skipped too). Without this the
-            // composite path would blit last frame's stale cached texture for one frame after the
-            // container is hidden — a 1-frame ghost (#3434).
-            if (!element.Visible)
-            {
-                return;
-            }
-
             // Composite the baked texture if a valid one exists; otherwise (degenerate/zero clamped
             // size, or entirely off-camera) render NOTHING and stop. We deliberately do NOT fall
             // through to draw the children directly: doing so would draw them unclamped, so content
@@ -431,8 +412,8 @@ public class Renderer : IRenderer
             return;
         }
 
-        element.Render(null);
-
+        // #4155: pushed before the element's own Render() so a clipping element's own draw is bounded
+        // by its own clip, matching HierarchicalOrderer (BeginClip precedes DrawRenderable).
         if (element.ClipsChildren)
         {
             System.Drawing.Rectangle rect = GetScissorRectangleFor(layer, element);
@@ -443,14 +424,16 @@ public class Renderer : IRenderer
             BatchDrawCallCounter.BeginScissorMode(effective.X, effective.Y, effective.Width, effective.Height);
         }
 
+        element.Render(null);
+
         if (element.Children != null)
         {
-            foreach (var child in element.Children)
+            // #4155: recurse into every child regardless of concrete type -- matching
+            // HierarchicalOrderer, which recurses into any visible IRenderableIpso. The Visible check
+            // above (run on entry to the recursive call) is what actually gates each child.
+            foreach (IRenderableIpso child in element.Children)
             {
-                if (child is GraphicalUiElement childGue && childGue.Visible)
-                {
-                    DrawGumRecursively(childGue, layer);
-                }
+                DrawGumRecursively(child, layer);
             }
         }
 
@@ -634,12 +617,11 @@ public class Renderer : IRenderer
 
         if (container.Children != null)
         {
+            // #4155: recurse into every child regardless of concrete type, mirroring the main walk's
+            // fix in DrawGumRecursively -- its own Visible check gates each child.
             foreach (IRenderableIpso child in container.Children)
             {
-                if (child is GraphicalUiElement childGue && childGue.Visible)
-                {
-                    DrawGumRecursively(childGue, layer);
-                }
+                DrawGumRecursively(child, layer);
             }
         }
 

--- a/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
@@ -1,0 +1,361 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Real-frame conformance suite for raylib's <c>DrawGumRecursively</c> walk (issue #4155), the
+/// off-screen-cull / clip-walk counterpart to <see cref="RenderTargetTests"/>. raylib reimplements
+/// the cull and clip walk inline instead of routing through the shared
+/// <see cref="RenderingLibrary.Graphics.HierarchicalOrderer"/> (#4154), so it can silently diverge
+/// from MonoGame's behavior even when every MonoGame-side test is green (#4144). Covers the
+/// off-screen cull at the clip edge and cull margin, nested-clip intersection, and one pinning
+/// test per divergence found auditing against <c>HierarchicalOrderer</c>: draw order relative to
+/// an element's own clip, non-<see cref="GraphicalUiElement"/> children, and top-level visibility.
+/// </summary>
+public class ClipWalkConformanceTests : BaseTestClass
+{
+    private static int DrawAndCountDrawCalls()
+    {
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+        return Renderer.Self.RenderStateChangeStatistics.DrawCallCount;
+    }
+
+    // Reads a pixel in top-left-origin draw space. A render texture is stored bottom-up in GL, so
+    // LoadImageFromTexture yields an image whose rows are flipped relative to draw space.
+    private static Color ReadRenderTargetPixel(RenderTexture2D renderTexture, int x, int y)
+    {
+        Image image = LoadImageFromTexture(renderTexture.Texture);
+        try
+        {
+            return GetImageColor(image, x, renderTexture.Texture.Height - 1 - y);
+        }
+        finally
+        {
+            UnloadImage(image);
+        }
+    }
+
+    // A raw (non-GraphicalUiElement) IRenderableIpso, drawn directly via raylib so its own draw call
+    // is counted by BatchDrawCallCounter the same way any renderable's is. Draws a rectangle larger
+    // than its own declared bounds by OverdrawPixels on every side, so a clip applied AFTER the draw
+    // (the divergence-1 bug) can be told apart from a clip applied BEFORE it.
+    private sealed class OverdrawRenderable : InvisibleRenderable
+    {
+        public Color FillColor { get; set; }
+        public int OverdrawPixels { get; set; }
+
+        public override void Render(ISystemManagers managers)
+        {
+            int x = (int)this.GetAbsoluteLeft() - OverdrawPixels;
+            int y = (int)this.GetAbsoluteTop() - OverdrawPixels;
+            int width = (int)Width + OverdrawPixels * 2;
+            int height = (int)Height + OverdrawPixels * 2;
+            Raylib.DrawRectangle(x, y, width, height, FillColor);
+        }
+    }
+
+    // Runtime wrapper for OverdrawRenderable, following the standard Gum Runtime-wraps-Renderable
+    // pattern (e.g. ColoredRectangleRuntime / SolidRectangle) so it can be positioned/sized through
+    // normal Gum layout and nested via ContainerRuntime.Children like any other runtime.
+    private sealed class OverdrawRuntime : GraphicalUiElement
+    {
+        private readonly OverdrawRenderable _renderable;
+
+        public OverdrawRuntime() : base(new OverdrawRenderable(), whatContainsThis: null)
+        {
+            _renderable = (OverdrawRenderable)RenderableComponent;
+        }
+
+        public Color FillColor { set => _renderable.FillColor = value; }
+        public int OverdrawPixels { set => _renderable.OverdrawPixels = value; }
+    }
+
+    [Fact]
+    public void Draw_ChildJustInsideCullMargin_IsNotCulled()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime clipParent = new();
+        clipParent.Y = 200; // away from the camera edge; see OffscreenCullWrappedTextTests remarks
+        clipParent.Width = 200;
+        clipParent.WidthUnits = DimensionUnitType.Absolute;
+        clipParent.Height = 150;
+        clipParent.HeightUnits = DimensionUnitType.Absolute;
+        clipParent.ClipsChildren = true;
+
+        // Clip bottom is at 200 + 150 = 350. The margin is 15px, so bounds starting up to 365 are
+        // kept. This child's top sits 10px past the clip bottom -- inside the margin.
+        ColoredRectangleRuntime nearMiss = new();
+        nearMiss.Width = 50;
+        nearMiss.Height = 50;
+        nearMiss.Y = 160;
+        clipParent.Children.Add(nearMiss);
+
+        GumService.Default.Root.Children.Add(clipParent);
+        GumService.Default.Root.UpdateLayout();
+
+        int withNearMiss = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        (withNearMiss - baseline).ShouldBe(1);
+    }
+
+    [Fact]
+    public void Draw_ChildStraddlingClipEdge_IsNotCulled()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime clipParent = new();
+        clipParent.Y = 200;
+        clipParent.Width = 200;
+        clipParent.WidthUnits = DimensionUnitType.Absolute;
+        clipParent.Height = 150;
+        clipParent.HeightUnits = DimensionUnitType.Absolute;
+        clipParent.ClipsChildren = true;
+
+        // Clip spans absolute Y [200, 350]. This child spans [330, 380] -- half inside, half past
+        // the clip edge.
+        ColoredRectangleRuntime straddler = new();
+        straddler.Width = 50;
+        straddler.Height = 50;
+        straddler.Y = 130;
+        clipParent.Children.Add(straddler);
+
+        GumService.Default.Root.Children.Add(clipParent);
+        GumService.Default.Root.UpdateLayout();
+
+        int withStraddler = DrawAndCountDrawCalls();
+
+        GumService.Default.Root.Children.Clear();
+
+        (withStraddler - baseline).ShouldBe(1);
+    }
+
+    // Pixel-based (not draw-call-count) because raylib's rlgl batcher coalesces consecutive
+    // same-state draws into a single banked segment -- two same-color rectangles drawn back to
+    // back would both count as "1" regardless of whether either was culled, hiding a regression.
+    [Fact]
+    public void Draw_ChildrenScrolledOutsideClip_AreCulledWhileInsideChildrenAreKept()
+    {
+        ContainerRuntime readableOuter = new();
+        readableOuter.X = 0;
+        readableOuter.Y = 0;
+        readableOuter.Width = 200;
+        readableOuter.Height = 200;
+        readableOuter.IsRenderTarget = true;
+
+        // Clips to the top half of the render target: [0,200] x [0,100].
+        ContainerRuntime clipParent = new();
+        clipParent.X = 0;
+        clipParent.Y = 0;
+        clipParent.Width = 200;
+        clipParent.Height = 100;
+        clipParent.ClipsChildren = true;
+
+        ColoredRectangleRuntime inside = new();
+        inside.Width = 180;
+        inside.Height = 80;
+        inside.Y = 0;
+        inside.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+        clipParent.Children.Add(inside);
+
+        // Absolute Y [150,190]: well past the clip bottom (100) plus its 15px margin, but still
+        // within the 200-tall readable render target so its pixels are checkable either way.
+        ColoredRectangleRuntime outside = new();
+        outside.Width = 180;
+        outside.Height = 40;
+        outside.Y = 150;
+        outside.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+        clipParent.Children.Add(outside);
+
+        readableOuter.Children.Add(clipParent);
+        GumService.Default.Root.Children.Add(readableOuter);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(readableOuter)!.Value;
+        Color insidePixel = ReadRenderTargetPixel(renderTexture, 90, 40);
+        Color outsidePixel = ReadRenderTargetPixel(renderTexture, 90, 170);
+
+        insidePixel.G.ShouldBeGreaterThan((byte)200);
+        outsidePixel.A.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    // Divergence 1 (#4155): HierarchicalOrderer emits BeginClip before DrawRenderable, so a
+    // clipping element's own draw is clipped by its own bounds. raylib rendered the element and
+    // pushed the scissor afterward, so an element that draws outside its own declared bounds (e.g.
+    // a border/overflow) leaked past its own clip.
+    [Fact]
+    public void Draw_ClippingElement_DoesNotDrawOutsideItsOwnClip()
+    {
+        ContainerRuntime readableOuter = new();
+        readableOuter.X = 0;
+        readableOuter.Y = 0;
+        readableOuter.Width = 100;
+        readableOuter.Height = 100;
+        readableOuter.IsRenderTarget = true;
+
+        OverdrawRuntime overdraw = new();
+        overdraw.X = 25;
+        overdraw.Y = 25;
+        overdraw.WidthUnits = DimensionUnitType.Absolute;
+        overdraw.HeightUnits = DimensionUnitType.Absolute;
+        overdraw.Width = 50;
+        overdraw.Height = 50;
+        overdraw.ClipsChildren = true;
+        overdraw.FillColor = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        // Draws [5,5]-[95,95] but its own declared bounds are [25,25]-[75,75].
+        overdraw.OverdrawPixels = 20;
+        readableOuter.Children.Add(overdraw);
+
+        GumService.Default.Root.Children.Add(readableOuter);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(readableOuter)!.Value;
+        Color insideOwnBounds = ReadRenderTargetPixel(renderTexture, 50, 50);
+        Color inOverdrawZone = ReadRenderTargetPixel(renderTexture, 10, 50);
+
+        insideOwnBounds.R.ShouldBeGreaterThan((byte)200);
+        // Outside the element's own bounds but within its overdraw -- must be clipped away.
+        inOverdrawZone.R.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    // Divergence 3 (#4155): HierarchicalOrderer skips an invisible renderable and its whole subtree
+    // up front. raylib's top-level Render() loop had no Visible check at all (only the IsRenderTarget
+    // branch checked it), so an invisible top-level container's own draw was already a no-op
+    // (InvisibleRenderable.Render is empty regardless), but the walk still recursed into its VISIBLE
+    // children and drew them -- a visibility leak. AddToManagers (rather than Root.Children.Add)
+    // places the container directly on the layer as a top-level renderable, exercising Render()'s
+    // loop directly rather than a parent's already-Visible-gated child recursion.
+    [Fact]
+    public void Draw_InvisibleTopLevelContainer_HidesVisibleChildren()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+        container.Visible = false;
+
+        ColoredRectangleRuntime visibleChild = new();
+        visibleChild.Width = 50;
+        visibleChild.Height = 50;
+        container.Children.Add(visibleChild);
+
+        container.AddToManagers();
+        container.UpdateLayout();
+
+        int withHiddenContainer = DrawAndCountDrawCalls();
+
+        container.RemoveFromManagers();
+
+        withHiddenContainer.ShouldBe(baseline);
+    }
+
+    // Coverage for existing (correct) behavior: raylib's BeginScissorMode replaces rather than
+    // intersects, which is why DrawGumRecursively maintains its own _scissorStack. A nested clip
+    // narrower than its ancestor must still be bounded by BOTH rectangles' intersection.
+    [Fact]
+    public void Draw_NestedClipContainers_IntersectRatherThanReplace()
+    {
+        ContainerRuntime readableOuter = new();
+        readableOuter.X = 0;
+        readableOuter.Y = 0;
+        readableOuter.Width = 100;
+        readableOuter.Height = 100;
+        readableOuter.IsRenderTarget = true;
+
+        // Clips to the top half: [0,100] x [0,50].
+        ContainerRuntime outerClip = new();
+        outerClip.X = 0;
+        outerClip.Y = 0;
+        outerClip.Width = 100;
+        outerClip.Height = 50;
+        outerClip.ClipsChildren = true;
+
+        // Clips to the left half, taller than outerClip: [0,50] x [0,100].
+        ContainerRuntime innerClip = new();
+        innerClip.X = 0;
+        innerClip.Y = 0;
+        innerClip.Width = 50;
+        innerClip.Height = 100;
+        innerClip.ClipsChildren = true;
+
+        ColoredRectangleRuntime fill = new();
+        fill.Width = 100;
+        fill.Height = 100;
+        fill.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+        innerClip.Children.Add(fill);
+        outerClip.Children.Add(innerClip);
+        readableOuter.Children.Add(outerClip);
+
+        GumService.Default.Root.Children.Add(readableOuter);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(readableOuter)!.Value;
+        // Inside both clips' intersection (the top-left quadrant).
+        Color intersection = ReadRenderTargetPixel(renderTexture, 25, 25);
+        // Inside innerClip's own rect but outside outerClip -- must stay clipped under intersect
+        // semantics; a "replace" bug would leave this filled since innerClip's own scissor alone
+        // reaches y=100.
+        Color belowOuterClip = ReadRenderTargetPixel(renderTexture, 25, 75);
+
+        intersection.G.ShouldBeGreaterThan((byte)200);
+        belowOuterClip.A.ShouldBeLessThan((byte)50);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
+    // Divergence 2 (#4155): HierarchicalOrderer recurses into any visible IRenderableIpso child.
+    // raylib's child loop tested `child is GraphicalUiElement`, so a raw (non-wrapped) renderable
+    // parented directly onto another renderable never drew.
+    [Fact]
+    public void Draw_NonGraphicalUiElementChild_IsRendered()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime container = new();
+        container.Width = 100;
+        container.Height = 100;
+
+        SolidRectangle rawChild = new();
+        rawChild.Width = 50;
+        rawChild.Height = 50;
+        rawChild.Parent = container;
+
+        container.AddToManagers();
+        container.UpdateLayout();
+
+        int withRawChild = DrawAndCountDrawCalls();
+
+        container.RemoveFromManagers();
+
+        (withRawChild - baseline).ShouldBe(1);
+    }
+}


### PR DESCRIPTION
## Summary
- raylib's `DrawGumRecursively` reimplements the cull/clip walk inline instead of routing through the shared `HierarchicalOrderer`, so a fix to the shared path (#4152) silently doesn't reach raylib — that's exactly what happened with #4144. Fixes the three divergences found auditing against `HierarchicalOrderer`, all converged onto MonoGame's behavior:
  1. A clipping element's own draw is now bounded by its own clip (scissor pushed before `Render()`, not after).
  2. Children are recursed into regardless of concrete type (not just `GraphicalUiElement`) — matches `HierarchicalOrderer`'s "any visible `IRenderableIpso`" contract. Fixed in both the main walk and the render-target bake's child loop (same bug, same file).
  3. An invisible top-level renderable's whole subtree is now skipped (previously only the `IsRenderTarget` branch checked `Visible`).
- Adds `Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs`: a real-headless-frame suite (mirrors `RenderTargetTests`' harness) covering the off-screen cull at the clip edge and cull margin, nested-clip intersection (pinning existing correct behavior), and one pinning test per divergence.
- Does NOT migrate raylib onto the shared `HierarchicalOrderer` — that's #4154, stays open. `DrawGumRecursively` remains the walk; this PR only corrects its behavior in place.

## Test plan
- [x] New tests reproduce each divergence red before the fix, green after (verified via Bash)
- [x] Full `RaylibGum.Tests` suite green (563/563)
- [x] Manually verified the nested-clip-intersect test discriminates real behavior (temporarily reverted the intersect to a "replace" bug, confirmed the test goes red, reverted back)
- [x] Zero new compiler warnings

Closes #4155
