### PR TITLE
Document gumcli screenshot --backend and diff-screenshots

### DIFF
--- a/Tools/Gum.Cli/gumcli.md
+++ b/Tools/Gum.Cli/gumcli.md
@@ -98,21 +98,40 @@ gumcli codegen MyProject.gumx --element Button --element Slider
 - Warnings are printed to stderr but do not block generation
 - Exit code `0` = success, `1` = elements blocked by errors, `2` = load failure or missing configuration
 
-### `gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>]`
+### `gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>] [--backend <name>]`
 
-Renders a Gum Screen or Component to a PNG file using MonoGame (DesktopGL), producing pixel-accurate output that matches a live MonoGame game.
+Renders a Gum Screen or Component to a PNG file, producing pixel-accurate output that matches a live game using that backend.
 
 ```
 gumcli screenshot MyProject.gumx MainMenu
 gumcli screenshot MyProject.gumx MainMenu --output screenshots/MainMenu.png
 gumcli screenshot MyProject.gumx MainMenu --width 1280 --height 720
+gumcli screenshot MyProject.gumx MainMenu --backend raylib
 ```
 
 - `<element>` is the Screen or Component name (without folder prefix or extension, e.g. `MainMenu` not `Screens/MainMenu.gusx`)
 - `--output` path for the PNG file; defaults to `<element>.png` in the current directory
 - `--width` / `--height` override the render dimensions; default to the project canvas size (800×600 if canvas size is not set)
-- Uses MonoGame rendering to match the exact visual output of a MonoGame game — fonts, textures, and anti-aliasing are identical
-- Exit code `0` = success, `1` = render error, `2` = project file not found
+- `--backend` selects the rendering backend: `monogame` (default, DesktopGL) or `raylib`. Fonts, textures, and anti-aliasing match a live game using that same backend
+- Exit code `0` = success, `1` = render error, `2` = project file not found or unknown `--backend` value
+
+### `gumcli diff-screenshots <project.gumx> [--output <dir>] [--tolerance <0-255>] [--proximity <px>] [--json]`
+
+Renders every Screen and Component in a project via both MonoGame and raylib and reports any pixel-level mismatch between the two, catching raylib rendering that silently diverges from the tool's MonoGame-based preview.
+
+```
+gumcli diff-screenshots MyProject.gumx
+gumcli diff-screenshots MyProject.gumx --output diffs/
+gumcli diff-screenshots MyProject.gumx --tolerance 4 --proximity 2
+gumcli diff-screenshots MyProject.gumx --json
+```
+
+- Renders each element through both backends into `<output>/A/` (MonoGame) and `<output>/B/` (raylib), then compares the two PNGs
+- A pixel only counts as a real mismatch if no pixel within `--proximity` pixels of it (default `1`) matches within `--tolerance` (default `2`, max per-channel difference), absorbing the few-pixel positional jitter different renderers' antialiasing/rounding produces at edges, without masking pixels that are actually wrong
+- Writes a side-by-side HTML report (`report.html` in the output directory) with MonoGame on the left and raylib on the right, mismatched elements listed first
+- Human-readable output lists each element's match/mismatch status, the mismatched pixel count/percentage, and the bounding box of the mismatched region; `--json` outputs the same data as a JSON document
+- `--output` defaults to a new temp directory when omitted (the path is always printed)
+- Exit code `0` = every element matched, `1` = at least one element mismatched or failed to render, `2` = project file not found or could not be loaded
 
 ### `gumcli fonts <project.gumx>`
 
@@ -134,5 +153,5 @@ gumcli fonts path/to/MyProject.gumx
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Errors found (check) or elements blocked (codegen) or font generation error or render error (screenshot) |
-| 2 | Project could not be loaded, invalid arguments, non-Windows platform (fonts), or project file not found (screenshot) |
+| 1 | Errors found (check) or elements blocked (codegen) or font generation error or render error (screenshot) or a mismatch/render failure (diff-screenshots) |
+| 2 | Project could not be loaded, invalid arguments, non-Windows platform (fonts), project file not found (screenshot, diff-screenshots), or unknown `--backend` (screenshot) |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -419,6 +419,7 @@
   * [fonts](cli/fonts.md)
   * [pack](cli/pack.md)
   * [screenshot](cli/screenshot.md)
+  * [diff-screenshots](cli/diff-screenshots.md)
   * [svg](cli/svg.md)
 
 ## Using Gum with AI

