### PR TITLE
Migrate raylib's main render walk onto the shared HierarchicalOrderer (steps 1-3)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Drawing;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -251,6 +252,62 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         {
             Renderer.RenderUsingHierarchy = originalValue;
         }
+    }
+
+    [Fact]
+    public void BuildDrawList_Roots_CullsOffscreenSubtreeUsingSuppliedCullTestBoundsMapping()
+    {
+        // getScissorRectangle deliberately returns an IN-clip rectangle for "cull" -- if the
+        // orderer used it (instead of getCullTestBounds) for the cull decision, "cull" would
+        // wrongly survive. getCullTestBounds returns the true (far outside the margin) rectangle,
+        // proving the subtree overload's cull decision is driven by getCullTestBounds, mirroring
+        // the Layer overload's GetCullTestBoundsFor/GetScissorRectangleFor split (#4144, #4154).
+        FakeRenderable clipContainer = new FakeRenderable("clipContainer");
+        clipContainer.ClipsChildren = true;
+        FakeRenderable keep = AddChild(clipContainer, "keep");
+        FakeRenderable cull = AddChild(clipContainer, "cull");
+
+        Rectangle clipRect = new Rectangle(0, 0, 100, 100);
+        Rectangle insideClip = new Rectangle(10, 10, 20, 20);
+        Rectangle farOutside = new Rectangle(1000, 1000, 10, 10);
+
+        Rectangle GetScissorRectangle(IRenderableIpso r) => r == clipContainer ? clipRect : insideClip;
+        Rectangle GetCullTestBounds(IRenderableIpso r) => r == cull ? farOutside : GetScissorRectangle(r);
+
+        List<DrawCommand> commands = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(
+            new List<IRenderableIpso> { clipContainer },
+            commands,
+            GetScissorRectangle,
+            GetCullTestBounds);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:clipContainer",
+            "DrawRenderable:clipContainer",
+            "DrawRenderable:keep",
+            "EndClip:clipContainer",
+        });
+    }
+
+    [Fact]
+    public void BuildDrawList_Roots_DepthFirstWalk_MatchesLayerOverload()
+    {
+        // Same BatchKey throughout so there is nothing to reorder -- isolates the roots-vs-layer
+        // entry point parity from the batch-grouping behavior covered elsewhere in this class.
+        FakeRenderable a = new FakeRenderable("a");
+        FakeRenderable a1 = AddChild(a, "a1");
+        AddChild(a1, "a1a");
+        FakeRenderable b = new FakeRenderable("b");
+
+        Layer layer = BuildLayer(a, b);
+        List<DrawCommand> commandsFromLayer = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commandsFromLayer);
+
+        List<DrawCommand> commandsFromRoots = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(new List<IRenderableIpso> { a, b }, commandsFromRoots);
+
+        Describe(commandsFromRoots).ShouldBe(Describe(commandsFromLayer));
     }
 
     [Fact]

--- a/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Drawing;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -237,15 +238,124 @@ public class HierarchicalOrdererTests : BaseTestClass
     }
 
     [Fact]
-    public void BuildDrawList_WithPreExistingCommands_ClearsDestinationFirst()
+    public void BuildDrawList_Roots_CullsOffscreenSubtreeUsingSuppliedCullTestBoundsMapping()
     {
-        Layer layer = BuildLayer(new FakeRenderable("only"));
+        // getScissorRectangle deliberately returns an IN-clip rectangle for "cull" -- if the
+        // orderer used it (instead of getCullTestBounds) for the cull decision, "cull" would
+        // wrongly survive. getCullTestBounds returns the true (far outside the margin) rectangle,
+        // proving the subtree overload's cull decision is driven by getCullTestBounds, mirroring
+        // the Layer overload's GetCullTestBoundsFor/GetScissorRectangleFor split (#4144, #4154).
+        FakeRenderable clipContainer = new FakeRenderable("clipContainer");
+        clipContainer.ClipsChildren = true;
+        FakeRenderable keep = AddChild(clipContainer, "keep");
+        FakeRenderable cull = AddChild(clipContainer, "cull");
+
+        Rectangle clipRect = new Rectangle(0, 0, 100, 100);
+        Rectangle insideClip = new Rectangle(10, 10, 20, 20);
+        Rectangle farOutside = new Rectangle(1000, 1000, 10, 10);
+
+        Rectangle GetScissorRectangle(IRenderableIpso r) => r == clipContainer ? clipRect : insideClip;
+        Rectangle GetCullTestBounds(IRenderableIpso r) => r == cull ? farOutside : GetScissorRectangle(r);
+
         List<DrawCommand> commands = new List<DrawCommand>();
-        commands.Add(new DrawCommand(DrawCommandKind.DrawRenderable, new FakeRenderable("stale")));
+        HierarchicalOrderer.Instance.BuildDrawList(
+            new List<IRenderableIpso> { clipContainer },
+            commands,
+            GetScissorRectangle,
+            GetCullTestBounds);
 
-        HierarchicalOrderer.Instance.BuildDrawList(layer, commands);
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:clipContainer",
+            "DrawRenderable:clipContainer",
+            "DrawRenderable:keep",
+            "EndClip:clipContainer",
+        });
+    }
 
