### PR TITLE
Recognize .gumj/.gucj/etc. JSON project files at tool-side entry points

### DIFF
--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -93,20 +93,30 @@ namespace Gum.CommandLine
                     {
                         string argExtension = FileManager.GetExtension(arg);
 
-                        if (argExtension == "gumx")
+                        if (argExtension == GumProjectSave.ProjectExtension || argExtension == GumProjectSave.ProjectJsonExtension)
                         {
                             GlueProjectToLoad = arg;
                         }
                         else if (argExtension == GumProjectSave.ComponentExtension ||
+                            argExtension == GumProjectSave.ComponentJsonExtension ||
                             argExtension == GumProjectSave.ScreenExtension ||
-                            argExtension == GumProjectSave.StandardExtension)
+                            argExtension == GumProjectSave.ScreenJsonExtension ||
+                            argExtension == GumProjectSave.StandardExtension ||
+                            argExtension == GumProjectSave.StandardJsonExtension)
                         {
                             ElementName = FileManager.RemovePath(FileManager.RemoveExtension(arg));
 
                             string gluxDirectory = FileManager.GetDirectory(FileManager.GetDirectory(arg));
 
+                            // The containing project may itself be XML or JSON-formatted (issue #4182) -
+                            // whichever project file sits next to the element wins.
                             GlueProjectToLoad = System.IO.Directory.GetFiles(gluxDirectory)
-                                .FirstOrDefault(item => item.ToLowerInvariant().EndsWith(".gumx"));
+                                .FirstOrDefault(item =>
+                                {
+                                    string lowerItem = item.ToLowerInvariant();
+                                    return lowerItem.EndsWith("." + GumProjectSave.ProjectExtension) ||
+                                        lowerItem.EndsWith("." + GumProjectSave.ProjectJsonExtension);
+                                });
                         }
 
                     }

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -119,7 +119,7 @@ public class MainStateAnimationPlugin : WpfPluginBase, IAnimationUndoProvider
         _undoManager = undoManager;
         _animationUndoProviderRegistrar = animationUndoProviderRegistrar;
 
-        _animationFilePathService = new AnimationFilePathService(_selectedState, fileCommands);
+        _animationFilePathService = new AnimationFilePathService(_selectedState, fileCommands, _projectManager);
         _duplicateService = new DuplicateService(_dialogService, _projectManager);
         _elementDeleteService = new ElementDeleteService(_animationFilePathService, _dialogService);
         _settingsManager = new SettingsManager();

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -821,7 +821,14 @@ public class GumProjectSave
         return content.Contains("Reference Name=");
     }
 
-    private static bool IsJsonFormat(string fileName) =>
+    /// <summary>
+    /// True when <paramref name="fileName"/>'s extension is <see cref="ProjectJsonExtension"/>
+    /// (case-insensitive) - the single source of truth for "is this project JSON or XML formatted"
+    /// used throughout Load/Save/Reload. Public so other tool-side code that needs to route a
+    /// per-element file name/serialization choice off the project's own format (e.g. the Animations
+    /// tab's <c>.ganx</c>/<c>.ganj</c> sidecar) doesn't hand-roll the same extension check.
+    /// </summary>
+    public static bool IsJsonFormat(string fileName) =>
         string.Equals(FileManager.GetExtension(fileName), ProjectJsonExtension, StringComparison.OrdinalIgnoreCase);
 
     public void Save(string fileName, bool saveElements)

--- a/MonoGameGum.Tests/Hot/GumHotReloadManagerWatchExtensionTests.cs
+++ b/MonoGameGum.Tests/Hot/GumHotReloadManagerWatchExtensionTests.cs
@@ -1,0 +1,42 @@
+using Gum;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Hot;
+
+/// <summary>
+/// Pins the set of file extensions <see cref="GumHotReloadManager"/> reacts to (issue #4182).
+/// The runtime reload pipeline (<c>GumProjectSave.Load</c>, <c>GumService.LoadAnimationsFromProvider</c>)
+/// already handles both XML and JSON project formats - only the watch-extension gate itself needed
+/// the JSON siblings added.
+/// </summary>
+public class GumHotReloadManagerWatchExtensionTests
+{
+    [Theory]
+    [InlineData(".gumx")]
+    [InlineData(".gumj")]
+    [InlineData(".gucx")]
+    [InlineData(".gucj")]
+    [InlineData(".gusx")]
+    [InlineData(".gusj")]
+    [InlineData(".gutx")]
+    [InlineData(".gutj")]
+    [InlineData(".ganx")]
+    [InlineData(".ganj")]
+    [InlineData(".behx")]
+    [InlineData(".behj")]
+    [InlineData(".fnt")]
+    public void IsWatchedExtension_ShouldReturnTrue_ForEveryRecognizedGumExtension(string extension)
+    {
+        GumHotReloadManager.IsWatchedExtension(extension).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(".png")]
+    [InlineData(".txt")]
+    [InlineData("")]
+    public void IsWatchedExtension_ShouldReturnFalse_ForUnrecognizedExtension(string extension)
+    {
+        GumHotReloadManager.IsWatchedExtension(extension).ShouldBeFalse();
+    }
+}

--- a/MonoGameGum/GumHotReloadManager.cs
+++ b/MonoGameGum/GumHotReloadManager.cs
@@ -130,8 +130,7 @@ public class GumHotReloadManager : IGumHotReloadManager
             $"[HotReload] event={e.ChangeType} file={Path.GetFileName(e.FullPath)} ext={extension} " +
             $"size={size} mtime={mtime} now={DateTime.UtcNow:HH:mm:ss.fff}");
 
-        if (extension == ".gumx" || extension == ".gucx" || extension == ".gusx" || extension == ".gutx"
-            || extension == ".fnt" || extension == ".ganx")
+        if (IsWatchedExtension(extension))
         {
             if (extension == ".fnt")
             {
@@ -145,6 +144,23 @@ public class GumHotReloadManager : IGumHotReloadManager
             _lastChangeTime = DateTime.UtcNow;
         }
     }
