### PR TITLE
Collapse cross-named color VariableReferences in Bubblegum and Hazard

### DIFF
--- a/.claude/skills/gum-forms-theme-import/SKILL.md
+++ b/.claude/skills/gum-forms-theme-import/SKILL.md
@@ -238,12 +238,13 @@ instances yourself, `--fix` already writes it into every state. This only works 
 missing outright, though; see "Recoloring after a clone" above for the stale-but-present case it
 can't touch.
 
-**A `Red`/`Green`/`Blue` triple only collapses to `Color`/`FillColor`/`StrokeColor` when both sides
-use the identical channel name** — `VariableReferenceLogic.TryGetCompositeExpansion` requires the
-RHS to end with `.` + the LHS. A plain-color instance borrowing a Rectangle swatch's fill
-(`Red = X.FillRed`, common for `Text` instances) doesn't qualify - collapsing it would reference a
-`Color` composite the swatch doesn't have. `FormsTemplate` (Standard)'s own instances use this
-mismatched-name pattern exclusively, so none of its `VariableReferences` triples are eligible.
+**A `Red`/`Green`/`Blue` triple collapses to one `*Color` line whenever both sides decompose to the
+same composite token** — the two names need not match, so cross-named forms like
+`DropshadowColor = X.FillColor` and `Color = X.FillColor` are valid. All three lines must target
+the same object, since channels pair positionally. The hard requirement is on the left side only: the owning instance's type must
+declare every channel (`ExpandCompositeReferenceLine`/`OwnerHasAllCompositeChannels`), otherwise
+the line silently fails to expand at apply time and `gumcli check-references` reports the
+unmaterialized `*Color` scalar.
 
 One more staged-output-specific gotcha, beyond the postbuild simply not rerunning (item 7 /
 "the staged build, not the source" above): `xcopy` never deletes, so a rename or removal in the

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
@@ -202,9 +202,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Strong.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Bubblegum/Styles.Strong.IsBold</string>
@@ -218,9 +216,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
-        <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>DropshadowColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -230,9 +226,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -281,9 +275,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -330,9 +322,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -379,9 +369,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -428,9 +416,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -477,9 +463,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -526,9 +510,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -575,9 +557,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ButtonIcon.gucx
@@ -205,9 +205,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Bubblegum/Styles.Accent.FillColor</string>
-        <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>DropshadowColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -217,9 +215,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -268,9 +264,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -317,9 +311,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -366,9 +358,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -415,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -464,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -513,9 +499,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -562,9 +546,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
@@ -339,9 +339,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -363,9 +361,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -385,9 +381,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -397,9 +391,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -450,9 +442,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -462,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -523,9 +511,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -535,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -596,9 +580,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -608,9 +590,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -669,9 +649,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -681,9 +659,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -742,9 +718,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -754,9 +728,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -815,9 +787,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -827,9 +797,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -888,9 +856,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -900,9 +866,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -970,9 +934,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -982,9 +944,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -994,9 +954,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1064,9 +1022,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1076,9 +1032,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1088,9 +1042,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1158,9 +1110,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1170,9 +1120,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1182,9 +1130,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1252,9 +1198,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1264,9 +1208,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1276,9 +1218,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1346,9 +1286,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1358,9 +1296,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1370,9 +1306,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1440,9 +1374,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1452,9 +1384,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1464,9 +1394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1534,9 +1462,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1546,9 +1472,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1558,9 +1482,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1619,9 +1541,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1631,9 +1551,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1692,9 +1610,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1704,9 +1620,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1765,9 +1679,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1777,9 +1689,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1838,9 +1748,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1850,9 +1758,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1911,9 +1817,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1923,9 +1827,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1984,9 +1886,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1996,9 +1896,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -2057,9 +1955,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -2069,9 +1965,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
@@ -298,9 +298,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -312,9 +310,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -324,9 +320,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -336,9 +330,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -402,9 +394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -414,9 +404,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -436,9 +424,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -490,9 +476,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -502,9 +486,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -524,9 +506,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -578,9 +558,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -590,9 +568,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -612,9 +588,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -666,9 +640,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -678,9 +650,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -700,9 +670,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -754,9 +722,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -766,9 +732,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -788,9 +752,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -842,9 +804,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -854,9 +814,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -876,9 +834,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -930,9 +886,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -942,9 +896,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -964,9 +916,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
@@ -186,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -210,9 +208,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
@@ -291,9 +291,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Label.gucx
@@ -43,9 +43,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Strong.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Bubblegum/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBox.gucx
@@ -333,9 +333,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -345,9 +343,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -393,9 +389,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -439,9 +433,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -485,9 +477,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -531,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -577,9 +565,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -623,9 +609,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -669,9 +653,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
@@ -129,9 +129,7 @@
       <Value>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -167,9 +165,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -203,9 +199,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -259,9 +253,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -305,9 +297,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -341,9 +331,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
