### PR TITLE
Host the wireframe canvas natively in WPF, dropping WindowsFormsHost

### DIFF
--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -429,6 +429,21 @@ as in-scope vs. deferred.
   plus pixel-buffer-out / input-in, and lift the cursor/keyboard off the WinForms control. The
   `3218-skiasharp-host-model` work is the prototype. *Payoff (even on WPF):* lets the
   `WindowsFormsHost` airspace/focus hacks be deleted.
+  The wireframe canvas has taken this path end to end: `WpfGraphicsDeviceControl` draws into the
+  shared device's render target, reads it back, and pushes the pixels into a `WriteableBitmap`, so
+  the editor tab is `WindowsFormsHost`-free. Points worth carrying to the next host:
+  - **A WPF host has no control handle to create the device against.** It is constructed before it
+    is attached to a window, so the device is created against the application's main window handle
+    instead, and it keeps calling the same ref-counted `GraphicsDeviceService` — giving a canvas its
+    *own* device would split `LoaderManager`'s process-wide texture cache against the other canvas.
+  - **Size the surface, the cursor, and the viewport in the same unit system.** WPF reports element
+    size and `PointFromScreen` in device-independent units, so the render target is sized in those
+    too; mixing in raw pixels puts hit-testing and the camera out of step on a scaled display.
+  - **`CompositionTarget.Rendering` is the render trigger, not a timer** (a `DispatcherTimer` caps
+    out far below the copy cost's actual limit). It fires at the compositor's cadence, so a
+    requested frame rate is honored by skipping passes rather than by setting an interval.
+  - **WPF does not carry a drag effect from `DragEnter` into `DragOver`** the way WinForms does; the
+    accept decision has to be re-applied on every move or the drop goes invalid mid-drag.
 
 **Phase 5 — The actual bet (deferred, and only now decidable).** Build *one* real Avalonia screen
 (the tree, or the canvas on the Skia host) against the now-unchanged logic. **Measure** the

--- a/Gum/Input/MouseExtensions.cs
+++ b/Gum/Input/MouseExtensions.cs
@@ -1,11 +1,14 @@
+using System.Windows;
+using System.Windows.Input;
 using WinForms = System.Windows.Forms;
+using WpfPoint = System.Windows.Point;
 
 namespace Gum.Input;
 
 /// <summary>
-/// Translates WinForms mouse event types to Gum's framework-neutral <see cref="GumMouseEventArgs"/> at
-/// the editor-host boundary (e.g. <c>WireframeControl</c>), so the wireframe editing subsystem
-/// (camera panning/zoom, etc.) need not reference WinForms.
+/// Translates WinForms and WPF mouse event types to Gum's framework-neutral <see cref="GumMouseEventArgs"/>
+/// at the editor-host boundary (e.g. <c>WireframeControl</c>), so the wireframe editing subsystem
+/// (camera panning/zoom, etc.) need not reference either framework.
 /// </summary>
 public static class MouseExtensions
 {
@@ -19,6 +22,16 @@ public static class MouseExtensions
             _ => GumMouseButton.None,
         };
 
+    /// <summary>Maps a WPF <see cref="MouseButton"/> value to the matching <see cref="GumMouseButton"/>.</summary>
+    public static GumMouseButton ToGumMouseButton(this MouseButton button) =>
+        button switch
+        {
+            MouseButton.Left => GumMouseButton.Left,
+            MouseButton.Right => GumMouseButton.Right,
+            MouseButton.Middle => GumMouseButton.Middle,
+            _ => GumMouseButton.None,
+        };
+
     /// <summary>Builds a framework-neutral <see cref="GumMouseEventArgs"/> from a WinForms mouse event.</summary>
     public static GumMouseEventArgs ToGumMouseEventArgs(this WinForms.MouseEventArgs e)
     {
@@ -29,5 +42,48 @@ public static class MouseExtensions
             Button = e.Button.ToGumMouseButton(),
             Delta = e.Delta,
         };
+    }
+
+    /// <summary>
+    /// Builds a framework-neutral <see cref="GumMouseEventArgs"/> from a WPF mouse event, with the
+    /// position expressed in <paramref name="relativeTo"/>'s coordinates.
+    /// </summary>
+    public static GumMouseEventArgs ToGumMouseEventArgs(this MouseEventArgs e, IInputElement relativeTo)
+    {
+        WpfPoint position = e.GetPosition(relativeTo);
+
+        return new GumMouseEventArgs
+        {
+            X = (int)position.X,
+            Y = (int)position.Y,
+            Button = GetButton(e),
+            Delta = e is MouseWheelEventArgs wheelArgs ? wheelArgs.Delta : 0,
+            Handled = e.Handled,
+        };
+    }
+
+    // A button event names the button that changed; a move/wheel event doesn't, so report whichever
+    // button is currently held - that is what WinForms' MouseEventArgs.Button carries during a drag.
+    private static GumMouseButton GetButton(MouseEventArgs e)
+    {
+        if (e is MouseButtonEventArgs buttonArgs)
+        {
+            return buttonArgs.ChangedButton.ToGumMouseButton();
+        }
+
+        if (e.LeftButton == MouseButtonState.Pressed)
+        {
+            return GumMouseButton.Left;
+        }
+        if (e.RightButton == MouseButtonState.Pressed)
+        {
+            return GumMouseButton.Right;
+        }
+        if (e.MiddleButton == MouseButtonState.Pressed)
+        {
+            return GumMouseButton.Middle;
+        }
+
+        return GumMouseButton.None;
     }
 }

--- a/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
+++ b/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
@@ -40,7 +40,7 @@ public class CameraControllerTests
         var zoomController = new Mock<IZoomController>();
 
         var controller = new CameraController();
-        controller.Initialize(camera, zoomController.Object, defaultWidth: 800, defaultHeight: 600, hotkeyManager.Object);
+        controller.Initialize(camera, zoomController.Object, hotkeyManager.Object);
 
         return (controller, camera, hotkeyManager, zoomController);
     }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -1,5 +1,4 @@
-﻿using CommonFormsAndControls;
-using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using EditorTabPlugin_XNA.Services;
 using EditorTabPlugin_XNA.ViewModels;
 using EditorTabPlugin_XNA.Views;
@@ -46,11 +45,10 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Forms;
-using System.Windows.Forms.Integration;
+using System.Windows.Input;
 using System.Windows.Markup;
 using ToolsUtilities;
-using DialogResult = System.Windows.Forms.DialogResult;
+using WpfScrollBar = System.Windows.Controls.Primitives.ScrollBar;
 
 namespace Gum.Plugins.InternalPlugins.EditorTab;
 
@@ -143,7 +141,6 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     private EditorControls _editorControls;
 
-    System.Windows.Forms.Panel gumEditorPanel;
     private LayerService _layerService;
     private System.Windows.Controls.ContextMenu _wireframeContextMenu;
     private EditingManager _editingManager;