+
+    /// <summary>
+    /// True when <paramref name="extension"/> (including the leading dot, lower-invariant) is a file
+    /// type that should trigger a hot reload - both the XML and JSON forms of the project, element,
+    /// animation, and behavior formats, plus bitmap fonts. Internal (not private) so tests can pin
+    /// the watched set directly; the actual reload dispatch (<c>GumProjectSave.Load</c>,
+    /// <c>GumService.LoadAnimationsFromProvider</c>) already handles both XML and JSON content, so
+    /// this gate is the only place that needed the JSON siblings added (issue #4182).
+    /// </summary>
+    internal static bool IsWatchedExtension(string extension) =>
+        extension is ".gumx" or ".gumj"
+            or ".gucx" or ".gucj"
+            or ".gusx" or ".gusj"
+            or ".gutx" or ".gutj"
+            or ".ganx" or ".ganj"
+            or ".behx" or ".behj"
+            or ".fnt";
 
     private void CopyAndUnloadChangedFonts()
     {

--- a/Tests/Gum.Presentation.Tests/AnimationFilePathServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/AnimationFilePathServiceTests.cs
@@ -1,5 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Managers;
 using Gum.ToolStates;
 using Moq;
 using Shouldly;
@@ -13,12 +14,16 @@ public class AnimationFilePathServiceTests
 {
     private static AnimationFilePathService BuildSut(
         out Mock<ISelectedState> selectedStateMock,
-        out Mock<IFileCommands> fileCommandsMock)
+        out Mock<IFileCommands> fileCommandsMock,
+        string projectFullFileName = @"C:\Project\Project.gumx")
     {
         selectedStateMock = new Mock<ISelectedState>();
         fileCommandsMock = new Mock<IFileCommands>();
 
-        return new AnimationFilePathService(selectedStateMock.Object, fileCommandsMock.Object);
+        Mock<IProjectManager> projectManagerMock = new Mock<IProjectManager>();
+        projectManagerMock.Setup(p => p.GumProjectSave).Returns(new GumProjectSave { FullFileName = projectFullFileName });
+
+        return new AnimationFilePathService(selectedStateMock.Object, fileCommandsMock.Object, projectManagerMock.Object);
     }
 
     [Fact]
@@ -47,6 +52,26 @@ public class AnimationFilePathServiceTests
     }
 
     [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementName_ShouldReturnGanjPath_WhenProjectIsJsonFormat()
+    {
+        // Issue #4182: a JSON-converted project's Animations tab must look for/create the .ganj
+        // sidecar, not .ganx.
+        AnimationFilePathService sut = BuildSut(
+            out Mock<ISelectedState> selectedStateMock,
+            out Mock<IFileCommands> fileCommandsMock,
+            projectFullFileName: @"C:\Project\Project.gumj");
+        ComponentSave selectedElement = new ComponentSave { Name = "MyComponent" };
+        selectedStateMock.Setup(s => s.SelectedElement).Returns(selectedElement);
+        fileCommandsMock.Setup(f => f.GetFullPathXmlFile(selectedElement, "MyComponent"))
+            .Returns(new FilePath(@"C:\Project\Components\MyComponent.gucx"));
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor("MyComponent");
+
+        result.ShouldNotBeNull();
+        result!.FullPath.ShouldBe(new FilePath(@"C:\Project\Components\MyComponentAnimations.ganj").FullPath);
+    }
+
+    [Fact]
     public void GetAbsoluteAnimationFileNameFor_ByElementSave_ShouldReturnNull_WhenXmlPathCannotBeResolved()
     {
         AnimationFilePathService sut = BuildSut(out _, out Mock<IFileCommands> fileCommandsMock);
@@ -70,5 +95,22 @@ public class AnimationFilePathServiceTests
 
         result.ShouldNotBeNull();
         result!.FullPath.ShouldBe(new FilePath(@"C:\Project\Components\MyComponentAnimations.ganx").FullPath);
+    }
+
+    [Fact]
+    public void GetAbsoluteAnimationFileNameFor_ByElementSave_ShouldReturnGanjPath_WhenProjectIsJsonFormat()
+    {
+        AnimationFilePathService sut = BuildSut(
+            out _,
+            out Mock<IFileCommands> fileCommandsMock,
+            projectFullFileName: @"C:\Project\Project.gumj");
+        ComponentSave elementSave = new ComponentSave { Name = "MyComponent" };
+        fileCommandsMock.Setup(f => f.GetFullPathXmlFile(elementSave, "MyComponent"))
+            .Returns(new FilePath(@"C:\Project\Components\MyComponent.gucx"));
+
+        FilePath? result = sut.GetAbsoluteAnimationFileNameFor(elementSave);
+
+        result.ShouldNotBeNull();
+        result!.FullPath.ShouldBe(new FilePath(@"C:\Project\Components\MyComponentAnimations.ganj").FullPath);
     }
 }

--- a/Tests/Gum.Presentation.Tests/FileChangeReactionLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileChangeReactionLogicTests.cs
@@ -15,16 +15,29 @@ using Xunit;
 
 namespace Gum.Presentation.Tests;
 
-public class FileChangeReactionLogicTests
+public class FileChangeReactionLogicTests : BaseTestClass
 {
     private static FileChangeReactionLogic BuildSut(
         out Mock<IGuiCommands> guiCommandsMock,
         out Mock<IFileCommands> fileCommandsMock,
         out Mock<IPluginManager> pluginManagerMock)
     {
+        return BuildSut(out guiCommandsMock, out fileCommandsMock, out pluginManagerMock, out _);
+    }
+
+    private static FileChangeReactionLogic BuildSut(
+        out Mock<IGuiCommands> guiCommandsMock,
+        out Mock<IFileCommands> fileCommandsMock,
+        out Mock<IPluginManager> pluginManagerMock,
+        out Mock<IProjectState> projectStateMock)
+    {
         guiCommandsMock = new Mock<IGuiCommands>();
         fileCommandsMock = new Mock<IFileCommands>();
         pluginManagerMock = new Mock<IPluginManager>();
+        projectStateMock = new Mock<IProjectState>();
+
+        Mock<IWireframeObjectManager> wireframeObjectManagerMock = new Mock<IWireframeObjectManager>();
+        wireframeObjectManagerMock.Setup(w => w.AllIpsos).Returns(new List<GraphicalUiElement>());
 
         return new FileChangeReactionLogic(
             new Mock<ISelectedState>().Object,
@@ -32,8 +45,8 @@ public class FileChangeReactionLogicTests
             guiCommandsMock.Object,
             fileCommandsMock.Object,
             new Mock<IOutputManager>().Object,
-            new Mock<IWireframeObjectManager>().Object,
-            new Mock<IProjectState>().Object,
+            wireframeObjectManagerMock.Object,
+            projectStateMock.Object,
             new Mock<IStandardElementsManagerGumTool>().Object,
             pluginManagerMock.Object);
     }
@@ -71,6 +84,112 @@ public class FileChangeReactionLogicTests
         {
             ObjectFinder.Self.GumProjectSave = null;
         }
+    }
+
+    [Fact]
+    public void ReactToFileDeleted_ShouldFlagElementAndRefresh_WhenJsonElementFileWasDeleted()
+    {
+        // Same wiring as above, but for a JSON-converted project's .gucj element (issue #4182).
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumJsonDeleteWiringTest_" + Guid.NewGuid().ToString("N"));
+        FilePath projectDirectory = new FilePath(tempDir);
+        FilePath deletedFile = new FilePath(Path.Combine(tempDir, "Components", "MyButton.gucj")); // never created -> "deleted"
+
+        FileChangeReactionLogic sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out Mock<IFileCommands> fileCommandsMock,
+            out Mock<IPluginManager> pluginManagerMock);
+        fileCommandsMock.Setup(f => f.ProjectDirectory).Returns(projectDirectory);
+
+        GumProjectSave project = new GumProjectSave();
+        ComponentSave component = new ComponentSave { Name = "MyButton" };
+        project.Components.Add(component);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            sut.ReactToFileDeleted(deletedFile);
+
+            component.IsSourceFileMissing.ShouldBeTrue();
+            guiCommandsMock.Verify(g => g.RefreshElementTreeView(), Times.Once);
+            pluginManagerMock.Verify(p => p.ElementReloaded(component), Times.Once);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void ReactToFileChanged_ShouldReloadElement_WhenJsonComponentFileChanges()
+    {
+        // A JSON-converted project's .gucj element change must reach the same reload path as .gucx
+        // (issue #4182). GumProjectSave.ReloadElement already picks the right XML/JSON extension
+        // once invoked - only the top-level extension dispatch was missing the JSON siblings.
+        FileChangeReactionLogic sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out Mock<IFileCommands> fileCommandsMock,
+            out Mock<IPluginManager> pluginManagerMock,
+            out Mock<IProjectState> projectStateMock);
+        FilePath projectDirectory = new FilePath(@"C:\proj\");
+        fileCommandsMock.Setup(f => f.ProjectDirectory).Returns(projectDirectory);
+
+        GumProjectSave project = new GumProjectSave { FullFileName = @"C:\proj\Project.gumj" };
+        ComponentSave component = new ComponentSave { Name = "MyButton" };
+        project.Components.Add(component);
+        projectStateMock.Setup(p => p.GumProjectSave).Returns(project);
+        ObjectFinder.Self.GumProjectSave = project;
+        try
+        {
+            FilePath changedFile = new FilePath(@"C:\proj\Components\MyButton.gucj");
+
+            sut.ReactToFileChanged(changedFile);
+
+            guiCommandsMock.Verify(g => g.RefreshElementTreeView(), Times.Once);
+            pluginManagerMock.Verify(p => p.ElementReloaded(component), Times.Once);
+        }
+        finally
+        {
+            ObjectFinder.Self.GumProjectSave = null;
+        }
+    }
+
+    [Fact]
+    public void ReactToFileChanged_ShouldReloadProject_WhenJsonProjectFileChangesAndMatchesCurrentProject()
+    {
+        FileChangeReactionLogic sut = BuildSut(
+            out _,
+            out Mock<IFileCommands> fileCommandsMock,
+            out _,
+            out Mock<IProjectState> projectStateMock);
+
+        GumProjectSave project = new GumProjectSave { FullFileName = @"C:\proj\Project.gumj" };
+        projectStateMock.Setup(p => p.GumProjectSave).Returns(project);
+
+        FilePath changedFile = new FilePath(@"C:\proj\Project.gumj");
+
+        sut.ReactToFileChanged(changedFile);
+
+        fileCommandsMock.Verify(f => f.LoadProject(changedFile.Standardized), Times.Once);
+    }
+
+    [Fact]
+    public void ReactToFileChanged_ShouldReloadBehavior_WhenJsonBehaviorFileChanges()
+    {
+        FileChangeReactionLogic sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out _,
+            out _,
+            out Mock<IProjectState> projectStateMock);
+
+        GumProjectSave project = new GumProjectSave { FullFileName = @"C:\proj\Project.gumj" };
+        Gum.DataTypes.Behaviors.BehaviorSave behavior = new() { Name = "ButtonBehavior" };
+        project.Behaviors.Add(behavior);
+        projectStateMock.Setup(p => p.GumProjectSave).Returns(project);
+
+        FilePath changedFile = new FilePath(@"C:\proj\Behaviors\ButtonBehavior.behj");
+
+        sut.ReactToFileChanged(changedFile);
+
+        guiCommandsMock.Verify(g => g.RefreshElementTreeView(), Times.Once);
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
@@ -111,6 +111,53 @@ public class FileWatchManagerTests : IDisposable
         pluginManagerMock.Verify(p => p.ReactToFileChanged(createdFile), Times.Once);
     }
 
