### PR TITLE
Wire Dropshadow* into CustomSetPropertyOnRenderable for Rectangle/Circle

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -3374,6 +3374,59 @@ public partial class CustomSetPropertyOnRenderable
             case "Blend":
                 circleRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
                 return true;
+            // #4169: Dropshadow* is the same runtime-only shape as the Fill/Stroke cases above -
+            // no case at all here (not even a legacy-era one), so it fell straight through to
+            // SetPropertyThroughReflection and was silently dropped.
+            case "HasDropshadow":
+                circleRuntime.HasDropshadow = (bool)value;
+                return true;
+            // DropshadowColor is backend-typed same as "Color" above.
+            case "DropshadowColor":
+#if RAYLIB
+                if (value is System.Drawing.Color raylibDropshadowDrawingColor)
+                {
+                    circleRuntime.DropshadowColor = raylibDropshadowDrawingColor.ToRaylib();
+                }
+                else
+                {
+                    return false;
+                }
+#else
+                if (value is System.Drawing.Color dropshadowDrawingColor)
+                {
+                    circleRuntime.DropshadowColor = new Microsoft.Xna.Framework.Color(dropshadowDrawingColor.R, dropshadowDrawingColor.G, dropshadowDrawingColor.B, dropshadowDrawingColor.A);
+                }
+                else if (value is Microsoft.Xna.Framework.Color xnaDropshadowColor)
+                {
+                    circleRuntime.DropshadowColor = xnaDropshadowColor;
+                }
+                else
+                {
+                    return false;
+                }
+#endif
+                return true;
+            case "DropshadowAlpha":
+                circleRuntime.DropshadowAlpha = (int)value;
+                return true;
+            case "DropshadowRed":
+                circleRuntime.DropshadowRed = (int)value;
+                return true;
+            case "DropshadowGreen":
+                circleRuntime.DropshadowGreen = (int)value;
+                return true;
+            case "DropshadowBlue":
+                circleRuntime.DropshadowBlue = (int)value;
+                return true;
+            case "DropshadowOffsetX":
+                circleRuntime.DropshadowOffsetX = (float)value;
+                return true;
+            case "DropshadowOffsetY":
+                circleRuntime.DropshadowOffsetY = (float)value;
+                return true;
+            case "DropshadowBlur":
+                circleRuntime.DropshadowBlur = (float)value;
+                return true;
         }
         return false;
 #pragma warning restore CS0618
@@ -3478,6 +3531,59 @@ public partial class CustomSetPropertyOnRenderable
                 return true;
             case "Blend":
                 rectangleRuntime.Blend = (Gum.RenderingLibrary.Blend)value;
+                return true;
+            // #4169: Dropshadow* is the same runtime-only shape as the Fill/Stroke cases above -
+            // no case at all here (not even a legacy-era one), so it fell straight through to
+            // SetPropertyThroughReflection and was silently dropped.
+            case "HasDropshadow":
+                rectangleRuntime.HasDropshadow = (bool)value;
+                return true;
+            // DropshadowColor is backend-typed same as "Color" above.
+            case "DropshadowColor":
+#if RAYLIB
+                if (value is System.Drawing.Color raylibDropshadowDrawingColor)
+                {
+                    rectangleRuntime.DropshadowColor = raylibDropshadowDrawingColor.ToRaylib();
+                }
+                else
+                {
+                    return false;
+                }
+#else
+                if (value is System.Drawing.Color dropshadowDrawingColor)
+                {
+                    rectangleRuntime.DropshadowColor = new Microsoft.Xna.Framework.Color(dropshadowDrawingColor.R, dropshadowDrawingColor.G, dropshadowDrawingColor.B, dropshadowDrawingColor.A);
+                }
+                else if (value is Microsoft.Xna.Framework.Color xnaDropshadowColor)
+                {
+                    rectangleRuntime.DropshadowColor = xnaDropshadowColor;
+                }
+                else
+                {
+                    return false;
+                }
+#endif
+                return true;
+            case "DropshadowAlpha":
+                rectangleRuntime.DropshadowAlpha = (int)value;
+                return true;
+            case "DropshadowRed":
+                rectangleRuntime.DropshadowRed = (int)value;
+                return true;
+            case "DropshadowGreen":
+                rectangleRuntime.DropshadowGreen = (int)value;
+                return true;
+            case "DropshadowBlue":
+                rectangleRuntime.DropshadowBlue = (int)value;
+                return true;
+            case "DropshadowOffsetX":
+                rectangleRuntime.DropshadowOffsetX = (float)value;
+                return true;
+            case "DropshadowOffsetY":
+                rectangleRuntime.DropshadowOffsetY = (float)value;
+                return true;
+            case "DropshadowBlur":
+                rectangleRuntime.DropshadowBlur = (float)value;
                 return true;
         }
         return false;