@@ -831,11 +828,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     private void HandleXnaInitialized()
     {
-        _scrollbarService.HandleWireframeInitialized(_wireframeControl, gumEditorPanel);
-
-
         _wireframeControl.Initialize(
-            gumEditorPanel,
             _hotkeyManager,
             _selectionManager,
             _dragDropManager,
@@ -871,49 +864,35 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _scrollbarService.HandleXnaInitialized();
 
 
-        this._wireframeControl.Parent.Resize += (_, _) =>
+        this._wireframeControl.SizeChanged += (_, _) =>
         {
-            UpdateWireframeControlSizes();
             _pluginManager.HandleWireframeResized();
         };
 
-        //this._wireframeControl.MouseClick += wireframeControl1_MouseClick;
         this._wireframeControl.MouseDown += wireframeControl1_MouseDown;
 
-
-        this._wireframeControl.DragDrop += OnWireframeDrop;
+        this._wireframeControl.Drop += OnWireframeDrop;
         this._wireframeControl.DragEnter += OnWireframeDragEnter;
-        this._wireframeControl.DragOver += (sender, e) =>
-        {
-            // Intentionally does NOT set e.Effect. The effect is chosen once in
-            // OnWireframeDragEnter, and WinForms carries it forward into each DragOver,
-            // so the drop stays valid for the whole drag without re-asserting it here.
-            // This is fine because the entire canvas accepts a drop the same way; if
-            // drop validity ever becomes position-dependent, set the effect per-move
-            // here the way the tree view's DragOver does.
-            //this.DoDragDrop(e.Data, DragDropEffects.Move | DragDropEffects.Copy);
-            //DragDropManager.Self.HandleDragOver(sender, e);
-
-        };
+        // Unlike WinForms, WPF does not carry the effect chosen on DragEnter forward into each
+        // DragOver, so the same decision has to be re-applied per move or the drop goes invalid.
+        this._wireframeControl.DragOver += OnWireframeDragOver;
 
         // December 29, 2024
         // AppCenter is dead - do we want to replace this?
         //_wireframeControl.ErrorOccurred += (exception) => Crashes.TrackError(exception);
 
-        this._wireframeControl.QueryContinueDrag += (sender, args) =>
-        {
-            args.Action = System.Windows.Forms.DragAction.Continue;
-        };
         _wireframeControl.CameraChanged += () =>
         {
             _pluginManager.CameraChanged();
         };
 
-        this._wireframeControl.KeyDown += (o, args) =>
+        this._wireframeControl.KeyDown += (_, args) =>
         {
-            if (args.KeyCode == Keys.Tab)
+            if (args.Key == Key.Tab)
             {
                 _guiCommands.ToggleToolVisibility();
+                // Otherwise WPF also moves focus off the canvas.
+                args.Handled = true;
             }
         };
 
@@ -921,79 +900,94 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         float frameRate = Math.Max(Math.Min(_projectManager.FrameRate, 60), 10);
         _wireframeControl.DesiredFramesPerSecond = frameRate;
 
-        UpdateWireframeControlSizes();
-
         IEffectiveThemeSettings themeSettings = _themingService.EffectiveSettings;
         ApplyThemeSettings(themeSettings);
     }
 
-    internal void OnWireframeDragEnter(object? sender, System.Windows.Forms.DragEventArgs e)
+    // WPF glue only - the decision and the drop handling below are framework-neutral.
+    private void OnWireframeDragEnter(object? sender, System.Windows.DragEventArgs e)
     {
-        // WinForms glue only: inspect the drag payload, ask the neutral manager
-        // whether to accept it, then apply the decision. The accept/reject logic
-        // itself lives in DragDropManager.DecideWireframeDragEffect.
-        bool hasFileDrop = e.Data.GetDataPresent(System.Windows.Forms.DataFormats.FileDrop);
-        bool hasNodes = MultiSelectTreeView.ExtractDraggedNodes(e.Data).Length > 0;
-        bool hasStandardChip = e.Data.GetDataPresent(DragDropManager.StandardElementNameDataFormat);
+        e.Effects = DecideWireframeDropEffect(
+            WpfWireframeDropPayloadReader.Read(e.Data), reportBlockedReason: true);
+        e.Handled = true;
+    }
 
-        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(hasFileDrop, hasNodes);
+    private void OnWireframeDragOver(object? sender, System.Windows.DragEventArgs e)
+    {
+        // Same decision as DragEnter, but silent: a rejected drag would otherwise report its reason
+        // on every mouse move rather than once per drag.
+        e.Effects = DecideWireframeDropEffect(
+            WpfWireframeDropPayloadReader.Read(e.Data), reportBlockedReason: false);
+        e.Handled = true;
+    }
+
+    private void OnWireframeDrop(object? sender, System.Windows.DragEventArgs e)
+    {
+        HandleWireframeDrop(WpfWireframeDropPayloadReader.Read(e.Data));
+        e.Handled = true;
+    }
+
+    internal System.Windows.DragDropEffects DecideWireframeDropEffect(
+        WireframeDropPayload payload, bool reportBlockedReason)
+    {
+        DragAcceptDecision decision = _dragDropManager.DecideWireframeDragEffect(
+            payload.HasFileDrop, payload.HasNodes);
 
         // A Standards-palette chip is accepted like a dragged Standard node — the drop creates an
         // instance of that type on the open Screen/Component at the cursor position.
-        if (decision.Accept || hasStandardChip)
+        if (decision.Accept || payload.HasStandardChip)
         {
-            e.Effect = System.Windows.Forms.DragDropEffects.Copy;
+            return System.Windows.DragDropEffects.Copy;
         }
-        else if (decision.BlockedReason != null)
+
+        if (reportBlockedReason && decision.BlockedReason != null)
         {
             _guiCommands.PrintOutput($"File drag rejected: {decision.BlockedReason}.");
         }
+
+        return System.Windows.DragDropEffects.None;
     }
 
-    internal void OnWireframeDrop(object? sender, System.Windows.Forms.DragEventArgs e)
+    internal void HandleWireframeDrop(WireframeDropPayload payload)
     {
-        // Handle Standards-palette chip drops: create + position an instance of the chip's type,
-        // reusing the same path as a dragged Standard node.
-        if (e.Data.GetData(DragDropManager.StandardElementNameDataFormat) is string standardTypeName)
+        switch (payload.ResolveAction())
         {
-            if (ObjectFinder.Self.GetStandardElement(standardTypeName) is { } standardElement)
-            {
-                _dragDropManager.OnNodeObjectDroppedInWireframe(standardElement);
-            }
-            return;
-        }
+            case WireframeDropAction.StandardChip standardChip:
+                // Create + position an instance of the chip's type, reusing the same path as a
+                // dragged Standard node.
+                if (ObjectFinder.Self.GetStandardElement(standardChip.StandardElementTypeName) is { } standardElement)
+                {
+                    _dragDropManager.OnNodeObjectDroppedInWireframe(standardElement);
+                }
+                break;
 
-        // Handle node drops
-        TreeNode[] droppedNodes = MultiSelectTreeView.ExtractDraggedNodes(e.Data);
+            case WireframeDropAction.Nodes nodes:
+                // A search-result drag's TreeNode.Tag doesn't survive the WPF -> WinForms boundary
+                // (see SearchResultDragPayload); fall back to it when Tag comes back null.
+                foreach (object draggedObject in nodes.Tags.Select(tag => tag ?? SearchResultDragPayload.Current))
+                {
+                    _dragDropManager.OnNodeObjectDroppedInWireframe(draggedObject);
+                }
+                break;
 
-        if (droppedNodes.Length > 0)
-        {
-            // A search-result drag's TreeNode.Tag doesn't survive the WPF -> WinForms boundary
-            // (see SearchResultDragPayload); fall back to it when Tag comes back null.
-            foreach (var draggedObject in droppedNodes.Select(x => x.Tag ?? SearchResultDragPayload.Current))
-            {
-                _dragDropManager.OnNodeObjectDroppedInWireframe(draggedObject);
-            }
-
-            return;
-        }
-
-        // Handle file drops.
-        // Wrapped in try/catch because exceptions thrown inside a WinForms/OLE
-        // DragDrop handler are swallowed by the drag loop — a failed drop then
-        // looks like drag+drop silently "stopped working". Surfacing it in the
-        // output window makes the failure diagnosable (#3128).
-        try
-        {
-            HandleWireframeFileDrop(e);
-        }
-        catch (Exception ex)
-        {
-            _outputManager.AddError($"Drag+drop failed while handling the dropped file(s): {ex}");
+            case WireframeDropAction.FileDrop fileDrop:
+                // Wrapped in try/catch because exceptions thrown inside an OLE drop handler are
+                // swallowed by the drag loop — a failed drop then looks like drag+drop silently
+                // "stopped working". Surfacing it in the output window makes the failure
+                // diagnosable (#3128).
+                try
+                {
+                    HandleWireframeFileDrop(fileDrop.Files);
+                }
+                catch (Exception ex)
+                {
+                    _outputManager.AddError($"Drag+drop failed while handling the dropped file(s): {ex}");
+                }
+                break;
         }
     }
 
-    private void HandleWireframeFileDrop(System.Windows.Forms.DragEventArgs e)
+    private void HandleWireframeFileDrop(string[] files)
     {
         if (!CanDrop())
         {
@@ -1002,13 +996,6 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         float worldX, worldY;
         Renderer.Self.Camera.ScreenToWorld(InputLibrary.Cursor.Self.X, InputLibrary.Cursor.Self.Y, out worldX, out worldY);
-        string[] files = (string[])e.Data.GetData(System.Windows.Forms.DataFormats.FileDrop);
-
-        if (files == null)
-        {
-            _guiCommands.PrintOutput("File drop ignored: the drag payload contained no file data.");
-            return;
-        }
 
         var handled = false;
         bool shouldUpdate = false;
@@ -1423,13 +1410,9 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     {
         _wireframeContextMenu = new System.Windows.Controls.ContextMenu();
 
-        gumEditorPanel = new ();
-        gumEditorPanel.Dock = DockStyle.Fill;
-
-        // 2025-01-02 UI Scale update
-        // WireFrameControl needs to be added to the gumEditorPanel first
-        // Otherwise, the combobox will be drawn ontop of the top yellow ruler
         CreateWireframeControl();
+        _scrollbarService.HandleWireframeInitialized(
+            new FrameworkElementScrollSurfaceAdapter(_wireframeControl));
 
         System.Windows.Controls.Grid wpfGrid = new();
         wpfGrid.RowDefinitions.Add(new () { Height = GridLength.Auto});
@@ -1439,18 +1422,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         wpfGrid.Children.Add(_editorControls);
         Grid.SetRow(_editorControls, 0);
 
-        WindowsFormsHost host = new WindowsFormsHost();
-        host.Child = gumEditorPanel;
-
-        // This is kind of a hack to deal with the airspace issue blocking mouse
-        // interaction with the grid splitter and window resize handle: WindowsFormsHost
-        // hosts a real HWND, which always paints on top of WPF siblings regardless of
-        // z-order, so without this margin the grid splitter can't receive mouse input
-        // right at the edge of this tab.
-        host.Margin = new Thickness(4, 0, 4, 0);
-
-        wpfGrid.Children.Add(host);
-        Grid.SetRow(host, 1);
+        wpfGrid.Children.Add(CreateCanvasGrid());
 
         _tabManager.AddControl(wpfGrid, "Editor", TabLocation.RightTop);
 
@@ -1465,30 +1437,38 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
     }
 
+    /// <summary>
+    /// Builds the canvas plus its scroll bars - vertical along the right edge, horizontal along the
+    /// bottom - and places it in the editor tab's second row.
+    /// </summary>
+    private System.Windows.Controls.Grid CreateCanvasGrid()
+    {
+        System.Windows.Controls.Grid canvasGrid = new();
+        canvasGrid.ColumnDefinitions.Add(new() { Width = new(1, GridUnitType.Star) });
+        canvasGrid.ColumnDefinitions.Add(new() { Width = GridLength.Auto });
+        canvasGrid.RowDefinitions.Add(new() { Height = new(1, GridUnitType.Star) });
+        canvasGrid.RowDefinitions.Add(new() { Height = GridLength.Auto });
+
+        canvasGrid.Children.Add(_wireframeControl);
+
+        WpfScrollBar verticalScrollBar = _scrollbarService.VerticalScrollBar!;
+        canvasGrid.Children.Add(verticalScrollBar);
+        Grid.SetColumn(verticalScrollBar, 1);
+
+        WpfScrollBar horizontalScrollBar = _scrollbarService.HorizontalScrollBar!;
+        canvasGrid.Children.Add(horizontalScrollBar);
+        Grid.SetRow(horizontalScrollBar, 1);
+
+        Grid.SetRow(canvasGrid, 1);
+        return canvasGrid;
+    }
+
     private void CreateWireframeControl()
     {
         this._wireframeControl = new WireframeControl(_dialogService, _outputManager, _pluginManager);
         this._wireframeControl.AllowDrop = true;
-        this._wireframeControl.Dock = DockStyle.Fill;
-        this._wireframeControl.Cursor = System.Windows.Forms.Cursors.Default;
         this._wireframeControl.DesiredFramesPerSecond = 30F;
         this._wireframeControl.Name = "wireframeControl1";
-        this._wireframeControl.TabIndex = 0;
-        this._wireframeControl.Text = "wireframeControl1";
-        gumEditorPanel.Controls.Add(this._wireframeControl);
-    }
-
-    /// <summary>
-    /// Refreshes the wifreframe control size - for some reason this is necessary if windows has a non-100% scale (for higher resolution displays)
-    /// </summary>
-    private void UpdateWireframeControlSizes()
-    {
-        // I don't think we need this for docking:
-        //WireframeEditControl.Width = WireframeEditControl.Parent.Width / 2;
-
-        //_toolbarPanel.Width = _toolbarPanel.Parent.Width;
-
-        _wireframeControl.Width = _wireframeControl.Parent.Width;
     }
 
     private void HandleStateSelected(StateSave? save)
@@ -1500,9 +1480,9 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _wireframeRefreshCoordinator.OnStateRebuild(_selectedState.SelectedElement);
     }
 
-    private void wireframeControl1_MouseDown(object? sender, MouseEventArgs e)
+    private void wireframeControl1_MouseDown(object? sender, MouseButtonEventArgs e)
     {
-        if (e.Button == MouseButtons.Right)
+        if (e.ChangedButton == MouseButton.Right)
         {
             _editingManager.OnRightClick();
 

--- a/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
+++ b/Tool/EditorTabPlugin_XNA/ScrollbarService.cs
@@ -2,14 +2,14 @@
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
-using Gum.Plugins.InternalPlugins.EditorTab.Views;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
-using System.Windows.Forms;
+using System.Windows.Controls;
+using WpfScrollBar = System.Windows.Controls.Primitives.ScrollBar;
 
 namespace Gum.Plugins.ScrollBarPlugin;
 
@@ -90,24 +90,31 @@ public class ScrollbarService
         }
     }
 
-    public void HandleWireframeInitialized(WireframeControl wireframeControl1, System.Windows.Forms.Panel gumEditorPanel)
-    {
-        // this used to be in MainWindow.cs,
-        // but was moved to a plugin. This changes
-        // the order of this code which had a comment
-        // about needing to be done in a particular order
-        // but it seems to be working okay. Adding this comment
-        // just in case the order does in fact matter.
-        ThemedScrollBar verticalScrollBar = new() { Orientation = ScrollOrientationEx.Vertical, Dock = DockStyle.Right };
-        gumEditorPanel.Controls.Add(verticalScrollBar);
+    /// <summary>
+    /// The vertical scroll bar for the wireframe canvas. Null until
+    /// <see cref="HandleWireframeInitialized"/> runs; the caller is responsible for placing it in
+    /// the editor's visual tree.
+    /// </summary>
+    public WpfScrollBar? VerticalScrollBar { get; private set; }
 
-        ThemedScrollBar horizontalScrollBar = new() { Orientation = ScrollOrientationEx.Horizontal, Dock = DockStyle.Bottom };
-        gumEditorPanel.Controls.Add(horizontalScrollBar);
+    /// <summary>
+    /// The horizontal scroll bar for the wireframe canvas. See <see cref="VerticalScrollBar"/>.
+    /// </summary>
+    public WpfScrollBar? HorizontalScrollBar { get; private set; }
+
+    /// <summary>
+    /// Creates the wireframe canvas's scroll bars and the logic driving them, over
+    /// <paramref name="scrollSurface"/>.
+    /// </summary>
+    public void HandleWireframeInitialized(IScrollSurface scrollSurface)
+    {
+        VerticalScrollBar = new WpfScrollBar { Orientation = Orientation.Vertical };
+        HorizontalScrollBar = new WpfScrollBar { Orientation = Orientation.Horizontal };
 
         scrollBarControlLogic = new ScrollBarControlLogic(
-            horizontalScrollBar,
-            verticalScrollBar,
-            new ControlScrollSurfaceAdapter(wireframeControl1));
+            new WpfScrollBarAdapter(HorizontalScrollBar),
+            new WpfScrollBarAdapter(VerticalScrollBar),
+            scrollSurface);
         scrollBarControlLogic.SetDisplayedArea(800, 600);
     }
 

--- a/Tool/EditorTabPlugin_XNA/Services/FrameworkElementScrollSurfaceAdapter.cs
+++ b/Tool/EditorTabPlugin_XNA/Services/FrameworkElementScrollSurfaceAdapter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Windows;
+using Gum.Controls;
+
+namespace Gum.Plugins.ScrollBarPlugin;
+
+/// <summary>
+/// Adapts a WPF <see cref="FrameworkElement"/> to <see cref="IScrollSurface"/> so
+/// <see cref="Gum.Plugins.InternalPlugins.EditorTab.Services.ScrollBarControlLogic"/> can size its
+/// bars from the wireframe canvas without referencing WPF. The WPF counterpart to
+/// <see cref="ControlScrollSurfaceAdapter"/>.
+/// </summary>
+public class FrameworkElementScrollSurfaceAdapter : IScrollSurface
+{
+    private readonly FrameworkElement _element;
+
+    public FrameworkElementScrollSurfaceAdapter(FrameworkElement element)
+    {
+        if (element == null)
+        {
+            throw new ArgumentNullException(nameof(element));
+        }
+
+        _element = element;
+        _element.SizeChanged += (_, _) => SizeChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc/>
+    public int Width => (int)_element.ActualWidth;
+
+    /// <inheritdoc/>
+    public int Height => (int)_element.ActualHeight;
+
+    /// <inheritdoc/>
+    public event EventHandler? SizeChanged;
+}

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -18,19 +18,14 @@ using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Math.Geometry;
 using System;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Security.Policy;
-using System.Windows.Forms;
+using System.Windows.Input;
 using XnaAndWinforms;
 using Color = System.Drawing.Color;
-using Matrix = System.Numerics.Matrix4x4;
-using WinCursor = System.Windows.Forms.Cursor;
 
 namespace Gum.Plugins.InternalPlugins.EditorTab.Views;
 
 
-public class WireframeControl : GraphicsDeviceControl
+public class WireframeControl : WpfGraphicsDeviceControl
 {
     #region Fields
 
@@ -94,14 +89,6 @@ public class WireframeControl : GraphicsDeviceControl
         get { return mCanvasBounds; }
     }
 
-    new InputLibrary.Cursor Cursor
-    {
-        get
-        {
-            return InputLibrary.Cursor.Self;
-        }
-    }
-
     Camera Camera
     {
         get { return Renderer.Self.Camera; }
@@ -118,28 +105,31 @@ public class WireframeControl : GraphicsDeviceControl
     {
         GumKeyEventArgs keyArgs = e.ToGumKeyEventArgs();
         _hotkeyManager.HandleEditorKeyDown(keyArgs);
-        e.Handled = keyArgs.Handled;
-        e.SuppressKeyPress = keyArgs.SuppressKeyPress;
+        // WPF has no SuppressKeyPress equivalent; marking the event handled stops both the key
+        // event and the text input it would otherwise produce.
+        e.Handled = keyArgs.Handled || keyArgs.SuppressKeyPress;
         _cameraController.HandleKeyPress(keyArgs);
     }
 
-    void HandleMouseDown(object? sender, MouseEventArgs e) =>
-        _cameraController.HandleMouseDown(e.ToGumMouseEventArgs());
+    void HandleMouseDown(object? sender, MouseButtonEventArgs e)
+    {
+        // The canvas only receives keys while it has keyboard focus, and clicking it is how the
+        // user hands focus over from the rest of the WPF UI.
+        Focus();
+        _cameraController.HandleMouseDown(e.ToGumMouseEventArgs(this));
+    }
 
     void HandleMouseMove(object? sender, MouseEventArgs e) =>
-        _cameraController.HandleMouseMove(e.ToGumMouseEventArgs());
+        _cameraController.HandleMouseMove(e.ToGumMouseEventArgs(this));
 
-    void HandleMouseWheel(object? sender, MouseEventArgs e)
+    void HandleMouseWheel(object? sender, MouseWheelEventArgs e)
     {
-        var gumMouseArgs = e.ToGumMouseEventArgs();
+        GumMouseEventArgs gumMouseArgs = e.ToGumMouseEventArgs(this);
         _cameraController.HandleMouseWheel(gumMouseArgs);
 
-        // WinForms reports MouseWheel via a HandledMouseEventArgs; read the neutral Handled
-        // back to suppress the container's default scroll behavior, mirroring HandleKeyDown above.
-        if (gumMouseArgs.Handled && e is HandledMouseEventArgs handledArgs)
-        {
-            handledArgs.Handled = true;
-        }
+        // Read the neutral Handled back to suppress a containing scroll viewer's default scroll
+        // behavior, mirroring HandleKeyDown above.
+        e.Handled = gumMouseArgs.Handled;
     }
 
     private void HandleKeyUp(object? sender, KeyEventArgs e)
@@ -147,23 +137,25 @@ public class WireframeControl : GraphicsDeviceControl
         _hotkeyManager.HandleKeyUpWireframe();
     }
 
-    protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+    /// <summary>
+    /// Gives the hotkey manager first refusal on every key, ahead of WPF's own handling (focus
+    /// navigation on Tab/arrows in particular). The WinForms counterpart was ProcessCmdKey.
+    /// </summary>
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
-        // Translate the WinForms key at this boundary so IHotkeyManager stays framework-neutral.
-        bool handled = _hotkeyManager.ProcessCmdKeyWireframe(
-            keyData.ToGumKey(),
-            isShiftDown: (keyData & Keys.Shift) == Keys.Shift,
-            isCtrlDown: (keyData & Keys.Control) == Keys.Control,
-            isAltDown: (keyData & Keys.Alt) == Keys.Alt);
+        GumKeyEventArgs keyArgs = e.ToGumKeyEventArgs();
 
-        if (handled)
+        if (_hotkeyManager != null && _hotkeyManager.ProcessCmdKeyWireframe(
+                keyArgs.Key,
+                isShiftDown: keyArgs.IsShiftDown,
+                isCtrlDown: keyArgs.IsCtrlDown,
+                isAltDown: keyArgs.IsAltDown))
         {
-            return true;
+            e.Handled = true;
+            return;
         }
-        else
-        {
-            return base.ProcessCmdKey(ref msg, keyData);
-        }
+
+        base.OnPreviewKeyDown(e);
     }
 
 
@@ -172,7 +164,6 @@ public class WireframeControl : GraphicsDeviceControl
     #region Initialize Methods
 
     public void Initialize(
-        Panel wireframeParentPanel,
         IHotkeyManager hotkeyManager,
         SelectionManager selectionManager,
         IDragDropManager dragDropManager,
@@ -229,10 +220,10 @@ public class WireframeControl : GraphicsDeviceControl
                 _outputManager.AddError(
                     "Default font file 'Content/TestFont.fnt' was not found. Text in the wireframe editor may not render correctly.");
             }
-            _cameraController.Initialize(Camera, editorViewModel, Width, Height, hotkeyManager);
+            _cameraController.Initialize(Camera, editorViewModel, hotkeyManager);
             _cameraController.CameraChanged += () => CameraChanged?.Invoke();
 
-            InputLibrary.Cursor.Self.Initialize(new InputLibrary.ControlInputHostAdapter(this));
+            InputLibrary.Cursor.Self.Initialize(new InputLibrary.WpfInputHostAdapter(this));
 
             mCanvasBounds = new LineRectangle();
             mCanvasBounds.IsDotted = true;
@@ -259,6 +250,7 @@ public class WireframeControl : GraphicsDeviceControl
             {
                 mouseHasEntered = false;
             };
+
 
             if (AfterXnaInitialize != null)
             {

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/MainEditorTabPluginDragDropTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/EditorTab/MainEditorTabPluginDragDropTests.cs
@@ -4,23 +4,22 @@ using Moq;
 using Shouldly;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Windows.Forms;
+using System.Windows;
 using Xunit;
+using WinFormsTreeNode = System.Windows.Forms.TreeNode;
 
 namespace GumToolUnitTests.Plugins.InternalPlugins.EditorTab;
 
 // Regression coverage for issue #3965: dragging a Component/Standard/Instance tree node onto the
-// wireframe canvas silently did nothing. OnWireframeDragEnter/OnWireframeDrop detected dragged nodes
-// via DragEventArgsExt.HasData<TreeNode>()/GetData<TreeNode>(), an exact-type format lookup that
-// never matches a GumTreeNode-boxed single drag (WinForms keys a boxed payload by its *runtime* type
-// name) or a multi-select TreeNode[] drag (the code checked List<TreeNode> first, which is never the
-// shape MultiSelectTreeView.Theming actually boxes). MultiSelectTreeView.ExtractDraggedNodes already
-// fixes this for the tree's own internal drag-reorder by scanning formats instead of doing an
-// exact-type lookup; these tests pin that MainEditorTabPlugin now routes through it too.
+// wireframe canvas silently did nothing, because the drag payload was detected via an exact-type
+// format lookup that never matches a GumTreeNode-boxed single drag (a boxed payload is keyed by its
+// *runtime* type name) or a multi-select TreeNode[] drag. These tests pin that the canvas's
+// accept/drop routing still sees both shapes, end to end from the OLE data object through
+// WpfWireframeDropPayloadReader (the WPF canvas's extraction) into the plugin.
 public class MainEditorTabPluginDragDropTests : BaseTestClass
 {
-    [Fact]
-    public void OnWireframeDragEnter_MultiSelectTreeNodeArray_AcceptsCopyEffect()
+    [StaFact]
+    public void DecideWireframeDropEffect_MultiSelectTreeNodeArray_AcceptsCopyEffect()
     {
         MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
         dragDropManager
@@ -29,17 +28,15 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
 
         GumTreeNode first = new GumTreeNode("Circle1");
         GumTreeNode second = new GumTreeNode("Circle2");
-        TreeNode[] draggedArray = { first, second };
-        DataObject dataObject = new DataObject((object)draggedArray);
-        DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy | DragDropEffects.Move, DragDropEffects.None);
+        WinFormsTreeNode[] draggedArray = { first, second };
 
-        plugin.OnWireframeDragEnter(null, args);
+        DragDropEffects effects = plugin.DecideWireframeDropEffect(ReadPayload(draggedArray), reportBlockedReason: true);
 
-        args.Effect.ShouldBe(DragDropEffects.Copy);
+        effects.ShouldBe(DragDropEffects.Copy);
     }
 
-    [Fact]
-    public void OnWireframeDragEnter_SingleGumTreeNodeBoxedAsPlainObject_AcceptsCopyEffect()
+    [StaFact]
+    public void DecideWireframeDropEffect_SingleGumTreeNodeBoxedAsPlainObject_AcceptsCopyEffect()
     {
         MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
         dragDropManager
@@ -49,16 +46,14 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
         // Mirrors MultiSelectTreeView.Theming.cs's single-node drag start:
         // DoDragDrop((object)nodeToDrag, ...), which boxes the concrete GumTreeNode.
         GumTreeNode draggedNode = new GumTreeNode("Circle1");
-        DataObject dataObject = new DataObject((object)draggedNode);
-        DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy | DragDropEffects.Move, DragDropEffects.None);
 
-        plugin.OnWireframeDragEnter(null, args);
+        DragDropEffects effects = plugin.DecideWireframeDropEffect(ReadPayload(draggedNode), reportBlockedReason: true);
 
-        args.Effect.ShouldBe(DragDropEffects.Copy);
+        effects.ShouldBe(DragDropEffects.Copy);
     }
 
-    [Fact]
-    public void OnWireframeDrop_MultiSelectTreeNodeArray_CreatesInstanceForEachDraggedTag()
+    [StaFact]
+    public void HandleWireframeDrop_MultiSelectTreeNodeArray_CreatesInstanceForEachDraggedTag()
     {
         MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
 
@@ -67,38 +62,34 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
         GumTreeNode first = new GumTreeNode("Circle1") { Tag = firstTag };
         GumTreeNode second = new GumTreeNode("Circle2") { Tag = secondTag };
         // Mirrors MultiSelectTreeView.Theming.cs's multi-select drag start: DoDragDrop(SelectedNodes.ToArray(), ...).
-        TreeNode[] draggedArray = { first, second };
-        DataObject dataObject = new DataObject((object)draggedArray);
-        DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.Copy);
+        WinFormsTreeNode[] draggedArray = { first, second };
 
-        plugin.OnWireframeDrop(null, args);
+        plugin.HandleWireframeDrop(ReadPayload(draggedArray));
 
         dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(firstTag), Times.Once);
         dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(secondTag), Times.Once);
     }
 