@@ -252,9 +252,7 @@
       <Value>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -266,9 +264,7 @@
       <Value>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -313,9 +309,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -325,9 +319,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -370,9 +362,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -382,9 +372,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -437,9 +425,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -459,9 +445,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -504,9 +488,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -516,9 +498,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -571,9 +551,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -583,9 +561,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
@@ -408,9 +408,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -422,9 +420,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -436,9 +432,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -448,9 +442,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -543,9 +535,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -555,9 +545,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -567,9 +555,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -650,9 +636,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -662,9 +646,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -674,9 +656,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -757,9 +737,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -769,9 +747,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -781,9 +757,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -864,9 +838,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -876,9 +848,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -888,9 +858,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
@@ -224,9 +224,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -238,9 +236,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -261,9 +257,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -321,9 +315,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -333,9 +325,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -401,9 +391,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -413,9 +401,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -481,9 +467,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -493,9 +477,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -561,9 +543,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -573,9 +553,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -641,9 +619,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -653,9 +629,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -721,9 +695,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -733,9 +705,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -801,9 +771,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -813,9 +781,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -881,9 +847,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -893,9 +857,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -961,9 +923,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -973,9 +933,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1041,9 +999,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1053,9 +1009,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1121,9 +1075,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1133,9 +1085,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1201,9 +1151,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1213,9 +1161,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1281,9 +1227,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1293,9 +1237,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1361,9 +1303,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1373,9 +1313,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ScrollViewer.gucx
@@ -278,9 +278,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -290,9 +288,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -406,9 +402,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -433,9 +427,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/SliderThumb.gucx
@@ -158,12 +158,8 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-        <string>DropshadowRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>DropshadowColor = Components/Bubblegum/Styles.Accent.FillColor</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -173,9 +169,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -215,9 +209,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -255,9 +247,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -295,9 +285,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.AccentLight.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.AccentDark.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.AccentDark.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.AccentDark.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.AccentDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -335,9 +323,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -375,9 +361,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -415,9 +399,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -455,9 +437,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Bubblegum/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
@@ -407,9 +407,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -421,9 +419,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
       </Value>
@@ -435,9 +431,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -447,9 +441,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -542,9 +534,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -554,9 +544,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -566,9 +554,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -649,9 +635,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -661,9 +645,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -673,9 +655,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -756,9 +736,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -768,9 +746,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -780,9 +756,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Text.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Text.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -863,9 +837,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -875,9 +847,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Bubblegum/Styles.Disabled.FillRed</string>
-          <string>StrokeGreen = Components/Bubblegum/Styles.Disabled.FillGreen</string>
-          <string>StrokeBlue = Components/Bubblegum/Styles.Disabled.FillBlue</string>
+          <string>StrokeColor = Components/Bubblegum/Styles.Disabled.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -887,9 +857,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Bubblegum/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Bubblegum/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Bubblegum/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
@@ -172,9 +172,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Strong.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Bubblegum/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Elements/Icon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Elements/Icon.gucx
@@ -83,9 +83,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.White.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.White.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.White.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.White.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Screens/Bubblegum/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Screens/Bubblegum/DemoScreenGum.gusx
@@ -699,9 +699,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Strong.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Bubblegum/Styles.Strong.IsBold</string>
@@ -714,9 +712,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Bubblegum/Styles.Accent.FillRed</string>
-        <string>Green = Components/Bubblegum/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Bubblegum/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Bubblegum/Styles.Accent.FillColor</string>
         <string>Font = Components/Bubblegum/Styles.Strong.Font</string>
         <string>FontSize = Components/Bubblegum/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Bubblegum/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Button.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Button.gucx
@@ -202,9 +202,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         <string>Font = Components/Hazard/Styles.Strong.Font</string>
         <string>FontSize = Components/Hazard/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Hazard/Styles.Strong.IsBold</string>