--- a/docs/ai/gumcli-for-agents.md
+++ b/docs/ai/gumcli-for-agents.md
@@ -40,6 +40,7 @@ After editing project XML — whether by hand, with custom tooling, or via an as
 Generated code that compiles is not proof the UI looks right. Rendering the result to an image gives the agent something concrete to inspect — and, with a multimodal model, to actually "see."
 
 * [`screenshot`](../cli/screenshot.md) — render a Screen or Component to a PNG. An agent can open the PNG to confirm the layout matches intent.
+* [`diff-screenshots`](../cli/diff-screenshots.md) — render every Screen and Component via both `monogame` and `raylib` and report any mismatch, so a raylib-specific rendering bug doesn't slip through if the project targets both.
 * [`svg`](../cli/svg.md) — render to SVG when a vector format is preferred.
 
 ## Supporting commands

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -37,6 +37,7 @@ Once installed, invoke it as `gumcli` from any terminal.
 | `fonts` | Generate missing bitmap font files |
 | `pack` | Pack a project into a single `.gumpkg` bundle |
 | `screenshot` | Render a Screen or Component to a PNG file |
+| `diff-screenshots` | Render every Screen and Component via MonoGame and raylib and report mismatches |
 | `svg` | Render a Screen or Component to an SVG file |
 
 ## Output Streams

--- a/docs/cli/diff-screenshots.md
+++ b/docs/cli/diff-screenshots.md
@@ -1,0 +1,88 @@
+# diff-screenshots
+
+```
+gumcli diff-screenshots <project.gumx> [--output <dir>] [--tolerance <0-255>] [--proximity <px>] [--json]
+```
+
+Renders every Screen and Component in a project through both the `monogame` and `raylib` [`screenshot`](screenshot.md) backends and reports any pixel-level mismatch between the two. Use this to catch a runtime backend silently rendering a project differently than the tool's preview, across an entire project at once.
+
+## Options
+
+- `<project.gumx>` — Path to the `.gumx` project file
+- `--output` — Directory the rendered PNGs are written to, under `A/` (MonoGame) and `B/` (raylib) subfolders. Defaults to a new temp directory (the path is always printed)
+- `--tolerance` — Maximum per-channel pixel difference (0-255) still considered a color match. Defaults to `2`
+- `--proximity` — How many pixels away to search for a matching color before counting a pixel as a real mismatch. Defaults to `1`
+- `--json` — Output the diff as a JSON document instead of human-readable text
+
+{% hint style="info" %}
+Two different renderers never produce byte-identical antialiasing at an edge, so a strict same-coordinate pixel comparison reports mismatches even between visually identical renders. A pixel only counts as a real mismatch if no pixel within `--proximity` of it matches within `--tolerance`, absorbing a renderer's few-pixel positional jitter at edges without masking pixels that are actually wrong. Raise `--proximity` if a project's antialiasing needs more slack; raise `--tolerance` if the color drift itself (not position) is the source of noise.
+{% endhint %}
+
+## Examples
+
+```
+gumcli diff-screenshots MyProject/MyProject.gumx
+gumcli diff-screenshots MyProject/MyProject.gumx --output diffs/
+gumcli diff-screenshots MyProject/MyProject.gumx --tolerance 4 --proximity 2
+gumcli diff-screenshots MyProject/MyProject.gumx --json
+```
+
+## Output
+
+**Human-readable:**
+
+```
+MATCH  Controls/Button
+DIFF   Elements/Dialog: 42 px mismatched (0.219%), region (100, 50)-(140, 90)
+DIFF   Screens/MainMenu: pixel dimensions differ
+
+Rendered PNGs: C:\Users\me\AppData\Local\Temp\GumScreenshotDiff_a1b2c3
+HTML report:   C:\Users\me\AppData\Local\Temp\GumScreenshotDiff_a1b2c3\report.html
+2 of 3 element(s) mismatched.
+```
+
+Every run also writes `report.html` into the output directory: one row per element with MonoGame's render on the left and raylib's on the right, mismatched elements listed first, so you can scroll through a whole project visually instead of opening each PNG.
+
+**JSON output:**
+
+```json
+{
+  "hasMismatch": true,
+  "outputDirectory": "C:\\Users\\me\\AppData\\Local\\Temp\\GumScreenshotDiff_a1b2c3",
+  "reportPath": "C:\\Users\\me\\AppData\\Local\\Temp\\GumScreenshotDiff_a1b2c3\\report.html",
+  "elements": [
+    {
+      "element": "Controls/Button",
+      "matches": true,
+      "errorMessage": null,
+      "monoGamePath": "...\\A\\Controls\\Button.png",
+      "raylibPath": "...\\B\\Controls\\Button.png",
+      "mismatchedPixelCount": 0,
+      "totalPixelCount": 48000,
+      "mismatchPercentage": 0.0,
+      "boundingBox": null,
+      "dimensionMismatch": null
+    },
+    {
+      "element": "Elements/Dialog",
+      "matches": false,
+      "errorMessage": null,
+      "monoGamePath": "...\\A\\Elements\\Dialog.png",
+      "raylibPath": "...\\B\\Elements\\Dialog.png",
+      "mismatchedPixelCount": 42,
+      "totalPixelCount": 19200,
+      "mismatchPercentage": 0.219,
+      "boundingBox": { "minX": 100, "minY": 50, "maxX": 140, "maxY": 90 },
+      "dimensionMismatch": null
+    }
+  ]
+}
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Every element matched |
+| 1 | One or more elements mismatched, or a backend failed to render an element |
+| 2 | Project `.gumx` file could not be loaded |

--- a/docs/cli/screenshot.md
+++ b/docs/cli/screenshot.md
@@ -1,10 +1,10 @@
 # screenshot
 
 ```
-gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>]
+gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>] [--backend <name>]
 ```
 
-Renders a Gum Screen or Component to a PNG file. The element is laid out and drawn using the same MonoGame (DesktopGL) backend a shipped game would use, so the output is pixel-accurate and suitable for visual regression testing, documentation screenshots, or asset pipelines.
+Renders a Gum Screen or Component to a PNG file. The element is laid out and drawn using the same backend a shipped game would use, so the output is pixel-accurate and suitable for visual regression testing, documentation screenshots, or asset pipelines.
 
 ## Arguments
 
@@ -16,6 +16,7 @@ Renders a Gum Screen or Component to a PNG file. The element is laid out and dra
 - `--output` — Path for the output PNG file. Defaults to `<element>.png` in the current directory.
 - `--width` — Width of the output image in pixels. Defaults to the project canvas width.
 - `--height` — Height of the output image in pixels. Defaults to the project canvas height.
+- `--backend` — Rendering backend to use: `monogame` (default, DesktopGL) or `raylib`.
 
 ## Examples
 
@@ -23,6 +24,7 @@ Renders a Gum Screen or Component to a PNG file. The element is laid out and dra
 gumcli screenshot MyProject/MyProject.gumx MainMenu
 gumcli screenshot MyProject/MyProject.gumx Controls/Button --output button.png
 gumcli screenshot MyProject/MyProject.gumx MainMenu --width 1920 --height 1080
+gumcli screenshot MyProject/MyProject.gumx MainMenu --backend raylib
 ```
 
 Output on success:
@@ -33,9 +35,10 @@ Screenshot written to: /full/path/to/MainMenu.png
 
 ## Notes
 
-- Works cross-platform — uses DesktopGL, not a Windows-specific rendering path.
+- Works cross-platform — the default `monogame` backend uses DesktopGL, not a Windows-specific rendering path.
 - Any fonts referenced by the element must already exist in the project's `FontCache/` folder. Run [`gumcli fonts`](fonts.md) first if fonts are missing.
 - Bitmap content (sprites, nine-slices, text) is rasterized into the PNG at the requested resolution.
+- To compare the two backends' output for every element in a project at once, see [`diff-screenshots`](diff-screenshots.md).
 
 ## Exit Codes
 
@@ -43,4 +46,4 @@ Screenshot written to: /full/path/to/MainMenu.png
 |------|---------|
 | 0 | Screenshot written successfully |
 | 1 | Rendering failed (for example, the named element does not exist) |
-| 2 | Project file not found |
+| 2 | Project file not found, or `--backend` is not `monogame` or `raylib` |


### PR DESCRIPTION
## Summary

`gumcli screenshot --backend` and `gumcli diff-screenshots` (#4177) shipped without doc coverage.

- New `docs/cli/diff-screenshots.md` reference page
- Updated `docs/cli/screenshot.md` for `--backend`
- Updated `docs/cli/README.md` and `docs/SUMMARY.md` nav
- Updated `Tools/Gum.Cli/gumcli.md` (packaged CLI readme)
- Pointed `docs/ai/gumcli-for-agents.md`'s "verify visually" section at `diff-screenshots`

FYI, not fixed here (pre-existing, unrelated to this change): `Tools/Gum.Cli/gumcli.md` is also
missing `svg`, `pack`, and `diff-standards` sections, and `docs/SUMMARY.md`/`docs/cli/README.md`
have no page for `diff-standards`.

Docs-only change.

Manual test: not needed, no runtime behavior touched.

FRB canary: not needed, no source touched.