-        Describe(commands).ShouldBe(new[] { "DrawRenderable:only" });
+    [Fact]
+    public void BuildDrawList_Roots_DepthFirstWalk_MatchesLayerOverload()
+    {
+        FakeRenderable a = new FakeRenderable("a");
+        FakeRenderable a1 = AddChild(a, "a1");
+        AddChild(a1, "a1a");
+        FakeRenderable b = new FakeRenderable("b");
+        b.ClipsChildren = true;
+        AddChild(b, "b1");
+
+        Layer layer = BuildLayer(a, b);
+        List<DrawCommand> commandsFromLayer = new List<DrawCommand>();
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commandsFromLayer);
+
+        List<DrawCommand> commandsFromRoots = new List<DrawCommand>();
+        HierarchicalOrderer.Instance.BuildDrawList(new List<IRenderableIpso> { a, b }, commandsFromRoots);
+
+        Describe(commandsFromRoots).ShouldBe(Describe(commandsFromLayer));
+    }
+
+    [Fact]
+    public void BuildDrawList_Roots_WhenCullTestBoundsMappingOmitted_FallsBackToScissorRectangleMapping()
+    {
+        FakeRenderable clipContainer = new FakeRenderable("clipContainer");
+        clipContainer.ClipsChildren = true;
+        FakeRenderable keep = AddChild(clipContainer, "keep");
+        FakeRenderable cull = AddChild(clipContainer, "cull");
+
+        Rectangle clipRect = new Rectangle(0, 0, 100, 100);
+        Rectangle insideClip = new Rectangle(10, 10, 20, 20);
+        Rectangle farOutside = new Rectangle(1000, 1000, 10, 10);
+
+        Rectangle GetScissorRectangle(IRenderableIpso r)
+        {
+            if (r == cull)
+            {
+                return farOutside;
+            }
+            return r == clipContainer ? clipRect : insideClip;
+        }
+
+        List<DrawCommand> commands = new List<DrawCommand>();
+        HierarchicalOrderer.Instance.BuildDrawList(
+            new List<IRenderableIpso> { clipContainer },
+            commands,
+            GetScissorRectangle);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:clipContainer",
+            "DrawRenderable:clipContainer",
+            "DrawRenderable:keep",
+            "EndClip:clipContainer",
+        });
+    }
+
+    // Regression guard: an ordinary (non-text) child genuinely scrolled off the bottom of an
+    // on-screen clip — the ListBox/ScrollViewer case the cull exists for — must still be culled.
+    [Fact]
+    public void BuildDrawList_ScrolledPlainRenderableOutsideOnScreenClip_IsStillCulled()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        FakeRenderable clipParent = new FakeRenderable("clipParent");
+        clipParent.ClipsChildren = true;
+        clipParent.Y = 300;
+        clipParent.Width = 200;
+        clipParent.Height = 200;
+
+        FakeRenderable scrolledOffItem = AddChild(clipParent, "scrolledOffItem");
+        scrolledOffItem.Width = 190;
+        scrolledOffItem.Height = 80;
+        scrolledOffItem.Y = 250; // well past the 200px-tall clip band (absolute Y: 300 + 250 = 550)
+
+        Layer layer = BuildLayer(clipParent);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera);
+
+        Describe(commands).ShouldNotContain("DrawRenderable:scrolledOffItem");
     }
 
     // #4144: a multi-line Forms TextBox scrolls by moving its Text's Y while Height stays fixed to
@@ -286,32 +396,15 @@ public class HierarchicalOrdererTests : BaseTestClass
         Describe(commands).ShouldContain("DrawRenderable:scrolledText");
     }
 
-    // Regression guard: an ordinary (non-text) child genuinely scrolled off the bottom of an
-    // on-screen clip — the ListBox/ScrollViewer case the cull exists for — must still be culled.
     [Fact]
-    public void BuildDrawList_ScrolledPlainRenderableOutsideOnScreenClip_IsStillCulled()
+    public void BuildDrawList_WithPreExistingCommands_ClearsDestinationFirst()
     {
-        Camera camera = new Camera();
-        camera.ClientWidth = 800;
-        camera.ClientHeight = 600;
-        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
-
-        FakeRenderable clipParent = new FakeRenderable("clipParent");
-        clipParent.ClipsChildren = true;
-        clipParent.Y = 300;
-        clipParent.Width = 200;
-        clipParent.Height = 200;
-
-        FakeRenderable scrolledOffItem = AddChild(clipParent, "scrolledOffItem");
-        scrolledOffItem.Width = 190;
-        scrolledOffItem.Height = 80;
-        scrolledOffItem.Y = 250; // well past the 200px-tall clip band (absolute Y: 300 + 250 = 550)
-
-        Layer layer = BuildLayer(clipParent);
+        Layer layer = BuildLayer(new FakeRenderable("only"));
         List<DrawCommand> commands = new List<DrawCommand>();
+        commands.Add(new DrawCommand(DrawCommandKind.DrawRenderable, new FakeRenderable("stale")));
 
-        HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera);
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commands);
 
-        Describe(commands).ShouldNotContain("DrawRenderable:scrolledOffItem");
+        Describe(commands).ShouldBe(new[] { "DrawRenderable:only" });
     }
 }