@@ -218,9 +216,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
-        <string>DropshadowRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>DropshadowColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -230,9 +226,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -281,9 +275,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -330,9 +322,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -379,9 +369,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -428,9 +416,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -477,9 +463,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -526,9 +510,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -575,9 +557,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ButtonIcon.gucx
@@ -205,9 +205,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Hazard/Styles.Accent.FillColor</string>
-        <string>DropshadowRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>DropshadowGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>DropshadowBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>DropshadowColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -217,9 +215,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -268,9 +264,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -317,9 +311,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -366,9 +358,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -415,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -464,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -513,9 +499,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -562,9 +546,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/CheckBox.gucx
@@ -339,9 +339,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -363,9 +361,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -385,9 +381,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -397,9 +391,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -450,9 +442,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -462,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -523,9 +511,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -535,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -596,9 +580,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -608,9 +590,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -669,9 +649,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -681,9 +659,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -742,9 +718,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -754,9 +728,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -815,9 +787,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -827,9 +797,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -888,9 +856,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -900,9 +866,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -970,9 +934,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -982,9 +944,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -994,9 +954,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1064,9 +1022,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1076,9 +1032,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1088,9 +1042,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1158,9 +1110,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1170,9 +1120,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1182,9 +1130,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1252,9 +1198,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1264,9 +1208,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1276,9 +1218,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1346,9 +1286,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1358,9 +1296,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1370,9 +1306,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1440,9 +1374,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1452,9 +1384,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1464,9 +1394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1534,9 +1462,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1546,9 +1472,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1558,9 +1482,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1619,9 +1541,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1631,9 +1551,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1692,9 +1610,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1704,9 +1620,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1765,9 +1679,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1777,9 +1689,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1838,9 +1748,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1850,9 +1758,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1911,9 +1817,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1923,9 +1827,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1984,9 +1886,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1996,9 +1896,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -2057,9 +1955,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -2069,9 +1965,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ComboBox.gucx
@@ -298,9 +298,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -312,9 +310,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -324,9 +320,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -336,9 +330,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -402,9 +394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -414,9 +404,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -436,9 +424,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -490,9 +476,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -502,9 +486,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -524,9 +506,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -578,9 +558,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -590,9 +568,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -612,9 +588,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -666,9 +640,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -678,9 +650,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>Green = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -700,9 +670,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -754,9 +722,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -766,9 +732,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -788,9 +752,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -842,9 +804,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -854,9 +814,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -876,9 +834,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -930,9 +886,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -942,9 +896,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -964,9 +916,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/DialogBox.gucx
@@ -186,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -210,9 +208,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ItemsControl.gucx
@@ -291,9 +291,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Label.gucx
@@ -43,9 +43,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Strong.Font</string>
         <string>FontSize = Components/Hazard/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Hazard/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBox.gucx
@@ -333,9 +333,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -345,9 +343,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -393,9 +389,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -439,9 +433,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -485,9 +477,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -531,9 +521,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -577,9 +565,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -623,9 +609,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -669,9 +653,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ListBoxItem.gucx
@@ -129,9 +129,7 @@
       <Value>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -167,9 +165,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -203,9 +199,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -259,9 +253,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>Green = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -305,9 +297,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>Green = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -341,9 +331,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/MenuItem.gucx
@@ -252,9 +252,7 @@
       <Value>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -266,9 +264,7 @@
       <Value>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -313,9 +309,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -325,9 +319,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -370,9 +362,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -382,9 +372,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -437,9 +425,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>Green = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -459,9 +445,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>Green = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -504,9 +488,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -516,9 +498,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -571,9 +551,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -583,9 +561,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.DisabledText.FillRed</string>
-          <string>Green = Components/Hazard/Styles.DisabledText.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.DisabledText.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/PasswordBox.gucx
@@ -408,9 +408,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -422,9 +420,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -436,9 +432,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -448,9 +442,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -543,9 +535,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -555,9 +545,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -567,9 +555,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -650,9 +636,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -662,9 +646,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -674,9 +656,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -757,9 +737,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -769,9 +747,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -781,9 +757,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -864,9 +838,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -876,9 +848,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -888,9 +858,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/RadioButton.gucx
@@ -224,9 +224,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -238,9 +236,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -261,9 +257,7 @@
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
         <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -321,9 +315,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -333,9 +325,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -401,9 +391,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -413,9 +401,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -481,9 +467,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -493,9 +477,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -561,9 +543,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -573,9 +553,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -641,9 +619,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -653,9 +629,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -721,9 +695,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -733,9 +705,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -801,9 +771,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -813,9 +781,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -881,9 +847,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.AccentPressed.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.AccentPressed.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.AccentPressed.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.AccentPressed.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -893,9 +857,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -961,9 +923,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -973,9 +933,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1041,9 +999,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1053,9 +1009,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1121,9 +1075,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1133,9 +1085,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1201,9 +1151,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1213,9 +1161,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1281,9 +1227,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1293,9 +1237,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1361,9 +1303,7 @@
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
           <string>FillColor = Components/Hazard/Styles.DisabledFill.FillColor</string>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1373,9 +1313,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ScrollViewer.gucx