-    [Fact]
-    public void OnWireframeDrop_SingleGumTreeNodeBoxedAsPlainObject_CreatesInstanceFromDraggedTag()
+    [StaFact]
+    public void HandleWireframeDrop_SingleGumTreeNodeBoxedAsPlainObject_CreatesInstanceFromDraggedTag()
     {
         MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
 
         object draggedTag = new();
         GumTreeNode draggedNode = new GumTreeNode("Circle1") { Tag = draggedTag };
-        DataObject dataObject = new DataObject((object)draggedNode);
-        DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.Copy);
 
-        plugin.OnWireframeDrop(null, args);
+        plugin.HandleWireframeDrop(ReadPayload(draggedNode));
 
         dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(draggedTag), Times.Once);
     }
 
-    [Fact]
-    public void OnWireframeDrop_DraggedNodeTagIsNull_FallsBackToSearchResultDragPayload()
+    [StaFact]
+    public void HandleWireframeDrop_DraggedNodeTagIsNull_FallsBackToSearchResultDragPayload()
     {
         // Issue #4123: a search-result drag (FlatSearchListBox) boxes its backing object into
-        // TreeNode.Tag, but Tag comes back null after crossing the WPF -> WinForms drag boundary
-        // (confirmed empirically: ComponentSave/ElementSave aren't [Serializable], and TreeNode's
-        // own serialization only carries Tag across when its type is). SearchResultDragPayload is
+        // TreeNode.Tag, but Tag comes back null after crossing the drag boundary (confirmed
+        // empirically: ComponentSave/ElementSave aren't [Serializable], and TreeNode's own
+        // serialization only carries Tag across when its type is). SearchResultDragPayload is
         // the in-process fallback that carries the real object instead.
         MainEditorTabPlugin plugin = CreatePlugin(out Mock<IDragDropManager> dragDropManager);
 
@@ -107,10 +98,8 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
         try
         {
             GumTreeNode draggedNode = new GumTreeNode("Circle1") { Tag = null };
-            DataObject dataObject = new DataObject((object)draggedNode);
-            DragEventArgs args = new DragEventArgs(dataObject, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.Copy);
 
-            plugin.OnWireframeDrop(null, args);
+            plugin.HandleWireframeDrop(ReadPayload(draggedNode));
 
             dragDropManager.Verify(x => x.OnNodeObjectDroppedInWireframe(backingObject), Times.Once);
         }
@@ -120,11 +109,14 @@ public class MainEditorTabPluginDragDropTests : BaseTestClass
         }
     }
 