--- a/MonoGameGum.Tests/Runtimes/DataDrivenShapePropertyTests.cs
+++ b/MonoGameGum.Tests/Runtimes/DataDrivenShapePropertyTests.cs
@@ -80,4 +80,77 @@ public class DataDrivenShapePropertyTests : BaseTestClass
         sut.FillGreen.ShouldBe(34);
         sut.FillBlue.ShouldBe(56);
     }
+
+    // #4169: DropshadowRed/Green/Blue/Alpha/Color are runtime-only, same as the v3 fill/stroke
+    // surface above, and had no case at all in the dispatcher (not even a legacy-era one) - so
+    // they hit the identical silent-drop fallback. HasDropshadow/DropshadowOffsetX/OffsetY/
+    // DropshadowBlur are the same runtime-only shape and are covered alongside for completeness,
+    // since they sit in the same switch and were found to have the same gap while fixing #4169.
+
+    [Fact]
+    public void SetProperty_DropshadowRedGreenBlueAlpha_OnRectangleRuntime_AppliesValues()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("DropshadowRed", 224);
+        sut.SetProperty("DropshadowGreen", 165);
+        sut.SetProperty("DropshadowBlue", 60);
+        sut.SetProperty("DropshadowAlpha", 128);
+
+        sut.DropshadowRed.ShouldBe(224);
+        sut.DropshadowGreen.ShouldBe(165);
+        sut.DropshadowBlue.ShouldBe(60);
+        sut.DropshadowAlpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void SetProperty_DropshadowRedGreenBlueAlpha_OnCircleRuntime_AppliesValues()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("DropshadowRed", 12);
+        sut.SetProperty("DropshadowGreen", 34);
+        sut.SetProperty("DropshadowBlue", 56);
+        sut.SetProperty("DropshadowAlpha", 78);
+
+        sut.DropshadowRed.ShouldBe(12);
+        sut.DropshadowGreen.ShouldBe(34);
+        sut.DropshadowBlue.ShouldBe(56);
+        sut.DropshadowAlpha.ShouldBe(78);
+    }
+
+    [Fact]
+    public void SetProperty_DropshadowColor_OnRectangleRuntime_AppliesValue()
+    {
+        RectangleRuntime sut = new();
+        Microsoft.Xna.Framework.Color dropshadowColor = new(10, 20, 30, 40);
+
+        sut.SetProperty("DropshadowColor", dropshadowColor);
+
+        sut.DropshadowColor.ShouldBe(dropshadowColor);
+    }
+
+    [Fact]
+    public void SetProperty_HasDropshadow_OnRectangleRuntime_AppliesValue()
+    {
+        RectangleRuntime sut = new();
+
+        sut.SetProperty("HasDropshadow", true);
+
+        sut.HasDropshadow.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetProperty_DropshadowOffsetsAndBlur_OnCircleRuntime_AppliesValues()
+    {
+        CircleRuntime sut = new();
+
+        sut.SetProperty("DropshadowOffsetX", 5f);
+        sut.SetProperty("DropshadowOffsetY", 7f);
+        sut.SetProperty("DropshadowBlur", 3f);
+
+        sut.DropshadowOffsetX.ShouldBe(5f);
+        sut.DropshadowOffsetY.ShouldBe(7f);
+        sut.DropshadowBlur.ShouldBe(3f);
+    }
 }

