### PR TITLE
Harden JSON round-trip test coverage: long/double/list types + FormsBehaviors fixtures

### DIFF
--- a/GumDataTypes/Serialization/Json/BoxedValueJson.cs
+++ b/GumDataTypes/Serialization/Json/BoxedValueJson.cs
@@ -17,6 +17,16 @@ namespace Gum.DataTypes.Serialization.Json;
 /// <see cref="int"/>, <see cref="long"/>, <see cref="float"/>, <see cref="double"/>, or
 /// <see cref="string"/>.
 /// </remarks>
+/// <remarks>
+/// Known, accepted limitation: <see cref="CustomPropertySave.Value"/>'s XML shape additionally
+/// declares a <c>[XmlElement("ValueAsObject", typeof(object))]</c> catch-all (plus a commented-out,
+/// never-implemented <c>ValueAsEnum</c> case) for values outside the six supported types above. This
+/// class does not replicate that catch-all - it throws <see cref="NotSupportedException"/> instead.
+/// Confirmed via repo-wide search: no <c>CustomPropertySave.Value</c> in any checked-in
+/// <c>.gumx</c>/<c>.gucx</c>/<c>.gusx</c>/<c>.gutx</c>/<c>.behx</c> file (including the FormsBehaviors
+/// templates) is ever populated at all, let alone with a type that would need the catch-all - every
+/// real project's <c>CustomProperties</c> list is empty. Revisit if a real project ever needs it.
+/// </remarks>
 internal static class BoxedValueJson
 {
     public static void Assign(

--- a/MonoGameGum.Tests/DataTypes/Json/GumJsonFixtureDifferentialTests.cs
+++ b/MonoGameGum.Tests/DataTypes/Json/GumJsonFixtureDifferentialTests.cs
@@ -5,18 +5,27 @@ using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Xml.Serialization;
 using Xunit;
 
 namespace MonoGameGum.Tests.DataTypes.Json;
 
 /// <summary>
 /// Differential check against every real <c>.gumx</c> file already checked into this repo: loads each
-/// via the existing XML path, then proves the JSON serializer round-trips its content losslessly
-/// (serialize -> deserialize -> serialize again, comparing the two JSON strings). This is a backstop,
-/// not the primary proof - <see cref="GumJsonSerializationTests"/> covers the same shapes with
-/// hand-constructed, in-memory data. If this ever catches something those tests miss, the fix is a
-/// new targeted case in <see cref="GumJsonSerializationTests"/>, not more reliance on this sweep.
+/// via the existing XML path, then proves the JSON serializer round-trips its content losslessly.
+/// This is a backstop, not the primary proof - <see cref="GumJsonSerializationTests"/> covers the same
+/// shapes with hand-constructed, in-memory data. If this ever catches something those tests miss, the
+/// fix is a new targeted case in <see cref="GumJsonSerializationTests"/>, not more reliance on this sweep.
 /// </summary>
+/// <remarks>
+/// Two independent checks per object, not one: (1) JSON self-consistency (serialize -> deserialize ->
+/// serialize again, same string) catches non-determinism in the JSON mapping itself, but would NOT
+/// catch a field the original <c>ToJson</c> mapper silently drops or mismaps, since both sides of that
+/// comparison went through the same (buggy) mapper. (2) Re-serializing the JSON-round-tripped object
+/// back through the already-proven XML compact serializer and diffing against the original XML-loaded
+/// object's own XML serialization gives an independent oracle that a dropped/mismapped field would
+/// actually fail.
+/// </remarks>
 public class GumJsonFixtureDifferentialTests
 {
     public static IEnumerable<object[]> FixtureGumxPaths()
@@ -68,12 +77,14 @@ public class GumJsonFixtureDifferentialTests
         string projectJson = GumJsonFileSerializer.SerializeProject(original);
         GumProjectSave reloadedProject = GumJsonFileSerializer.DeserializeProject(projectJson);
         GumJsonFileSerializer.SerializeProject(reloadedProject).ShouldBe(projectJson);
+        SerializeProjectToXml(reloadedProject).ShouldBe(SerializeProjectToXml(original));
 
         foreach (ScreenSave screen in original.Screens)
         {
             string json = GumJsonFileSerializer.SerializeElement(screen);
             ScreenSave reloaded = GumJsonFileSerializer.DeserializeElement<ScreenSave>(json);
             GumJsonFileSerializer.SerializeElement(reloaded).ShouldBe(json);
+            SerializeElementToXml(reloaded).ShouldBe(SerializeElementToXml(screen));
         }
 
         foreach (ComponentSave component in original.Components)
@@ -81,6 +92,7 @@ public class GumJsonFixtureDifferentialTests
             string json = GumJsonFileSerializer.SerializeElement(component);
             ComponentSave reloaded = GumJsonFileSerializer.DeserializeElement<ComponentSave>(json);
             GumJsonFileSerializer.SerializeElement(reloaded).ShouldBe(json);
+            SerializeElementToXml(reloaded).ShouldBe(SerializeElementToXml(component));
         }
 
         foreach (StandardElementSave standard in original.StandardElements)
@@ -88,6 +100,7 @@ public class GumJsonFixtureDifferentialTests
             string json = GumJsonFileSerializer.SerializeElement(standard);
             StandardElementSave reloaded = GumJsonFileSerializer.DeserializeElement<StandardElementSave>(json);
             GumJsonFileSerializer.SerializeElement(reloaded).ShouldBe(json);
+            SerializeElementToXml(reloaded).ShouldBe(SerializeElementToXml(standard));
         }
 
         foreach (BehaviorSave behavior in original.Behaviors)
@@ -95,7 +108,58 @@ public class GumJsonFixtureDifferentialTests
             string json = GumJsonFileSerializer.SerializeBehavior(behavior);
             BehaviorSave reloaded = GumJsonFileSerializer.DeserializeBehavior(json);
             GumJsonFileSerializer.SerializeBehavior(reloaded).ShouldBe(json);
+            SerializeBehaviorToXml(reloaded).ShouldBe(SerializeBehaviorToXml(behavior));
         }