+    private static WireframeDropPayload ReadPayload(object draggedData) =>
+        WpfWireframeDropPayloadReader.Read(new DataObject(draggedData));
+
     // Stubs MainEditorTabPlugin headlessly without running its ~20-argument constructor (which stands
     // up a WireframeEditorFactory, SelectionManager, ScreenshotService, etc.) - see the
-    // "Plugin/DI composition tests" entry in the gum-unit-tests skill. OnWireframeDragEnter/
-    // OnWireframeDrop only touch _dragDropManager (and _guiCommands on the rejected-drop path, which
-    // these tests don't exercise), so only that field needs to be wired up.
+    // "Plugin/DI composition tests" entry in the gum-unit-tests skill. DecideWireframeDropEffect/
+    // HandleWireframeDrop only touch _dragDropManager (and _guiCommands on the rejected-drop path,
+    // which these tests don't exercise), so only that field needs to be wired up.
     private static MainEditorTabPlugin CreatePlugin(out Mock<IDragDropManager> dragDropManager)
     {
         MainEditorTabPlugin plugin = (MainEditorTabPlugin)RuntimeHelpers.GetUninitializedObject(typeof(MainEditorTabPlugin));

--- a/Tool/Tests/GumToolUnitTests/Wireframe/FrameRateThrottleTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/FrameRateThrottleTests.cs
@@ -1,0 +1,38 @@
+using Shouldly;
+using XnaAndWinforms;
+
+namespace GumToolUnitTests.Wireframe;
+
+/// <summary>
+/// Pins <see cref="FrameRateThrottle"/>, which is what lets a WPF render surface driven by
+/// <c>CompositionTarget.Rendering</c> (a fixed ~vsync cadence) honor a requested frame rate.
+/// </summary>
+public class FrameRateThrottleTests
+{
+    [Fact]
+    public void ShouldRenderFrame_IsFalse_WhenTheRequestedIntervalHasNotElapsed()
+    {
+        FrameRateThrottle throttle = new FrameRateThrottle();
+
+        throttle.ShouldRenderFrame(millisecondsSinceLastFrame: 16.7, desiredFramesPerSecond: 30)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldRenderFrame_IsTrue_OnceTheRequestedIntervalHasElapsed()
+    {
+        FrameRateThrottle throttle = new FrameRateThrottle();
+
+        throttle.ShouldRenderFrame(millisecondsSinceLastFrame: 33.4, desiredFramesPerSecond: 30)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShouldRenderFrame_IsTrue_WhenTheRequestedRateIsNotPositive()
+    {
+        FrameRateThrottle throttle = new FrameRateThrottle();
+
+        throttle.ShouldRenderFrame(millisecondsSinceLastFrame: 0, desiredFramesPerSecond: 0)
+            .ShouldBeTrue();
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
@@ -21,8 +21,7 @@ public class CameraController
     public event Action? CameraChanged;
     IHotkeyManager _hotkeyManager;
 
-    public void Initialize(Camera camera,
-        IZoomController zoomController, int defaultWidth, int defaultHeight, IHotkeyManager hotkeyManager)
+    public void Initialize(Camera camera, IZoomController zoomController, IHotkeyManager hotkeyManager)
     {
         _hotkeyManager = hotkeyManager;
         _zoomController = zoomController;

--- a/XnaAndWinforms/FrameRateThrottle.cs
+++ b/XnaAndWinforms/FrameRateThrottle.cs
@@ -1,0 +1,16 @@
+namespace XnaAndWinforms;
+
+/// <inheritdoc/>
+public class FrameRateThrottle : IFrameRateThrottle
+{
+    /// <inheritdoc/>
+    public bool ShouldRenderFrame(double millisecondsSinceLastFrame, float desiredFramesPerSecond)
+    {
+        if (desiredFramesPerSecond <= 0)
+        {
+            return true;
+        }
+
+        return millisecondsSinceLastFrame >= 1000.0 / desiredFramesPerSecond;
+    }
+}

--- a/XnaAndWinforms/IFrameRateThrottle.cs
+++ b/XnaAndWinforms/IFrameRateThrottle.cs
@@ -1,0 +1,16 @@
+namespace XnaAndWinforms;
+
+/// <summary>
+/// Decides whether enough time has passed to render another frame. Pulled out of the render loop
+/// so the decision is testable without a graphics device: a WPF render surface is driven by
+/// <c>CompositionTarget.Rendering</c>, which fires at the compositor's own cadence rather than at a
+/// requested rate, so the requested rate has to be honored by skipping passes.
+/// </summary>
+public interface IFrameRateThrottle
+{
+    /// <summary>
+    /// Returns whether a frame should be rendered now. A non-positive
+    /// <paramref name="desiredFramesPerSecond"/> means unthrottled - every pass renders.
+    /// </summary>
+    bool ShouldRenderFrame(double millisecondsSinceLastFrame, float desiredFramesPerSecond);
+}

--- a/XnaAndWinforms/WpfGraphicsDeviceControl.cs
+++ b/XnaAndWinforms/WpfGraphicsDeviceControl.cs
@@ -1,0 +1,309 @@
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+
+namespace XnaAndWinforms;
+
+/// <summary>
+/// Hosts XNA/KNI rendering inside a WPF visual tree - the WPF counterpart to
+/// <see cref="GraphicsDeviceControl"/>. Draws into the <see cref="RenderTarget2D"/> of a
+/// <see cref="ISharedRenderDeviceHost"/> (so it shares the one process-wide
+/// <see cref="Microsoft.Xna.Framework.Graphics.GraphicsDevice"/> with every other client), reads it
+/// back, and pushes it into a <see cref="IWpfRenderSurfaceHost"/>'s <c>WriteableBitmap</c>.
+/// Derived classes override <see cref="PreDrawUpdate"/> and <see cref="Draw"/>.
+/// </summary>
+/// <remarks>
+/// Sizes its surface from <see cref="FrameworkElement.ActualWidth"/>/<see cref="FrameworkElement.ActualHeight"/>,
+/// which are device-independent units. Cursor coordinates arrive through the same units (see
+/// <c>InputLibrary.WpfInputHostAdapter</c>), so the two stay consistent; the cost is that on a
+/// scaled display the canvas renders at fewer pixels than the monitor has and WPF scales the bitmap up.
+/// </remarks>
+public class WpfGraphicsDeviceControl : Grid, IDisposable
+{
+    #region Fields
+
+    private readonly IWpfRenderSurfaceHost _surfaceHost;
+    private readonly IFrameRateThrottle _frameRateThrottle;
+    private readonly RenderingError _renderError;
+    private readonly Stopwatch _frameClock;
+    private readonly TextBlock _errorTextBlock;
+
+    private ISharedRenderDeviceHost? _deviceHost;
+    private double _lastFrameMilliseconds;
+    private bool _isRenderingFrame;
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    /// The frame rate this control aims for. The underlying WPF render pass fires at the
+    /// compositor's cadence; frames beyond this rate are skipped.
+    /// </summary>
+    public float DesiredFramesPerSecond { get; set; }
+
+    /// <summary>Gets the shared GraphicsDevice this control draws with.</summary>
+    public GraphicsDevice GraphicsDevice => _deviceHost!.GraphicsDevice;
+
+    /// <summary>
+    /// Gets this control's share of the process-wide graphics device, for code that only needs the
+    /// render-host contract rather than the control itself.
+    /// </summary>
+    public IRenderDeviceHost RenderDeviceHost => _deviceHost!;
+
+    /// <summary>
+    /// Gets an IServiceProvider containing the IGraphicsDeviceService, for components such as
+    /// ContentManager which look the device up through it.
+    /// </summary>
+    public IServiceProvider Services => _deviceHost!.Services;
+
+    #endregion
+
+    #region Events
+
+    /// <summary>Raised once per rendered frame, after <see cref="PreDrawUpdate"/> and before <see cref="Draw"/>.</summary>
+    public event Action? XnaUpdate;
+
+    /// <summary>Raised by the default <see cref="Draw"/> implementation.</summary>
+    public event Action? XnaDraw;
+
+    /// <summary>Raised when a frame throws. The failure is also shown on the canvas.</summary>
+    public event Action<Exception>? ErrorOccurred;
+
+    #endregion
+
+    public WpfGraphicsDeviceControl()
+        : this(new WpfRenderSurfaceHost(), new FrameRateThrottle())
+    {
+    }
+
+    public WpfGraphicsDeviceControl(IWpfRenderSurfaceHost surfaceHost, IFrameRateThrottle frameRateThrottle)
+    {
+        _surfaceHost = surfaceHost;
+        _frameRateThrottle = frameRateThrottle;
+        _renderError = new RenderingError();
+        _frameClock = new Stopwatch();
+        _lastFrameMilliseconds = double.NegativeInfinity;
+        DesiredFramesPerSecond = 30;
+
+        Focusable = true;
+        ClipToBounds = true;
+        // A null Background makes a Panel invisible to hit testing, which would leave the canvas
+        // unable to receive mouse input or take focus.
+        Background = Brushes.Transparent;
+
+        // Anchored top-left rather than the default stretch/center so pixel (0,0) of the bitmap
+        // stays at the control's origin while a resize is in flight, matching the coordinate space
+        // the cursor and camera math assume.
+        _surfaceHost.ImageElement.HorizontalAlignment = HorizontalAlignment.Left;
+        _surfaceHost.ImageElement.VerticalAlignment = VerticalAlignment.Top;
+        _surfaceHost.ImageElement.IsHitTestVisible = false;
+        Children.Add(_surfaceHost.ImageElement);
+
+        _errorTextBlock = new TextBlock
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = Brushes.Black,
+            Background = Brushes.CornflowerBlue,
+            Visibility = Visibility.Collapsed,
+        };
+        Children.Add(_errorTextBlock);
+
+        if (!DesignerProperties.GetIsInDesignMode(this))
+        {
+            InitializeDevice();
+        }
+
+        _frameClock.Start();
+    }
+
+    #region Initialization
+
+    private void InitializeDevice()
+    {
+        int width = Math.Max(1, (int)ActualWidth);
+        int height = Math.Max(1, (int)ActualHeight);
+
+        _deviceHost = new SharedRenderDeviceHost(GetWindowHandle(), width, height);
+        _deviceHost.RenderTargetRecreated += HandleRenderTargetRecreated;
+
+        _surfaceHost.Initialize(width, height);
+        _surfaceHost.RenderFrame += HandleRenderFrame;
+    }
+
+    /// <summary>
+    /// The window handle the graphics device presents against. This control is normally constructed
+    /// before it is attached to a window, so it falls back to the application's main window.
+    /// </summary>
+    protected virtual IntPtr GetWindowHandle()
+    {
+        if (PresentationSource.FromVisual(this) is HwndSource hwndSource)
+        {
+            return hwndSource.Handle;
+        }
+
+        Window? mainWindow = Application.Current?.MainWindow;
+        return mainWindow != null ? new WindowInteropHelper(mainWindow).EnsureHandle() : IntPtr.Zero;
+    }
+
+    // The bitmap the frame is pushed into and the raw readback buffer are both sized to the render
+    // target, so the host recreating it is what drives resizing them.
+    private void HandleRenderTargetRecreated(int width, int height) => _surfaceHost.Resize(width, height);
+
+    #endregion
+
+    #region Render loop
+
+    private void HandleRenderFrame()
+    {
+        if (_isRenderingFrame || _deviceHost == null || !IsVisible)
+        {
+            return;
+        }
+
+        int width = (int)ActualWidth;
+        int height = (int)ActualHeight;
+        if (width < 1 || height < 1)
+        {
+            return;
+        }
+
+        double nowMilliseconds = _frameClock.Elapsed.TotalMilliseconds;
+        if (!_frameRateThrottle.ShouldRenderFrame(nowMilliseconds - _lastFrameMilliseconds, DesiredFramesPerSecond))
+        {
+            return;
+        }
+        _lastFrameMilliseconds = nowMilliseconds;
+
+        _isRenderingFrame = true;
+        try
+        {
+            RenderFrame(width, height);
+        }
+        finally
+        {
+            _isRenderingFrame = false;
+        }
+    }
+
+    private void RenderFrame(int width, int height)
+    {
+        PreDrawUpdate();
+
+        if (!_renderError.HasErrors)
+        {
+            BeginDraw(width, height);
+        }
+
+        if (!_renderError.HasErrors)
+        {
+            try
+            {
+                XnaUpdate?.Invoke();
+                Draw();
+                EndDraw();
+                ShowError(null);
+            }
+            catch (Exception exception)
+            {
+                ErrorOccurred?.Invoke(exception);
+                _renderError.Message = exception.ToString();
+            }
+        }
+        else
+        {
+            ShowError(_renderError.ProcessedMessage);
+            DesiredFramesPerSecond = 0.5f;
+        }
+    }
+
+    private void BeginDraw(int width, int height)
+    {
+        if (!_renderError.HasErrors || _renderError.GraphicsDeviceNeedsReset)
+        {
+            _deviceHost!.EnsureSurfaceSize(width, height, _renderError);
+        }
+
+        if (!_renderError.HasErrors)
+        {
+            GraphicsDevice.SetRenderTarget(_deviceHost!.RenderTarget);
+            GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
+
+            GraphicsDevice.Viewport = new Viewport
+            {
+                X = 0,
+                Y = 0,
+                Width = width,
+                Height = height,
+                MinDepth = 0,
+                MaxDepth = 1,
+            };
+        }
+    }
+
+    private void EndDraw()
+    {
+        try
+        {
+            GraphicsDevice.SetRenderTarget(null);
+
+            RenderTarget2D? renderTarget = _deviceHost!.RenderTarget;
+            if (renderTarget != null)
+            {
+                renderTarget.GetData(_surfaceHost.RawImageBuffer);
+                _surfaceHost.PushFrame(renderTarget.Format);
+            }
+        }
+        catch
+        {
+            // The device can be lost mid-frame; the next BeginDraw handles the reset, so the
+            // dropped frame is swallowed here the same way GraphicsDeviceControl does.
+        }
+    }
+
+    private void ShowError(string? message)
+    {
+        _errorTextBlock.Text = message ?? string.Empty;
+        _errorTextBlock.Visibility = message == null ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    #endregion
+
+    #region Protected Virtual Methods
+
+    /// <summary>Derived classes override this to run per-frame logic before drawing.</summary>
+    protected virtual void PreDrawUpdate()
+    {
+    }
+
+    /// <summary>Derived classes override this to draw themselves using the GraphicsDevice.</summary>
+    protected virtual void Draw()
+    {
+        XnaDraw?.Invoke();
+    }
+
+    #endregion
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _surfaceHost.RenderFrame -= HandleRenderFrame;
+        _surfaceHost.Dispose();
+
+        if (_deviceHost != null)
+        {
+            _deviceHost.RenderTargetRecreated -= HandleRenderTargetRecreated;
+            _deviceHost.Dispose();
+            _deviceHost = null;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
Step 3 of the plan on #3833: the wireframe canvas is now a WPF element, not a WinForms control inside a `WindowsFormsHost`.

**What changed**
- `XnaAndWinforms.WpfGraphicsDeviceControl` — the WPF counterpart to `GraphicsDeviceControl`. Draws into `SharedRenderDeviceHost`'s render target (so it keeps sharing the one process-wide `GraphicsDevice` with `ImageRegionSelectionControl`), reads it back, and pushes the pixels through `WpfRenderSurfaceHost`. `WireframeControl` just changes base class.
- Input: WPF `KeyDown`/`MouseDown`/`MouseMove`/`MouseWheel`, `OnPreviewKeyDown` in place of `ProcessCmdKey`, and `WpfInputHostAdapter` driving `InputLibrary.Cursor`.
- Drag+drop: `WpfWireframeDropPayloadReader` + `WireframeDropPayload.ResolveAction()` replace the inline WinForms OLE extraction. The accept decision is re-applied on `DragOver` (WPF doesn't carry it forward from `DragEnter`), silently — otherwise a rejected drag reports its reason on every mouse move.
- Scroll bars: `ScrollbarService` creates WPF `ScrollBar`s driven through `WpfScrollBarAdapter` and a new `FrameworkElementScrollSurfaceAdapter`, laid out in a WPF grid instead of docked into a WinForms `Panel`.
- `FrameRateThrottle` honors the project's FrameRate setting; `CompositionTarget.Rendering` fires at the compositor's cadence, so the rate is honored by skipping passes.
- The `WindowsFormsHost` and its airspace margin hack (#3831) are gone, along with `gumEditorPanel` and `UpdateWireframeControlSizes`.

**Tests** — `FrameRateThrottle` unit tested; `MainEditorTabPluginDragDropTests` re-pointed at payload-taking `DecideWireframeDropEffect`/`HandleWireframeDrop` (WPF's `DragEventArgs` has no public constructor), keeping the #3965 / #4123 regression coverage end to end through the WPF reader. `GumToolUnitTests` 1177 green, `Gum.Presentation.Tests` 754 green.

**Boy-scout** — `CameraController.Initialize` drops its never-read `defaultWidth`/`defaultHeight` parameters. `ControlScrollSurfaceAdapter` is now unreferenced; left in place rather than deleted.

Part of #3833 (steps 1-3 done; step 4 mirrors this onto `ImageRegionSelectionControl`).