--- a/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableRectangleCircleColorTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/CustomSetPropertyOnRenderableRectangleCircleColorTests.cs
@@ -44,4 +44,30 @@ public class CustomSetPropertyOnRenderableRectangleCircleColorTests : BaseTestCl
 
         circleRuntime.Color.ShouldBe(new Color(40, 50, 60, 255));
     }
+
+    // #4169: DropshadowColor is backend-typed the same as "Color" above, and had no dispatch
+    // case at all (not just a raylib gap) - see CustomSetPropertyOnRenderable.Dropshadow* cases.
+    [Fact]
+    public void SetPropertyOnRenderable_DropshadowColorOnRectangleRuntime_AppliesValue()
+    {
+        RectangleRuntime rectangleRuntime = new();
+        IRenderableIpso renderable = (IRenderableIpso)rectangleRuntime.RenderableComponent!;
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(200, 70, 80, 90);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, rectangleRuntime, "DropshadowColor", drawingColor);
+
+        rectangleRuntime.DropshadowColor.ShouldBe(new Color(70, 80, 90, 200));
+    }
+
+    [Fact]
+    public void SetPropertyOnRenderable_DropshadowColorOnCircleRuntime_AppliesValue()
+    {
+        CircleRuntime circleRuntime = new();
+        IRenderableIpso renderable = (IRenderableIpso)circleRuntime.RenderableComponent!;
+        System.Drawing.Color drawingColor = System.Drawing.Color.FromArgb(210, 15, 25, 35);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(renderable, circleRuntime, "DropshadowColor", drawingColor);
+
+        circleRuntime.DropshadowColor.ShouldBe(new Color(15, 25, 35, 210));
+    }
 }


### PR DESCRIPTION
Closes #4169.

`TrySetPropertyOnRectangleRuntime`/`TrySetPropertyOnCircleRuntime` had no case at all for
`Dropshadow*` — unlike the v3 Fill/Stroke surface (fixed for the identical silent-drop in
#4176/#2768), `HasDropshadow`/`DropshadowColor`/`Alpha`/`Red`/`Green`/`Blue`/`OffsetX`/`OffsetY`/`Blur`
are runtime-only properties and fell through to `SetPropertyThroughReflection`, which reflects on
the low-level renderable slot and silently drops them. Affects `VariableReferences` application,
animations, and the tool's live wireframe preview (`SetVariableLogic.cs:687`).

Added cases for all 9 Dropshadow* properties — the issue named 5 (Color/Alpha/Red/Green/Blue);
the other 4 (HasDropshadow/OffsetX/OffsetY/Blur) are the same runtime-only surface in the same
switch, same root cause, found while fixing. `DropshadowColor` needed the same backend-typed
branch as the existing legacy `Color` case (raylib holds `Raylib_cs.Color`, not XNA's).

Red-then-green tests in `MonoGameGum.Tests/DataDrivenShapePropertyTests` and
`RaylibGum.Tests/CustomSetPropertyOnRenderableRectangleCircleColorTests`; full `MonoGameGum.Tests`
(2079) and the touched `RaylibGum.Tests` subset green; `GumFull.sln` builds clean.

FRB canary: not needed — both edited methods sit entirely inside the pre-existing `#if !FRB` gate;
no symbol reachable under FRB1 changed.

Manual test: needed (dropshadow color/offset is rendering-visible). Steps:
1. In the opened Gum.sln, run the tool and add a Rectangle to a Screen.
2. In the Variables tab, set `HasDropshadow = true`.
3. Set `DropshadowRed`/`DropshadowGreen`/`DropshadowBlue` to a custom color (e.g. 255/0/0).
4. Confirm the wireframe preview's dropshadow updates to the new color live (pre-fix, the preview
   stayed at the default black regardless of the channel values entered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)