+    }
+
+    /// <summary>
+    /// Loads each real, standalone <c>.behx</c> file under the FormsBehaviors template folder - not
+    /// referenced by any of the 23 project fixtures above - and round-trips it through JSON, using the
+    /// same independent-XML-oracle approach as <see cref="JsonRoundTrip_RealGumxFixture_IsLossless"/>.
+    /// These are the only real, checked-in files anywhere in the repo with <c>double</c>-typed
+    /// <c>FormsProperty</c> values (13 instances across the three files; every other real project uses
+    /// only int/float/bool/string, already covered by the 23-fixture sweep above).
+    /// </summary>
+    [Theory]
+    [InlineData("Tools/Gum.ProjectServices/Templates/FormsBehaviors/ScrollBarBehavior.behx")]
+    [InlineData("Tools/Gum.ProjectServices/Templates/FormsBehaviors/ScrollViewerBehavior.behx")]
+    [InlineData("Tools/Gum.ProjectServices/Templates/FormsBehaviors/SliderBehavior.behx")]
+    public void JsonRoundTrip_RealFormsBehaviorFixture_IsLossless(string relativePath)
+    {
+        string behxPath = Path.Combine(LocateRepoRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(behxPath).ShouldBeTrue($"Fixture .behx missing at {behxPath}");
+
+        BehaviorSave original = BehaviorReference.DeserializeBehavior(behxPath, projectVersion: GumProjectSave.NativeVersion);
+
+        string json = GumJsonFileSerializer.SerializeBehavior(original);
+        BehaviorSave reloaded = GumJsonFileSerializer.DeserializeBehavior(json);
+
+        GumJsonFileSerializer.SerializeBehavior(reloaded).ShouldBe(json);
+        SerializeBehaviorToXml(reloaded).ShouldBe(SerializeBehaviorToXml(original));
+    }
+
+    private static string SerializeProjectToXml(GumProjectSave project)
+    {
+        XmlSerializer serializer = GumFileSerializer.GetGumProjectCompactSerializer();
+        using StringWriter writer = new StringWriter();
+        serializer.Serialize(writer, project);
+        return writer.ToString();
+    }
+
+    private static string SerializeElementToXml<T>(T element) where T : ElementSave
+    {
+        XmlSerializer serializer = GumFileSerializer.GetCompactSerializer(typeof(T));
+        using StringWriter writer = new StringWriter();
+        serializer.Serialize(writer, element);
+        return writer.ToString();
+    }
+
+    private static string SerializeBehaviorToXml(BehaviorSave behavior)
+    {
+        XmlSerializer serializer = GumFileSerializer.GetCompactSerializer(typeof(BehaviorSave));
+        using StringWriter writer = new StringWriter();
+        serializer.Serialize(writer, behavior);
+        return writer.ToString();
     }
 
     private static string LocateRepoRoot()

--- a/MonoGameGum.Tests/DataTypes/Json/GumJsonSerializationTests.cs
+++ b/MonoGameGum.Tests/DataTypes/Json/GumJsonSerializationTests.cs
@@ -180,9 +180,15 @@ public class GumJsonSerializationTests
     [Fact]
     public void SerializeDeserialize_VariableSave_PreservesEachBoxedValueType()
     {
+        // Covers every CLR type BoxedValueJson supports. long/double are real but rare in checked-in
+        // project content (double: 13 instances, all in the FormsBehaviors slider/scrollbar/scrollviewer
+        // templates covered separately by GumJsonFixtureDifferentialTests; long: zero instances anywhere
+        // in this repo, so this is the only coverage for it).
         StateSave state = new StateSave { Name = "Default" };
         state.Variables.Add(new VariableSave { Name = "FloatVar", Type = "float", Value = 1.5f });
         state.Variables.Add(new VariableSave { Name = "IntVar", Type = "int", Value = 42 });
+        state.Variables.Add(new VariableSave { Name = "LongVar", Type = "long", Value = 9_000_000_000L });
+        state.Variables.Add(new VariableSave { Name = "DoubleVar", Type = "double", Value = 3.14159265358979 });
         state.Variables.Add(new VariableSave { Name = "BoolVar", Type = "bool", Value = true });
         state.Variables.Add(new VariableSave { Name = "StringVar", Type = "string", Value = "hello" });
         state.Variables.Add(new VariableSave { Name = "NullVar", Type = "string", Value = null, SetsValue = false });
@@ -195,6 +201,8 @@ public class GumJsonSerializationTests
         List<VariableSave> resultVariables = result.States[0].Variables;
         resultVariables.First(v => v.Name == "FloatVar").Value.ShouldBe(1.5f);
         resultVariables.First(v => v.Name == "IntVar").Value.ShouldBe(42);
+        resultVariables.First(v => v.Name == "LongVar").Value.ShouldBe(9_000_000_000L);
+        resultVariables.First(v => v.Name == "DoubleVar").Value.ShouldBe(3.14159265358979);
         resultVariables.First(v => v.Name == "BoolVar").Value.ShouldBe(true);
         resultVariables.First(v => v.Name == "StringVar").Value.ShouldBe("hello");
         resultVariables.First(v => v.Name == "NullVar").Value.ShouldBeNull();
@@ -217,5 +225,58 @@ public class GumJsonSerializationTests
         VariableListSave<Vector2> resultList = (VariableListSave<Vector2>)result.States[0].VariableLists[0];
         resultList.Name.ShouldBe("Points");
         resultList.Value.ShouldBe(new[] { new Vector2(1, 2), new Vector2(3, 4) });
+    }
+
+    [Fact]
+    public void SerializeDeserialize_VariableListSave_PreservesEveryOtherClosedGenericType()
+    {
+        // VariableListSaveJsonMapper explicitly switches on all 7 closed VariableListSave<T> generics
+        // (see the [XmlInclude] list on VariableListSave); Vector2 is covered by the test above, this
+        // covers the remaining 6 so every branch that mapper switches on has a pinning test.
+        StateSave state = new StateSave { Name = "Default" };
+
+        VariableListSave<string> stringList = new VariableListSave<string> { Name = "StringList", Type = "string" };
+        stringList.Value.Add("a");
+        stringList.Value.Add("b");
+        state.VariableLists.Add(stringList);
+
+        VariableListSave<float> floatList = new VariableListSave<float> { Name = "FloatList", Type = "float" };
+        floatList.Value.Add(1.5f);
+        floatList.Value.Add(2.5f);
+        state.VariableLists.Add(floatList);
+
+        VariableListSave<int> intList = new VariableListSave<int> { Name = "IntList", Type = "int" };
+        intList.Value.Add(1);
+        intList.Value.Add(2);
+        state.VariableLists.Add(intList);
+
+        VariableListSave<long> longList = new VariableListSave<long> { Name = "LongList", Type = "long" };
+        longList.Value.Add(9_000_000_000L);
+        longList.Value.Add(10_000_000_000L);
+        state.VariableLists.Add(longList);
+
+        VariableListSave<double> doubleList = new VariableListSave<double> { Name = "DoubleList", Type = "double" };
+        doubleList.Value.Add(3.14159265358979);
+        doubleList.Value.Add(2.71828182845905);
+        state.VariableLists.Add(doubleList);
+
+        VariableListSave<bool> boolList = new VariableListSave<bool> { Name = "BoolList", Type = "bool" };
+        boolList.Value.Add(true);
+        boolList.Value.Add(false);
+        state.VariableLists.Add(boolList);
+
+        StandardElementSave element = new StandardElementSave { Name = "Container" };
+        element.States.Add(state);
+
+        string json = GumJsonFileSerializer.SerializeElement(element);
+        StandardElementSave result = GumJsonFileSerializer.DeserializeElement<StandardElementSave>(json);
+
+        List<VariableListSave> resultLists = result.States[0].VariableLists;
+        ((VariableListSave<string>)resultLists.First(v => v.Name == "StringList")).Value.ShouldBe(new[] { "a", "b" });
+        ((VariableListSave<float>)resultLists.First(v => v.Name == "FloatList")).Value.ShouldBe(new[] { 1.5f, 2.5f });
+        ((VariableListSave<int>)resultLists.First(v => v.Name == "IntList")).Value.ShouldBe(new[] { 1, 2 });
+        ((VariableListSave<long>)resultLists.First(v => v.Name == "LongList")).Value.ShouldBe(new[] { 9_000_000_000L, 10_000_000_000L });
+        ((VariableListSave<double>)resultLists.First(v => v.Name == "DoubleList")).Value.ShouldBe(new[] { 3.14159265358979, 2.71828182845905 });
+        ((VariableListSave<bool>)resultLists.First(v => v.Name == "BoolList")).Value.ShouldBe(new[] { true, false });
     }
 }