+    [Theory]
+    [InlineData("gusx")]
+    [InlineData("gusj")]
+    [InlineData("gucx")]
+    [InlineData("gucj")]
+    [InlineData("gutx")]
+    [InlineData("gutj")]
+    public void IsElementFileExtension_ShouldReturnTrue_ForXmlAndJsonElementExtensions(string extension)
+    {
+        // Issue #4182: a JSON-converted project's element files must be recognized the same way
+        // as their XML counterparts (used to flag missing/reappeared elements on external delete).
+        FilePath file = new FilePath($@"C:\proj\Components\MyButton.{extension}");
+
+        FileWatchManager.IsElementFileExtension(file).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsElementFileExtension_ShouldReturnFalse_ForNonElementExtension()
+    {
+        FilePath file = new FilePath(@"C:\proj\Components\MyButtonAnimations.ganx");
+
+        FileWatchManager.IsElementFileExtension(file).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EnableWithDirectories_ThenFlush_ShouldReactToJsonComponentRenamedIntoWatchedDirectory()
+    {
+        // A rename (the atomic-save pattern many editors/tools use) into a .gucj name must be
+        // recognized the same way as a .gucx rename (issue #4182).
+        FilePath watchedDirectory = new FilePath(_tempDirectory + "/");
+        FileWatchManager sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out Mock<IPluginManager> pluginManagerMock,
+            out _,
+            watchedDirectory);
+
+        sut.EnableWithDirectories(new HashSet<FilePath> { watchedDirectory });
+
+        string tempName = Path.Combine(_tempDirectory, "MyComponent.gucj.tmp");
+        File.WriteAllText(tempName, "{}");
+        FilePath renamedFile = new FilePath(Path.Combine(_tempDirectory, "MyComponent.gucj"));
+        File.Move(tempName, renamedFile.FullPath);
+
+        PollUntil(() => sut.ChangedFilesWaitingForFlush.Contains(renamedFile)).ShouldBeTrue(
+            "a rename onto a .gucj file should be treated like any other recognized Gum file change");
+    }
+
     [Fact]
     public void IgnoreNextChangeUntil_ShouldSuppressQueuedChange_ForIgnoredFile()
     {

--- a/Tests/Gum.Presentation.Tests/ProjectManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectManagerTests.cs
@@ -303,6 +303,34 @@ public class ProjectManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void LoadProject_ShowsOpenDialogAcceptingBothXmlAndJsonProjects()
+    {
+        // A converted .gumj project (issue #4182) must appear in the Open dialog's file picker.
+        _dialogService
+            .Setup(d => d.OpenFile(It.IsAny<OpenFileDialogOptions?>()))
+            .Returns((List<string>?)null);
+
+        _projectManager.LoadProject();
+
+        _dialogService.Verify(d => d.OpenFile(It.Is<OpenFileDialogOptions>(o =>
+            o.Filter.Contains("*.gumx") && o.Filter.Contains("*.gumj"))), Times.Once);
+    }
+
+    [Fact]
+    public void AskUserForProjectNameIfNecessary_ShowsSaveDialogAcceptingBothXmlAndJsonProjects()
+    {
+        SetCurrentProject(new GumProjectSave());
+        _dialogService
+            .Setup(d => d.SaveFile(It.IsAny<SaveFileDialogOptions?>()))
+            .Returns((string?)null);
+
+        _projectManager.AskUserForProjectNameIfNecessary(out _);
+
+        _dialogService.Verify(d => d.SaveFile(It.Is<SaveFileDialogOptions>(o =>
+            o.Filter.Contains("*.gumx") && o.Filter.Contains("*.gumj"))), Times.Once);
+    }
+
+    [Fact]
     public void RecreateMissingStandardElements_DoesNotCrash_AndInforms_ForMissingPluginStandard()
     {
         // Repro of #3373: clicking "Yes" to recreate a missing Skia standard (Arc) crashed with

--- a/Tool/Tests/GumToolUnitTests/CommandLine/CommandLineManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommandLine/CommandLineManagerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum;
@@ -77,5 +79,41 @@ public class CommandLineManagerTests
         await _commandLineManager.ReadCommandLine(new[] { "Gum.exe", "MyProject.gumx" });
 
         _commandLineManager.GlueProjectToLoad.ShouldBe("MyProject.gumx");
+    }
+
+    [Fact]
+    public async Task ReadCommandLine_SetsGlueProjectToLoad_WhenGumjArg()
+    {
+        // A JSON-converted project (issue #4182) must be launchable the same way as a .gumx.
+        await _commandLineManager.ReadCommandLine(new[] { "Gum.exe", "MyProject.gumj" });
+
+        _commandLineManager.GlueProjectToLoad.ShouldBe("MyProject.gumj");
+    }
+
+    [Fact]
+    public async Task ReadCommandLine_FindsSiblingGumjProject_WhenGucjElementArg()
+    {
+        // Double-clicking (or scripting a launch against) a JSON-converted element file must still
+        // resolve the containing project - here the project itself was also converted, so only the
+        // .gumj sibling exists on disk (issue #4182).
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "CommandLineManagerTests_" + Guid.NewGuid().ToString("N"));
+        string componentsDirectory = Path.Combine(tempDirectory, "Components");
+        Directory.CreateDirectory(componentsDirectory);
+        string projectPath = Path.Combine(tempDirectory, "MyProject.gumj");
+        string componentPath = Path.Combine(componentsDirectory, "Foo.gucj");
+        File.WriteAllText(projectPath, "{}");
+        File.WriteAllText(componentPath, "{}");
+
+        try
+        {
+            await _commandLineManager.ReadCommandLine(new[] { "Gum.exe", componentPath });
+
+            _commandLineManager.ElementName.ShouldBe("Foo");
+            _commandLineManager.GlueProjectToLoad.ShouldBe(projectPath);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
@@ -186,6 +186,36 @@ public class GumxImportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ImportAsync_CopiesJsonAnimationSidecar_WhenSourceHasGanjFile()
+    {
+        // Issue #4182: importing from a source project whose animations were converted to JSON
+        // must copy the .ganj sidecar the same way .ganx already is - both are a plain byte copy,
+        // no format-specific parsing involved.
+        string componentName = "AnimatedButton";
+        WriteSourceComponent(componentName);
+        string sourceGanjPath = Path.Combine(_sourceDir, "Components", $"{componentName}Animations.ganj");
+        File.WriteAllText(sourceGanjPath, "{}");
+
+        ComponentSave component = ComponentNoAssets(componentName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(component);
+
+        ImportSelections selections = new ImportSelections
+        {
+            DirectComponents = new() { component },
+            TransitiveComponents = new(),
+            DirectScreens = new(),
+            Behaviors = new(),
+            Standards = new(),
+        };
+
+        await _sut.ImportAsync(selections, source, _sourceDir, destinationSubfolder: "");
+
+        string destGanjPath = Path.Combine(_projectDir, "Components", $"{componentName}Animations.ganj");
+        File.Exists(destGanjPath).ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task ImportAsync_NoConflicts_ConflictingElementsIsEmpty()
     {
         // Arrange — no pre-existing destination files

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using ToolsUtilities;
 
 namespace GumToolUnitTests.Plugins.ImportFromGumxPlugin;
@@ -43,6 +44,21 @@ public class ImportFromGumxViewModelTests
         _dialogService = new FakeDialogService();
         _sut = new ImportFromGumxViewModel(
             sourceService, resolver, importService, _projectState, _dialogService, new SynchronousDispatcher());
+    }
+
+    [Fact]
+    public async Task BrowseCommand_ShowsOpenDialogAcceptingBothXmlAndJsonSourceProjects()
+    {
+        // Local .gumj sources already import correctly (GumxSourceService.LoadProjectAsync just
+        // calls GumProjectSave.Load) - the Browse picker just needs to let the user select one
+        // (issue #4182).
+        _dialogService.OpenFileStub = _ => null;
+
+        await _sut.BrowseCommand.ExecuteAsync(null);
+
+        _dialogService.LastOpenFileOptions.ShouldNotBeNull();
+        _dialogService.LastOpenFileOptions!.Filter.ShouldContain("*.gumx");
+        _dialogService.LastOpenFileOptions!.Filter.ShouldContain("*.gumj");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportBehaviorDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportBehaviorDialogTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Linq;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
@@ -6,7 +9,9 @@ using Gum.Plugins.ImportPlugin.ViewModel;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
+using Shouldly;
 using ToolsUtilities;
+using Xunit;
 
 namespace GumToolUnitTests.ViewModels.Dialogs;
 
@@ -20,6 +25,7 @@ public class ImportBehaviorDialogTests : BaseTestClass
     private readonly Mock<IProjectState> _projectState;
     private readonly Mock<IProjectManager> _projectManager;
     private readonly GumProjectSave _gumProjectSave;
+    private string? _behaviorsDirectory;
 
     public ImportBehaviorDialogTests()
     {
@@ -39,6 +45,15 @@ public class ImportBehaviorDialogTests : BaseTestClass
         _projectManager.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
     }
 
+    public override void Dispose()
+    {
+        if (_behaviorsDirectory != null && Directory.Exists(_behaviorsDirectory))
+        {
+            Directory.Delete(_behaviorsDirectory, recursive: true);
+        }
+        base.Dispose();
+    }
+
     private ImportBehaviorDialog CreateSut() => new(
         _fileCommands.Object,
         _guiCommands.Object,
@@ -56,5 +71,31 @@ public class ImportBehaviorDialogTests : BaseTestClass
         sut.OnAffirmative();
 
         _projectManager.Verify(x => x.GumProjectSave, Times.Once);
+    }
+
+    [Fact]
+    public void Constructor_ListsBothXmlAndJsonBehaviorFiles_ThatAreNotYetInProject()
+    {
+        // A JSON-converted behavior (issue #4182) must be offered for import the same way a .behx
+        // one is.
+        _behaviorsDirectory = Path.Combine(Path.GetTempPath(), "ImportBehaviorDialogTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_behaviorsDirectory);
+        File.WriteAllText(Path.Combine(_behaviorsDirectory, "XmlOnly.behx"), "");
+        File.WriteAllText(Path.Combine(_behaviorsDirectory, "JsonOnly.behj"), "{}");
+        _projectState.Setup(x => x.BehaviorFilePath).Returns(new FilePath(_behaviorsDirectory + "/"));
+
+        ImportBehaviorDialog sut = CreateSut();
+
+        sut.UnfilteredFiles.Any(f => f.EndsWith("XmlOnly.behx")).ShouldBeTrue();
+        sut.UnfilteredFiles.Any(f => f.EndsWith("JsonOnly.behj")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BrowseFileFilter_AcceptsBothXmlAndJsonBehaviorFiles()
+    {
+        ImportBehaviorDialog sut = CreateSut();
+
+        sut.BrowseFileFilter.ShouldContain("*.behx");
+        sut.BrowseFileFilter.ShouldContain("*.behj");
     }
 }

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportComponentDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportComponentDialogTests.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Linq;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
@@ -6,7 +9,9 @@ using Gum.Plugins.ImportPlugin.ViewModel;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
+using Shouldly;
 using ToolsUtilities;
+using Xunit;
 
 namespace GumToolUnitTests.ViewModels.Dialogs;
 
@@ -20,6 +25,7 @@ public class ImportComponentDialogTests : BaseTestClass
     private readonly Mock<IProjectState> _projectState;
     private readonly Mock<IProjectManager> _projectManager;
     private readonly GumProjectSave _gumProjectSave;
+    private string? _componentsDirectory;
 
     public ImportComponentDialogTests()
     {
@@ -39,6 +45,15 @@ public class ImportComponentDialogTests : BaseTestClass
         _projectManager.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
     }
 
+    public override void Dispose()
+    {
+        if (_componentsDirectory != null && Directory.Exists(_componentsDirectory))
+        {
+            Directory.Delete(_componentsDirectory, recursive: true);
+        }
+        base.Dispose();
+    }
+
     private ImportComponentDialog CreateSut() => new(
         _fileCommands.Object,
         _guiCommands.Object,
@@ -56,5 +71,31 @@ public class ImportComponentDialogTests : BaseTestClass
         sut.OnAffirmative();
 
         _projectManager.Verify(x => x.GumProjectSave, Times.Once);
+    }
+
+    [Fact]
+    public void Constructor_ListsBothXmlAndJsonComponentFiles_ThatAreNotYetInProject()
+    {
+        // A JSON-converted component (issue #4182) must be offered for import the same way a .gucx
+        // one is.
+        _componentsDirectory = Path.Combine(Path.GetTempPath(), "ImportComponentDialogTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_componentsDirectory);
+        File.WriteAllText(Path.Combine(_componentsDirectory, "XmlOnly.gucx"), "");
+        File.WriteAllText(Path.Combine(_componentsDirectory, "JsonOnly.gucj"), "{}");
+        _projectState.Setup(x => x.ComponentFilePath).Returns(new FilePath(_componentsDirectory + "/"));
+
+        ImportComponentDialog sut = CreateSut();
+
+        sut.UnfilteredFiles.Any(f => f.EndsWith("XmlOnly.gucx")).ShouldBeTrue();
+        sut.UnfilteredFiles.Any(f => f.EndsWith("JsonOnly.gucj")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BrowseFileFilter_AcceptsBothXmlAndJsonComponentFiles()
+    {
+        ImportComponentDialog sut = CreateSut();
+
+        sut.BrowseFileFilter.ShouldContain("*.gucx");
+        sut.BrowseFileFilter.ShouldContain("*.gucj");
     }
 }

--- a/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportScreenDialogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/Dialogs/ImportScreenDialogTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.Plugins.ImportPlugin.Manager;
+using Gum.Plugins.ImportPlugin.ViewModel;
+using Gum.Services.Dialogs;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+using ToolsUtilities;
+using Xunit;
+
+namespace GumToolUnitTests.ViewModels.Dialogs;
+
+public class ImportScreenDialogTests : BaseTestClass
+{
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IImportLogic> _importLogic;
+    private readonly Mock<IProjectState> _projectState;
+    private readonly GumProjectSave _gumProjectSave;
+    private string? _screensDirectory;
+
+    public ImportScreenDialogTests()
+    {
+        _dialogService = new Mock<IDialogService>();
+        _importLogic = new Mock<IImportLogic>();
+        _projectState = new Mock<IProjectState>();
+        _gumProjectSave = new GumProjectSave { FullFileName = "C:/project/Test.gumx" };
+
+        // The constructor scans the screens folder (returns empty for a non-existent dir)
+        // and reads the project's existing screens, so those reads must not throw.
+        _projectState.Setup(x => x.ScreenFilePath).Returns(new FilePath("C:/project/Screens/"));
+        _projectState.Setup(x => x.GumProjectSave).Returns(_gumProjectSave);
+    }
+
+    public override void Dispose()
+    {
+        if (_screensDirectory != null && Directory.Exists(_screensDirectory))
+        {
+            Directory.Delete(_screensDirectory, recursive: true);
+        }
+        base.Dispose();
+    }
+
+    private ImportScreenDialog CreateSut() => new(
+        _dialogService.Object,
+        _importLogic.Object,
+        _projectState.Object);
+
+    [Fact]
+    public void Constructor_ListsBothXmlAndJsonScreenFiles_ThatAreNotYetInProject()
+    {
+        // A JSON-converted screen (issue #4182) must be offered for import the same way a .gusx
+        // one is.
+        _screensDirectory = Path.Combine(Path.GetTempPath(), "ImportScreenDialogTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_screensDirectory);
+        File.WriteAllText(Path.Combine(_screensDirectory, "XmlOnly.gusx"), "");
+        File.WriteAllText(Path.Combine(_screensDirectory, "JsonOnly.gusj"), "{}");
+        _projectState.Setup(x => x.ScreenFilePath).Returns(new FilePath(_screensDirectory + "/"));
+
+        ImportScreenDialog sut = CreateSut();
+
+        sut.UnfilteredFiles.Any(f => f.EndsWith("XmlOnly.gusx")).ShouldBeTrue();
+        sut.UnfilteredFiles.Any(f => f.EndsWith("JsonOnly.gusj")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Constructor_ExcludesScreenAlreadyInProject()
+    {
+        // Boyscout pin (issue #4182): the exclusion check previously compared against
+        // ComponentFilePath instead of ScreenFilePath, so an already-imported screen never matched
+        // and always re-appeared in the "available to import" list.
+        _screensDirectory = Path.Combine(Path.GetTempPath(), "ImportScreenDialogTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_screensDirectory);
+        File.WriteAllText(Path.Combine(_screensDirectory, "AlreadyImported.gusx"), "");
+        _projectState.Setup(x => x.ScreenFilePath).Returns(new FilePath(_screensDirectory + "/"));
+        _gumProjectSave.Screens.Add(new ScreenSave { Name = "AlreadyImported" });
+
+        ImportScreenDialog sut = CreateSut();
+
+        sut.UnfilteredFiles.Any(f => f.EndsWith("AlreadyImported.gusx")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void BrowseFileFilter_AcceptsBothXmlAndJsonScreenFiles()
+    {
+        ImportScreenDialog sut = CreateSut();
+
+        sut.BrowseFileFilter.ShouldContain("*.gusx");
+        sut.BrowseFileFilter.ShouldContain("*.gusj");
+    }
+}

--- a/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
+++ b/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
@@ -140,7 +140,8 @@ public class FileWatchManager : IFileWatchManager
         // every extension we know how to react to.
         var extension = fileName.Extension;
         if(extension is "png" or "csv" or "resx"
-            or "gumx" or "gusx" or "gutx" or "gucx" or "ganx" or "behx" or "fnt"
+            or "gumx" or "gumj" or "gusx" or "gusj" or "gutx" or "gutj" or "gucx" or "gucj"
+            or "ganx" or "ganj" or "behx" or "behj" or "fnt"
             or "achx" or "gif" or "tga" or "bmp")
         {
             HandleFileSystemChange(fileName);
@@ -161,12 +162,16 @@ public class FileWatchManager : IFileWatchManager
         }
     }
 
-    private static bool IsElementFileExtension(FilePath file)
+    // internal (not private) so tests can pin the recognized extension set directly.
+    internal static bool IsElementFileExtension(FilePath file)
     {
         var extension = file.Extension;
         return extension == GumProjectSave.ScreenExtension
+            || extension == GumProjectSave.ScreenJsonExtension
             || extension == GumProjectSave.ComponentExtension
-            || extension == GumProjectSave.StandardExtension;
+            || extension == GumProjectSave.ComponentJsonExtension
+            || extension == GumProjectSave.StandardExtension
+            || extension == GumProjectSave.StandardJsonExtension;
     }
 
     private void HandleFileSystemChange(object? sender, FileSystemEventArgs e)
@@ -174,7 +179,8 @@ public class FileWatchManager : IFileWatchManager
         var fileName = new FilePath(e.FullPath);
         var extension = fileName.Extension;
 
-        var isGum = extension is "gumx" or "gusx" or "gutx" or "gucx" or "ganx" or "behx";
+        var isGum = extension is "gumx" or "gumj" or "gusx" or "gusj" or "gutx" or "gutj"
+            or "gucx" or "gucj" or "ganx" or "ganj" or "behx" or "behj";
 
         // for some reason if we include created here, we'll get double-adds for XML files like screens...
         if (e.ChangeType != WatcherChangeTypes.Created || !isGum)

--- a/Tools/Gum.Presentation/ImportFromGumx/ImportFromGumxViewModel.cs
+++ b/Tools/Gum.Presentation/ImportFromGumx/ImportFromGumxViewModel.cs
@@ -198,7 +198,7 @@ public class ImportFromGumxViewModel : DialogViewModel
         List<string>? selectedFiles = _dialogService.OpenFile(new OpenFileDialogOptions
         {
             Title = "Open Gum Project",
-            Filter = "Gum Project Files (*.gumx)|*.gumx|All Files (*.*)|*.*"
+            Filter = "Gum Project Files (*.gumx;*.gumj)|*.gumx;*.gumj|All Files (*.*)|*.*"
         });
 
         string? selectedPath = selectedFiles?.FirstOrDefault();

--- a/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
+++ b/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
@@ -208,10 +208,12 @@ public class GumxImportService : IGumxImportService
     }
 
     /// <summary>
-    /// Copies the sibling .ganx (state animation) file for each element, if one exists in the source.
-    /// The naming convention is {elementName}Animations.ganx, located in the same subfolder
-    /// as the element file (e.g. Components/Controls/ButtonAnimations.ganx).
-    /// Silently skips elements that have no .ganx file.
+    /// Copies the sibling .ganx (or JSON .ganj - issue #4182) state-animation file for each
+    /// element, if one exists in the source. The naming convention is
+    /// {elementName}Animations.ganx/.ganj, located in the same subfolder as the element file
+    /// (e.g. Components/Controls/ButtonAnimations.ganx). Both extensions are attempted - a plain
+    /// byte copy, so there's no format-specific parsing to keep in sync. Silently skips elements
+    /// that have neither file.
     /// </summary>
     private async Task CopyGanxFilesAsync(
         IEnumerable<ElementSave> elements,
@@ -225,14 +227,17 @@ public class GumxImportService : IGumxImportService
             string sourceName = element.Name;
             string destName = nameMap.TryGetValue(sourceName, out var mapped) ? mapped : sourceName;
 
-            string relativeSourcePath = $"{elementSubfolder}/{sourceName}Animations.ganx";
-            string destPath = Path.Combine(projectDir, elementSubfolder, $"{destName}Animations.ganx");
-
-            byte[]? bytes = await _sourceService.FetchBinaryAsync(relativeSourcePath, sourceBase);
-            if (bytes != null)
+            foreach (string extension in new[] { "ganx", "ganj" })
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-                await File.WriteAllBytesAsync(destPath, bytes);
+                string relativeSourcePath = $"{elementSubfolder}/{sourceName}Animations.{extension}";
+                string destPath = Path.Combine(projectDir, elementSubfolder, $"{destName}Animations.{extension}");
+
+                byte[]? bytes = await _sourceService.FetchBinaryAsync(relativeSourcePath, sourceBase);
+                if (bytes != null)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+                    await File.WriteAllBytesAsync(destPath, bytes);
+                }
             }
         }
     }

--- a/Tools/Gum.Presentation/Managers/FileChangeReactionLogic.cs
+++ b/Tools/Gum.Presentation/Managers/FileChangeReactionLogic.cs
@@ -64,12 +64,11 @@ namespace Gum.Managers
             {
                 ReactToFontFileChanged(file);
             }
-            else if(extension == GumProjectSave.ScreenExtension || extension == GumProjectSave.ComponentExtension || 
-                extension == GumProjectSave.StandardExtension)
+            else if(IsElementExtension(extension))
             {
                 ReactToElementSaveChanged(file);
             }
-            else if(extension == GumProjectSave.ProjectExtension)
+            else if(extension == GumProjectSave.ProjectExtension || extension == GumProjectSave.ProjectJsonExtension)
             {
                 var isCurrentProject = file == _projectState.GumProjectSave.FullFileName;
                 if(isCurrentProject)
@@ -77,11 +76,11 @@ namespace Gum.Managers
                     ReactToProjectChanged(file);
                 }
             }
-            // .ganx (animation collection) reload is handled by the StateAnimationPlugin via the
+            // .ganx/.ganj (animation collection) reload is handled by the StateAnimationPlugin via the
             // _pluginManager.ReactToFileChanged call below. The animation data is a per-element
             // sidecar owned by that plugin (not part of GumProjectSave), so there is no core-side
             // reload to perform here (issue #3410).
-            else if(extension == "behx")
+            else if(extension == BehaviorReference.Extension || extension == BehaviorReference.JsonExtension)
             {
                 ReactToBehaviorChanged(file);
             }
@@ -94,21 +93,28 @@ namespace Gum.Managers
         }
 
         /// <summary>
-        /// Reacts to an element file (.gusx/.gucx/.gutx) that was deleted on disk while the tool
-        /// is running. The flush routes here (instead of the change path) only once the file is
-        /// confirmed gone, so a delete-then-recreate within the debounce window is handled as a
-        /// normal reload instead. See <see cref="ReactToElementSaveDeleted"/> for why the element
-        /// is flagged rather than reloaded.
+        /// Reacts to an element file (.gusx/.gucx/.gutx, or their JSON siblings .gusj/.gucj/.gutj)
+        /// that was deleted on disk while the tool is running. The flush routes here (instead of the
+        /// change path) only once the file is confirmed gone, so a delete-then-recreate within the
+        /// debounce window is handled as a normal reload instead. See
+        /// <see cref="ReactToElementSaveDeleted"/> for why the element is flagged rather than reloaded.
         /// </summary>
         public void ReactToFileDeleted(FilePath file)
         {
             var extension = file.Extension;
-            if (extension == GumProjectSave.ScreenExtension || extension == GumProjectSave.ComponentExtension ||
-                extension == GumProjectSave.StandardExtension)
+            if (IsElementExtension(extension))
             {
                 ReactToElementSaveDeleted(file);
             }
         }
+
+        /// <summary>
+        /// True for a Screen/Component/StandardElement file's extension, XML or JSON (issue #4182).
+        /// </summary>
+        private static bool IsElementExtension(string extension) =>
+            extension == GumProjectSave.ScreenExtension || extension == GumProjectSave.ScreenJsonExtension ||
+            extension == GumProjectSave.ComponentExtension || extension == GumProjectSave.ComponentJsonExtension ||
+            extension == GumProjectSave.StandardExtension || extension == GumProjectSave.StandardJsonExtension;
 
         private void ReactToElementSaveDeleted(FilePath file)
         {

--- a/Tools/Gum.Presentation/Managers/ProjectManager.cs
+++ b/Tools/Gum.Presentation/Managers/ProjectManager.cs
@@ -230,7 +230,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     {
         List<string>? files = _dialogService.OpenFile(new OpenFileDialogOptions
         {
-            Filter = "Gum Project (*.gumx)|*.gumx",
+            Filter = "Gum Project (*.gumx;*.gumj)|*.gumx;*.gumj",
             Title = "Select project to load",
         });
 
@@ -698,7 +698,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
             string? chosenFileName = _dialogService.SaveFile(new SaveFileDialogOptions
             {
-                Filter = "Gum Project (*.gumx)|*.gumx",
+                Filter = "Gum Project (*.gumx;*.gumj)|*.gumx;*.gumj",
                 Title = "Where would you like to save the Gum project?",
             });
 

--- a/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportBehaviorDialog.cs
+++ b/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportBehaviorDialog.cs
@@ -21,7 +21,9 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
     private readonly IProjectManager _projectManager;
 
     public override string Title => "Import Behavior";
-    public override string BrowseFileFilter => "Behavior Files (*.behaviors)|*.behaviors";
+    public override string BrowseFileFilter =>
+        $"Behavior Files (*.{BehaviorReference.Extension};*.{BehaviorReference.JsonExtension})" +
+        $"|*.{BehaviorReference.Extension};*.{BehaviorReference.JsonExtension}";
 
     public ImportBehaviorDialog(
         IFileCommands fileCommands,
@@ -40,14 +42,22 @@ public class ImportBehaviorDialog : ImportBaseDialogViewModel
         _projectState = projectState;
         _projectManager = projectManager;
 
+        // A JSON-converted behavior (issue #4182) must be offered for import the same way its
+        // XML counterpart is.
         List<FilePath> behaviorFilesNotInProject = FileManager.GetAllFilesInDirectory(
-            _projectState.BehaviorFilePath.FullPath, "behx")
+                _projectState.BehaviorFilePath.FullPath, BehaviorReference.Extension)
+            .Concat(FileManager.GetAllFilesInDirectory(
+                _projectState.BehaviorFilePath.FullPath, BehaviorReference.JsonExtension))
             .Select(item => new FilePath(item))
             .ToList();
 
         FilePath[] behaviorFilesInProject = _projectState.GumProjectSave
             .Behaviors
-            .Select(item => new FilePath(_projectState.BehaviorFilePath + item.Name + ".behx"))
+            .SelectMany(item => new[]
+            {
+                new FilePath(_projectState.BehaviorFilePath + item.Name + "." + BehaviorReference.Extension),
+                new FilePath(_projectState.BehaviorFilePath + item.Name + "." + BehaviorReference.JsonExtension),
+            })
             .ToArray();
 
         behaviorFilesNotInProject = behaviorFilesNotInProject

--- a/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportComponentDialog.cs
+++ b/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportComponentDialog.cs
@@ -21,7 +21,9 @@ public class ImportComponentDialog : ImportBaseDialogViewModel
     private readonly IProjectState _projectState;
 
     public override string Title => "Import Component";
-    public override string BrowseFileFilter => "Gum Component (*.gucx)|*.gucx";
+    public override string BrowseFileFilter =>
+        $"Gum Component (*.{GumProjectSave.ComponentExtension};*.{GumProjectSave.ComponentJsonExtension})" +
+        $"|*.{GumProjectSave.ComponentExtension};*.{GumProjectSave.ComponentJsonExtension}";
 
     public ImportComponentDialog(
         IFileCommands fileCommands,
@@ -40,14 +42,22 @@ public class ImportComponentDialog : ImportBaseDialogViewModel
         _projectManager = projectManager;
         _projectState = projectState;
 
+        // A JSON-converted component (issue #4182) must be offered for import the same way its
+        // XML counterpart is.
         List<FilePath> componentFilesNotInProject = FileManager.GetAllFilesInDirectory(
-            _projectState.ComponentFilePath.FullPath, "gucx")
+                _projectState.ComponentFilePath.FullPath, GumProjectSave.ComponentExtension)
+            .Concat(FileManager.GetAllFilesInDirectory(
+                _projectState.ComponentFilePath.FullPath, GumProjectSave.ComponentJsonExtension))
             .Select(item => new FilePath(item))
             .ToList();
 
         FilePath[] componentFilesInProject = _projectState.GumProjectSave
             .Components
-            .Select(item => new FilePath(_projectState.ComponentFilePath + item.Name + ".gucx"))
+            .SelectMany(item => new[]
+            {
+                new FilePath(_projectState.ComponentFilePath + item.Name + "." + GumProjectSave.ComponentExtension),
+                new FilePath(_projectState.ComponentFilePath + item.Name + "." + GumProjectSave.ComponentJsonExtension),
+            })
             .ToArray();
 
         componentFilesNotInProject = componentFilesNotInProject

--- a/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportScreenDialog.cs
+++ b/Tools/Gum.Presentation/Plugins/ImportPlugin/ViewModel/ImportScreenDialog.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Gum.DataTypes;
 using Gum.Plugins.ImportPlugin.Manager;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
@@ -14,7 +15,9 @@ public class ImportScreenDialog : ImportBaseDialogViewModel
     private readonly IProjectState _projectState;
 
     public override string Title => "Import Screen";
-    public override string BrowseFileFilter => "Gum Screen (*.gusx)|*.gusx";
+    public override string BrowseFileFilter =>
+        $"Gum Screen (*.{GumProjectSave.ScreenExtension};*.{GumProjectSave.ScreenJsonExtension})" +
+        $"|*.{GumProjectSave.ScreenExtension};*.{GumProjectSave.ScreenJsonExtension}";
     public ImportScreenDialog(IDialogService dialogService,
         IImportLogic importLogic,
         IProjectState projectState
@@ -24,14 +27,25 @@ public class ImportScreenDialog : ImportBaseDialogViewModel
         _importLogic = importLogic;
         _projectState = projectState;
 
+        // A JSON-converted screen (issue #4182) must be offered for import the same way its XML
+        // counterpart is.
         List<FilePath> screenFilesNotInProject = FileManager.GetAllFilesInDirectory(
-                _projectState.ScreenFilePath.FullPath, "gusx")
+                _projectState.ScreenFilePath.FullPath, GumProjectSave.ScreenExtension)
+            .Concat(FileManager.GetAllFilesInDirectory(
+                _projectState.ScreenFilePath.FullPath, GumProjectSave.ScreenJsonExtension))
             .Select(item => new FilePath(item))
             .ToList();
 
+        // Boyscout (issue #4182): this previously compared against ComponentFilePath instead of
+        // ScreenFilePath, so an already-imported screen never matched here and always re-appeared
+        // in the "available to import" list.
         FilePath[] screenFilesInProject = _projectState.GumProjectSave
             .Screens
-            .Select(item => new FilePath(_projectState.ComponentFilePath + item.Name + ".gusx"))
+            .SelectMany(item => new[]
+            {
+                new FilePath(_projectState.ScreenFilePath + item.Name + "." + GumProjectSave.ScreenExtension),
+                new FilePath(_projectState.ScreenFilePath + item.Name + "." + GumProjectSave.ScreenJsonExtension),
+            })
             .ToArray();
 
         screenFilesNotInProject = screenFilesNotInProject

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
@@ -1,5 +1,6 @@
 using Gum.Commands;
 using Gum.DataTypes;
+using Gum.Managers;
 using Gum.ToolStates;
 using ToolsUtilities;
 
@@ -9,12 +10,22 @@ public class AnimationFilePathService : IAnimationFilePathService
 {
     private readonly ISelectedState _selectedState;
     private readonly IFileCommands _fileCommands;
+    private readonly IProjectManager _projectManager;
 
-    public AnimationFilePathService(ISelectedState selectedState, IFileCommands fileCommands)
+    public AnimationFilePathService(ISelectedState selectedState, IFileCommands fileCommands, IProjectManager projectManager)
     {
         _selectedState = selectedState;
         _fileCommands = fileCommands;
+        _projectManager = projectManager;
     }
+
+    /// <summary>
+    /// "Animations.ganx" or "Animations.ganj" depending on the currently-open project's own format
+    /// (issue #4182) - independent of whichever extension <see cref="IFileCommands.GetFullPathXmlFile"/>
+    /// happened to resolve for the element itself.
+    /// </summary>
+    private string AnimationsFileNameSuffix =>
+        "Animations." + (GumProjectSave.IsJsonFormat(_projectManager.GumProjectSave?.FullFileName ?? "") ? "ganj" : "ganx");
 
     /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(string elementName)
@@ -30,7 +41,7 @@ public class AnimationFilePathService : IAnimationFilePathService
         }
         else
         {
-            var absoluteFileName = fullPathXmlForElement.RemoveExtension() + "Animations.ganx";
+            var absoluteFileName = fullPathXmlForElement.RemoveExtension() + AnimationsFileNameSuffix;
 
             return absoluteFileName;
         }
@@ -47,7 +58,7 @@ public class AnimationFilePathService : IAnimationFilePathService
         }
         else
         {
-            var absoluteFileName = fullPathXmlForElement.RemoveExtension() + "Animations.ganx";
+            var absoluteFileName = fullPathXmlForElement.RemoveExtension() + AnimationsFileNameSuffix;
 
             return absoluteFileName;
         }

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/IAnimationFilePathService.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/IAnimationFilePathService.cs
@@ -4,7 +4,8 @@ using ToolsUtilities;
 namespace StateAnimationPlugin.Managers;
 
 /// <summary>
-/// Resolves the absolute path of an element's animation (.ganx) file.
+/// Resolves the absolute path of an element's animation (.ganx, or .ganj for a JSON-formatted
+/// project - issue #4182) file.
 /// </summary>
 public interface IAnimationFilePathService
 {


### PR DESCRIPTION
## Summary

JSON project support (#4170/#4178/#4180) made `GumProjectSave`/`ElementSave`/`BehaviorSave` load/save dispatch correctly by extension, but several tool-side entry points that *recognize* a project/element file still hardcoded the XML extensions only. A `.gumj`-converted project could be created, but couldn't actually be opened, launched from the CLI, watched, or imported through ordinary tool workflows.

Fixed, with the JSON extension added everywhere its XML counterpart was already recognized:

- **Open/Save project dialogs** (`ProjectManager.cs`) — filter now accepts `*.gumx;*.gumj`.
- **CLI launch args** (`CommandLineManager.cs`) — `Gum.exe project.gumj` and `Gum.exe Components/Foo.gucj` both resolve correctly now.
- **Tool file-watch** (`FileWatchManager.cs`, `FileChangeReactionLogic.cs`) — external edits to `.gumj/.gucj/.gusj/.gutj/.behj` now trigger the same reload/delete-detection path as their XML counterparts.
- **Runtime hot-reload** (`GumHotReloadManager.cs`) — the watch-extension gate now includes the JSON siblings (plus `.behx/.behj`, previously unwatched entirely). The actual reload dispatch (`GumProjectSave.Load`, `GumService.LoadAnimationsFromProvider`) already handled both formats — only the gate was behind.
- **Import Screen/Component/Behavior dialogs** — both the directory scan and the Browse-button file filter now recognize the JSON siblings.
- **Animations tab sidecar** (`AnimationFilePathService`) — now emits `.ganj` instead of `.ganx` when the open project is JSON-formatted.
- **Import-from-.gumx cross-project import** — the source-picker filter now accepts `.gumj`, and the animation-sidecar copy (a plain byte copy) now also looks for `.ganj`.

**Boyscout fixes bundled in** (same files, same context already loaded):
- `ImportScreenDialog`'s "already in project" exclusion check compared against `ComponentFilePath` instead of `ScreenFilePath` — an already-imported screen never matched and always re-appeared in the import list.
- `ImportBehaviorDialog.BrowseFileFilter` referenced a nonexistent `.behaviors` extension instead of `.behx`.
- `GumProjectSave.IsJsonFormat` made `public` (was `private`) so other tool code can reuse the canonical "is this project JSON?" check instead of hand-rolling extension comparisons.

## Deliberately out of scope (reported to the user, not silently dropped)

- **`FileCommands.GetFullPathXmlFileForElement`/`GetFullPathXmlFile(BehaviorSave,...)`** (and the parallel `ElementFilePathHelper` in `Gum.ProjectServices`, and `DragDropManager`'s own duplicate) always resolve an element's own file path using a *fixed* XML extension constant, never the project's actual JSON/XML format. This affects `ForceSaveElement`/`ForceSaveBehavior`, Rename, Delete, DragDrop, Codegen, and the self-save `IgnoreNextChangeUntil` suppression in `ProjectManager.SaveProject`. Real gap for day-to-day *editing* a JSON project (not just opening/watching it), but fixing it safely means auditing every one of those call sites — much bigger than "recognition," and left for a follow-up issue.
- The tool-side **Animation editing subsystem** beyond `AnimationFilePathService` (`RenameManager`'s cross-element rename branch, `Gum/StateAnimationPlugin/Managers/DuplicateService.cs`, `AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile`) has the same root cause, *plus* downstream `FileManager.XmlDeserialize`/`XmlSerialize` calls that assume XML unconditionally — fixing recognition alone there would turn a silent no-op into a hard crash for a JSON project. Same follow-up issue as above.
- **"Add Forms" wizard** and **`SkiaShapeStandardsLogic`** deploy fixed embedded XML template content into the project regardless of its format — JSON-aware deployment needs on-the-fly content conversion, a distinct feature.
- **"Import from .gumx" URL-based source** (`GumxSourceService.LoadProjectFromUrlAsync`) is an entirely separate, hand-rolled XML-only HTTP deserializer; a `.gumj` URL source wouldn't work. **Local-file sources already work with zero changes** — `LoadProjectAsync` just calls `GumProjectSave.Load`, which is already JSON-aware.

## Test plan

- [x] New/updated unit tests for every fix above (TDD: each reproduced red against the pre-fix code, confirmed via `git stash`).
- [x] Full suites green: `Gum.Presentation.Tests` (779), `GumToolUnitTests` (1188, includes `AllPluginsCompositionTests`/`UiDecouplingRatchetTests`), `MonoGameGum.Tests` (2074), `Gum.ProjectServices.Tests` (431).
- [x] `dotnet build GumFull.sln` — 0 errors.
- Manual test: not strictly required (behavior is covered by the unit tests above, which exercise the actual dialog filters/dispatch logic), but this is tool-UI-facing (File → Open recognizing `.gumj`) — see notes for the maintainer on manual verification if desired.

FRB canary: not needed. The only `GumCoreShared.projitems`-shared file touched is `GumDataTypes/GumProjectSave.cs`, and the only change there is a `private` → `public` visibility bump (plus a doc comment) on an existing method — no new API surface, no new BCL usage, no `#if` platform gate touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KLF71YTVU5QJZ6WrVtLBFY