@@ -278,9 +278,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -290,9 +288,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -406,9 +402,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -433,9 +427,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/SliderThumb.gucx
@@ -131,9 +131,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/TextBox.gucx
@@ -407,9 +407,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -421,9 +419,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         <string>Font = Components/Hazard/Styles.Normal.Font</string>
         <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
       </Value>
@@ -435,9 +431,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -447,9 +441,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-        <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-        <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+        <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -542,9 +534,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -554,9 +544,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Border.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Border.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Border.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Border.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -566,9 +554,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -649,9 +635,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -661,9 +645,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -673,9 +655,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -756,9 +736,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -768,9 +746,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.Accent.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.Accent.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.Accent.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -780,9 +756,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Text.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Text.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Text.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Text.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -863,9 +837,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -875,9 +847,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>StrokeRed = Components/Hazard/Styles.DisabledBorder.FillRed</string>
-          <string>StrokeGreen = Components/Hazard/Styles.DisabledBorder.FillGreen</string>
-          <string>StrokeBlue = Components/Hazard/Styles.DisabledBorder.FillBlue</string>
+          <string>StrokeColor = Components/Hazard/Styles.DisabledBorder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -887,9 +857,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Hazard/Styles.Placeholder.FillRed</string>
-          <string>Green = Components/Hazard/Styles.Placeholder.FillGreen</string>
-          <string>Blue = Components/Hazard/Styles.Placeholder.FillBlue</string>
+          <string>Color = Components/Hazard/Styles.Placeholder.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Toast.gucx
@@ -172,9 +172,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
         <string>Font = Components/Hazard/Styles.Strong.Font</string>
         <string>FontSize = Components/Hazard/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Hazard/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Elements/Icon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Elements/Icon.gucx
@@ -83,9 +83,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Ink.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Ink.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Ink.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Ink.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Screens/Hazard/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Screens/Hazard/DemoScreenGum.gusx
@@ -719,9 +719,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         <string>Font = Components/Hazard/Styles.Strong.Font</string>
         <string>FontSize = Components/Hazard/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Hazard/Styles.Strong.IsBold</string>
@@ -734,9 +732,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Hazard/Styles.Accent.FillRed</string>
-        <string>Green = Components/Hazard/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Hazard/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Hazard/Styles.Accent.FillColor</string>
         <string>Font = Components/Hazard/Styles.Strong.Font</string>
         <string>FontSize = Components/Hazard/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Hazard/Styles.Strong.IsBold</string>


### PR DESCRIPTION
## Summary

Collapses the 409 remaining `Red`/`Green`/`Blue` `VariableReferences` triples in Bubblegum (209) and Hazard (200) into single composite lines, now that cross-named composite references are supported (#4160 / #4167). 1227 reference lines become 409.

Patterns collapsed (all cross-named, all targeting a swatch's `Fill*` channels):

| Left | Count |
|---|---|
| `Red/Green/Blue` → `Color = X.FillColor` (`Text` borrowing a `Rectangle` swatch's fill) | 242 |
| `Stroke*` → `StrokeColor = X.FillColor` | 162 |
| `Dropshadow*` → `DropshadowColor = X.FillColor` | 5 |

No engine or test changes needed — `AllColorVariables_ShouldBeStylesWired` keys its composite expansion off the left side only, so cross-named lines were already handled.

FormsTemplate/Standard is untouched — that's #4158.

## Verification

- Dumped every variable value in both theme projects after `ApplyAllVariableReferences`, before and after the change: **byte-identical** (3715 Bubblegum / 3714 Hazard values). This is the real proof — it shows each collapsed line resolves to exactly what the three expanded lines did.
- `gumcli check` / `check-references` / `diff-standards` on both themes — output identical to baseline, exit 0.
- `gumcli check-references --fix` — zero changes (every collapsed line expands and its scalars are materialized).
- `dotnet test Tests/Gum.ProjectServices.Tests` — 439 passed, 3 skipped.
- `dotnet build GumFull.sln` — 0 errors; staged `Gum/bin/Debug/Content/FormsThemes/*` confirmed matching source (postbuild copy did re-run).

Also updates the `gum-forms-theme-import` skill, whose collapse-eligibility rule still said both sides must use the identical channel name.

Closes #4161
