### PR TITLE
Add MonoGame-vs-raylib screenshot diffing (gumcli diff-screenshots)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -19,6 +19,10 @@ Why a different home: these runtimes wrap Skia-specific renderables on one side 
 
 **Scope of this pair — do not over-generalize.** This Apos↔Skia pairing covers only the **Apos-specific** runtimes (`RoundedRectangleRuntime`, `ColoredCircleRuntime`, `ArcRuntime`, `LineRuntime`). It is **not** a statement that shape support is MonoGame/Skia-only or that raylib lacks shapes. The general-purpose `RectangleRuntime`/`CircleRuntime` are unified on the normal `MonoGameGum/GueDeriving/` axis (`#if RAYLIB`/`SOKOL`/`SKIA`/`XNALIKE`) and reach full filled/rounded/shadowed capability on **every** backend — raylib included (it wraps the fully-featured `LineRectangle`/`LineCircle`). See [gum-runtime-topology](../gum-runtime-topology/SKILL.md) "Shapes are NOT MonoGame/Skia-only" for the per-backend renderable table.
 
+## Don't Route Tests Around a Divergence You Find — Fix or Surface It
+
+A per-platform `#if`-gated dispatch (e.g. `CustomSetPropertyOnRenderable.cs`'s `TrySetPropertyOn*Runtime` methods) can silently drop a property for one backend: the gate skips it, reflection falls back to the low-level renderable, finds no matching member, and no-ops with no exception. Don't write a test that passes by asserting that fallback's default instead of the property actually applying — that hides the divergence. Fix the gate (see "Disagreements Are the Whole Job" below) or write a failing/pinned test that names the gap.
+
 ## Disagreements Are the Whole Job
 
 When three files diverge, every difference falls into one of two buckets:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -397,13 +397,18 @@ jobs:
       #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
       #                                     SKSvgCanvas, CPU-only like SkiaGum.Tests)
       #   - Gum.Analyzers.Tests            (Roslyn analyzers; pure compilation)
-      #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts and
-      #                                     the raylib-backend screenshot test both
-      #                                     self-gate by OS at runtime — see
-      #                                     ScreenshotCommandTests, #4174 — rather
-      #                                     than being excluded via a Trait. Runs
-      #                                     after "Install Mesa" below since that
-      #                                     raylib-backend test needs it on Windows)
+      #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts, the
+      #                                     raylib-backend screenshot test, and the
+      #                                     diff-screenshots test (which renders via
+      #                                     BOTH MonoGame and raylib) all self-gate
+      #                                     by OS at runtime — see
+      #                                     ScreenshotCommandTests/
+      #                                     DiffScreenshotsCommandTests, #4174 —
+      #                                     rather than being excluded via a Trait.
+      #                                     Runs after "Install Mesa" below since
+      #                                     those tests need it on Windows)
+      #   - Gum.ImageDiff.Tests            (PixelComparer; pure SkiaSharp bitmap
+      #                                     comparison, no window/GL, fully headless)
       #   - SkiaGum.Tests                  (renders into an in-memory CPU raster
       #                                     SKSurface — no GPU / window / GL. It
       #                                     was wrongly excluded as "needs a
@@ -461,6 +466,10 @@ jobs:
       - name: Gum.ProjectServices.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/Gum.ProjectServices.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      - name: Gum.ImageDiff.Tests
+        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
+        run: dotnet test "Tests/Gum.ImageDiff.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Gum.Presentation.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
@@ -547,14 +556,16 @@ jobs:
               Format-Table Name, Length
           }
 
-      # Moved here (after Mesa is installed) because ScreenshotCommandTests exercises
-      # `gumcli screenshot --backend raylib` (#4174), which needs the same software-GL override as
-      # RaylibGum.Tests below. Runs on both OSes (no runner.os gate) like before this move — only the
-      # raylib-backend test self-skips on non-Windows (see its own comment).
+      # Moved here (after Mesa is installed) because ScreenshotCommandTests and
+      # DiffScreenshotsCommandTests exercise `gumcli screenshot --backend raylib` and
+      # `gumcli diff-screenshots` (#4174), which need the same software-GL override as RaylibGum.Tests
+      # below (diff-screenshots also renders via MonoGame — same Mesa DLLs cover both). Runs on both
+      # OSes (no runner.os gate) like before this move — only the raylib-touching tests self-skip on
+      # non-Windows (see their own comments).
       - name: Gum.Cli.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         env:
-          GALLIUM_DRIVER: llvmpipe   # only consulted by the raylib-backend screenshot test, itself
+          GALLIUM_DRIVER: llvmpipe   # only consulted by the raylib-touching tests, themselves
                                      # Windows-only; harmless no-op elsewhere
         run: dotnet test "Tests/Gum.Cli.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -397,10 +397,13 @@ jobs:
       #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
       #                                     SKSvgCanvas, CPU-only like SkiaGum.Tests)
       #   - Gum.Analyzers.Tests            (Roslyn analyzers; pure compilation)
-      #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts
-      #                                     tests self-gate by OS, no screenshot
-      #                                     tests exist yet — if one is added,
-      #                                     fence it with a Trait and exclude here)
+      #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts and
+      #                                     the raylib-backend screenshot test both
+      #                                     self-gate by OS at runtime — see
+      #                                     ScreenshotCommandTests, #4174 — rather
+      #                                     than being excluded via a Trait. Runs
+      #                                     after "Install Mesa" below since that
+      #                                     raylib-backend test needs it on Windows)
       #   - SkiaGum.Tests                  (renders into an in-memory CPU raster
       #                                     SKSurface — no GPU / window / GL. It
       #                                     was wrongly excluded as "needs a
@@ -413,6 +416,10 @@ jobs:
       #                                     lack, supplied by Mesa llvmpipe software
       #                                     GL dropped in by the "Install Mesa" step
       #                                     right before it. #3250)
+      #   - Gum.ProjectServices.Raylib.Tests (RaylibScreenshotService — same real
+      #                                     raylib window/OpenGL context as
+      #                                     RaylibGum.Tests above, needs the same
+      #                                     Mesa llvmpipe DLLs. #4174)
       #
       # Bucket B — DEFERRED, NEEDS INVESTIGATION (likely safe in part, but may
       # mix headless and graphics-using tests in the same project; would need
@@ -462,10 +469,6 @@ jobs:
       - name: Gum.Analyzers.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/Gum.Analyzers.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
-
-      - name: Gum.Cli.Tests
-        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
-        run: dotnet test "Tests/Gum.Cli.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       # SkiaGum.Tests renders into an in-memory CPU raster SKSurface (no GPU / window /
       # GL), so it runs headless on CI like the suites above and blocks on failure. It
@@ -531,12 +534,29 @@ jobs:
           $opengl = Get-ChildItem -Path $extract -Recurse -Filter opengl32.dll |
                     Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1
           if (-not $opengl) { Write-Error "x64 opengl32.dll not found in Mesa archive"; exit 1 }