--- a/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
@@ -173,6 +173,32 @@ public class HierarchicalOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void BuildDrawList_IsRenderTargetNodeWithClipsChildren_StillBracketsButDoesNotRecurse()
+    {
+        // Real-world shape: a scrolling panel rendered to a texture for group opacity, which also
+        // (redundantly) declares ClipsChildren. The orderer brackets ClipsChildren independently of
+        // IsRenderTarget -- consumers (raylib's Renderer.Submit, #4154) rely on this and special-case
+        // IsRenderTarget uniformly across BeginClip/DrawRenderable/EndClip, rather than assuming the
+        // orderer already omits the brackets for a render-target node.
+        FakeRenderable rt = new FakeRenderable("rt");
+        rt.IsRenderTarget = true;
+        rt.ClipsChildren = true;
+        AddChild(rt, "rtChild");
+
+        Layer layer = BuildLayer(rt);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        HierarchicalOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:rt",
+            "DrawRenderable:rt",
+            "EndClip:rt",
+        });
+    }
+
+    [Fact]
     public void BuildDrawList_IsRenderTargetNode_DoesNotRecurseIntoChildren()
     {
         FakeRenderable rt = new FakeRenderable("rt");

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Drawing;
 
 namespace RenderingLibrary.Graphics;
 
@@ -28,7 +28,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     private struct Entry
     {
         public IRenderableIpso Item;
-        public Rectangle Bounds;
+        public System.Drawing.Rectangle Bounds;
         public string BatchKey;
     }
 
@@ -36,10 +36,33 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
-        ProcessLayerTopLevel(layer, camera, destination);
+
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = camera != null
+            ? renderable => camera.GetScissorRectangleFor(layer, renderable)
+            : null;
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = camera != null
+            ? renderable => camera.GetCullTestBoundsFor(layer, renderable)
+            : null;
+
+        ProcessLayerTopLevel(layer, getScissorRectangle, getCullTestBounds, destination);
     }
 
-    private static void ProcessLayerTopLevel(Layer layer, Camera? camera, List<DrawCommand> destination)
+    /// <inheritdoc/>
+    public void BuildDrawList(
+        IList<IRenderableIpso> roots,
+        List<DrawCommand> destination,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null)
+    {
+        destination.Clear();
+        ProcessWindow(roots, getScissorRectangle, getCullTestBounds ?? getScissorRectangle, destination);
+    }
+
+    private static void ProcessLayerTopLevel(
+        Layer layer,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        List<DrawCommand> destination)
     {
         ReadOnlyCollection<IRenderableIpso> top = layer.Renderables;
         int count = top.Count;
@@ -66,7 +89,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 List<Entry> window = new List<Entry>();
                 for (int i = runStart; i < runEnd; i++)
                 {
-                    ProcessRenderable(top[i], layer, camera, null, window, destination);
+                    ProcessRenderable(top[i], getScissorRectangle, getCullTestBounds, null, window, destination);
                 }
                 FlushWindow(window, destination);
 
@@ -75,20 +98,35 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         }
         else
         {
-            List<Entry> window = new List<Entry>();
-            for (int i = 0; i < count; i++)
-            {
-                ProcessRenderable(top[i], layer, camera, null, window, destination);
-            }
-            FlushWindow(window, destination);
+            ProcessWindow(top, getScissorRectangle, getCullTestBounds, destination);
         }
+    }
+
+    private static void ProcessWindow(
+        IList<IRenderableIpso> renderables,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        List<DrawCommand> destination)
+    {
+        int count = renderables.Count;
+        if (count == 0)
+        {
+            return;
+        }
+
+        List<Entry> window = new List<Entry>();
+        for (int i = 0; i < count; i++)
+        {
+            ProcessRenderable(renderables[i], getScissorRectangle, getCullTestBounds, null, window, destination);
+        }
+        FlushWindow(window, destination);
     }
 
     private static void ProcessRenderable(
         IRenderableIpso renderable,
-        Layer layer,
-        Camera? camera,
-        Rectangle? activeClip,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        System.Drawing.Rectangle? activeClip,
         List<Entry> currentWindow,
         List<DrawCommand> destination)
     {
@@ -98,14 +136,12 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         }
 
         // #2998 off-screen cull: skip a renderable (and its subtree) fully outside the active
-        // clip. Gated on a non-null camera, mirroring HierarchicalOrderer — see its rationale.
-        // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for
-        // wrapped text whose actual rendered extent exceeds its declared bounds (#4144).
-        if (camera != null
+        // clip. Gated on a non-null mapping, mirroring HierarchicalOrderer — see its rationale.
+        if (getCullTestBounds != null
             && activeClip.HasValue
             && CameraScissorExtensions.CullOffscreenWhenClipped
             && CameraScissorExtensions.IsFullyOutside(
-                camera.GetCullTestBoundsFor(layer, renderable),
+                getCullTestBounds(renderable),
                 activeClip.Value,
                 CameraScissorExtensions.OffscreenCullMarginInPixels))
         {
@@ -126,11 +162,11 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             AddEntry(renderable, innerWindow);
 
             // Entering a clipper narrows the active clip for descendants (intersect).
-            Rectangle? childClip = activeClip;
-            if (camera != null)
+            System.Drawing.Rectangle? childClip = activeClip;
+            if (getScissorRectangle != null)
             {
-                Rectangle thisClip = camera.GetScissorRectangleFor(layer, renderable);
-                childClip = activeClip.HasValue ? Rectangle.Intersect(activeClip.Value, thisClip) : thisClip;
+                System.Drawing.Rectangle thisClip = getScissorRectangle(renderable);
+                childClip = activeClip.HasValue ? System.Drawing.Rectangle.Intersect(activeClip.Value, thisClip) : thisClip;
             }
 
             if (Renderer.RenderUsingHierarchy && !renderable.IsRenderTarget)
@@ -141,7 +177,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], layer, camera, childClip, innerWindow, destination);
+                        ProcessRenderable(children[i], getScissorRectangle, getCullTestBounds, childClip, innerWindow, destination);
                     }
                 }
             }
@@ -161,7 +197,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], layer, camera, activeClip, currentWindow, destination);
+                        ProcessRenderable(children[i], getScissorRectangle, getCullTestBounds, activeClip, currentWindow, destination);
                     }
                 }
             }
