### PR TITLE
Support cross-named composite VariableReferences (e.g. DropshadowColor = X.FillColor)

### DIFF
--- a/GumRuntime/ElementSaveExtensions.GumRuntime.cs
+++ b/GumRuntime/ElementSaveExtensions.GumRuntime.cs
@@ -935,20 +935,6 @@ namespace GumRuntime
             return null;
         }
 
-        private static bool TryGetCompositeChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
-        {
-            foreach (CompositeReferenceDescriptor descriptor in CompositeReferenceDescriptors)
-            {
-                if (descriptor.TryGetChannelNames(compositeName, out channelNames))
-                {
-                    return true;
-                }
-            }
-
-            channelNames = Array.Empty<string>();
-            return false;
-        }
-
         /// <summary>
         /// True only if <paramref name="channelOwner"/> declares a root variable for every channel -
         /// i.e. the composite name really is backed by real channels on this element, not just a
@@ -975,14 +961,18 @@ namespace GumRuntime
 
         /// <summary>
         /// Expands a single reference line into one line per channel when its left side is a
-        /// composite property directly referencing the same composite on another object (e.g.
-        /// <c>Color = Other.Color</c> -&gt; <c>Red = Other.Red</c>, <c>Green = Other.Green</c>,
-        /// <c>Blue = Other.Blue</c>). Returns the line unchanged (as a single-item sequence) when it
-        /// isn't a composite reference. This is what lets the collapsed form stay on disk while
-        /// every apply/evaluate/validate path downstream only ever sees plain single-channel lines.
-        /// Public so other GumCommon-tier consumers of raw <c>VariableReferences</c> line text
-        /// (e.g. <c>HeadlessErrorChecker</c>'s reference-conflict check) can expand consistently
-        /// with how references are actually applied, instead of duplicating the channel table.
+        /// composite property whose right side ends in another composite name of the *same*
+        /// underlying token (e.g. <c>Color = Other.Color</c>, or a cross-named
+        /// <c>DropshadowColor = Other.FillColor</c>). Left and right channel names are paired
+        /// positionally (channel order is fixed per descriptor - e.g. Red/Green/Blue), so the two
+        /// sides don't need identical composite names, only the same composite token (both
+        /// "Color", not one "Color" and one "CornerRadius"). Returns the line unchanged (as a
+        /// single-item sequence) when it isn't a composite reference. This is what lets the
+        /// collapsed form stay on disk while every apply/evaluate/validate path downstream only
+        /// ever sees plain single-channel lines. Public so other GumCommon-tier consumers of raw
+        /// <c>VariableReferences</c> line text (e.g. <c>HeadlessErrorChecker</c>'s reference-conflict
+        /// check) can expand consistently with how references are actually applied, instead of
+        /// duplicating the channel table.
         /// </summary>
         public static IEnumerable<string> ExpandCompositeReferenceLine(string referenceString, ElementSave? channelOwner)
         {
@@ -1001,17 +991,26 @@ namespace GumRuntime
             {
                 string left = split[0];
                 string right = split[1];
+                int lastDot = right.LastIndexOf('.');
 
-                if (right.EndsWith("." + left, StringComparison.Ordinal) &&
-                    TryGetCompositeChannelNames(left, out IReadOnlyList<string> channelNames) &&
-                    OwnerHasAllCompositeChannels(channelNames, channelOwner))
+                if (lastDot >= 0)
                 {
-                    string withoutVariable = right.Substring(0, right.Length - (1 + left.Length));
-                    foreach (string channelName in channelNames)
+                    string rightMemberName = right.Substring(lastDot + 1);
+                    string withoutVariable = right.Substring(0, lastDot);
+
+                    foreach (CompositeReferenceDescriptor descriptor in CompositeReferenceDescriptors)
                     {
-                        yield return $"{channelName} = {withoutVariable}.{channelName}";
+                        if (descriptor.TryGetChannelNames(left, out IReadOnlyList<string> leftChannelNames) &&
+                            descriptor.TryGetChannelNames(rightMemberName, out IReadOnlyList<string> rightChannelNames) &&
+                            OwnerHasAllCompositeChannels(leftChannelNames, channelOwner))
+                        {
+                            for (int i = 0; i < leftChannelNames.Count; i++)
+                            {
+                                yield return $"{leftChannelNames[i]} = {withoutVariable}.{rightChannelNames[i]}";
+                            }
+                            yield break;
+                        }
                     }
-                    yield break;
                 }
             }
 

--- a/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/ApplyVariableReferencesRuntimeTests.cs
@@ -6,6 +6,8 @@ using Gum.Wireframe;
 using GumRuntime;
 using Gum.GueDeriving;
 using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace MonoGameGum.Tests.Runtimes;
@@ -185,6 +187,79 @@ public class ApplyVariableReferencesRuntimeTests : BaseTestClass
         parent.Red.ShouldBe(10);
         parent.Green.ShouldBe(20);
         parent.Blue.ShouldBe(30);
+    }
+
+    [Fact]
+    public void ApplyVariableReferences_CrossNamedCompositeReference_PairsChannelsPositionally()
+    {
+        // "StrokeColor = Source.FillColor" - different composite names on each side (Stroke vs Fill)
+        // that both resolve to the same Color descriptor (Red/Green/Blue order), so channels must
+        // pair positionally: StrokeRed = Source.FillRed, etc. - not require identical names.
+        RectangleRuntime parent = new RectangleRuntime();
+        parent.StrokeRed = 0;
+        parent.StrokeGreen = 0;
+        parent.StrokeBlue = 0;
+
+        StateSave state = BuildStateWithVariableReference(
+            "StrokeColor = Source.FillColor",
+            null,
+            ("StrokeRed", 0, "int"),
+            ("StrokeGreen", 0, "int"),
+            ("StrokeBlue", 0, "int"),
+            ("Source.FillRed", 10, "int"),
+            ("Source.FillGreen", 20, "int"),
+            ("Source.FillBlue", 30, "int"));
+
+        parent.ApplyVariableReferences(state);
+
+        parent.StrokeRed.ShouldBe(10);
+        parent.StrokeGreen.ShouldBe(20);
+        parent.StrokeBlue.ShouldBe(30);
+    }
+
+    #endregion
+
+    #region ExpandCompositeReferenceLine
+
+    [Fact]
+    public void ExpandCompositeReferenceLine_CrossNamedComposite_PairsChannelsPositionally()
+    {
+        ScreenSave owner = new ScreenSave { Name = "Owner" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = owner };
+        owner.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "DropshadowRed", Value = 0, Type = "int", SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "DropshadowGreen", Value = 0, Type = "int", SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "DropshadowBlue", Value = 0, Type = "int", SetsValue = true });
+
+        List<string> expanded = ElementSaveExtensions
+            .ExpandCompositeReferenceLine("DropshadowColor = Source.FillColor", owner)
+            .ToList();
+
+        expanded.ShouldBe(new[]
+        {
+            "DropshadowRed = Source.FillRed",
+            "DropshadowGreen = Source.FillGreen",
+            "DropshadowBlue = Source.FillBlue"
+        });
+    }
+
+    [Fact]
+    public void ExpandCompositeReferenceLine_RightSideNotSameCompositeToken_LeavesLineUnchanged()
+    {
+        // Left is a real Color composite, but the right side's trailing member ("Width") doesn't
+        // contain the "Color" token at all - not a composite reference, must not be mangled.
+        ScreenSave owner = new ScreenSave { Name = "Owner" };
+        StateSave state = new StateSave { Name = "Default", ParentContainer = owner };
+        owner.States.Add(state);
+        state.Variables.Add(new VariableSave { Name = "Red", Value = 0, Type = "int", SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Green", Value = 0, Type = "int", SetsValue = true });
+        state.Variables.Add(new VariableSave { Name = "Blue", Value = 0, Type = "int", SetsValue = true });
+
+        List<string> expanded = ElementSaveExtensions
+            .ExpandCompositeReferenceLine("Color = Source.Width", owner)
+            .ToList();
+
+        expanded.ShouldBe(new[] { "Color = Source.Width" });
     }
 
     #endregion

--- a/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableReferenceLogicTests.cs
@@ -650,6 +650,77 @@ public class VariableReferenceLogicTests : BaseTestClass
         defaultState.GetValue("Blue").ShouldBe(30);
     }
 
+    [Fact]
+    public void DoVariableReferenceReaction_CrossNamedCompositeReference_AcceptsLineAndAppliesChannelsPositionally()
+    {
+        // "DropshadowColor = Source.FillColor" - different composite names on each side that both
+        // resolve to the same Color descriptor - channels must pair positionally
+        // (DropshadowRed = Source.FillRed, etc.) rather than requiring identical composite names.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "DropshadowColor = Source.FillColor",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowRed", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowGreen", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowBlue", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.FillRed", Value = 10, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.FillGreen", Value = 20, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.FillBlue", Value = 30, Type = "int", SetsValue = true });
+
+        project.Screens.Add(screen);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value.Count.ShouldBe(1);
+        varList.Value[0].ShouldBe("DropshadowColor = Source.FillColor");
+        defaultState.GetValue("DropshadowRed").ShouldBe(10);
+        defaultState.GetValue("DropshadowGreen").ShouldBe(20);
+        defaultState.GetValue("DropshadowBlue").ShouldBe(30);
+    }
+
+    [Fact]
+    public void DoVariableReferenceReaction_CompositeLeftSideWithNonCompositeRightSide_CommentsLine()
+    {
+        // "DropshadowColor" is a genuine composite (owner declares DropshadowRed/Green/Blue), but the
+        // right side's trailing member ("Width") isn't a Color composite at all - must not be mangled
+        // into a bogus expansion. Since "DropshadowColor" is never a real scalar, the line then fails
+        // ordinary validation and gets commented out.
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ScreenSave screen = BuildScreenWithVariableReference(
+            line: "DropshadowColor = Source.Width",
+            out StateSave defaultState,
+            out VariableListSave<string> varList);
+
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowRed", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowGreen", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "DropshadowBlue", Value = 0, Type = "int", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "Source.Width", Value = 100f, Type = "float", SetsValue = true });
+
+        project.Screens.Add(screen);
+
+        _sut.DoVariableReferenceReaction(
+            parentElement: screen,
+            leftSideInstance: null,
+            unqualifiedMember: "VariableReferences",
+            stateSave: defaultState,
+            qualifiedName: "VariableReferences",
+            trySave: false);
+
+        varList.Value[0].ShouldStartWith("//");
+    }
+
     #endregion
 
     #region Helpers

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableReferenceLogic.cs
@@ -822,24 +822,6 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     }
 
     /// <summary>