### PR DESCRIPTION
## Summary

Focused follow-up to #4171 (JSON project format, phase 1): closes concrete round-trip test coverage gaps found by reading the test code and grepping real repo content.

- `VariableSave` `long`/`double` scalars had zero coverage despite `BoxedValueJson` explicitly supporting both. `long` has zero real instances anywhere in this repo; `double` has exactly 13, all in the `FormsBehaviors` slider/scrollbar/scrollviewer templates (not referenced by any of the 23 `.gumx` fixtures the existing differential sweep covers).
- `VariableListSave<T>` only had a `Vector2` pinning test — the other six closed generics `VariableListSaveJsonMapper` explicitly switches on (`string`/`float`/`int`/`long`/`double`/`bool`) had none.
- Added a real-file round-trip test for the three `FormsBehaviors` `.behx` files (the only real, checked-in `double`-typed content anywhere), loaded via the same `BehaviorReference.DeserializeBehavior` path used elsewhere in the codebase.
- Documented (not replicated) `CustomPropertySave`'s XML `ValueAsObject` catch-all as an accepted limitation — confirmed via repo-wide search that no real `CustomProperties` list anywhere is ever populated at all.
- Strengthened `GumJsonFixtureDifferentialTests`: it previously only proved JSON self-consistency (serialize → deserialize → serialize again, same string), which would not catch a field the original `ToJson` mapper silently drops, since both sides of that comparison share the same mapper. Now also re-serializes the JSON-round-tripped object back through the already-proven XML compact serializer and diffs against the original's own XML serialization — an independent oracle.

**Result:** all new cases confirmed already-correct behavior; none exposed a real bug in the existing mapper/DTO code. 36/36 JSON-specific tests pass (up from 32), 2057/2057 full `MonoGameGum.Tests` suite passes, zero regressions.

Closes #4170