@@ -188,13 +224,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     /// bounds don't intersect the parent's, fall back to the parent's bounds — it's a
     /// safe over-estimate that keeps the overlap test honest.
     /// </summary>
-    private static Rectangle GetEffectiveBounds(IRenderableIpso renderable)
+    private static System.Drawing.Rectangle GetEffectiveBounds(IRenderableIpso renderable)
     {
-        Rectangle bounds = renderable.GetAbsoluteBounds();
+        System.Drawing.Rectangle bounds = renderable.GetAbsoluteBounds();
         IRenderableIpso? parent = renderable.Parent;
         if (parent != null)
         {
-            Rectangle parentBounds = parent.GetAbsoluteBounds();
+            System.Drawing.Rectangle parentBounds = parent.GetAbsoluteBounds();
             if (parentBounds.Width > 0 && parentBounds.Height > 0 && !bounds.IntersectsWith(parentBounds))
             {
                 return parentBounds;
@@ -218,7 +254,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         List<int>?[] successors = new List<int>?[n];
         for (int i = 0; i < n; i++)
         {
-            Rectangle bi = window[i].Bounds;
+            System.Drawing.Rectangle bi = window[i].Bounds;
             for (int j = i + 1; j < n; j++)
             {
                 if (bi.IntersectsWith(window[j].Bounds))

--- a/RenderingLibrary/Graphics/DrawCommand.cs
+++ b/RenderingLibrary/Graphics/DrawCommand.cs
@@ -14,9 +14,11 @@ public enum DrawCommandKind
 }
 
 /// <summary>
-/// One entry in the flat command list produced by <see cref="IRenderableOrderer.BuildDrawList"/>
-/// and consumed by <c>Renderer.Submit</c>. Splits the main-pass render path into a build phase
-/// (tree walk produces the list) and a submit phase (renderer iterates the list).
+/// One entry in the flat command list produced by
+/// <see cref="IRenderableOrderer.BuildDrawList(Layer, System.Collections.Generic.List{DrawCommand}, Camera?)"/>
+/// (or its subtree-rooted overload) and consumed by <c>Renderer.Submit</c>. Splits the main-pass
+/// render path into a build phase (tree walk produces the list) and a submit phase (renderer
+/// iterates the list).
 /// </summary>
 public readonly struct DrawCommand
 {

--- a/RenderingLibrary/Graphics/HierarchicalOrderer.cs
+++ b/RenderingLibrary/Graphics/HierarchicalOrderer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -22,11 +23,34 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
     public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
-        AppendRenderables(layer.Renderables, layer, camera, null, destination);
+
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = camera != null
+            ? renderable => camera.GetScissorRectangleFor(layer, renderable)
+            : null;
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = camera != null
+            ? renderable => camera.GetCullTestBoundsFor(layer, renderable)
+            : null;
+
+        AppendRenderables(layer.Renderables, getScissorRectangle, getCullTestBounds, null, destination);
     }
 
-    private static void AppendRenderables(IList<IRenderableIpso> renderables, Layer layer, Camera? camera,
-        System.Drawing.Rectangle? activeClip, List<DrawCommand> destination)
+    /// <inheritdoc/>
+    public void BuildDrawList(
+        IList<IRenderableIpso> roots,
+        List<DrawCommand> destination,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null)
+    {
+        destination.Clear();
+        AppendRenderables(roots, getScissorRectangle, getCullTestBounds ?? getScissorRectangle, null, destination);
+    }
+
+    private static void AppendRenderables(
+        IList<IRenderableIpso> renderables,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        System.Drawing.Rectangle? activeClip,
+        List<DrawCommand> destination)
     {
         int count = renderables.Count;
         for (int i = 0; i < count; i++)
@@ -38,15 +62,13 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
             }
 
             // #2998 off-screen cull: when a clip is active, skip this renderable and its whole
-            // subtree if its bounds fall entirely outside the clip. Gated on a non-null camera
-            // (the render path) so the camera-less order-only unit tests are unaffected.
-            // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for
-            // wrapped text whose actual rendered extent exceeds its declared bounds (#4144).
-            if (camera != null
+            // subtree if its bounds fall entirely outside the clip. Gated on a non-null mapping
+            // (the render path) so the mapping-less order-only unit tests are unaffected.
+            if (getCullTestBounds != null
                 && activeClip.HasValue
                 && CameraScissorExtensions.CullOffscreenWhenClipped
                 && CameraScissorExtensions.IsFullyOutside(
-                    camera.GetCullTestBoundsFor(layer, renderable),
+                    getCullTestBounds(renderable),
                     activeClip.Value,
                     CameraScissorExtensions.OffscreenCullMarginInPixels))
             {
@@ -67,16 +89,16 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
                 if (children != null && children.Count > 0)
                 {
                     // Entering a clipper narrows the active clip for descendants (intersect, mirroring
-                    // Renderer.AdjustRenderStates). Without a camera we can't compute it, so leave it null.
+                    // Renderer.AdjustRenderStates). Without a mapping we can't compute it, so leave it null.
                     System.Drawing.Rectangle? childClip = activeClip;
-                    if (clips && camera != null)
+                    if (clips && getScissorRectangle != null)
                     {
-                        System.Drawing.Rectangle thisClip = camera.GetScissorRectangleFor(layer, renderable);
+                        System.Drawing.Rectangle thisClip = getScissorRectangle(renderable);
                         childClip = activeClip.HasValue
                             ? System.Drawing.Rectangle.Intersect(activeClip.Value, thisClip)
                             : thisClip;
                     }
-                    AppendRenderables(children, layer, camera, childClip, destination);
+                    AppendRenderables(children, getScissorRectangle, getCullTestBounds, childClip, destination);
                 }
             }
 

--- a/RenderingLibrary/Graphics/IRenderableOrderer.cs
+++ b/RenderingLibrary/Graphics/IRenderableOrderer.cs
@@ -1,12 +1,13 @@
+using System;
 using System.Collections.Generic;
 
 namespace RenderingLibrary.Graphics;
 
 /// <summary>
-/// Produces the flat <see cref="DrawCommand"/> sequence for a layer's main render pass.
-/// Pluggable so that alternative orderings (e.g. batch-grouped) can be swapped in without
-/// touching the renderer's submit phase. The default implementation is
-/// <see cref="HierarchicalOrderer"/>, which preserves the legacy depth-first walk.
+/// Produces the flat <see cref="DrawCommand"/> sequence for a render pass. Pluggable so that
+/// alternative orderings (e.g. batch-grouped) can be swapped in without touching the renderer's
+/// submit phase. The default implementation is <see cref="HierarchicalOrderer"/>, which
+/// preserves the legacy depth-first walk.
 /// </summary>
 public interface IRenderableOrderer
 {
@@ -23,4 +24,36 @@ public interface IRenderableOrderer
     /// tests) no culling is performed and the full walk is emitted.
     /// </param>
     void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null);
+
+    /// <summary>
+    /// Builds the ordered command list for an arbitrary subtree of renderables — e.g. a
+    /// render-target container's children being baked into an offscreen texture — rather than a
+    /// <see cref="Layer"/>'s top-level renderables. Lets a caller outside the main render pass
+    /// reuse the same visibility / off-screen-cull / <see cref="IRenderableIpso.ClipsChildren"/> /
+    /// hierarchy-traversal semantics as <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/>
+    /// without requiring a <see cref="Layer"/> or a screen-space <see cref="Camera"/> — the caller
+    /// supplies the renderable-to-rectangle mappings directly, in whatever coordinate space it is
+    /// drawing into (screen space for the main pass, render-target-local space for a bake).
+    /// </summary>
+    /// <param name="roots">The top-level renderables of the subtree to flatten.</param>
+    /// <param name="destination">Caller-owned buffer; cleared, then filled with the ordered commands.</param>
+    /// <param name="getScissorRectangle">
+    /// Maps a renderable to the clip/scissor rectangle it establishes when it has
+    /// <see cref="IRenderableIpso.ClipsChildren"/> set — used to narrow the active clip for its
+    /// descendants. Optional — when null, no off-screen culling or clip narrowing is performed
+    /// (e.g. order-only unit tests), matching the <c>camera == null</c> behavior of the
+    /// <see cref="Layer"/> overload.
+    /// </param>
+    /// <param name="getCullTestBounds">
+    /// Maps a renderable to the bounds used for the off-screen cull (#2998) — separate from
+    /// <paramref name="getScissorRectangle"/> so a caller can widen the cull test for content whose
+    /// actual drawn extent exceeds its declared bounds (e.g. wrapped text, #4144) without changing
+    /// what is actually clipped. Optional — when null but <paramref name="getScissorRectangle"/>
+    /// is supplied, falls back to <paramref name="getScissorRectangle"/> for the cull test.
+    /// </param>
+    void BuildDrawList(
+        IList<IRenderableIpso> roots,
+        List<DrawCommand> destination,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null);
 }

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -160,6 +160,16 @@
 		<Compile Include="..\..\MonoGameGum\Input\Cursor.Forms.cs" Link="Input\Cursor.Forms.cs" />
 		<Compile Include="..\..\MonoGameGum\Input\CursorExtensions.cs" Link="Input\CursorExtensions.cs" />
 		<Compile Include="..\..\MonoGameGum\Renderables\RenderableCreator.cs" Link="Renderables\RenderableCreator.cs" />
+		<!--
+			HierarchicalOrderer / IRenderableOrderer / DrawCommand / BatchKeyGroupedOrderer are
+			included via GumCoreShared.projitems, which only MonoGameGum / KniGum / FnaGum
+			consume. Raylib does not import that projitems, so they need an explicit file link
+			here too, exactly like RenderStateChangeStatistics.cs below (#4154 step 1).
+		-->
+		<Compile Include="..\..\RenderingLibrary\Graphics\BatchKeyGroupedOrderer.cs" Link="RenderingLibrary\BatchKeyGroupedOrderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\DrawCommand.cs" Link="RenderingLibrary\DrawCommand.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\HierarchicalOrderer.cs" Link="RenderingLibrary\HierarchicalOrderer.cs" />
+		<Compile Include="..\..\RenderingLibrary\Graphics\IRenderableOrderer.cs" Link="RenderingLibrary\IRenderableOrderer.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\Fonts\ParsedFontFile.cs" Link="RenderingLibrary\Fonts\ParsedFontFile.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderStateChangeStatistics.cs" Link="RenderingLibrary\RenderStateChangeStatistics.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -393,7 +393,12 @@ public class Renderer : IRenderer
             // was already baked into an offscreen texture during the pre-pass) and never
             // participates in the scissor stack, even if it also has ClipsChildren set --
             // mirrors DrawGumRecursively, which composites and returns before ever touching the
-            // scissor stack.
+            // scissor stack. The orderer brackets ClipsChildren independently of IsRenderTarget
+            // (see HierarchicalOrdererTests.BuildDrawList_IsRenderTargetNodeWithClipsChildren_
+            // StillBracketsButDoesNotRecurse), so this guard applies uniformly across BeginClip /
+            // DrawRenderable / EndClip rather than assuming the brackets are already absent. Covered
+            // by ClipWalkConformanceTests.Draw_TopLevelRenderTargetContainerWithClipsChildren_
+            // CompositesOnceWithoutDoubleDrawingChildren (#4154).
             if (command.Target.IsRenderTarget)
             {
                 if (command.Kind == DrawCommandKind.DrawRenderable)

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -62,6 +62,11 @@ public class Renderer : IRenderer
     // for the duration of a bake and restored afterward; balanced push/pop leaves it empty.
     readonly Stack<System.Drawing.Rectangle> _bakeScissorStack = new();
 
+    // Reused across layers and frames so the build phase does not allocate per frame after
+    // warm-up, mirroring the xnalike Renderer's _scratchCommands (#4154). The renderer owns
+    // the buffer; the orderer writes into it.
+    readonly List<DrawCommand> _scratchCommands = new();
+
     // Set during the PreRender walk (which already traverses the whole visible tree) when any
     // render-target container is present, so the bake pre-pass is skipped entirely for the common
     // case of screens with no render targets — no extra full traversal.
@@ -359,9 +364,83 @@ public class Renderer : IRenderer
     private void Render(ReadOnlyCollection<IRenderableIpso> renderables, ISystemManagers managers, Layer layer)
     {
         _scissorStack.Clear();
-        for(int i = 0; i < renderables.Count; i++)
+
+        // Build phase: flatten the (already Z-sorted) layer into a sequence of DrawCommands via
+        // the shared HierarchicalOrderer -- the same builder MonoGame/KNI/FNA use for their main
+        // pass (#4154). Submit phase below walks that sequence, issuing the raylib-specific
+        // scissor stack / BatchDrawCallCounter / render-target composite calls. BakeRenderTarget's
+        // own child walk stays on the recursive DrawGumRecursively -- unifying the bake path onto
+        // the orderer's subtree entry point is a separate follow-up (#4154 step 4).
+        HierarchicalOrderer.Instance.BuildDrawList(layer, _scratchCommands, _camera);
+        Submit(_scratchCommands, layer);
+    }
+
+    /// <summary>
+    /// Main-pass submit phase: walks the flat <see cref="DrawCommand"/> list produced by
+    /// <see cref="HierarchicalOrderer"/> and issues the corresponding raylib scissor / draw
+    /// calls. The orderer is responsible for visibility, off-screen culling, ClipsChildren
+    /// bracketing, and hierarchy traversal; this method only translates commands into raylib
+    /// calls.
+    /// </summary>
+    private void Submit(List<DrawCommand> commands, Layer layer)
+    {
+        int count = commands.Count;
+        for (int i = 0; i < count; i++)
         {
-            DrawGumRecursively(renderables[i], layer);
+            DrawCommand command = commands[i];
+
+            // A render-target container always renders as a single composited unit (its subtree
+            // was already baked into an offscreen texture during the pre-pass) and never
+            // participates in the scissor stack, even if it also has ClipsChildren set --
+            // mirrors DrawGumRecursively, which composites and returns before ever touching the
+            // scissor stack.
+            if (command.Target.IsRenderTarget)
+            {
+                if (command.Kind == DrawCommandKind.DrawRenderable)
+                {
+                    CompositeRenderTarget(command.Target);
+                }
+                continue;
+            }
+
+            switch (command.Kind)
+            {
+                case DrawCommandKind.BeginClip:
+                    BeginClipScope(layer, command.Target);
+                    break;
+                case DrawCommandKind.DrawRenderable:
+                    command.Target.Render(null);
+                    break;
+                case DrawCommandKind.EndClip:
+                    EndClipScope();
+                    break;
+            }
+        }
+    }
+
+    // #4155: pushed before the element's own Render() -- BeginClip precedes DrawRenderable in the
+    // orderer's command list, so a clipping element's own draw is bounded by its own clip.
+    private void BeginClipScope(Layer layer, IRenderableIpso element)
+    {
+        System.Drawing.Rectangle rect = GetScissorRectangleFor(layer, element);
+        System.Drawing.Rectangle effective = _scissorStack.Count > 0
+            ? System.Drawing.Rectangle.Intersect(_scissorStack.Peek(), rect)
+            : rect;
+        _scissorStack.Push(effective);
+        BatchDrawCallCounter.BeginScissorMode(effective.X, effective.Y, effective.Width, effective.Height);
+    }
+
+    private void EndClipScope()
+    {
+        _scissorStack.Pop();
+        if (_scissorStack.Count > 0)
+        {
+            System.Drawing.Rectangle parent = _scissorStack.Peek();
+            BatchDrawCallCounter.BeginScissorMode(parent.X, parent.Y, parent.Width, parent.Height);
+        }
+        else
+        {
+            BatchDrawCallCounter.EndScissorMode();
         }
     }
 

--- a/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
@@ -332,6 +332,80 @@ public class ClipWalkConformanceTests : BaseTestClass
         GumService.Default.Root.Children.Clear();
     }
 
+    // #4154: a container that is both IsRenderTarget and ClipsChildren -- e.g. a scrolling panel
+    // rendered to a texture for group opacity. DrawGumRecursively checks IsRenderTarget and
+    // composites-then-returns BEFORE ever reaching the ClipsChildren scissor push, so the node's
+    // own clip has no effect and its children are never walked outside the bake. Pinned here via a
+    // sibling drawn immediately afterward in the SAME bake: if that ordering regressed (the scissor
+    // push moved ahead of the composite-and-return, or its pop got skipped on the early-return
+    // path), the pushed scissor would leak onto the sibling with nothing to pop it. Draw-call count
+    // can't discriminate a scissor leak -- a scissored-away draw is still issued and counted,
+    // scissoring is a fragment-level test, not something that suppresses the draw call itself --
+    // so this needs pixel readback.
+    //
+    // This exercises the shared DrawGumRecursively walk (used by BakeRenderTarget's child loop),
+    // not Renderer.Submit's own IsRenderTarget guard: this harness has no way to read the actual
+    // screen framebuffer Submit draws to, only RenderTexture2D content populated by a bake, and any
+    // node nested under an IsRenderTarget ancestor is (by the orderer's own recursion gate) reached
+    // via the bake's DrawGumRecursively walk, never via Submit. Submit's matching guard -- applied
+    // uniformly across BeginClip/DrawRenderable/EndClip rather than gated by command kind -- is
+    // covered by Draw_TopLevelRenderTargetContainerWithClipsChildren_
+    // CompositesOnceWithoutDoubleDrawingChildren below (draw-call count) and by
+    // HierarchicalOrdererTests.BuildDrawList_IsRenderTargetNodeWithClipsChildren_
+    // StillBracketsButDoesNotRecurse (the orderer contract Submit's guard depends on).
+    [Fact]
+    public void Draw_NestedRenderTargetContainerWithClipsChildren_DoesNotLeakScissorToFollowingSibling()
+    {
+        ContainerRuntime readableOuter = new();
+        readableOuter.X = 0;
+        readableOuter.Y = 0;
+        readableOuter.Width = 200;
+        readableOuter.Height = 200;
+        readableOuter.IsRenderTarget = true;
+
+        ContainerRuntime containerUnderTest = new();
+        containerUnderTest.X = 0;
+        containerUnderTest.Y = 0;
+        containerUnderTest.Width = 40;
+        containerUnderTest.Height = 40;
+        containerUnderTest.IsRenderTarget = true;
+        containerUnderTest.ClipsChildren = true;
+
+        ColoredRectangleRuntime fill = new();
+        fill.Width = 40;
+        fill.Height = 40;
+        fill.Color = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        containerUnderTest.Children.Add(fill);
+
+        // Well outside containerUnderTest's [0,40]x[0,40] rect -- if that rect leaked onto the
+        // scissor stack and was never popped, this would be clipped away.
+        ColoredRectangleRuntime siblingAfter = new();
+        siblingAfter.X = 100;
+        siblingAfter.Y = 100;
+        siblingAfter.Width = 50;
+        siblingAfter.Height = 50;
+        siblingAfter.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+
+        readableOuter.Children.Add(containerUnderTest);
+        readableOuter.Children.Add(siblingAfter);
+
+        GumService.Default.Root.Children.Add(readableOuter);
+        GumService.Default.Root.UpdateLayout();
+
+        BeginDrawing();
+        GumService.Default.Draw();
+        EndDrawing();
+
+        RenderTexture2D renderTexture = Renderer.Self.TryGetBakedRenderTargetFor(readableOuter)!.Value;
+        Color compositedContainer = ReadRenderTargetPixel(renderTexture, 20, 20);
+        Color siblingPixel = ReadRenderTargetPixel(renderTexture, 120, 120);
+
+        compositedContainer.R.ShouldBeGreaterThan((byte)200);
+        siblingPixel.G.ShouldBeGreaterThan((byte)200);
+
+        GumService.Default.Root.Children.Clear();
+    }
+
     // Divergence 2 (#4155): HierarchicalOrderer recurses into any visible IRenderableIpso child.
     // raylib's child loop tested `child is GraphicalUiElement`, so a raw (non-wrapped) renderable
     // parented directly onto another renderable never drew.
@@ -357,5 +431,47 @@ public class ClipWalkConformanceTests : BaseTestClass
         container.RemoveFromManagers();
 
         (withRawChild - baseline).ShouldBe(1);
+    }
+
+    // #4154: raylib's Renderer.Submit (the migrated main-pass walk) special-cases IsRenderTarget
+    // uniformly for BeginClip/DrawRenderable/EndClip -- mirroring DrawGumRecursively's composite-
+    // then-return-before-ClipsChildren ordering -- so a TOP-LEVEL container that is both
+    // IsRenderTarget and ClipsChildren composites exactly once and never draws its children a
+    // second time in the main pass (only once, inside the bake). Unlike the multi-child cull case,
+    // draw-call count is reliable here: the bake and the main-pass composite land in different FBO
+    // segments (BeginTextureMode/EndTextureMode force a flush before the main pass's BeginMode2D
+    // even starts), so a spurious extra main-pass draw of the child cannot coalesce with its bake
+    // draw into the same counted slot.
+    [Fact]
+    public void Draw_TopLevelRenderTargetContainerWithClipsChildren_CompositesOnceWithoutDoubleDrawingChildren()
+    {
+        int baseline = DrawAndCountDrawCalls();
+
+        ContainerRuntime containerUnderTest = new();
+        containerUnderTest.Width = 100;
+        containerUnderTest.Height = 100;
+        containerUnderTest.IsRenderTarget = true;
+        containerUnderTest.ClipsChildren = true;
+
+        ColoredRectangleRuntime child = new();
+        child.Width = 50;
+        child.Height = 50;
+        child.Color = new Color((byte)255, (byte)0, (byte)0, (byte)255);
+        containerUnderTest.Children.Add(child);
+
+        GumService.Default.Root.Children.Add(containerUnderTest);
+        GumService.Default.Root.UpdateLayout();
+
+        int withContainer = DrawAndCountDrawCalls();
+
+        RenderTexture2D bakedTexture = Renderer.Self.TryGetBakedRenderTargetFor(containerUnderTest)!.Value;
+        Color bakedPixel = ReadRenderTargetPixel(bakedTexture, 10, 10);
+
+        // One draw for the child baked into the texture, one for the on-screen composite blit. A
+        // regression that also draws the child directly in the main pass would raise this to 3.
+        (withContainer - baseline).ShouldBe(2);
+        bakedPixel.R.ShouldBeGreaterThan((byte)200);
+
+        GumService.Default.Root.Children.Clear();
     }
 }


### PR DESCRIPTION
## Summary

Part of #4154. Implements steps 1-3 of the settled implementation order (see issue decisions comment):

1. File-linked `HierarchicalOrderer.cs`, `IRenderableOrderer.cs`, `DrawCommand.cs`, `BatchKeyGroupedOrderer.cs` into `Runtimes/RaylibGum/RaylibGum.csproj`. They previously came in only via `GumCoreShared.projitems`, which raylib does not consume.
2. Extended `IRenderableOrderer` with a subtree entry point (`BuildDrawList(IList<IRenderableIpso> roots, ...)`) plus caller-supplied renderable-to-rectangle mappings (`getScissorRectangle`, `getCullTestBounds`), replacing `HierarchicalOrderer`'s/`BatchKeyGroupedOrderer`'s direct `camera.GetScissorRectangleFor`/`GetCullTestBoundsFor` calls. The existing `BuildDrawList(Layer, ...)` overload is byte-identical for current callers (proven by the full existing `MonoGameGum.Tests` suite staying green, 2017/2017).
3. Migrated raylib's main walk (`Runtimes/RaylibGum/RenderingLibrary/Renderer.cs`) to build-then-submit via `HierarchicalOrderer.Instance.BuildDrawList(layer, _scratchCommands, _camera)` + a new `Submit`/`BeginClipScope`/`EndClipScope`. The raylib-specific scissor stack (raylib's `BeginScissorMode` replaces rather than intersects), `BatchDrawCallCounter` routing, and render-target composite all moved into the submit phase. `BakeRenderTarget` stays on the existing recursive `DrawGumRecursively` walk — migrating both backends' bake paths onto the subtree entry point is step 4, a separate PR (it changes real MonoGame behavior per decision 2 in the issue).

## Added coverage: IsRenderTarget + ClipsChildren on the same node

Per review, pinned the case where a container is both `IsRenderTarget` and `ClipsChildren` (e.g. a scrolling panel rendered to a texture for group opacity) — its own clip is ignored entirely and its children are never walked a second time in the main pass:

- `HierarchicalOrdererTests.BuildDrawList_IsRenderTargetNodeWithClipsChildren_StillBracketsButDoesNotRecurse` — the orderer still brackets such a node with `BeginClip`/`DrawRenderable`/`EndClip` (ClipsChildren bracketing is independent of IsRenderTarget), with no child recursion. This is the contract `Renderer.Submit`'s guard depends on.
- `ClipWalkConformanceTests.Draw_TopLevelRenderTargetContainerWithClipsChildren_CompositesOnceWithoutDoubleDrawingChildren` — top-level, exercises `Renderer.Submit` directly. Draw-call count proves the container composites exactly once and its child is never drawn a second time in the main pass (only once, inside the bake); the bake/composite draws land in different FBO segments so this can't coalesce the way multi-child cull counts can.
- `ClipWalkConformanceTests.Draw_NestedRenderTargetContainerWithClipsChildren_DoesNotLeakScissorToFollowingSibling` — pixel readback, proving a sibling drawn immediately after the node in the same bake is not clipped away by a leaked scissor.

Note on scope: this harness can only read pixels back from a `RenderTexture2D`, never the actual screen framebuffer `Renderer.Submit` draws to. Any node nested under an `IsRenderTarget` ancestor is (by the orderer's own recursion gate) rendered via the bake's `DrawGumRecursively` walk, not `Submit` — so the pixel-based sibling-leak test necessarily exercises `DrawGumRecursively` (unchanged in this PR, but the identical ordering hazard), while `Submit`'s own guard is covered by the top-level draw-call-count test above. Both tests were verified red against deliberately reintroduced breaks in each method before being reverted to the real fix (see commit message for details).

Added a comment at `Renderer.Submit`'s `IsRenderTarget` guard pointing at this coverage.

## Test plan
- [x] New `IRenderableOrderer` subtree-overload tests added to `HierarchicalOrdererTests.cs` / `BatchKeyGroupedOrdererTests.cs`, TDD (red on missing overload, green after implementation)
- [x] New IsRenderTarget+ClipsChildren pinning tests (see above), each verified red against a deliberately reintroduced break before being reverted
- [x] `MonoGameGum.Tests` full suite: 2018/2018 passing
- [x] `RaylibGum.Tests` full suite: 565/565 passing
- [x] `KniGum` builds clean
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`, built from the primary checkout): 0 errors, warning count unchanged from the `origin/main` baseline (1956), zero warnings from the changed files
- [x] Zero new compiler warnings (fixed one ambiguous-`cref` warning in `DrawCommand.cs`'s XML doc introduced by the new overload)

Closes nothing — step 4 (migrating both backends' render-target bake paths onto the subtree entry point, which also changes MonoGame's no-cull bake behavior per decision 2) is still open and will be a follow-up PR.