-          $dest = "Tests/RaylibGum.Tests/bin/Release/net8.0"
-          Copy-Item (Join-Path $opengl.Directory.FullName "*.dll") -Destination $dest -Force
-          Write-Host "Mesa GL runtime copied to $dest"
-          Get-ChildItem (Join-Path $dest "*.dll") |
-            Where-Object { $_.Name -match "opengl32|gallium|glapi|dxil" } |
-            Format-Table Name, Length
+          $dests = @(
+            "Tests/RaylibGum.Tests/bin/Release/net8.0",
+            "Tests/Gum.ProjectServices.Raylib.Tests/bin/Release/net8.0",
+            "Tests/Gum.Cli.Tests/bin/Release/net8.0"
+          )
+          foreach ($dest in $dests) {
+            Copy-Item (Join-Path $opengl.Directory.FullName "*.dll") -Destination $dest -Force
+            Write-Host "Mesa GL runtime copied to $dest"
+            Get-ChildItem (Join-Path $dest "*.dll") |
+              Where-Object { $_.Name -match "opengl32|gallium|glapi|dxil" } |
+              Format-Table Name, Length
+          }
+
+      # Moved here (after Mesa is installed) because ScreenshotCommandTests exercises
+      # `gumcli screenshot --backend raylib` (#4174), which needs the same software-GL override as
+      # RaylibGum.Tests below. Runs on both OSes (no runner.os gate) like before this move — only the
+      # raylib-backend test self-skips on non-Windows (see its own comment).
+      - name: Gum.Cli.Tests
+        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
+        env:
+          GALLIUM_DRIVER: llvmpipe   # only consulted by the raylib-backend screenshot test, itself
+                                     # Windows-only; harmless no-op elsewhere
+        run: dotnet test "Tests/Gum.Cli.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: "RaylibGum.Tests (Windows, #3250)"
         if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
@@ -544,6 +564,15 @@ jobs:
         env:
           GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
         run: dotnet test "Tests/RaylibGum.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      # RaylibScreenshotService (#4174) — same real raylib window/OpenGL context as
+      # RaylibGum.Tests above, via the same Mesa llvmpipe DLLs copied in the step above.
+      - name: "Gum.ProjectServices.Raylib.Tests (Windows, #4174)"
+        if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
+        timeout-minutes: 10
+        env:
+          GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
+        run: dotnet test "Tests/Gum.ProjectServices.Raylib.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Publish Test Results
         if: always() && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -183,6 +183,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.Raylib"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.Raylib.Tests", "Tests\Gum.ProjectServices.Raylib.Tests\Gum.ProjectServices.Raylib.Tests.csproj", "{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ImageDiff", "Tools\Gum.ImageDiff\Gum.ImageDiff.csproj", "{0035DE6B-986D-4B75-ADF0-8D286C170807}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ImageDiff.Tests", "Tests\Gum.ImageDiff.Tests\Gum.ImageDiff.Tests.csproj", "{2561CC66-26AC-4050-8990-3684A920EBDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1672,6 +1676,42 @@ Global
 		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x64.Build.0 = Release|Any CPU
 		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x86.Build.0 = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|x64.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Debug|x86.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|x64.ActiveCfg = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|x64.Build.0 = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|x86.ActiveCfg = Release|Any CPU
+		{0035DE6B-986D-4B75-ADF0-8D286C170807}.Release|x86.Build.0 = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|x64.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Debug|x86.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x64.ActiveCfg = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x64.Build.0 = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x86.ActiveCfg = Release|Any CPU
+		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1759,6 +1799,8 @@ Global
 		{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{0035DE6B-986D-4B75-ADF0-8D286C170807} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{2561CC66-26AC-4050-8990-3684A920EBDF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -179,6 +179,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SilkNetGum.Tests", "Tests\S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrossAssemblyAttributeFixture", "Tests\CrossAssemblyAttributeFixture\CrossAssemblyAttributeFixture.csproj", "{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.Raylib", "Tools\Gum.ProjectServices.Raylib\Gum.ProjectServices.Raylib.csproj", "{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ProjectServices.Raylib.Tests", "Tests\Gum.ProjectServices.Raylib.Tests\Gum.ProjectServices.Raylib.Tests.csproj", "{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1632,6 +1636,42 @@ Global
 		{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7}.Release|x64.Build.0 = Release|Any CPU
 		{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7}.Release|x86.ActiveCfg = Release|Any CPU
 		{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7}.Release|x86.Build.0 = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|x64.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|x64.ActiveCfg = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|x64.Build.0 = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C}.Release|x86.Build.0 = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Debug|x86.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x64.Build.0 = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1717,6 +1757,8 @@ Global
 		{65C432AE-B1C8-4776-8671-F1C942B75FAD} = {BB4FD3E1-BF37-801A-7591-DC4DC6E3BB2D}
 		{C26B20E9-C5F4-4398-8215-13A998F6A4D8} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{38E3E7D1-9C16-4AA1-A2FD-0FC6B2FFC9F7} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{C998BC78-9319-4B2F-BA6C-74DCFB49E48C} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -207,9 +207,6 @@ public partial class CustomSetPropertyOnRenderable
         {
             handled = TrySetPropertyOnText(renderableText, graphicalUiElement, propertyName, value);
         }
-#if !RAYLIB
-
-
 #if !FRB
         // Issue #2925 — dispatch by RUNTIME type for CircleRuntime / RectangleRuntime before
         // falling through to the renderable-type tree. Both runtimes now own two renderable
@@ -217,6 +214,13 @@ public partial class CustomSetPropertyOnRenderable
         // renderable-type-only dispatch lands legacy "Color" / "Alpha" / "Red" / etc. on the
         // wrong slot. Routing through the runtime's typed property setters keeps each variable
         // landing where its pre-two-slot equivalent did, independent of which slot is contained.
+        //
+        // Included on RAYLIB too (#4176): the v3 shape properties (IsFilled/FillRed/FillGreen/
+        // FillBlue/FillAlpha/Stroke*/CustomRadius*/Blend/Color) only exist on the runtime, not on
+        // either raylib renderable slot, so without this dispatch they silently fell through to
+        // SetPropertyThroughReflection, which reflects on the renderable and drops them — a
+        // Rectangle with a custom fill color saved in a project rendered with its default fill
+        // instead on raylib, indistinguishable from a real rendering bug.
         else if (graphicalUiElement is Gum.GueDeriving.CircleRuntime circleRuntime)
         {
             handled = TrySetPropertyOnCircleRuntime(circleRuntime, propertyName, value);
@@ -226,6 +230,7 @@ public partial class CustomSetPropertyOnRenderable
             handled = TrySetPropertyOnRectangleRuntime(rectangleRuntime, propertyName, value);
         }
 #endif
+#if !RAYLIB
         else if (renderableIpso is LineCircle)
         {
             handled = TrySetPropertyOnLineCircle(renderableIpso, graphicalUiElement, propertyName, value);
@@ -3276,7 +3281,7 @@ public partial class CustomSetPropertyOnRenderable
         }
     }
 
-#if !RAYLIB && !FRB
+#if !FRB
     // Issue #2925 — legacy variable routing for the two-slot CircleRuntime. The legacy
     // properties (Color/Alpha/Red/Green/Blue) on the runtime are intentionally obsolete and
     // already route to the stroke slot internally, preserving pre-two-slot behavior. Going
@@ -3287,7 +3292,21 @@ public partial class CustomSetPropertyOnRenderable
 #pragma warning disable CS0618 // legacy obsolete properties are the public surface this dispatch was written against
         switch (propertyName)
         {
+            // #4176: CircleRuntime.Color is backend-typed (Raylib_cs.Color on raylib,
+            // Microsoft.Xna.Framework.Color elsewhere), so the conversion branches by platform.
+            // Mirrors the raylib NineSlice/Sprite/Text "Color" cases elsewhere in this file: only
+            // System.Drawing.Color arrives from a loaded project, so that's the only branch needed.
             case "Color":
+#if RAYLIB
+                if (value is System.Drawing.Color raylibDrawingColor)
+                {
+                    circleRuntime.Color = raylibDrawingColor.ToRaylib();
+                }
+                else
+                {
+                    return false;
+                }
+#else
                 if (value is System.Drawing.Color drawingColor)
                 {
                     circleRuntime.Color = new Microsoft.Xna.Framework.Color(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
@@ -3300,6 +3319,7 @@ public partial class CustomSetPropertyOnRenderable
                 {
                     return false;
                 }
+#endif
                 return true;
             case "Alpha":
                 circleRuntime.Alpha = (int)value;
@@ -3365,7 +3385,21 @@ public partial class CustomSetPropertyOnRenderable
 #pragma warning disable CS0618
         switch (propertyName)
         {
+            // #4176: RectangleRuntime.Color is backend-typed (Raylib_cs.Color on raylib,
+            // Microsoft.Xna.Framework.Color elsewhere), so the conversion branches by platform.
+            // Mirrors the raylib NineSlice/Sprite/Text "Color" cases elsewhere in this file: only
+            // System.Drawing.Color arrives from a loaded project, so that's the only branch needed.
             case "Color":
+#if RAYLIB
+                if (value is System.Drawing.Color raylibDrawingColor)
+                {
+                    rectangleRuntime.Color = raylibDrawingColor.ToRaylib();
+                }
+                else
+                {
+                    return false;
+                }
+#else
                 if (value is System.Drawing.Color drawingColor)
                 {
                     rectangleRuntime.Color = new Microsoft.Xna.Framework.Color(drawingColor.R, drawingColor.G, drawingColor.B, drawingColor.A);
@@ -3378,6 +3412,7 @@ public partial class CustomSetPropertyOnRenderable
                 {
                     return false;
                 }
+#endif
                 return true;
             case "Alpha":
                 rectangleRuntime.Alpha = (int)value;

--- a/Tests/Gum.Cli.Tests/DiffScreenshotsCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/DiffScreenshotsCommandTests.cs
@@ -1,0 +1,81 @@
+using System.Runtime.InteropServices;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices;
+using Shouldly;
+
+namespace Gum.Cli.Tests;
+
+// Windows-only, and the only Gum.Cli.Tests suite that renders through BOTH MonoGame and raylib in
+// the same process (screenshot --backend raylib exercises only one). See ScreenshotCommandTests for
+// why raylib itself is Windows-only in CI; MonoGame DesktopGL needs the same Mesa llvmpipe override
+// there (already wired for this project, #4174).
+public class DiffScreenshotsCommandTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public DiffScreenshotsCommandTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumCliDiffScreenshotsTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void DiffScreenshots_IdenticallyRenderingProject_ReturnsExitCode0()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string projectPath = CreateProjectWithScreen();
+
+        CliTestHelper result = CliTestHelper.Run(
+            "diff-screenshots", projectPath, "--output", Path.Combine(_tempDirectory, "renders"));
+
+        result.ExitCode.ShouldBe(0, $"stdout: {result.StandardOutput}\nstderr: {result.StandardError}");
+        result.StandardOutput.ShouldContain("MATCH  Screen");
+        result.StandardOutput.ShouldContain("All 1 element(s) matched.");
+    }
+
+    [Fact]
+    public void DiffScreenshots_ProjectFileDoesNotExist_ReturnsExitCode2()
+    {
+        CliTestHelper result = CliTestHelper.Run(
+            "diff-screenshots", Path.Combine(_tempDirectory, "DoesNotExist.gumx"));
+
+        result.ExitCode.ShouldBe(2);
+        result.StandardError.ShouldContain("not found");
+    }
+
+    private string CreateProjectWithScreen()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        return projectPath;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Gum.Cli.Tests/DiffScreenshotsCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/DiffScreenshotsCommandTests.cs
@@ -29,13 +29,17 @@ public class DiffScreenshotsCommandTests : IDisposable
         }
 
         string projectPath = CreateProjectWithScreen();
+        string outputDirectory = Path.Combine(_tempDirectory, "renders");
 
         CliTestHelper result = CliTestHelper.Run(
-            "diff-screenshots", projectPath, "--output", Path.Combine(_tempDirectory, "renders"));
+            "diff-screenshots", projectPath, "--output", outputDirectory);
 
         result.ExitCode.ShouldBe(0, $"stdout: {result.StandardOutput}\nstderr: {result.StandardError}");
         result.StandardOutput.ShouldContain("MATCH  Screen");
         result.StandardOutput.ShouldContain("All 1 element(s) matched.");
+        string reportPath = Path.Combine(outputDirectory, "report.html");
+        result.StandardOutput.ShouldContain(reportPath);
+        File.Exists(reportPath).ShouldBeTrue();
     }
 
     [Fact]

--- a/Tests/Gum.Cli.Tests/ScreenshotCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/ScreenshotCommandTests.cs
@@ -1,0 +1,88 @@
+using System.Runtime.InteropServices;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices;
+using Shouldly;
+
+namespace Gum.Cli.Tests;
+
+public class ScreenshotCommandTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public ScreenshotCommandTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumCliScreenshotTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    // Proves `--backend raylib` actually dispatches to RaylibScreenshotService end-to-end through
+    // the CLI's option parsing (#4174) — pixel-level rendering correctness is covered by
+    // Gum.ProjectServices.Raylib.Tests. The default ("monogame") backend's dispatch is pre-existing,
+    // unchanged behavior and is not covered here to avoid initializing both graphics backends in
+    // this shared, non-graphics-focused test process.
+    //
+    // Windows-only: raylib's window creation hangs on macOS CI runners (GLFW/Cocoa needs the main
+    // thread — see RaylibGum.Tests' CI history, #3233), and this project's CI step runs on both
+    // OSes, unlike RaylibGum.Tests' own step which is gated to Windows.
+    [Fact]
+    public void Screenshot_WithRaylibBackend_WritesPngFile()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string projectPath = CreateProjectWithScreen();
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+
+        CliTestHelper result = CliTestHelper.Run(
+            "screenshot", projectPath, "Screen", "--output", outputPath, "--backend", "raylib");
+
+        result.ExitCode.ShouldBe(0, result.StandardError);
+        File.Exists(outputPath).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Screenshot_WithUnknownBackend_ReturnsExitCode2()
+    {
+        string projectPath = CreateProjectWithScreen();
+
+        CliTestHelper result = CliTestHelper.Run(
+            "screenshot", projectPath, "Screen", "--backend", "nonexistent");
+
+        result.ExitCode.ShouldBe(2);
+        result.StandardError.ShouldContain("Unknown backend");
+    }
+
+    private string CreateProjectWithScreen()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        return projectPath;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Gum.ImageDiff.Tests/Gum.ImageDiff.Tests.csproj
+++ b/Tests/Gum.ImageDiff.Tests/Gum.ImageDiff.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tools\Gum.ImageDiff\Gum.ImageDiff.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Gum.ImageDiff.Tests/ImageDiffResultTests.cs
+++ b/Tests/Gum.ImageDiff.Tests/ImageDiffResultTests.cs
@@ -1,0 +1,110 @@
+using Gum.ImageDiff;
+using Shouldly;
+using SkiaSharp;
+
+namespace Gum.ImageDiff.Tests;
+
+/// <summary>
+/// Tests for <see cref="PixelComparer.CompareApproximate"/>, the cross-renderer image comparer used
+/// by <c>gumcli diff-screenshots</c> (#4174). Unlike <see cref="PixelComparer.Compare"/> (exact
+/// same-coordinate comparison for single-renderer golden-image regression tests), this tolerates a
+/// small positional shift between two different renderers' antialiasing/rounding before counting a
+/// pixel as a real mismatch, and reports aggregate stats instead of only the first differing pixel.
+/// </summary>
+public class ImageDiffResultTests
+{
+    [Fact]
+    public void CompareApproximate_IdenticalBitmaps_ReturnsMatchWithZeroMismatches()
+    {
+        using SKBitmap expected = CreateSolidBitmap(10, 10, SKColors.Blue);
+        using SKBitmap actual = CreateSolidBitmap(10, 10, SKColors.Blue);
+
+        ImageDiffResult result = PixelComparer.CompareApproximate(expected, actual);
+
+        result.Matches.ShouldBeTrue();
+        result.MismatchedPixelCount.ShouldBe(0);
+        result.TotalPixelCount.ShouldBe(100);
+    }
+
+    [Fact]
+    public void CompareApproximate_ContentShiftedByOnePixel_AbsorbedAsMatch()
+    {
+        // A single red pixel on a white background, shifted one pixel to the right between the two
+        // images — exactly the antialiasing/rounding jitter a proximity check exists to absorb.
+        using SKBitmap expected = CreateSolidBitmap(5, 5, SKColors.White);
+        expected.SetPixel(2, 2, SKColors.Red);
+        using SKBitmap actual = CreateSolidBitmap(5, 5, SKColors.White);
+        actual.SetPixel(3, 2, SKColors.Red);
+
+        ImageDiffResult result = PixelComparer.CompareApproximate(expected, actual, colorTolerance: 2, proximityRadius: 1);
+
+        result.Matches.ShouldBeTrue();
+        result.MismatchedPixelCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CompareApproximate_ContentMissingEntirely_ReportsRealMismatchWithBoundingBox()
+    {
+        // A 3x3 red block present in expected but entirely absent from actual — no amount of nearby
+        // searching finds a match, so this must be reported as a real, sizeable mismatch.
+        using SKBitmap expected = CreateSolidBitmap(10, 10, SKColors.White);
+        FillRegion(expected, 3, 3, 3, 3, SKColors.Red);
+        using SKBitmap actual = CreateSolidBitmap(10, 10, SKColors.White);
+
+        ImageDiffResult result = PixelComparer.CompareApproximate(expected, actual, colorTolerance: 2, proximityRadius: 1);
+
+        result.Matches.ShouldBeFalse();
+        result.MismatchedPixelCount.ShouldBe(9);
+        result.BoundingBoxMinX.ShouldBe(3);
+        result.BoundingBoxMinY.ShouldBe(3);
+        result.BoundingBoxMaxX.ShouldBe(5);
+        result.BoundingBoxMaxY.ShouldBe(5);
+    }
+
+    [Fact]
+    public void CompareApproximate_DifferentDimensions_ReturnsMismatchWithDescription()
+    {
+        using SKBitmap expected = CreateSolidBitmap(4, 4, SKColors.Red);
+        using SKBitmap actual = CreateSolidBitmap(4, 5, SKColors.Red);
+
+        ImageDiffResult result = PixelComparer.CompareApproximate(expected, actual);
+
+        result.Matches.ShouldBeFalse();
+        result.DimensionMismatchDescription.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CompareApproximate_ShiftBeyondProximityRadius_ReportsRealMismatch()
+    {
+        // Same shift as the "absorbed" test above, but with proximityRadius: 0 (no neighborhood
+        // search at all) the shift must NOT be absorbed — proves the radius parameter is load-bearing.
+        using SKBitmap expected = CreateSolidBitmap(5, 5, SKColors.White);
+        expected.SetPixel(2, 2, SKColors.Red);
+        using SKBitmap actual = CreateSolidBitmap(5, 5, SKColors.White);
+        actual.SetPixel(3, 2, SKColors.Red);
+
+        ImageDiffResult result = PixelComparer.CompareApproximate(expected, actual, colorTolerance: 2, proximityRadius: 0);
+
+        result.Matches.ShouldBeFalse();
+        result.MismatchedPixelCount.ShouldBe(2);
+    }
+
+    private static SKBitmap CreateSolidBitmap(int width, int height, SKColor color)
+    {
+        SKBitmap bitmap = new(width, height);
+        using SKCanvas canvas = new(bitmap);
+        canvas.Clear(color);
+        return bitmap;
+    }
+
+    private static void FillRegion(SKBitmap bitmap, int x, int y, int width, int height, SKColor color)
+    {
+        for (int i = x; i < x + width; i++)
+        {
+            for (int j = y; j < y + height; j++)
+            {
+                bitmap.SetPixel(i, j, color);
+            }
+        }
+    }
+}

--- a/Tests/Gum.ImageDiff.Tests/PixelComparerTests.cs
+++ b/Tests/Gum.ImageDiff.Tests/PixelComparerTests.cs
@@ -1,7 +1,8 @@
+using Gum.ImageDiff;
 using Shouldly;
 using SkiaSharp;
 
-namespace SkiaGum.Tests.GoldenImages;
+namespace Gum.ImageDiff.Tests;
 
 public class PixelComparerTests
 {

--- a/Tests/Gum.ProjectServices.Raylib.Tests/Gum.ProjectServices.Raylib.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Raylib.Tests/Gum.ProjectServices.Raylib.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Raylib-cs" VersionOverride="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tools\Gum.ProjectServices\Gum.ProjectServices.csproj" />
+    <ProjectReference Include="..\..\Tools\Gum.ProjectServices.Raylib\Gum.ProjectServices.Raylib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Gum.ProjectServices.Raylib.Tests/RaylibScreenshotServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Raylib.Tests/RaylibScreenshotServiceTests.cs
@@ -1,0 +1,117 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices;
+using Gum.ProjectServices.Screenshot;
+using Raylib_cs;
+using Shouldly;
+
+namespace Gum.ProjectServices.Raylib.Tests;
+
+/// <summary>
+/// Tests for <see cref="RaylibScreenshotService"/>, the raylib-backed implementation of
+/// <see cref="IScreenshotService"/> that lets <c>gumcli screenshot --backend raylib</c> render the
+/// same project MonoGameScreenshotService renders, for cross-runtime pixel comparison (#4174).
+/// </summary>
+/// <remarks>
+/// Only <c>IsFilled</c> is set here, not <c>FillRed</c>/<c>FillGreen</c>/<c>FillBlue</c> — those
+/// silently no-op when loaded from a saved project on raylib today (the property dispatcher's
+/// <c>TrySetPropertyOnRectangleRuntime</c> is gated <c>#if !RAYLIB</c>, a real cross-runtime gap
+/// tracked separately, not something this test should route around by asserting the broken
+/// behavior). Asserting on the well-defined default fill (opaque white) instead still proves the
+/// full pipeline: project load, layout, transparent-background render-to-texture, and PNG export.
+/// </remarks>
+public class RaylibScreenshotServiceTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public RaylibScreenshotServiceTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumRaylibScreenshotTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void TakeScreenshot_FilledRectangleScreen_WritesPngWithRectangleInExpectedRegion()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "RectInstance",
+            BaseType = "Rectangle",
+            ParentContainer = screen,
+        };
+        screen.Instances.Add(instance);
+
+        // Covers only the top-left quadrant of the 200x150 render, so a point inside (50,37) and
+        // a point clearly outside (150,120) can be distinguished.
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.X", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Y", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Width", Type = "float", Value = 100f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Height", Type = "float", Value = 75f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+        RaylibScreenshotService service = new RaylibScreenshotService();
+
+        ScreenshotResult result = service.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "Screen",
+            OutputPath = outputPath,
+            Width = 200,
+            Height = 150,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+        File.Exists(outputPath).ShouldBeTrue();
+
+        Image image = Raylib_cs.Raylib.LoadImage(outputPath);
+        try
+        {
+            image.Width.ShouldBe(200);
+            image.Height.ShouldBe(150);
+
+            // Default fill for a v3 Rectangle with IsFilled = true and no explicit fill color is
+            // opaque white.
+            Color inside = Raylib_cs.Raylib.GetImageColor(image, 50, 37);
+            inside.R.ShouldBeInRange((byte)245, (byte)255);
+            inside.G.ShouldBeInRange((byte)245, (byte)255);
+            inside.B.ShouldBeInRange((byte)245, (byte)255);
+            inside.A.ShouldBeInRange((byte)245, (byte)255);
+
+            // Outside the rectangle the background clear must stay fully transparent.
+            Color outside = Raylib_cs.Raylib.GetImageColor(image, 150, 120);
+            outside.A.ShouldBeLessThan((byte)10);
+        }
+        finally
+        {
+            Raylib_cs.Raylib.UnloadImage(image);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Raylib.Tests/RaylibScreenshotServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Raylib.Tests/RaylibScreenshotServiceTests.cs
@@ -1,3 +1,4 @@
+using Gum.Converters;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.ProjectServices;
@@ -13,12 +14,12 @@ namespace Gum.ProjectServices.Raylib.Tests;
 /// same project MonoGameScreenshotService renders, for cross-runtime pixel comparison (#4174).
 /// </summary>
 /// <remarks>
-/// Only <c>IsFilled</c> is set here, not <c>FillRed</c>/<c>FillGreen</c>/<c>FillBlue</c> — those
-/// silently no-op when loaded from a saved project on raylib today (the property dispatcher's
-/// <c>TrySetPropertyOnRectangleRuntime</c> is gated <c>#if !RAYLIB</c>, a real cross-runtime gap
-/// tracked separately, not something this test should route around by asserting the broken
-/// behavior). Asserting on the well-defined default fill (opaque white) instead still proves the
-/// full pipeline: project load, layout, transparent-background render-to-texture, and PNG export.
+/// <see cref="TakeScreenshot_FilledRectangleScreen_WritesPngWithRectangleInExpectedRegion"/> also
+/// pins the fix for #4176: <c>FillRed</c>/<c>FillGreen</c>/<c>FillBlue</c> loaded from a saved
+/// project used to silently no-op on raylib (the property dispatcher's
+/// <c>TrySetPropertyOnRectangleRuntime</c> was gated <c>#if !RAYLIB</c>, so a Rectangle with a
+/// custom fill color rendered with its default white fill instead — indistinguishable from a real
+/// rendering bug when only comparing against MonoGame's correct output).
 /// </remarks>
 public class RaylibScreenshotServiceTests : IDisposable
 {
@@ -34,6 +35,7 @@ public class RaylibScreenshotServiceTests : IDisposable
     [Fact]
     public void TakeScreenshot_FilledRectangleScreen_WritesPngWithRectangleInExpectedRegion()
     {
+        // Also pins #4176's fix: FillRed/FillGreen/FillBlue must apply, not just IsFilled's default.
         string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
 
         ProjectCreator creator = new ProjectCreator();
@@ -58,6 +60,10 @@ public class RaylibScreenshotServiceTests : IDisposable
         defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Width", Type = "float", Value = 100f, SetsValue = true });
         defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Height", Type = "float", Value = 75f, SetsValue = true });
         defaultState.Variables.Add(new VariableSave { Name = "RectInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.FillRed", Type = "int", Value = 255, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.FillGreen", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.FillBlue", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.FillAlpha", Type = "int", Value = 255, SetsValue = true });
 
         project.Screens.Add(screen);
         project.ScreenReferences.Add(new ElementReference
@@ -89,17 +95,91 @@ public class RaylibScreenshotServiceTests : IDisposable
             image.Width.ShouldBe(200);
             image.Height.ShouldBe(150);
 
-            // Default fill for a v3 Rectangle with IsFilled = true and no explicit fill color is
-            // opaque white.
             Color inside = Raylib_cs.Raylib.GetImageColor(image, 50, 37);
             inside.R.ShouldBeInRange((byte)245, (byte)255);
-            inside.G.ShouldBeInRange((byte)245, (byte)255);
-            inside.B.ShouldBeInRange((byte)245, (byte)255);
+            inside.G.ShouldBeLessThan((byte)10);
+            inside.B.ShouldBeLessThan((byte)10);
             inside.A.ShouldBeInRange((byte)245, (byte)255);
 
             // Outside the rectangle the background clear must stay fully transparent.
             Color outside = Raylib_cs.Raylib.GetImageColor(image, 150, 120);
             outside.A.ShouldBeLessThan((byte)10);
+        }
+        finally
+        {
+            Raylib_cs.Raylib.UnloadImage(image);
+        }
+    }
+
+    // Regression test for #4174's Airpig triage: dialogs positioned via PixelsFromMiddle (the unit
+    // a parentless element's X/Y resolve "the middle" against GraphicalUiElement.CanvasWidth/
+    // CanvasHeight) rendered pinned to the top-left corner on raylib instead of centered, because
+    // RaylibScreenshotService never set CanvasWidth/CanvasHeight the way MonoGameScreenshotService
+    // does — so the "middle" it centered against was 0, not the requested render size.
+    [Fact]
+    public void TakeScreenshot_ElementCenteredViaPixelsFromMiddle_RendersAtCanvasCenter()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "RectInstance",
+            BaseType = "Rectangle",
+            ParentContainer = screen,
+        };
+        screen.Instances.Add(instance);
+
+        // X/Y = 0 with PixelsFromMiddle centers the 50x50 rectangle on whatever CanvasWidth/
+        // CanvasHeight resolve to at render time.
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.X", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.XUnits", Type = "GeneralUnitType", Value = GeneralUnitType.PixelsFromMiddle, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Y", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.YUnits", Type = "GeneralUnitType", Value = GeneralUnitType.PixelsFromMiddle, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Width", Type = "float", Value = 50f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.Height", Type = "float", Value = 50f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+        RaylibScreenshotService service = new RaylibScreenshotService();
+
+        ScreenshotResult result = service.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "Screen",
+            OutputPath = outputPath,
+            Width = 200,
+            Height = 150,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+
+        Image image = Raylib_cs.Raylib.LoadImage(outputPath);
+        try
+        {
+            // The 50x50 rectangle centered on a 200x150 canvas spans x:[75,125], y:[50,100] —
+            // its own center (100, 75) must be filled...
+            Color center = Raylib_cs.Raylib.GetImageColor(image, 100, 75);
+            center.A.ShouldBeGreaterThan((byte)245);
+
+            // ...and the corner, which the bug pinned the rectangle to, must NOT be.
+            Color corner = Raylib_cs.Raylib.GetImageColor(image, 5, 5);
+            corner.A.ShouldBeLessThan((byte)10);
         }
         finally
         {

--- a/Tests/Gum.ProjectServices.Raylib.Tests/TestAssemblyInitialize.cs
+++ b/Tests/Gum.ProjectServices.Raylib.Tests/TestAssemblyInitialize.cs
@@ -1,0 +1,5 @@
+// RaylibScreenshotService drives process-wide statics (a single hidden raylib window,
+// GumService.Default, SystemManagers.Default). Disable parallel execution so concurrent
+// screenshot tests don't stomp on that shared state — mirrors
+// Gum.ProjectServices.SkiaGum.Tests' TestAssemblyInitialize.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
@@ -16,6 +16,10 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <!-- ScreenshotDiffServiceTests writes tiny synthetic PNGs from mocked IScreenshotService
+         backends; SkiaSharp is already a transitive dependency via Gum.ProjectServices ->
+         Gum.ImageDiff, referenced directly here only to encode those fixtures. -->
+    <PackageReference Include="SkiaSharp" VersionOverride="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.ProjectServices.Tests/ScreenshotDiffHtmlReportWriterTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenshotDiffHtmlReportWriterTests.cs
@@ -1,0 +1,155 @@
+using Gum.ProjectServices.Screenshot;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScreenshotDiffHtmlReportWriter"/>, which turns a
+/// <see cref="ScreenshotDiffResult"/> into a side-by-side (MonoGame | raylib) HTML report for
+/// visually triaging mismatches (#4174).
+/// </summary>
+public class ScreenshotDiffHtmlReportWriterTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public ScreenshotDiffHtmlReportWriterTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumHtmlReportTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void Write_MatchingElement_RendersBothImagesWithRelativePaths()
+    {
+        ScreenshotDiffResult result = new ScreenshotDiffResult
+        {
+            OutputDirectory = _tempDirectory,
+            ElementDiffs = new[]
+            {
+                new ElementScreenshotDiff
+                {
+                    ElementName = "Screens/Main",
+                    Matches = true,
+                    BackendAPath = Path.Combine(_tempDirectory, "A", "Screens", "Main.png"),
+                    BackendBPath = Path.Combine(_tempDirectory, "B", "Screens", "Main.png"),
+                },
+            },
+        };
+
+        string reportPath = Path.Combine(_tempDirectory, "report.html");
+        ScreenshotDiffHtmlReportWriter writer = new ScreenshotDiffHtmlReportWriter();
+
+        writer.Write(result, reportPath);
+
+        string html = File.ReadAllText(reportPath);
+        html.ShouldContain("Screens/Main");
+        html.ShouldContain("src=\"A/Screens/Main.png\"");
+        html.ShouldContain("src=\"B/Screens/Main.png\"");
+    }
+
+    [Fact]
+    public void Write_MismatchedElement_IncludesDiffDetails()
+    {
+        ScreenshotDiffResult result = new ScreenshotDiffResult
+        {
+            OutputDirectory = _tempDirectory,
+            ElementDiffs = new[]
+            {
+                new ElementScreenshotDiff
+                {
+                    ElementName = "Controls/Button",
+                    Matches = false,
+                    BackendAPath = Path.Combine(_tempDirectory, "A", "Controls", "Button.png"),
+                    BackendBPath = Path.Combine(_tempDirectory, "B", "Controls", "Button.png"),
+                    DiffX = 12,
+                    DiffY = 34,
+                    MaxChannelDifference = 200,
+                },
+            },
+        };
+
+        string reportPath = Path.Combine(_tempDirectory, "report.html");
+        ScreenshotDiffHtmlReportWriter writer = new ScreenshotDiffHtmlReportWriter();
+
+        writer.Write(result, reportPath);
+
+        string html = File.ReadAllText(reportPath);
+        html.ShouldContain("Controls/Button");
+        html.ShouldContain("(12, 34)");
+        html.ShouldContain("200");
+    }
+
+    [Fact]
+    public void Write_ElementWithRenderError_ShowsErrorInsteadOfImages()
+    {
+        ScreenshotDiffResult result = new ScreenshotDiffResult
+        {
+            OutputDirectory = _tempDirectory,
+            ElementDiffs = new[]
+            {
+                new ElementScreenshotDiff
+                {
+                    ElementName = "Broken/Element",
+                    Matches = false,
+                    ErrorMessage = "simulated render failure",
+                },
+            },
+        };
+
+        string reportPath = Path.Combine(_tempDirectory, "report.html");
+        ScreenshotDiffHtmlReportWriter writer = new ScreenshotDiffHtmlReportWriter();
+
+        writer.Write(result, reportPath);
+
+        string html = File.ReadAllText(reportPath);
+        html.ShouldContain("Broken/Element");
+        html.ShouldContain("simulated render failure");
+        html.ShouldNotContain("<img");
+    }
+
+    [Fact]
+    public void Write_MismatchesAndMatches_ListsMismatchesFirst()
+    {
+        ScreenshotDiffResult result = new ScreenshotDiffResult
+        {
+            OutputDirectory = _tempDirectory,
+            ElementDiffs = new[]
+            {
+                new ElementScreenshotDiff
+                {
+                    ElementName = "Matching",
+                    Matches = true,
+                    BackendAPath = Path.Combine(_tempDirectory, "A", "Matching.png"),
+                    BackendBPath = Path.Combine(_tempDirectory, "B", "Matching.png"),
+                },
+                new ElementScreenshotDiff
+                {
+                    ElementName = "Mismatched",
+                    Matches = false,
+                    BackendAPath = Path.Combine(_tempDirectory, "A", "Mismatched.png"),
+                    BackendBPath = Path.Combine(_tempDirectory, "B", "Mismatched.png"),
+                    DiffX = 1,
+                    DiffY = 1,
+                    MaxChannelDifference = 100,
+                },
+            },
+        };
+
+        string reportPath = Path.Combine(_tempDirectory, "report.html");
+        ScreenshotDiffHtmlReportWriter writer = new ScreenshotDiffHtmlReportWriter();
+
+        writer.Write(result, reportPath);
+
+        string html = File.ReadAllText(reportPath);
+        html.IndexOf("Mismatched", StringComparison.Ordinal)
+            .ShouldBeLessThan(html.IndexOf("Matching", StringComparison.Ordinal));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/ScreenshotDiffHtmlReportWriterTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenshotDiffHtmlReportWriterTests.cs
@@ -61,9 +61,13 @@ public class ScreenshotDiffHtmlReportWriterTests : IDisposable
                     Matches = false,
                     BackendAPath = Path.Combine(_tempDirectory, "A", "Controls", "Button.png"),
                     BackendBPath = Path.Combine(_tempDirectory, "B", "Controls", "Button.png"),
-                    DiffX = 12,
-                    DiffY = 34,
-                    MaxChannelDifference = 200,
+                    MismatchedPixelCount = 42,
+                    TotalPixelCount = 1000,
+                    MismatchPercentage = 4.2,
+                    BoundingBoxMinX = 12,
+                    BoundingBoxMinY = 34,
+                    BoundingBoxMaxX = 56,
+                    BoundingBoxMaxY = 78,
                 },
             },
         };
@@ -75,8 +79,10 @@ public class ScreenshotDiffHtmlReportWriterTests : IDisposable
 
         string html = File.ReadAllText(reportPath);
         html.ShouldContain("Controls/Button");
+        html.ShouldContain("42");
+        html.ShouldContain("4.2%");
         html.ShouldContain("(12, 34)");
-        html.ShouldContain("200");
+        html.ShouldContain("(56, 78)");
     }
 
     [Fact]
@@ -128,9 +134,13 @@ public class ScreenshotDiffHtmlReportWriterTests : IDisposable
                     Matches = false,
                     BackendAPath = Path.Combine(_tempDirectory, "A", "Mismatched.png"),
                     BackendBPath = Path.Combine(_tempDirectory, "B", "Mismatched.png"),
-                    DiffX = 1,
-                    DiffY = 1,
-                    MaxChannelDifference = 100,
+                    MismatchedPixelCount = 5,
+                    TotalPixelCount = 100,
+                    MismatchPercentage = 5.0,
+                    BoundingBoxMinX = 1,
+                    BoundingBoxMinY = 1,
+                    BoundingBoxMaxX = 2,
+                    BoundingBoxMaxY = 2,
                 },
             },
         };

--- a/Tests/Gum.ProjectServices.Tests/ScreenshotDiffServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenshotDiffServiceTests.cs
@@ -1,0 +1,173 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices.Screenshot;
+using Moq;
+using Shouldly;
+using SkiaSharp;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScreenshotDiffService"/>, which renders every Screen and Component in a
+/// project through two <see cref="IScreenshotService"/> backends and diffs each pair (#4174) — the
+/// orchestration behind <c>gumcli diff-screenshots</c>. Backends are mocked so this suite exercises
+/// enumeration/tolerance/aggregation logic without a real MonoGame or raylib render.
+/// </summary>
+public class ScreenshotDiffServiceTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public ScreenshotDiffServiceTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumScreenshotDiffTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [Fact]
+    public void Diff_BothBackendsRenderIdenticalPixels_ReportsAllElementsMatching()
+    {
+        string projectPath = CreateProjectWithScreenAndComponent();
+
+        Mock<IScreenshotService> backendA = MockBackendWritingSolidColor(SKColors.Red);
+        Mock<IScreenshotService> backendB = MockBackendWritingSolidColor(SKColors.Red);
+
+        ScreenshotDiffService service = new ScreenshotDiffService();
+        ScreenshotDiffResult result = service.Diff(new ScreenshotDiffRequest
+        {
+            ProjectPath = projectPath,
+            BackendA = backendA.Object,
+            BackendB = backendB.Object,
+            OutputDirectory = _tempDirectory,
+        });
+
+        result.HasMismatch.ShouldBeFalse();
+        result.ElementDiffs.Count.ShouldBe(2);
+        result.ElementDiffs.ShouldAllBe(d => d.Matches);
+    }
+
+    [Fact]
+    public void Diff_OneElementRendersDifferentColor_ReportsThatElementAsMismatch()
+    {
+        string projectPath = CreateProjectWithScreenAndComponent();
+
+        Mock<IScreenshotService> backendA = MockBackendWritingSolidColor(SKColors.Red);
+        Mock<IScreenshotService> backendB = new Mock<IScreenshotService>();
+        backendB.Setup(s => s.TakeScreenshot(It.IsAny<ScreenshotRequest>()))
+            .Returns((ScreenshotRequest request) =>
+            {
+                SKColor color = request.ElementName == "MismatchedScreen" ? SKColors.Blue : SKColors.Red;
+                WriteSolidPng(request.OutputPath, color);
+                return ScreenshotResult.Succeeded(request.OutputPath);
+            });
+
+        ScreenshotDiffService service = new ScreenshotDiffService();
+        ScreenshotDiffResult result = service.Diff(new ScreenshotDiffRequest
+        {
+            ProjectPath = projectPath,
+            BackendA = backendA.Object,
+            BackendB = backendB.Object,
+            OutputDirectory = _tempDirectory,
+        });
+
+        result.HasMismatch.ShouldBeTrue();
+        ElementScreenshotDiff mismatched = result.ElementDiffs.Single(d => d.ElementName == "MismatchedScreen");
+        mismatched.Matches.ShouldBeFalse();
+        ElementScreenshotDiff matched = result.ElementDiffs.Single(d => d.ElementName != "MismatchedScreen");
+        matched.Matches.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Diff_BackendReturnsFailure_ReportsElementAsMismatchWithErrorMessage()
+    {
+        string projectPath = CreateProjectWithScreenAndComponent();
+
+        Mock<IScreenshotService> backendA = MockBackendWritingSolidColor(SKColors.Red);
+        Mock<IScreenshotService> backendB = new Mock<IScreenshotService>();
+        backendB.Setup(s => s.TakeScreenshot(It.IsAny<ScreenshotRequest>()))
+            .Returns(ScreenshotResult.Failed("simulated render failure"));
+
+        ScreenshotDiffService service = new ScreenshotDiffService();
+        ScreenshotDiffResult result = service.Diff(new ScreenshotDiffRequest
+        {
+            ProjectPath = projectPath,
+            BackendA = backendA.Object,
+            BackendB = backendB.Object,
+            OutputDirectory = _tempDirectory,
+        });
+
+        result.HasMismatch.ShouldBeTrue();
+        result.ElementDiffs.ShouldAllBe(d => !d.Matches && d.ErrorMessage == "simulated render failure");
+    }
+
+    [Fact]
+    public void Diff_ProjectFileDoesNotExist_ThrowsInvalidOperationException()
+    {
+        ScreenshotDiffService service = new ScreenshotDiffService();
+
+        Should.Throw<InvalidOperationException>(() => service.Diff(new ScreenshotDiffRequest
+        {
+            ProjectPath = Path.Combine(_tempDirectory, "DoesNotExist.gumx"),
+            BackendA = Mock.Of<IScreenshotService>(),
+            BackendB = Mock.Of<IScreenshotService>(),
+            OutputDirectory = _tempDirectory,
+        }));
+    }
+
+    private static Mock<IScreenshotService> MockBackendWritingSolidColor(SKColor color)
+    {
+        Mock<IScreenshotService> backend = new Mock<IScreenshotService>();
+        backend.Setup(s => s.TakeScreenshot(It.IsAny<ScreenshotRequest>()))
+            .Returns((ScreenshotRequest request) =>
+            {
+                WriteSolidPng(request.OutputPath, color);
+                return ScreenshotResult.Succeeded(request.OutputPath);
+            });
+        return backend;
+    }
+
+    private static void WriteSolidPng(string path, SKColor color)
+    {
+        string? directory = Path.GetDirectoryName(path);
+        if (directory != null)
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using SKBitmap bitmap = new SKBitmap(4, 4);
+        using SKCanvas canvas = new SKCanvas(bitmap);
+        canvas.Clear(color);
+        using SKData encoded = bitmap.Encode(SKEncodedImageFormat.Png, quality: 100);
+        using FileStream stream = File.Create(path);
+        encoded.SaveTo(stream);
+    }
+
+    private string CreateProjectWithScreenAndComponent()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "MismatchedScreen" };
+        screen.States.Add(new StateSave { Name = "Default", ParentContainer = screen });
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference { Name = screen.Name, ElementType = ElementType.Screen });
+
+        ComponentSave component = new ComponentSave { Name = "MatchingComponent" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        project.Components.Add(component);
+        project.ComponentReferences.Add(new ElementReference { Name = component.Name, ElementType = ElementType.Component });
+
+        project.Save(projectPath, saveElements: true);
+
+        return projectPath;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableRectangleCircleColorTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableRectangleCircleColorTests.cs
@@ -1,0 +1,47 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Raylib_cs;
+using RaylibGum.Renderables;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+#pragma warning disable CS0618 // legacy obsolete "Color" is the exact case under test
+
+namespace RaylibGum.Tests.Runtimes;
+
+/// <summary>
+/// Pins the raylib branch of <c>CustomSetPropertyOnRenderable</c>'s legacy "Color" dispatch for
+/// <see cref="RectangleRuntime"/>/<see cref="CircleRuntime"/> (#4176 follow-up). The v3 shape
+/// properties (IsFilled/FillRed/etc.) were fixed to dispatch on raylib in the first #4176 pass, but
+/// "Color" stayed excluded because it constructed an XNA-typed <c>Color</c> the raylib runtime
+/// can't hold — a gap only found by testing the fix against a real project (Airpig) that still uses
+/// the pre-v3 "Color" property. Fixed by branching the conversion per backend
+/// (<c>System.Drawing.Color</c> -&gt; <see cref="Raylib_cs.Color"/> via <c>ColorExtensions.ToRaylib</c>),
+/// mirroring the existing raylib Sprite/NineSlice/Text "Color" cases in the same dispatcher.
+/// </summary>
+public class CustomSetPropertyOnRenderableRectangleCircleColorTests : BaseTestClass
+{
+    [Fact]
+    public void SetPropertyOnRenderable_ColorOnRectangleRuntime_AppliesToStrokeColor()
+    {
+        RectangleRuntime rectangleRuntime = new();
+        IRenderableIpso renderable = (IRenderableIpso)rectangleRuntime.RenderableComponent!;
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(255, 10, 200, 30);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, rectangleRuntime, "Color", drawingColor);
+
+        rectangleRuntime.Color.ShouldBe(new Color(10, 200, 30, 255));
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_ColorOnCircleRuntime_AppliesToStrokeColor()
+    {
+        CircleRuntime circleRuntime = new();
+        IRenderableIpso renderable = (IRenderableIpso)circleRuntime.RenderableComponent!;
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(255, 40, 50, 60);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, circleRuntime, "Color", drawingColor);
+
+        circleRuntime.Color.ShouldBe(new Color(40, 50, 60, 255));
+    }
+}

--- a/Tests/SkiaGum.Tests/GoldenImages/GoldenImageAssert.cs
+++ b/Tests/SkiaGum.Tests/GoldenImages/GoldenImageAssert.cs
@@ -1,3 +1,4 @@
+using Gum.ImageDiff;
 using SkiaSharp;
 
 namespace SkiaGum.Tests.GoldenImages;

--- a/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
+++ b/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
@@ -17,6 +17,12 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
+	  <!-- PixelComparer/PixelDiffResult (used by GoldenImages/*Tests.cs) live in the dependency-free
+	       Gum.ImageDiff so gumcli diff-screenshots (#4174) can reuse the same comparer instead of
+	       duplicating it. Deliberately NOT Gum.ProjectServices.SkiaGum — that project file-links the
+	       same GumService.cs this test project also file-links below, and referencing it would
+	       produce a duplicate-type (CS0433) conflict on GumService. -->
+	  <ProjectReference Include="..\..\Tools\Gum.ImageDiff\Gum.ImageDiff.csproj" />
 	</ItemGroup>
 
 	<!-- Render-only GumService (evicted from Gum.SkiaSharp core, #3218). Shared source,

--- a/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
+++ b/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
@@ -97,24 +97,28 @@ public static class DiffScreenshotsCommand
             return 2;
         }
 
+        IScreenshotDiffHtmlReportWriter reportWriter = new ScreenshotDiffHtmlReportWriter();
+        string reportPath = reportWriter.Write(result, Path.Combine(result.OutputDirectory, "report.html"));
+
         if (json)
         {
-            WriteJson(result);
+            WriteJson(result, reportPath);
         }
         else
         {
-            WriteHumanReadable(result);
+            WriteHumanReadable(result, reportPath);
         }
 
         return result.HasMismatch ? 1 : 0;
     }
 
-    private static void WriteJson(ScreenshotDiffResult result)
+    private static void WriteJson(ScreenshotDiffResult result, string reportPath)
     {
         var payload = new
         {
             hasMismatch = result.HasMismatch,
             outputDirectory = result.OutputDirectory,
+            reportPath,
             elements = result.ElementDiffs.Select(d => new
             {
                 element = d.ElementName,
@@ -132,7 +136,7 @@ public static class DiffScreenshotsCommand
         Console.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
     }
 
-    private static void WriteHumanReadable(ScreenshotDiffResult result)
+    private static void WriteHumanReadable(ScreenshotDiffResult result, string reportPath)
     {
         foreach (ElementScreenshotDiff diff in result.ElementDiffs)
         {
@@ -151,6 +155,7 @@ public static class DiffScreenshotsCommand
 
         Console.WriteLine();
         Console.WriteLine($"Rendered PNGs: {result.OutputDirectory}");
+        Console.WriteLine($"HTML report:   {reportPath}");
         int mismatchCount = result.ElementDiffs.Count(d => !d.Matches);
         Console.WriteLine(mismatchCount == 0
             ? $"All {result.ElementDiffs.Count} element(s) matched."

--- a/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
+++ b/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
@@ -1,0 +1,159 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Gum.ProjectServices.MonoGame;
+using Gum.ProjectServices.Raylib;
+using Gum.ProjectServices.Screenshot;
+
+namespace Gum.Cli.Commands;
+
+/// <summary>
+/// Defines the <c>gumcli diff-screenshots</c> command, which renders every Screen and Component in
+/// a project via both MonoGame and raylib and reports any pixel-level mismatch (#4174) — the check
+/// that would have caught #4172 (raylib blend modes not matching the tool) automatically.
+/// </summary>
+public static class DiffScreenshotsCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Creates the <c>diff-screenshots</c> command definition.
+    /// </summary>
+    public static Command Create()
+    {
+        Argument<string> projectArgument = new Argument<string>(
+            "project",
+            "Path to the .gumx project file.");
+
+        Option<string> outputOption = new Option<string>(
+            "--output",
+            "Directory the rendered PNGs are written to, under 'A/' (MonoGame) and 'B/' (raylib) subfolders. Defaults to a temp directory.");
+
+        Option<byte> toleranceOption = new Option<byte>(
+            "--tolerance",
+            () => 2,
+            "Maximum per-channel pixel difference (0-255) still considered a match.");
+
+        Option<bool> jsonOption = new Option<bool>(
+            "--json",
+            "Output the diff as a JSON document.");
+
+        Command command = new Command(
+            "diff-screenshots",
+            "Render every Screen and Component via MonoGame and raylib, and report any pixel-level mismatch.")
+        {
+            projectArgument,
+            outputOption,
+            toleranceOption,
+            jsonOption,
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            string projectPath = context.ParseResult.GetValueForArgument(projectArgument);
+            string? output = context.ParseResult.GetValueForOption(outputOption);
+            byte tolerance = context.ParseResult.GetValueForOption(toleranceOption);
+            bool json = context.ParseResult.GetValueForOption(jsonOption);
+
+            context.ExitCode = Execute(projectPath, output, tolerance, json);
+        });
+
+        return command;
+    }
+
+    private static int Execute(string projectPath, string? output, byte tolerance, bool json)
+    {
+        string fullProjectPath = Path.GetFullPath(projectPath);
+
+        if (!File.Exists(fullProjectPath))
+        {
+            Console.Error.WriteLine($"error: Project file not found: {fullProjectPath}");
+            return 2;
+        }
+
+        IScreenshotDiffService diffService = new ScreenshotDiffService();
+        ScreenshotDiffResult result;
+        try
+        {
+            result = diffService.Diff(new ScreenshotDiffRequest
+            {
+                ProjectPath = fullProjectPath,
+                BackendA = new MonoGameScreenshotService(),
+                BackendB = new RaylibScreenshotService(),
+                OutputDirectory = output != null ? Path.GetFullPath(output) : null,
+                Tolerance = tolerance,
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine($"error: {ex.Message}");
+            return 2;
+        }
+
+        if (json)
+        {
+            WriteJson(result);
+        }
+        else
+        {
+            WriteHumanReadable(result);
+        }
+
+        return result.HasMismatch ? 1 : 0;
+    }
+
+    private static void WriteJson(ScreenshotDiffResult result)
+    {
+        var payload = new
+        {
+            hasMismatch = result.HasMismatch,
+            outputDirectory = result.OutputDirectory,
+            elements = result.ElementDiffs.Select(d => new
+            {
+                element = d.ElementName,
+                matches = d.Matches,
+                errorMessage = d.ErrorMessage,
+                monoGamePath = d.BackendAPath,
+                raylibPath = d.BackendBPath,
+                diffX = d.DiffX,
+                diffY = d.DiffY,
+                maxChannelDifference = d.MaxChannelDifference,
+                dimensionMismatch = d.DimensionMismatchDescription,
+            }),
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+    }
+
+    private static void WriteHumanReadable(ScreenshotDiffResult result)
+    {
+        foreach (ElementScreenshotDiff diff in result.ElementDiffs)
+        {
+            if (diff.Matches)
+            {
+                Console.WriteLine($"MATCH  {diff.ElementName}");
+                continue;
+            }
+
+            string reason = diff.ErrorMessage
+                ?? diff.DimensionMismatchDescription
+                ?? $"pixel ({diff.DiffX}, {diff.DiffY}) differs by {diff.MaxChannelDifference}";
+
+            Console.WriteLine($"DIFF   {diff.ElementName}: {reason}");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Rendered PNGs: {result.OutputDirectory}");
+        int mismatchCount = result.ElementDiffs.Count(d => !d.Matches);
+        Console.WriteLine(mismatchCount == 0
+            ? $"All {result.ElementDiffs.Count} element(s) matched."
+            : $"{mismatchCount} of {result.ElementDiffs.Count} element(s) mismatched.");
+    }
+}

--- a/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
+++ b/Tools/Gum.Cli/Commands/DiffScreenshotsCommand.cs
@@ -41,6 +41,11 @@ public static class DiffScreenshotsCommand
             () => 2,
             "Maximum per-channel pixel difference (0-255) still considered a match.");
 
+        Option<int> proximityOption = new Option<int>(
+            "--proximity",
+            () => 1,
+            "How many pixels away to search for a matching color before counting a pixel as a real mismatch. Absorbs positional jitter between renderers (e.g. a 1px antialiasing shift) without masking real differences.");
+
         Option<bool> jsonOption = new Option<bool>(
             "--json",
             "Output the diff as a JSON document.");
@@ -52,6 +57,7 @@ public static class DiffScreenshotsCommand
             projectArgument,
             outputOption,
             toleranceOption,
+            proximityOption,
             jsonOption,
         };
 
@@ -60,15 +66,16 @@ public static class DiffScreenshotsCommand
             string projectPath = context.ParseResult.GetValueForArgument(projectArgument);
             string? output = context.ParseResult.GetValueForOption(outputOption);
             byte tolerance = context.ParseResult.GetValueForOption(toleranceOption);
+            int proximity = context.ParseResult.GetValueForOption(proximityOption);
             bool json = context.ParseResult.GetValueForOption(jsonOption);
 
-            context.ExitCode = Execute(projectPath, output, tolerance, json);
+            context.ExitCode = Execute(projectPath, output, tolerance, proximity, json);
         });
 
         return command;
     }
 
-    private static int Execute(string projectPath, string? output, byte tolerance, bool json)
+    private static int Execute(string projectPath, string? output, byte tolerance, int proximity, bool json)
     {
         string fullProjectPath = Path.GetFullPath(projectPath);
 
@@ -89,6 +96,7 @@ public static class DiffScreenshotsCommand
                 BackendB = new RaylibScreenshotService(),
                 OutputDirectory = output != null ? Path.GetFullPath(output) : null,
                 Tolerance = tolerance,
+                ProximityRadius = proximity,
             });
         }
         catch (InvalidOperationException ex)
@@ -126,9 +134,16 @@ public static class DiffScreenshotsCommand
                 errorMessage = d.ErrorMessage,
                 monoGamePath = d.BackendAPath,
                 raylibPath = d.BackendBPath,
-                diffX = d.DiffX,
-                diffY = d.DiffY,
-                maxChannelDifference = d.MaxChannelDifference,
+                mismatchedPixelCount = d.MismatchedPixelCount,
+                totalPixelCount = d.TotalPixelCount,
+                mismatchPercentage = d.MismatchPercentage,
+                boundingBox = d.Matches ? null : new
+                {
+                    minX = d.BoundingBoxMinX,
+                    minY = d.BoundingBoxMinY,
+                    maxX = d.BoundingBoxMaxX,
+                    maxY = d.BoundingBoxMaxY,
+                },
                 dimensionMismatch = d.DimensionMismatchDescription,
             }),
         };
@@ -148,7 +163,8 @@ public static class DiffScreenshotsCommand
 
             string reason = diff.ErrorMessage
                 ?? diff.DimensionMismatchDescription
-                ?? $"pixel ({diff.DiffX}, {diff.DiffY}) differs by {diff.MaxChannelDifference}";
+                ?? $"{diff.MismatchedPixelCount:N0} px mismatched ({diff.MismatchPercentage:0.###}%), " +
+                   $"region ({diff.BoundingBoxMinX}, {diff.BoundingBoxMinY})–({diff.BoundingBoxMaxX}, {diff.BoundingBoxMaxY})";
 
             Console.WriteLine($"DIFF   {diff.ElementName}: {reason}");
         }

--- a/Tools/Gum.Cli/Commands/ScreenshotCommand.cs
+++ b/Tools/Gum.Cli/Commands/ScreenshotCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using Gum.ProjectServices.MonoGame;
+using Gum.ProjectServices.Raylib;
 using Gum.ProjectServices.Screenshot;
 
 namespace Gum.Cli.Commands;
@@ -11,19 +12,18 @@ namespace Gum.Cli.Commands;
 /// Defines the <c>gumcli screenshot</c> command which renders a Gum Screen or Component to a PNG file.
 /// </summary>
 /// <remarks>
-/// Uses MonoGame (DesktopGL) to render the element with the same backend as a MonoGame game,
-/// producing pixel-accurate output suitable for visual regression testing.
-/// <para>
-/// FUTURE: When a second backend is added (e.g. Skia), do not add it as a direct ProjectReference.
-/// Both backends compile copies of shared types (RenderingLibrary, SystemManagers, etc.) and share
-/// static singletons via GumCommon. Instead, load backends dynamically using a custom
-/// AssemblyLoadContext + AssemblyDependencyResolver so each backend's dependencies are isolated
-/// and only one is loaded per process run. Add a --backend flag to select between them.
-/// See the comment in Gum.Cli.csproj for more detail.
-/// </para>
+/// Defaults to MonoGame (DesktopGL); <c>--backend raylib</c> renders the same element via raylib
+/// instead, so the two outputs can be diffed pixel-for-pixel against the same project (#4174) —
+/// exactly the gap that let raylib's rendering silently diverge from the tool's undetected (#4172).
+/// Both backends are referenced directly (see Gum.Cli.csproj) rather than loaded via a custom
+/// AssemblyLoadContext: each `gumcli screenshot` invocation is a one-shot process that only ever
+/// initializes one backend, so the static-singleton collision a shared-process concurrent-init would
+/// risk never arises in practice.
 /// </remarks>
 public static class ScreenshotCommand
 {
+    private const string MonoGameBackend = "monogame";
+    private const string RaylibBackend = "raylib";
 
     /// <summary>
     /// Creates the <c>screenshot</c> command definition.
@@ -50,6 +50,11 @@ public static class ScreenshotCommand
             "--height",
             "Height of the output image in pixels. Defaults to the project canvas height.");
 
+        Option<string> backendOption = new Option<string>(
+            "--backend",
+            () => MonoGameBackend,
+            $"Rendering backend to use: '{MonoGameBackend}' (default) or '{RaylibBackend}'.");
+
         Command command = new Command("screenshot", "Render a Gum Screen or Component to a PNG file.")
         {
             projectArgument,
@@ -57,6 +62,7 @@ public static class ScreenshotCommand
             outputOption,
             widthOption,
             heightOption,
+            backendOption,
         };
 
         command.SetHandler((InvocationContext context) =>
@@ -66,16 +72,18 @@ public static class ScreenshotCommand
             string? output = context.ParseResult.GetValueForOption(outputOption);
             int? width = context.ParseResult.GetValueForOption(widthOption);
             int? height = context.ParseResult.GetValueForOption(heightOption);
+            string backend = context.ParseResult.GetValueForOption(backendOption) ?? MonoGameBackend;
 
             string outputPath = output ?? $"{elementName}.png";
 
-            context.ExitCode = Execute(projectPath, elementName, outputPath, width, height);
+            context.ExitCode = Execute(projectPath, elementName, outputPath, width, height, backend);
         });
 
         return command;
     }
 
-    private static int Execute(string projectPath, string elementName, string outputPath, int? width, int? height)
+    private static int Execute(
+        string projectPath, string elementName, string outputPath, int? width, int? height, string backend)
     {
         string fullProjectPath = Path.GetFullPath(projectPath);
 
@@ -85,7 +93,20 @@ public static class ScreenshotCommand
             return 2;
         }
 
-        IScreenshotService service = new MonoGameScreenshotService();
+        IScreenshotService service;
+        switch (backend.ToLowerInvariant())
+        {
+            case MonoGameBackend:
+                service = new MonoGameScreenshotService();
+                break;
+            case RaylibBackend:
+                service = new RaylibScreenshotService();
+                break;
+            default:
+                Console.Error.WriteLine(
+                    $"error: Unknown backend '{backend}'. Expected '{MonoGameBackend}' or '{RaylibBackend}'.");
+                return 2;
+        }
 
         ScreenshotRequest request = new ScreenshotRequest
         {

--- a/Tools/Gum.Cli/Gum.Cli.csproj
+++ b/Tools/Gum.Cli/Gum.Cli.csproj
@@ -29,18 +29,19 @@
 		     Without it, only simple dot-path lookups work; literals (X = 100) and expressions
 		     (X = A + B) would silently fail to evaluate during `gumcli check-references` fix mode. -->
 		<ProjectReference Include="..\..\Runtimes\GumExpressions\GumExpressions.csproj" />
-		<!-- FUTURE: When a second rendering backend is added (e.g. Gum.ProjectServices.Skia), both
-		     backends compile copies of shared types (RenderingLibrary, SystemManagers, etc.) from
-		     GumCommon into their own assemblies, and both share static singletons (ObjectFinder.Self,
-		     SystemManagers.Default) via GumCommon. Referencing both directly from Gum.Cli will not
-		     cause compile errors (Gum.Cli only uses IScreenshotService), but loading both into the
-		     same process risks static-state collisions if they are ever initialized concurrently.
-
-		     The intended long-term architecture is to load backend assemblies dynamically via a custom
-		     AssemblyLoadContext with AssemblyDependencyResolver, so each backend's dependencies are
-		     isolated and only one backend is loaded per process run. Switch to that pattern when a
-		     second backend is introduced. -->
+		<!-- Each rendering backend compiles its own copies of shared types (RenderingLibrary,
+		     SystemManagers, etc.) from GumCommon into a separate assembly, so their static
+		     singletons (ObjectFinder.Self, SystemManagers.Default) are distinct per-assembly
+		     statics, not shared process-wide state. Referencing all three directly (rather than
+		     loading them via a custom AssemblyLoadContext + AssemblyDependencyResolver, as an
+		     earlier version of this comment proposed) has been the practice since Skia was added
+		     for `gumcli svg`, and is safe here for the same reason: each `gumcli` invocation is a
+		     one-shot process that only ever initializes the single backend the command it ran
+		     actually needs (screenshot picks MonoGame or Raylib via the backend option; svg always
+		     uses Skia) — no command initializes two backends in the same process run, so the
+		     concurrent-init collision risk this comment used to warn about never arises. -->
 		<ProjectReference Include="..\Gum.ProjectServices.MonoGame\Gum.ProjectServices.MonoGame.csproj" />
+		<ProjectReference Include="..\Gum.ProjectServices.Raylib\Gum.ProjectServices.Raylib.csproj" />
 		<ProjectReference Include="..\Gum.ProjectServices.SkiaGum\Gum.ProjectServices.SkiaGum.csproj" />
 	</ItemGroup>
 

--- a/Tools/Gum.Cli/Program.cs
+++ b/Tools/Gum.Cli/Program.cs
@@ -33,6 +33,7 @@ public class Program
         rootCommand.AddCommand(CodegenInitCommand.Create());
         rootCommand.AddCommand(FontsCommand.Create());
         rootCommand.AddCommand(ScreenshotCommand.Create());
+        rootCommand.AddCommand(DiffScreenshotsCommand.Create());
         rootCommand.AddCommand(SvgCommand.Create());
 
         return rootCommand.Invoke(args);

--- a/Tools/Gum.ImageDiff/Gum.ImageDiff.csproj
+++ b/Tools/Gum.ImageDiff/Gum.ImageDiff.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/Gum.ImageDiff/ImageDiffResult.cs
+++ b/Tools/Gum.ImageDiff/ImageDiffResult.cs
@@ -1,0 +1,54 @@
+namespace Gum.ImageDiff;
+
+/// <summary>
+/// Result of <see cref="PixelComparer.CompareApproximate"/> — an aggregate, proximity-tolerant
+/// comparison of two images, as opposed to <see cref="PixelDiffResult"/>'s single first-differing
+/// pixel from an exact same-coordinate comparison.
+/// </summary>
+public readonly struct ImageDiffResult
+{
+    public bool Matches { get; }
+    public int MismatchedPixelCount { get; }
+    public int TotalPixelCount { get; }
+    public double MismatchPercentage => TotalPixelCount == 0 ? 0 : (double)MismatchedPixelCount / TotalPixelCount * 100;
+    public int? BoundingBoxMinX { get; }
+    public int? BoundingBoxMinY { get; }
+    public int? BoundingBoxMaxX { get; }
+    public int? BoundingBoxMaxY { get; }
+    public string? DimensionMismatchDescription { get; }
+
+    private ImageDiffResult(
+        bool matches,
+        int mismatchedPixelCount,
+        int totalPixelCount,
+        int? boundingBoxMinX,
+        int? boundingBoxMinY,
+        int? boundingBoxMaxX,
+        int? boundingBoxMaxY,
+        string? dimensionMismatchDescription)
+    {
+        Matches = matches;
+        MismatchedPixelCount = mismatchedPixelCount;
+        TotalPixelCount = totalPixelCount;
+        BoundingBoxMinX = boundingBoxMinX;
+        BoundingBoxMinY = boundingBoxMinY;
+        BoundingBoxMaxX = boundingBoxMaxX;
+        BoundingBoxMaxY = boundingBoxMaxY;
+        DimensionMismatchDescription = dimensionMismatchDescription;
+    }
+
+    public static ImageDiffResult Match(int totalPixelCount) =>
+        new(matches: true, mismatchedPixelCount: 0, totalPixelCount: totalPixelCount,
+            boundingBoxMinX: null, boundingBoxMinY: null, boundingBoxMaxX: null, boundingBoxMaxY: null,
+            dimensionMismatchDescription: null);
+
+    public static ImageDiffResult Mismatch(int mismatchedPixelCount, int totalPixelCount, int minX, int minY, int maxX, int maxY) =>
+        new(matches: false, mismatchedPixelCount: mismatchedPixelCount, totalPixelCount: totalPixelCount,
+            boundingBoxMinX: minX, boundingBoxMinY: minY, boundingBoxMaxX: maxX, boundingBoxMaxY: maxY,
+            dimensionMismatchDescription: null);
+
+    public static ImageDiffResult DimensionMismatch(int expectedWidth, int expectedHeight, int actualWidth, int actualHeight) =>
+        new(matches: false, mismatchedPixelCount: 0, totalPixelCount: 0,
+            boundingBoxMinX: null, boundingBoxMinY: null, boundingBoxMaxX: null, boundingBoxMaxY: null,
+            dimensionMismatchDescription: $"expected {expectedWidth}x{expectedHeight}, actual {actualWidth}x{actualHeight}");
+}

--- a/Tools/Gum.ImageDiff/PixelComparer.cs
+++ b/Tools/Gum.ImageDiff/PixelComparer.cs
@@ -40,6 +40,89 @@ public static class PixelComparer
         return PixelDiffResult.Match();
     }
 
+    /// <summary>
+    /// Aggregate, proximity-tolerant comparison for two images rendered by different backends.
+    /// </summary>
+    /// <remarks>
+    /// A pixel that fails the strict same-coordinate tolerance check is only counted as a real
+    /// mismatch if no pixel within <paramref name="proximityRadius"/> of it in <paramref
+    /// name="actual"/> matches <paramref name="expected"/>'s color — this absorbs the few-pixel
+    /// positional jitter two different renderers' antialiasing/rounding produces at edges without
+    /// masking pixels that are actually wrong. Reports the mismatch count/percentage and bounding
+    /// box of all real mismatches, rather than <see cref="Compare"/>'s single first-differing pixel
+    /// — a global shift or one missing region look identical under "first pixel that differs."
+    /// </remarks>
+    public static ImageDiffResult CompareApproximate(
+        SKBitmap expected, SKBitmap actual, byte colorTolerance = 2, int proximityRadius = 1)
+    {
+        if (expected.Width != actual.Width || expected.Height != actual.Height)
+        {
+            return ImageDiffResult.DimensionMismatch(expected.Width, expected.Height, actual.Width, actual.Height);
+        }
+
+        int width = expected.Width;
+        int height = expected.Height;
+        int mismatchCount = 0;
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                SKColor expectedPixel = expected.GetPixel(x, y);
+                if (MaxChannelDifference(expectedPixel, actual.GetPixel(x, y)) <= colorTolerance)
+                {
+                    continue;
+                }
+
+                if (HasNearbyMatch(actual, expectedPixel, x, y, colorTolerance, proximityRadius, width, height))
+                {
+                    continue;
+                }
+
+                mismatchCount++;
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        int totalPixelCount = width * height;
+        return mismatchCount == 0
+            ? ImageDiffResult.Match(totalPixelCount)
+            : ImageDiffResult.Mismatch(mismatchCount, totalPixelCount, minX, minY, maxX, maxY);
+    }
+
+    private static bool HasNearbyMatch(
+        SKBitmap actual, SKColor expectedPixel, int x, int y, byte colorTolerance, int radius, int width, int height)
+    {
+        for (int dy = -radius; dy <= radius; dy++)
+        {
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                if (dx == 0 && dy == 0)
+                {
+                    continue;
+                }
+
+                int nx = x + dx;
+                int ny = y + dy;
+                if (nx < 0 || nx >= width || ny < 0 || ny >= height)
+                {
+                    continue;
+                }
+
+                if (MaxChannelDifference(expectedPixel, actual.GetPixel(nx, ny)) <= colorTolerance)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static int MaxChannelDifference(SKColor expected, SKColor actual)
     {
         int diff = Math.Abs(expected.Red - actual.Red);

--- a/Tools/Gum.ImageDiff/PixelComparer.cs
+++ b/Tools/Gum.ImageDiff/PixelComparer.cs
@@ -1,12 +1,21 @@
+using System;
 using SkiaSharp;
 
-namespace SkiaGum.Tests.GoldenImages;
+namespace Gum.ImageDiff;
 
 /// <summary>
-/// Per-pixel, per-channel comparison for golden-image tests. Tolerance absorbs the
+/// Per-pixel, per-channel comparison for two rendered images. Tolerance absorbs the
 /// antialiasing/hinting drift that makes exact-pixel image comparisons brittle across
-/// Skia versions and platforms.
+/// renderers, Skia versions, and platforms.
 /// </summary>
+/// <remarks>
+/// Shared by <c>SkiaGum.Tests</c>' golden-image regression tests and
+/// <c>gumcli diff-screenshots</c> (#4174), which decodes each backend's rendered PNG through
+/// SkiaSharp purely for pixel comparison — no SkiaGum rendering happens in that path. Lives in its
+/// own dependency-free project (only SkiaSharp) rather than Gum.ProjectServices.SkiaGum so it can be
+/// referenced from projects that already file-link SkiaGum.Standalone's GumService.cs (e.g.
+/// SkiaGum.Tests) without a duplicate-type conflict on that shared source.
+/// </remarks>
 public static class PixelComparer
 {
     public static PixelDiffResult Compare(SKBitmap expected, SKBitmap actual, byte tolerance = 2)

--- a/Tools/Gum.ImageDiff/PixelDiffResult.cs
+++ b/Tools/Gum.ImageDiff/PixelDiffResult.cs
@@ -1,4 +1,4 @@
-namespace SkiaGum.Tests.GoldenImages;
+namespace Gum.ImageDiff;
 
 public readonly struct PixelDiffResult
 {

--- a/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
+++ b/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Raylib-cs" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Gum.ProjectServices\Gum.ProjectServices.csproj" />
+    <ProjectReference Include="..\..\Runtimes\RaylibGum\RaylibGum.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
+++ b/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
@@ -15,24 +15,28 @@ namespace Gum.ProjectServices.Raylib;
 /// <remarks>
 /// Mirrors <c>MonoGameScreenshotService</c>'s render pipeline (load project, instantiate the
 /// element, run layout, draw once) so the two backends can be diffed pixel-for-pixel against the
-/// same project — the whole point of adding this backend (#4174). Reuses the current process'
-/// hidden raylib window if one is already open (e.g. from a previous call in the same process)
-/// rather than closing/reopening it, since raylib window re-creation is unreliable — see
-/// RaylibGum.Tests' TestAssemblyInitialize.
+/// same project — the whole point of adding this backend (#4174).
+///
+/// <para>Creates and closes its own hidden window on every call rather than reusing one already
+/// open in the process. An earlier version reused an existing window (matching RaylibGum.Tests'
+/// persistent-window design), but <c>gumcli diff-screenshots</c> (#4174) calls this and
+/// <c>MonoGameScreenshotService</c> back-to-back for every element — MonoGame's DesktopGL
+/// teardown between calls left the reused raylib window's OpenGL context no longer valid, so a
+/// second raylib render in the same process silently produced a corrupt image
+/// (<c>ExportImage</c> failing). Owning a fresh window per call sidesteps that: it matches what a
+/// real one-shot <c>gumcli screenshot --backend raylib</c> process already does (open, render,
+/// process exits) with no added cost there, and gives every render its own valid GL context
+/// regardless of what other graphics backends ran earlier in the process.</para>
 /// </remarks>
 public class RaylibScreenshotService : IScreenshotService
 {
     /// <inheritdoc/>
     public ScreenshotResult TakeScreenshot(ScreenshotRequest request)
     {
+        Raylib_cs.Raylib.SetConfigFlags(ConfigFlags.HiddenWindow);
+        Raylib_cs.Raylib.InitWindow(1, 1, "Gum Screenshot");
         try
         {
-            if (!Raylib_cs.Raylib.IsWindowReady())
-            {
-                Raylib_cs.Raylib.SetConfigFlags(ConfigFlags.HiddenWindow);
-                Raylib_cs.Raylib.InitWindow(1, 1, "Gum Screenshot");
-            }
-
             var gumService = GumService.Default;
             GumProjectSave? project = gumService.Initialize(request.ProjectPath);
 
@@ -114,6 +118,8 @@ public class RaylibScreenshotService : IScreenshotService
             {
                 // best-effort cleanup
             }
+
+            Raylib_cs.Raylib.CloseWindow();
         }
     }
 }

--- a/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
+++ b/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
@@ -60,6 +60,14 @@ public class RaylibScreenshotService : IScreenshotService
             int width = request.Width ?? 800;
             int height = request.Height ?? 600;
 
+            // Must be set before UpdateLayout: a parentless element's PixelsFromMiddle/Percentage
+            // positioning resolves against these, not against the render texture's actual size.
+            // MonoGameScreenshotService gets this for free because its GraphicsDeviceManager backs
+            // straight onto the real backbuffer; raylib always renders into an explicitly-sized
+            // off-screen RenderTexture2D below, so nothing else tells the layout engine that size.
+            gumService.CanvasWidth = width;
+            gumService.CanvasHeight = height;
+
             var element = elementSave.ToGraphicalUiElement(SystemManagers.Default);
             element.AddToManagers(SystemManagers.Default);
             element.UpdateLayout();

--- a/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
+++ b/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
@@ -1,0 +1,119 @@
+using Gum.DataTypes;
+using Gum.ProjectServices.Screenshot;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Gum.ProjectServices.Raylib;
+
+/// <summary>
+/// Renders a Gum element to a PNG using raylib (OpenGL).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>MonoGameScreenshotService</c>'s render pipeline (load project, instantiate the
+/// element, run layout, draw once) so the two backends can be diffed pixel-for-pixel against the
+/// same project — the whole point of adding this backend (#4174). Reuses the current process'
+/// hidden raylib window if one is already open (e.g. from a previous call in the same process)
+/// rather than closing/reopening it, since raylib window re-creation is unreliable — see
+/// RaylibGum.Tests' TestAssemblyInitialize.
+/// </remarks>
+public class RaylibScreenshotService : IScreenshotService
+{
+    /// <inheritdoc/>
+    public ScreenshotResult TakeScreenshot(ScreenshotRequest request)
+    {
+        try
+        {
+            if (!Raylib_cs.Raylib.IsWindowReady())
+            {
+                Raylib_cs.Raylib.SetConfigFlags(ConfigFlags.HiddenWindow);
+                Raylib_cs.Raylib.InitWindow(1, 1, "Gum Screenshot");
+            }
+
+            var gumService = GumService.Default;
+            GumProjectSave? project = gumService.Initialize(request.ProjectPath);
+
+            if (project == null)
+            {
+                return ScreenshotResult.Failed($"Failed to load project: {request.ProjectPath}");
+            }
+
+            ElementSave? elementSave = project.AllElements
+                .FirstOrDefault(e => e.Name == request.ElementName);
+
+            if (elementSave == null)
+            {
+                return ScreenshotResult.Failed(
+                    $"Element '{request.ElementName}' not found in project.");
+            }
+
+            // Matches MonoGameScreenshotService's fallback exactly (800x600) rather than the
+            // project's own canvas size, so the two backends stay directly diffable when Width/
+            // Height are omitted. See #4174 for the follow-up to make both honor canvas size.
+            int width = request.Width ?? 800;
+            int height = request.Height ?? 600;
+
+            var element = elementSave.ToGraphicalUiElement(SystemManagers.Default);
+            element.AddToManagers(SystemManagers.Default);
+            element.UpdateLayout();
+
+            RenderTexture2D renderTexture = Raylib_cs.Raylib.LoadRenderTexture(width, height);
+            try
+            {
+                Raylib_cs.Raylib.BeginTextureMode(renderTexture);
+                Raylib_cs.Raylib.ClearBackground(new Color((byte)0, (byte)0, (byte)0, (byte)0));
+                gumService.Draw();
+                Raylib_cs.Raylib.EndTextureMode();
+
+                Image image = Raylib_cs.Raylib.LoadImageFromTexture(renderTexture.Texture);
+                try
+                {
+                    // Render textures are stored bottom-up in GL; flip so the exported PNG reads
+                    // right-side-up like any other screenshot.
+                    Raylib_cs.Raylib.ImageFlipVertical(ref image);
+
+                    string outputPath = Path.GetFullPath(request.OutputPath);
+                    string? outputDir = Path.GetDirectoryName(outputPath);
+                    if (outputDir != null)
+                    {
+                        Directory.CreateDirectory(outputDir);
+                    }
+
+                    bool exported = Raylib_cs.Raylib.ExportImage(image, outputPath);
+                    if (!exported)
+                    {
+                        return ScreenshotResult.Failed($"Failed to export image to '{outputPath}'.");
+                    }
+
+                    return ScreenshotResult.Succeeded(outputPath);
+                }
+                finally
+                {
+                    Raylib_cs.Raylib.UnloadImage(image);
+                }
+            }
+            finally
+            {
+                Raylib_cs.Raylib.UnloadRenderTexture(renderTexture);
+            }
+        }
+        catch (Exception ex)
+        {
+            return ScreenshotResult.Failed(ex.ToString());
+        }
+        finally
+        {
+            try
+            {
+                GumService.Default.Uninitialize();
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -35,6 +35,9 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+		<!-- ScreenshotDiffService (#4174) decodes/diffs rendered PNGs via the shared, dependency-free
+		     PixelComparer rather than duplicating pixel-comparison logic. -->
+		<ProjectReference Include="..\Gum.ImageDiff\Gum.ImageDiff.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Tools/Gum.ProjectServices/Screenshot/ElementScreenshotDiff.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ElementScreenshotDiff.cs
@@ -20,14 +20,29 @@ public class ElementScreenshotDiff
     /// <summary>Path to backend B's rendered PNG, when rendering succeeded.</summary>
     public string? BackendBPath { get; init; }
 
-    /// <summary>X coordinate of the first out-of-tolerance pixel, when the images differ in content.</summary>
-    public int? DiffX { get; init; }
+    /// <summary>
+    /// Count of pixels that differ beyond tolerance even after the proximity check absorbs
+    /// positional jitter — see <c>Gum.ImageDiff.PixelComparer.CompareApproximate</c>.
+    /// </summary>
+    public int MismatchedPixelCount { get; init; }
 
-    /// <summary>Y coordinate of the first out-of-tolerance pixel, when the images differ in content.</summary>
-    public int? DiffY { get; init; }
+    /// <summary>Total pixel count of the compared images.</summary>
+    public int TotalPixelCount { get; init; }
 
-    /// <summary>Max per-channel difference at (<see cref="DiffX"/>, <see cref="DiffY"/>).</summary>
-    public int? MaxChannelDifference { get; init; }
+    /// <summary><see cref="MismatchedPixelCount"/> as a percentage of <see cref="TotalPixelCount"/>.</summary>
+    public double MismatchPercentage { get; init; }
+
+    /// <summary>Bounding box of all real mismatches, when <see cref="Matches"/> is false.</summary>
+    public int? BoundingBoxMinX { get; init; }
+
+    /// <inheritdoc cref="BoundingBoxMinX"/>
+    public int? BoundingBoxMinY { get; init; }
+
+    /// <inheritdoc cref="BoundingBoxMinX"/>
+    public int? BoundingBoxMaxX { get; init; }
+
+    /// <inheritdoc cref="BoundingBoxMinX"/>
+    public int? BoundingBoxMaxY { get; init; }
 
     /// <summary>Set instead of the pixel-diff fields when the two renders have different dimensions.</summary>
     public string? DimensionMismatchDescription { get; init; }

--- a/Tools/Gum.ProjectServices/Screenshot/ElementScreenshotDiff.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ElementScreenshotDiff.cs
@@ -1,0 +1,34 @@
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Per-element result of a <see cref="ScreenshotDiffService"/> run.
+/// </summary>
+public class ElementScreenshotDiff
+{
+    /// <summary>Name of the Screen or Component that was rendered.</summary>
+    public required string ElementName { get; init; }
+
+    /// <summary>Whether both backends' renders matched within tolerance.</summary>
+    public required bool Matches { get; init; }
+
+    /// <summary>Set when either backend failed to render the element; <see cref="Matches"/> is false.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Path to backend A's rendered PNG, when rendering succeeded.</summary>
+    public string? BackendAPath { get; init; }
+
+    /// <summary>Path to backend B's rendered PNG, when rendering succeeded.</summary>
+    public string? BackendBPath { get; init; }
+
+    /// <summary>X coordinate of the first out-of-tolerance pixel, when the images differ in content.</summary>
+    public int? DiffX { get; init; }
+
+    /// <summary>Y coordinate of the first out-of-tolerance pixel, when the images differ in content.</summary>
+    public int? DiffY { get; init; }
+
+    /// <summary>Max per-channel difference at (<see cref="DiffX"/>, <see cref="DiffY"/>).</summary>
+    public int? MaxChannelDifference { get; init; }
+
+    /// <summary>Set instead of the pixel-diff fields when the two renders have different dimensions.</summary>
+    public string? DimensionMismatchDescription { get; init; }
+}

--- a/Tools/Gum.ProjectServices/Screenshot/IScreenshotDiffHtmlReportWriter.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/IScreenshotDiffHtmlReportWriter.cs
@@ -1,0 +1,12 @@
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Writes a <see cref="ScreenshotDiffResult"/> to a side-by-side HTML report for visual triage.
+/// </summary>
+public interface IScreenshotDiffHtmlReportWriter
+{
+    /// <summary>
+    /// Writes the report to <paramref name="outputPath"/> and returns that same path.
+    /// </summary>
+    string Write(ScreenshotDiffResult result, string outputPath);
+}

--- a/Tools/Gum.ProjectServices/Screenshot/IScreenshotDiffService.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/IScreenshotDiffService.cs
@@ -1,0 +1,14 @@
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Renders every Screen and Component in a project through two <see cref="IScreenshotService"/>
+/// backends and diffs each pair pixel-for-pixel.
+/// </summary>
+public interface IScreenshotDiffService
+{
+    /// <summary>
+    /// Runs the diff described by <paramref name="request"/>.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">The project could not be loaded.</exception>
+    ScreenshotDiffResult Diff(ScreenshotDiffRequest request);
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffHtmlReportWriter.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffHtmlReportWriter.cs
@@ -80,7 +80,9 @@ public class ScreenshotDiffHtmlReportWriter : IScreenshotDiffHtmlReportWriter
         }
         else if (!diff.Matches)
         {
-            html.AppendLine($"<p>pixel ({diff.DiffX}, {diff.DiffY}) differs by {diff.MaxChannelDifference}</p>");
+            html.AppendLine(
+                $"<p>{diff.MismatchedPixelCount:N0} px mismatched ({diff.MismatchPercentage:0.###}%), " +
+                $"region ({diff.BoundingBoxMinX}, {diff.BoundingBoxMinY})–({diff.BoundingBoxMaxX}, {diff.BoundingBoxMaxY})</p>");
         }
 
         html.AppendLine("</div>");

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffHtmlReportWriter.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffHtmlReportWriter.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Writes a <see cref="ScreenshotDiffResult"/> as a static HTML page with one row per element,
+/// MonoGame's render on the left and raylib's on the right, so a mismatch can be spotted by eye
+/// without opening each PNG individually (#4174).
+/// </summary>
+/// <remarks>
+/// Image <c>src</c> attributes are relative paths computed against the report file's own
+/// directory, so the report only works when opened from beside the rendered PNGs (i.e. written
+/// into <see cref="ScreenshotDiffResult.OutputDirectory"/>, which is where
+/// <c>gumcli diff-screenshots</c> always places it) — no images are embedded.
+/// </remarks>
+public class ScreenshotDiffHtmlReportWriter : IScreenshotDiffHtmlReportWriter
+{
+    /// <inheritdoc/>
+    public string Write(ScreenshotDiffResult result, string outputPath)
+    {
+        string reportDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath))
+            ?? throw new System.ArgumentException("Output path must have a directory.", nameof(outputPath));
+
+        IEnumerable<ElementScreenshotDiff> ordered = result.ElementDiffs
+            .OrderBy(d => d.Matches)
+            .ThenBy(d => d.ElementName);
+
+        StringBuilder html = new StringBuilder();
+        html.AppendLine("<!DOCTYPE html>");
+        html.AppendLine("<html><head><meta charset=\"utf-8\"><title>Gum screenshot diff</title>");
+        html.AppendLine("<style>");
+        html.AppendLine("body { font-family: sans-serif; background: #1e1e1e; color: #eee; }");
+        html.AppendLine("h1 { font-size: 1.2rem; }");
+        html.AppendLine(".row { display: flex; align-items: flex-start; gap: 1rem; padding: 1rem; margin-bottom: 1rem; border-radius: 6px; }");
+        html.AppendLine(".row.match { background: #1f3320; }");
+        html.AppendLine(".row.mismatch { background: #3a2020; }");
+        html.AppendLine(".row .info { flex: 0 0 260px; }");
+        html.AppendLine(".row .pane { flex: 1; text-align: center; }");
+        html.AppendLine(".row .pane img { max-width: 100%; background: repeating-conic-gradient(#444 0% 25%, #333 0% 50%) 0 / 16px 16px; }");
+        html.AppendLine(".badge { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 4px; font-weight: bold; font-size: 0.85rem; }");
+        html.AppendLine(".badge.match { background: #2e7d32; }");
+        html.AppendLine(".badge.mismatch { background: #c62828; }");
+        html.AppendLine("</style></head><body>");
+
+        int mismatchCount = result.ElementDiffs.Count(d => !d.Matches);
+        html.AppendLine($"<h1>{result.ElementDiffs.Count} element(s), {mismatchCount} mismatched — MonoGame (left) vs raylib (right)</h1>");
+
+        foreach (ElementScreenshotDiff diff in ordered)
+        {
+            AppendRow(html, diff, reportDirectory);
+        }
+
+        html.AppendLine("</body></html>");
+
+        File.WriteAllText(outputPath, html.ToString());
+        return outputPath;
+    }
+
+    private static void AppendRow(StringBuilder html, ElementScreenshotDiff diff, string reportDirectory)
+    {
+        string rowClass = diff.Matches ? "match" : "mismatch";
+        string badgeText = diff.Matches ? "MATCH" : "DIFF";
+
+        html.AppendLine($"<div class=\"row {rowClass}\">");
+        html.AppendLine("<div class=\"info\">");
+        html.AppendLine($"<span class=\"badge {rowClass}\">{badgeText}</span><br>");
+        html.AppendLine($"<strong>{WebUtility.HtmlEncode(diff.ElementName)}</strong>");
+
+        if (diff.ErrorMessage != null)
+        {
+            html.AppendLine($"<p>{WebUtility.HtmlEncode(diff.ErrorMessage)}</p>");
+        }
+        else if (diff.DimensionMismatchDescription != null)
+        {
+            html.AppendLine($"<p>{WebUtility.HtmlEncode(diff.DimensionMismatchDescription)}</p>");
+        }
+        else if (!diff.Matches)
+        {
+            html.AppendLine($"<p>pixel ({diff.DiffX}, {diff.DiffY}) differs by {diff.MaxChannelDifference}</p>");
+        }
+
+        html.AppendLine("</div>");
+        html.AppendLine(RenderPane(diff.BackendAPath, reportDirectory));
+        html.AppendLine(RenderPane(diff.BackendBPath, reportDirectory));
+        html.AppendLine("</div>");
+    }
+
+    private static string RenderPane(string? imagePath, string reportDirectory)
+    {
+        if (imagePath == null)
+        {
+            return "<div class=\"pane\">(not rendered)</div>";
+        }
+
+        string relativePath = Path.GetRelativePath(reportDirectory, imagePath).Replace('\\', '/');
+        return $"<div class=\"pane\"><img src=\"{WebUtility.HtmlEncode(relativePath)}\"></div>";
+    }
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffRequest.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffRequest.cs
@@ -31,4 +31,11 @@ public class ScreenshotDiffRequest
     /// antialiasing/hinting drift between renderers.
     /// </summary>
     public byte Tolerance { get; init; } = 2;
+
+    /// <summary>
+    /// How many pixels away (in any direction) to search for a matching color before counting a
+    /// pixel as a real mismatch. Absorbs the few-pixel positional jitter two different renderers'
+    /// antialiasing/rounding produces at edges, without masking pixels that are actually wrong.
+    /// </summary>
+    public int ProximityRadius { get; init; } = 1;
 }

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffRequest.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffRequest.cs
@@ -1,0 +1,34 @@
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Parameters for diffing every Screen and Component in a project across two rendering backends.
+/// </summary>
+public class ScreenshotDiffRequest
+{
+    /// <summary>
+    /// Absolute path to the .gumx project file.
+    /// </summary>
+    public required string ProjectPath { get; init; }
+
+    /// <summary>
+    /// First rendering backend (e.g. <c>MonoGameScreenshotService</c>).
+    /// </summary>
+    public required IScreenshotService BackendA { get; init; }
+
+    /// <summary>
+    /// Second rendering backend (e.g. <c>RaylibScreenshotService</c>).
+    /// </summary>
+    public required IScreenshotService BackendB { get; init; }
+
+    /// <summary>
+    /// Directory each backend's rendered PNGs are written to, under a per-backend subfolder.
+    /// Defaults to a new temp directory when not specified.
+    /// </summary>
+    public string? OutputDirectory { get; init; }
+
+    /// <summary>
+    /// Maximum per-channel pixel difference (0-255) still considered a match. Absorbs
+    /// antialiasing/hinting drift between renderers.
+    /// </summary>
+    public byte Tolerance { get; init; } = 2;
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffResult.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffResult.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Result of a <see cref="ScreenshotDiffService"/> run across every Screen and Component in a project.
+/// </summary>
+public class ScreenshotDiffResult
+{
+    /// <summary>One entry per Screen/Component in the project, in enumeration order.</summary>
+    public required IReadOnlyList<ElementScreenshotDiff> ElementDiffs { get; init; }
+
+    /// <summary>
+    /// Directory the rendered PNGs were written to (the request's <c>OutputDirectory</c>, or the
+    /// temp directory generated when it was omitted).
+    /// </summary>
+    public required string OutputDirectory { get; init; }
+
+    /// <summary>True when at least one element failed to render or differs beyond tolerance.</summary>
+    public bool HasMismatch => ElementDiffs.Any(d => !d.Matches);
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffService.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffService.cs
@@ -75,7 +75,7 @@ public class ScreenshotDiffService : IScreenshotDiffService
         using SKBitmap bitmapB = SKBitmap.Decode(resultB.OutputPath)
             ?? throw new InvalidOperationException($"Failed to decode '{resultB.OutputPath}'.");
 
-        PixelDiffResult diff = PixelComparer.Compare(bitmapA, bitmapB, request.Tolerance);
+        ImageDiffResult diff = PixelComparer.CompareApproximate(bitmapA, bitmapB, request.Tolerance, request.ProximityRadius);
 
         return new ElementScreenshotDiff
         {
@@ -83,9 +83,13 @@ public class ScreenshotDiffService : IScreenshotDiffService
             Matches = diff.Matches,
             BackendAPath = resultA.OutputPath,
             BackendBPath = resultB.OutputPath,
-            DiffX = diff.DiffX,
-            DiffY = diff.DiffY,
-            MaxChannelDifference = diff.Matches ? null : diff.MaxChannelDifference,
+            MismatchedPixelCount = diff.MismatchedPixelCount,
+            TotalPixelCount = diff.TotalPixelCount,
+            MismatchPercentage = diff.MismatchPercentage,
+            BoundingBoxMinX = diff.BoundingBoxMinX,
+            BoundingBoxMinY = diff.BoundingBoxMinY,
+            BoundingBoxMaxX = diff.BoundingBoxMaxX,
+            BoundingBoxMaxY = diff.BoundingBoxMaxY,
             DimensionMismatchDescription = diff.DimensionMismatchDescription,
         };
     }

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffService.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotDiffService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.ImageDiff;
+using SkiaSharp;
+
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Renders every Screen and Component in a project through two <see cref="IScreenshotService"/>
+/// backends and diffs each pair via <see cref="PixelComparer"/>.
+/// </summary>
+/// <remarks>
+/// Backend-agnostic: takes both <see cref="IScreenshotService"/> instances via
+/// <see cref="ScreenshotDiffRequest"/> rather than referencing MonoGame/raylib concretely, so this
+/// project needs no dependency on either runtime. <c>gumcli diff-screenshots</c> supplies the
+/// concrete backends. Comparison decodes each backend's PNG through SkiaSharp purely for pixel
+/// access — no SkiaGum rendering is involved.
+/// </remarks>
+public class ScreenshotDiffService : IScreenshotDiffService
+{
+    /// <inheritdoc/>
+    public ScreenshotDiffResult Diff(ScreenshotDiffRequest request)
+    {
+        IProjectLoader loader = new ProjectLoader();
+        ProjectLoadResult loadResult = loader.Load(request.ProjectPath);
+
+        if (!loadResult.Success)
+        {
+            throw new InvalidOperationException(loadResult.ErrorMessage ?? $"Failed to load project: {request.ProjectPath}");
+        }
+
+        GumProjectSave project = loadResult.Project!;
+        string outputDirectory = request.OutputDirectory
+            ?? Path.Combine(Path.GetTempPath(), "GumScreenshotDiff_" + Guid.NewGuid().ToString("N"));
+
+        IEnumerable<ElementSave> elements = project.Screens.Cast<ElementSave>().Concat(project.Components);
+
+        List<ElementScreenshotDiff> diffs = elements
+            .Select(element => DiffElement(request, element.Name, outputDirectory))
+            .ToList();
+
+        return new ScreenshotDiffResult { ElementDiffs = diffs, OutputDirectory = outputDirectory };
+    }
+
+    private static ElementScreenshotDiff DiffElement(ScreenshotDiffRequest request, string elementName, string outputDirectory)
+    {
+        string pathA = Path.Combine(outputDirectory, "A", $"{elementName}.png");
+        string pathB = Path.Combine(outputDirectory, "B", $"{elementName}.png");
+
+        ScreenshotResult resultA = request.BackendA.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = request.ProjectPath,
+            ElementName = elementName,
+            OutputPath = pathA,
+        });
+
+        ScreenshotResult resultB = request.BackendB.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = request.ProjectPath,
+            ElementName = elementName,
+            OutputPath = pathB,
+        });
+
+        if (!resultA.Success || !resultB.Success)
+        {
+            string errorMessage = !resultA.Success ? resultA.ErrorMessage! : resultB.ErrorMessage!;
+            return new ElementScreenshotDiff { ElementName = elementName, Matches = false, ErrorMessage = errorMessage };
+        }
+
+        using SKBitmap bitmapA = SKBitmap.Decode(resultA.OutputPath)
+            ?? throw new InvalidOperationException($"Failed to decode '{resultA.OutputPath}'.");
+        using SKBitmap bitmapB = SKBitmap.Decode(resultB.OutputPath)
+            ?? throw new InvalidOperationException($"Failed to decode '{resultB.OutputPath}'.");
+
+        PixelDiffResult diff = PixelComparer.Compare(bitmapA, bitmapB, request.Tolerance);
+
+        return new ElementScreenshotDiff
+        {
+            ElementName = elementName,
+            Matches = diff.Matches,
+            BackendAPath = resultA.OutputPath,
+            BackendBPath = resultB.OutputPath,
+            DiffX = diff.DiffX,
+            DiffY = diff.DiffY,
+            MaxChannelDifference = diff.Matches ? null : diff.MaxChannelDifference,
+            DimensionMismatchDescription = diff.DimensionMismatchDescription,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Built cross-runtime (MonoGame vs raylib) screenshot-diffing tooling for Gum, to catch the class of
bug in #4172 (raylib rendering silently diverging from the tool) automatically instead of relying on
manual visual inspection. Part of #4174.

- `Gum.ProjectServices.Raylib` / `RaylibScreenshotService : IScreenshotService` — `gumcli screenshot
  --backend {monogame|raylib}`
- `gumcli diff-screenshots <project.gumx>` — renders every Screen/Component via both backends and
  reports mismatches, with a side-by-side HTML report (MonoGame left / raylib right, mismatches
  sorted first)
- `PixelComparer.CompareApproximate` (new `Gum.ImageDiff` project, shared with `SkiaGum.Tests`'
  golden-image tests) — proximity-tolerant comparison: a pixel only counts as a real mismatch if no
  pixel within a small search radius (default 1px, `--proximity`) matches in color, so a 1px
  antialiasing/rounding shift between renderers doesn't get reported as a divergence. Reports
  mismatch count/percentage + bounding box instead of a single first-differing pixel.
- Wired into CI (Windows, Mesa llvmpipe) alongside `RaylibGum.Tests`

**Two real bugs found and fixed while validating this against a real production project
(Airpig.Engine/Content/Gum/Gum.gumx)**, tracked as #4176:
1. `RaylibScreenshotService` never set `CanvasWidth`/`CanvasHeight` before layout — any element
   positioned via `PixelsFromMiddle`/`Percentage` (e.g. a centered dialog) rendered pinned to the
   top-left corner on raylib instead of centered.
2. `CustomSetPropertyOnRenderable`'s RectangleRuntime/CircleRuntime property dispatch was gated
   `#if !RAYLIB` entirely, so v3 shape properties (`IsFilled`/`FillRed`/`FillGreen`/`FillBlue`/
   `Stroke*`/`Blend`/`Color`) silently no-op when loaded from a saved project on raylib.

**Does NOT fix or close #4172.** After both bug fixes and the proximity-tolerant comparer, running
`diff-screenshots` against Airpig goes from 45/73 to 9/73 mismatched elements, and the remaining 9
are all tiny (<0.01% of pixels, small bounding boxes) — visually nothing like the stark blend-mode
difference in #4172's screenshot. Two likely explanations, left for follow-up: (a) `diff-screenshots`
only renders each Screen/Component's **default state** — if #4172's bug only manifests in a specific
runtime state/instance/blend combination, this sweep wouldn't surface it; (b) the actual repro
project from #4172 hasn't been obtained yet. #4172 is intentionally left open for a fresh
investigation, ideally using this new tooling against the actual reported repro.

## Test plan

- [x] `Tests/Gum.ProjectServices.Raylib.Tests` — real raylib window + render-to-texture + PNG
      export/decode; canvas-centering and Fill*/Color dispatch regressions each pinned red-then-green
- [x] `Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableRectangleCircleColorTests.cs` —
      direct dispatch-level pin for the `Color` fix
- [x] `Tests/Gum.ImageDiff.Tests` — proximity comparer: identical/shifted/missing-content/dimension-
      mismatch cases
- [x] `Tests/Gum.Cli.Tests` — `--backend raylib`, `diff-screenshots` end-to-end (both backends in one
      process), unknown backend exits 2
- [x] Full suites green: `RaylibGum.Tests` (567), `Gum.Cli.Tests` (61), `Gum.ProjectServices.Tests`
      (434), `Gum.ImageDiff.Tests` (9)
- [x] CI: both new projects added to `AllLibraries.sln`, wired into `build-and-test.yaml`'s Mesa
      llvmpipe step

Manual test: not needed — the automated tests read back real rendered pixels from a real GPU context
and assert on them, which is a stronger check than eyeballing a screenshot.

FRB canary: verified clean (0 errors) from the primary checkout, both before and after the
`CustomSetPropertyOnRenderable.cs` dispatch change (the only FRB-shared file touched).