-    /// Returns the channel variable names for <paramref name="compositeName"/> if it matches any registered
-    /// composite descriptor (e.g. "StrokeColor" -&gt; StrokeRed/StrokeGreen/StrokeBlue); otherwise false.
-    /// </summary>
-    private bool TryGetCompositeChannelNames(string compositeName, out IReadOnlyList<string> channelNames)
-    {
-        foreach (var descriptor in _compositeMemberRegistry.Descriptors)
-        {
-            if (descriptor.TryGetChannelNames(compositeName, out channelNames))
-            {
-                return true;
-            }
-        }
-
-        channelNames = Array.Empty<string>();
-        return false;
-    }
-
-    /// <summary>
     /// Returns true only if the reference owner (the selected instance's type, or the owning element for an
     /// element-level reference) declares a root variable for every channel - i.e. the composite name really is
     /// a composite on this object. Mirrors the channel-existence check <c>CompositeMemberLogic</c> uses to
@@ -869,10 +851,11 @@ public class VariableReferenceLogic : IVariableReferenceLogic
     }
 
     /// <summary>
-    /// If <paramref name="line"/> is a composite reference directly assigning the same composite
-    /// from another object (e.g. <c>Color = Other.Color</c>), outputs the equivalent per-channel
-    /// lines (e.g. <c>Red = Other.Red</c>, <c>Green = Other.Green</c>, <c>Blue = Other.Blue</c>)
-    /// and returns true. Used by validation only - the collapsed line itself is what gets
+    /// If <paramref name="line"/> is a composite reference whose right side ends in another
+    /// composite name of the *same* underlying token - identically named (<c>Color = Other.Color</c>)
+    /// or cross-named (<c>DropshadowColor = Other.FillColor</c>) - outputs the equivalent per-channel
+    /// lines with left/right channels paired positionally (e.g. <c>DropshadowRed = Other.FillRed</c>,
+    /// ...) and returns true. Used by validation only - the collapsed line itself is what gets
     /// persisted; expansion happens again at apply time in <c>GumRuntime.ElementSaveExtensions</c>.
     /// </summary>
     private bool TryGetCompositeExpansion(ElementSave parentElement, InstanceSave? leftSideInstance, string line,
@@ -887,14 +870,25 @@ public class VariableReferenceLogic : IVariableReferenceLogic
         {
             var leftSide = split[0];
             var rightSide = split[1];
+            var lastDot = rightSide.LastIndexOf('.');
 
-            if (rightSide.EndsWith("." + leftSide) &&
-                TryGetCompositeChannelNames(leftSide, out var channelNames) &&
-                OwnerHasAllChannels(channelNames, leftSideInstance, parentElement))
+            if (lastDot >= 0)
             {
-                var withoutVariable = rightSide.Substring(0, rightSide.Length - ("." + leftSide).Length);
-                expandedLines = channelNames.Select(channelName => $"{channelName} = {withoutVariable}.{channelName}").ToArray();
-                return true;
+                var rightMemberName = rightSide.Substring(lastDot + 1);
+                var withoutVariable = rightSide.Substring(0, lastDot);
+
+                foreach (var descriptor in _compositeMemberRegistry.Descriptors)
+                {
+                    if (descriptor.TryGetChannelNames(leftSide, out var leftChannelNames) &&
+                        descriptor.TryGetChannelNames(rightMemberName, out var rightChannelNames) &&
+                        OwnerHasAllChannels(leftChannelNames, leftSideInstance, parentElement))
+                    {
+                        expandedLines = leftChannelNames
+                            .Select((channelName, i) => $"{channelName} = {withoutVariable}.{rightChannelNames[i]}")
+                            .ToArray();
+                        return true;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Generalizes composite `VariableReferences` expansion (`Color = X.Color` → `Red = X.Red`, etc.) to support **cross-named** composites — both sides just need to resolve to the same composite descriptor (e.g. both "Color"), not identical text.

Covers both patterns from the issue:
- `DropshadowColor = X.FillColor` (a `Dropshadow` channel borrowing a swatch's `Fill` channel)
- `Color = X.FillColor` (a `Text` instance's plain color borrowing a `Rectangle` swatch's `Fill` channel — the pattern blocking #4158)

## What changed

- `GumRuntime.ElementSaveExtensions.ExpandCompositeReferenceLine` and the tool's `VariableReferenceLogic.TryGetCompositeExpansion` now split the right side at its own trailing member (not the left side's name), independently decompose *that* name against each registered composite descriptor, and require the left and right names to match the **same** descriptor. When they do, channels pair positionally (fixed per-descriptor order, e.g. Red/Green/Blue) instead of requiring identical text. The old identical-name case is subsumed — same name on both sides just produces identical channel pairs.
- Existing owner-channel-existence guard (prevents e.g. a literal `BackgroundColor` scalar from being mangled) is unchanged and still applies to the left side.

## What's intentionally out of scope

- **No new authoring UI.** The existing "Copy Qualified Variable Name" + hand-editing the `References` category text already lets you author a cross-named line once the engine accepts it (manual verification pending, see below) — no dedicated dialog needed.
- **Bubblegum/Hazard's ~809 remaining Dropshadow→Fill triples are not collapsed in this PR.** This PR is the engine capability only; the actual theme-file collapse (mirroring what #4157/#4153 did for identical-name triples) is separate follow-up work, and #4158 (FormsTemplate) can likely now be solved the same way.

## Testing

- New unit tests in `MonoGameGum.Tests` (`ExpandCompositeReferenceLine` directly + an end-to-end `ApplyVariableReferences` run through a real `RectangleRuntime`) and `Gum.Presentation.Tests` (`VariableReferenceLogic` validation/apply, including a guard test for a composite left side paired with a non-composite right side).
- Full existing composite/reference test suites re-run clean (`VariableReferenceLogicTests`, `ApplyVariableReferencesRuntimeTests`, `HeadlessErrorCheckerTests`, `ReferencePropagationServiceTests`, `DetectUnpropagatedReferencesTests`, `CompositeMemberRegistryTests`/`CompositeMemberLogicTests`/`CompositeMemberDescriptorTests`, `BubblegumTemplateTests`/`HazardTemplateTests`/`FormsTemplateCreatorTests`).
- `GumFull.sln`, `KniGum`, `RaylibGum`, `SkiaGum` all build clean.
- FRB canary: pass (`GumCore.DesktopGlNet6.csproj` builds clean at baseline `origin/main` and with this change).
- Manual test: pending — will verify in the tool that a hand-typed `StrokeColor = Source.FillColor` reference validates and live-updates instead of getting commented out.

Closes #4160
