### PR TITLE
Migrate both backends' render-target bake onto the shared orderer subtree entry point (#4154)

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -653,8 +653,8 @@ public class Renderer : IRenderer
         // Submit phase: walk that sequence, issuing the actual SpriteBatch / orchestrator
         // calls. Splitting these phases is what #2879's batch-grouped orderer needs — and
         // by itself it produces byte-identical output via HierarchicalOrderer (the default).
-        // The recursive Render/Draw helpers below remain in use for the prerender path
-        // (RenderToRenderTarget) and the GumBatch immediate-mode path (Renderer.Draw).
+        // The render-target bake shares the same build-then-submit shape via SubmitBake; the
+        // recursive Render/Draw helpers below remain only for the GumBatch immediate-mode path.
         SiblingOrdering.BuildDrawList(layer, _scratchCommands, mCamera);
         Submit(_scratchCommands, managers, layer);
 
@@ -703,7 +703,7 @@ public class Renderer : IRenderer
         // are not supported on this path.
         InvokePreRenderRecursively(renderable);
 
-        Draw(SystemManagers.Default, _layers[0], renderable, forceRenderHierarchy:false, isPreRender:false);
+        Draw(SystemManagers.Default, _layers[0], renderable);
     }
 
     private void InvokePreRenderRecursively(IRenderableIpso renderable)
@@ -927,8 +927,14 @@ public class Renderer : IRenderer
             var effectivePixelOffsetX = Camera.PixelPerfectOffsetX;
             var effectivePixelOffsetY = Camera.PixelPerfectOffsetY;
 
-            Camera.X = Math.MathFunctions.RoundToInt(Camera.X * CurrentZoom) / CurrentZoom + effectivePixelOffsetX / CurrentZoom;
-            Camera.Y = Math.MathFunctions.RoundToInt(Camera.Y * CurrentZoom) / CurrentZoom + effectivePixelOffsetY / CurrentZoom;
+            // CurrentZoom only becomes meaningful once a SpriteBatch has begun, but the bake runs
+            // in PreRender — before the frame's first BeginSpriteBatch. Fall back to the camera's
+            // own zoom so the snap below doesn't divide by zero and push Camera.X/Y to NaN, which
+            // then propagates into every world->screen scissor computed inside the bake.
+            var snapZoom = CurrentZoom > 0 ? CurrentZoom : Camera.Zoom;
+
+            Camera.X = Math.MathFunctions.RoundToInt(Camera.X * snapZoom) / snapZoom + effectivePixelOffsetX / snapZoom;
+            Camera.Y = Math.MathFunctions.RoundToInt(Camera.Y * snapZoom) / snapZoom + effectivePixelOffsetY / snapZoom;
 
 
             gumBatch = gumBatch ?? new GumBatch();
@@ -949,7 +955,7 @@ public class Renderer : IRenderer
             // substitute the bake-safe blend for that case instead (#1696). A child with an
             // explicitly custom BlendState is unaffected, same as the composite-back override.
             _isBakingRenderTarget = true;
-            Draw(systemManagers, _layers[0], renderable, forceRenderHierarchy:true, isPreRender:true);
+            SubmitBake(renderable, systemManagers, _layers[0]);
             _isBakingRenderTarget = false;
 
             gumBatch.End();
@@ -988,13 +994,53 @@ public class Renderer : IRenderer
 
     }
 
-    private void Render(IList<IRenderableIpso> whatToRender, SystemManagers managers, Layer layer, bool isPreRender)
+    /// <summary>
+    /// Bake submit phase: draws a render-target container and its subtree into the offscreen target
+    /// <see cref="RenderToRenderTarget"/> has already bound. The subtree goes through
+    /// <see cref="SiblingOrdering"/>'s subtree entry point so the bake shares the main pass's
+    /// visibility, off-screen-cull, clip and traversal semantics instead of running its own
+    /// recursive walk (#4154). <see cref="RenderToRenderTarget"/> has already rebased the camera
+    /// into render-target-local space, so the scissor and cull-bounds mappings are the ordinary
+    /// camera ones.
+    /// </summary>
+    private void SubmitBake(IRenderableIpso container, SystemManagers managers, Layer layer)
+    {
+        bool clips = container.ClipsChildren;
+        if (clips)
+        {
+            BeginClipScope(layer, container, managers);
+        }
+
+        // The container's own visual bakes first: a runtime container's InvisibleRenderable draws
+        // nothing, but the editor's LineRectangle-backed container draws its outline.
+        AdjustNonClipRenderStates(mRenderStateVariables, layer, container, managers);
+        _batchOrchestrator.OnRenderable(container, managers);
+        container.Render(managers);
+
+        var children = container.Children;
+        if (children != null && children.Count > 0)
+        {
+            SiblingOrdering.BuildDrawList(
+                children,
+                _bakeCommands,
+                renderable => Camera.GetScissorRectangleFor(layer, renderable),
+                renderable => Camera.GetCullTestBoundsFor(layer, renderable));
+            Submit(_bakeCommands, managers, layer);
+        }
+
+        if (clips)
+        {
+            EndClipScope(layer, container, managers);
+        }
+    }
+
+    private void Render(IList<IRenderableIpso> whatToRender, SystemManagers managers, Layer layer)
     {
         var count = whatToRender.Count;
         for (int i = 0; i < count; i++)
         {
             var renderable = whatToRender[i];
-            Draw(managers, layer, renderable, forceRenderHierarchy:false, isPreRender:isPreRender);
+            Draw(managers, layer, renderable);
         }
     }
 
@@ -1007,20 +1053,28 @@ public class Renderer : IRenderer
     // after warm-up. The renderer owns the buffer; the orderer writes into it.
     readonly List<DrawCommand> _scratchCommands = new List<DrawCommand>();
 
+    // Separate buffer for the render-target bake so a bake can never stomp the main pass's
+    // in-flight command list. Bakes run post-order in PreRender and are never re-entrant, so a
+    // single buffer serves all of them.
+    readonly List<DrawCommand> _bakeCommands = new List<DrawCommand>();
+
     // Tracks clip state during Submit so EndClip can restore the rect that BeginClip saw.
     // Balanced by construction (the orderer always emits matched BeginClip/EndClip pairs),
     // so this is empty at the end of every Submit call.
     readonly Stack<Rectangle?> _clipScopeStack = new Stack<Rectangle?>();
 
-    private void Draw(SystemManagers managers, Layer layer, IRenderableIpso renderable, bool forceRenderHierarchy, bool isPreRender)
+    // Legacy recursive walk, still used by the GumBatch immediate-mode path (Renderer.Draw).
+    // The layered main pass and the render-target bake both go through the shared
+    // SiblingOrdering build phase plus Submit instead.
+    private void Draw(SystemManagers managers, Layer layer, IRenderableIpso renderable)
     {
-        if (renderable.Visible || ( renderable.IsRenderTarget && isPreRender))
+        if (renderable.Visible)
         {
             var oldClip = mRenderStateVariables.ClipRectangle;
             AdjustRenderStates(mRenderStateVariables, layer, renderable, managers);
             bool didClipChange = oldClip != mRenderStateVariables.ClipRectangle;
 
-            if (renderable.IsRenderTarget && !forceRenderHierarchy)
+            if (renderable.IsRenderTarget)
             {
                 // Resolved cache key — see the matching comment in RenderToRenderTarget (#3451).
                 var renderTarget = renderTargetService.GetRenderTargetFor(
@@ -1040,7 +1094,7 @@ public class Renderer : IRenderer
 
                 if (RenderUsingHierarchy)
                 {
-                    Render(renderable.Children, managers, layer, isPreRender);
+                    Render(renderable.Children, managers, layer);
                 }
             }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -47,14 +47,14 @@ public class Renderer : IRenderer
     readonly Gum.Renderables.RenderTextureService _renderTargetService = new();
 
     // True while baking a render-target container's subtree into its offscreen texture. Inside a
-    // bake, DrawGumRecursively rebases scissor rects into RT-local space (the clamped top-left is
+    // bake, GetScissorRectangleFor rebases scissor rects into RT-local space (the clamped top-left is
     // the RT origin) so a ClipsChildren descendant clips correctly within the RT (#3440).
     bool _isBakingRenderTarget;
 
-    // The active bake's clamped top-left in world coords, captured so DrawGumRecursively can convert
-    // a descendant's absolute bounds into RT-local scissor pixels. Only meaningful while
-    // _isBakingRenderTarget is true; bakes are never re-entrant (post-order means an inner RT is
-    // fully baked before its outer one begins), so single fields suffice.
+    // The active bake's clamped top-left in world coords, captured so the bake-local scissor and
+    // cull-bounds mappings can convert a descendant's absolute bounds into RT-local pixels. Only
+    // meaningful while _isBakingRenderTarget is true; bakes are never re-entrant (post-order means
+    // an inner RT is fully baked before its outer one begins), so single fields suffice.
     float _bakeLeft;
     float _bakeTop;
 
@@ -66,6 +66,11 @@ public class Renderer : IRenderer
     // warm-up, mirroring the xnalike Renderer's _scratchCommands (#4154). The renderer owns
     // the buffer; the orderer writes into it.
     readonly List<DrawCommand> _scratchCommands = new();
+
+    // Separate buffer for the render-target bake so a bake can never stomp the main pass's
+    // in-flight command list. Bakes run post-order and are never re-entrant, so one buffer
+    // serves all of them.
+    readonly List<DrawCommand> _bakeCommands = new();
 
     // Set during the PreRender walk (which already traverses the whole visible tree) when any
     // render-target container is present, so the bake pre-pass is skipped entirely for the common
@@ -368,9 +373,9 @@ public class Renderer : IRenderer
         // Build phase: flatten the (already Z-sorted) layer into a sequence of DrawCommands via
         // the shared HierarchicalOrderer -- the same builder MonoGame/KNI/FNA use for their main
         // pass (#4154). Submit phase below walks that sequence, issuing the raylib-specific
-        // scissor stack / BatchDrawCallCounter / render-target composite calls. BakeRenderTarget's
-        // own child walk stays on the recursive DrawGumRecursively -- unifying the bake path onto
-        // the orderer's subtree entry point is a separate follow-up (#4154 step 4).
+        // scissor stack / BatchDrawCallCounter / render-target composite calls. BakeRenderTarget
+        // uses the same build-then-submit shape via the orderer's subtree entry point, so raylib
+        // has a single walk implementation.
         HierarchicalOrderer.Instance.BuildDrawList(layer, _scratchCommands, _camera);
         Submit(_scratchCommands, layer);
     }
@@ -391,9 +396,8 @@ public class Renderer : IRenderer
 
             // A render-target container always renders as a single composited unit (its subtree
             // was already baked into an offscreen texture during the pre-pass) and never
-            // participates in the scissor stack, even if it also has ClipsChildren set --
-            // mirrors DrawGumRecursively, which composites and returns before ever touching the
-            // scissor stack. The orderer brackets ClipsChildren independently of IsRenderTarget
+            // participates in the scissor stack, even if it also has ClipsChildren set.
+            // The orderer brackets ClipsChildren independently of IsRenderTarget
             // (see HierarchicalOrdererTests.BuildDrawList_IsRenderTargetNodeWithClipsChildren_
             // StillBracketsButDoesNotRecurse), so this guard applies uniformly across BeginClip /
             // DrawRenderable / EndClip rather than assuming the brackets are already absent. Covered
@@ -446,93 +450,6 @@ public class Renderer : IRenderer
         else
         {
             BatchDrawCallCounter.EndScissorMode();
-        }
-    }
-
-    private void DrawGumRecursively(IRenderableIpso element, Layer layer)
-    {
-        // Mirrors HierarchicalOrderer's own top-of-node check: an invisible renderable and its whole
-        // subtree are skipped. Covers both top-level layer renderables (Render's loop above has no
-        // Visible check of its own) and children (the loop below no longer filters on Visible either,
-        // relying on this single check — #4155).
-        if (!element.Visible)
-        {
-            return;
-        }
-
-        // #2998 off-screen cull: when a clip is active (the scissor stack is non-empty), skip this
-        // element and its subtree if it falls entirely outside the active clip, expanded by a small
-        // margin. Mirrors the XNA orderer cull via the same shared predicate.
-        // GetCullTestBoundsFor (rather than the plain GetScissorRectangleFor) accounts for wrapped
-        // text whose actual rendered extent exceeds its declared bounds (#4144).
-        if (CameraScissorExtensions.CullOffscreenWhenClipped
-            && _scissorStack.Count > 0
-            && CameraScissorExtensions.IsFullyOutside(
-                GetCullTestBoundsFor(layer, element),
-                _scissorStack.Peek(),
-                CameraScissorExtensions.OffscreenCullMarginInPixels))
-        {
-            return;
-        }
-
-        // Render-target container (#3434): its subtree was already baked into an offscreen texture
-        // during the pre-pass, so composite that texture in place of walking the live children. This
-        // fires both in the main walk (composite to screen) and inside an outer container's bake
-        // (composite a nested inner RT into the outer texture), which is what makes nesting work. A
-        // render-target container ALWAYS renders as a single composited unit and never falls through
-        // to draw its children directly.
-        if (element.IsRenderTarget)
-        {
-            // Composite the baked texture if a valid one exists; otherwise (degenerate/zero clamped
-            // size, or entirely off-camera) render NOTHING and stop. We deliberately do NOT fall
-            // through to draw the children directly: doing so would draw them unclamped, so content
-            // that reaches back into the visible camera area (a negative offset, an oversized child,
-            // a dropshadow bleeding past the edge) would appear on raylib but be invisible on
-            // MonoGame for the same project. This converges raylib onto MonoGame, whose draw-list
-            // builder never recurses into render-target children (HierarchicalOrderer's
-            // !IsRenderTarget gate) and whose composite sites skip when GetRenderTargetFor is null
-            // (#3478).
-            CompositeRenderTarget(element);
-            return;
-        }
-
-        // #4155: pushed before the element's own Render() so a clipping element's own draw is bounded
-        // by its own clip, matching HierarchicalOrderer (BeginClip precedes DrawRenderable).
-        if (element.ClipsChildren)
-        {
-            System.Drawing.Rectangle rect = GetScissorRectangleFor(layer, element);
-            System.Drawing.Rectangle effective = _scissorStack.Count > 0
-                ? System.Drawing.Rectangle.Intersect(_scissorStack.Peek(), rect)
-                : rect;
-            _scissorStack.Push(effective);
-            BatchDrawCallCounter.BeginScissorMode(effective.X, effective.Y, effective.Width, effective.Height);
-        }
-
-        element.Render(null);
-
-        if (element.Children != null)
-        {
-            // #4155: recurse into every child regardless of concrete type -- matching
-            // HierarchicalOrderer, which recurses into any visible IRenderableIpso. The Visible check
-            // above (run on entry to the recursive call) is what actually gates each child.
-            foreach (IRenderableIpso child in element.Children)
-            {
-                DrawGumRecursively(child, layer);
-            }
-        }
-
-        if (element.ClipsChildren)
-        {
-            _scissorStack.Pop();
-            if (_scissorStack.Count > 0)
-            {
-                System.Drawing.Rectangle parent = _scissorStack.Peek();
-                BatchDrawCallCounter.BeginScissorMode(parent.X, parent.Y, parent.Width, parent.Height);
-            }
-            else
-            {
-                BatchDrawCallCounter.EndScissorMode();
-            }
         }
     }
 
@@ -666,7 +583,7 @@ public class Renderer : IRenderer
         };
 
         // Swap in the reusable bake scissor stack (avoids a per-bake allocation) so the main-walk
-        // scissor stack is isolated from the bake, and capture the bake origin so DrawGumRecursively
+        // scissor stack is isolated from the bake, and capture the bake origin so the scissor mapping
         // can rebase a ClipsChildren descendant's clip rect into RT-local space (#3440).
         Stack<System.Drawing.Rectangle> savedScissorStack = _scissorStack;
         _bakeScissorStack.Clear();
@@ -699,14 +616,18 @@ public class Renderer : IRenderer
         // counter re-establishes this pass on EndBlendMode so later siblings still bake premultiplied.
         counter.BeginRenderTargetBlend();
 
-        if (container.Children != null)
+        ObservableCollection<IRenderableIpso> children = container.Children;
+        if (children != null && children.Count > 0)
         {
-            // #4155: recurse into every child regardless of concrete type, mirroring the main walk's
-            // fix in DrawGumRecursively -- its own Visible check gates each child.
-            foreach (IRenderableIpso child in container.Children)
-            {
-                DrawGumRecursively(child, layer);
-            }
+            // Same shared builder the main pass uses, entered at this container's subtree instead of
+            // at a Layer (#4154). The RT-local scissor / cull-bounds mappings below are what let the
+            // bake express its own coordinate space through the shared walk.
+            HierarchicalOrderer.Instance.BuildDrawList(
+                children,
+                _bakeCommands,
+                renderable => GetScissorRectangleFor(layer, renderable),
+                renderable => GetCullTestBoundsFor(layer, renderable));
+            Submit(_bakeCommands, layer);
         }
 
         counter.EndRenderTargetBlend();

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetBakeClipWalkTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetBakeClipWalkTests.cs
@@ -1,0 +1,212 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Covers the render-target bake walk after it was migrated onto the shared
+/// <see cref="IRenderableOrderer"/> subtree entry point (#4154). The bake previously ran its own
+/// recursive walk with no off-screen cull, so a clipping container inside a render target drew
+/// every scrolled-off descendant. Going through the shared builder gives the bake the same
+/// visibility / cull / clip semantics as the main pass — matching raylib, which already culled
+/// inside bakes.
+/// </summary>
+public class RenderTargetBakeClipWalkTests : BaseTestClass
+{
+    [Fact]
+    public void ClippedChild_ScrolledOutsideClip_InsideRenderTargetBake_IsCulled()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        ContainerRuntime renderTargetRoot = new();
+        renderTargetRoot.X = 0;
+        renderTargetRoot.Y = 0;
+        renderTargetRoot.Width = 200;
+        renderTargetRoot.Height = 200;
+        renderTargetRoot.IsRenderTarget = true;
+
+        // Clips to the top half of the render target: absolute Y [0, 100].
+        ContainerRuntime clipParent = new();
+        clipParent.Width = 200;
+        clipParent.Height = 100;
+        clipParent.ClipsChildren = true;
+
+        RenderCountingRuntime inside = new();
+        inside.Width = 180;
+        inside.Height = 80;
+        inside.Y = 0;
+        clipParent.AddChild(inside);
+
+        // Absolute Y [150, 190] — past the clip bottom plus its cull margin, but still inside the
+        // 200-tall render target, so only the cull (not the render-target bounds) can skip it.
+        RenderCountingRuntime outside = new();
+        outside.Width = 180;
+        outside.Height = 40;
+        outside.Y = 150;
+        clipParent.AddChild(outside);
+
+        renderTargetRoot.AddChild(clipParent);
+        renderTargetRoot.AddToManagers(managers, null);
+        renderTargetRoot.UpdateLayout();
+
+        try
+        {
+            CameraScissorExtensions.CullOffscreenWhenClipped = false;
+            renderer.Draw(managers);
+            inside.RenderCallCount.ShouldBeGreaterThan(0);
+            outside.RenderCallCount.ShouldBeGreaterThan(0);
+
+            inside.ResetRenderCallCount();
+            outside.ResetRenderCallCount();
+
+            CameraScissorExtensions.CullOffscreenWhenClipped = true;
+            renderer.Draw(managers);
+            inside.RenderCallCount.ShouldBeGreaterThan(0);
+            outside.RenderCallCount.ShouldBe(0);
+        }
+        finally
+        {
+            CameraScissorExtensions.CullOffscreenWhenClipped = true;
+            renderTargetRoot.RemoveFromManagers();
+        }
+    }
+
+    [Fact]
+    public void ClippedContent_InsideRenderTargetBake_ClipsToItsContainer()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        GraphicsDevice gd = game.GraphicsDevice;
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+
+        const int renderTargetSize = 200;
+
+        ContainerRuntime renderTargetRoot = new();
+        renderTargetRoot.X = 0;
+        renderTargetRoot.Y = 0;
+        renderTargetRoot.Width = renderTargetSize;
+        renderTargetRoot.Height = renderTargetSize;
+        renderTargetRoot.IsRenderTarget = true;
+
+        // Clips to the top half of the render target: absolute Y [0, 100].
+        ContainerRuntime clipParent = new();
+        clipParent.Width = renderTargetSize;
+        clipParent.Height = 100;
+        clipParent.ClipsChildren = true;
+
+        // Taller than the clip, so its bottom half must be scissored away inside the bake.
+#pragma warning disable CS0618 // ColoredRectangleRuntime is obsolete; simplest solid fill without the shape dependency.
+        ColoredRectangleRuntime tallChild = new();
+#pragma warning restore CS0618
+        tallChild.Width = 180;
+        tallChild.Height = 180;
+        tallChild.Y = 0;
+        tallChild.Color = new Color((byte)0, (byte)255, (byte)0, (byte)255);
+        clipParent.AddChild(tallChild);
+
+        renderTargetRoot.AddChild(clipParent);
+        renderTargetRoot.AddToManagers(managers, null);
+        renderTargetRoot.UpdateLayout();
+
+        try
+        {
+            renderer.Draw(managers);
+            gd.SetRenderTarget(null);
+
+            RenderTarget2D baked = renderer.TryGetBakedRenderTargetFor(renderTargetRoot)!;
+            baked.Width.ShouldBe(renderTargetSize);
+            baked.Height.ShouldBe(renderTargetSize);
+
+            Color[] pixels = new Color[baked.Width * baked.Height];
+            baked.GetData(pixels);
+
+            Color insideClip = pixels[(40 * baked.Width) + 90];
+            Color belowClip = pixels[(150 * baked.Width) + 90];
+
+            insideClip.G.ShouldBeGreaterThan((byte)200);
+            belowClip.A.ShouldBeLessThan((byte)50);
+        }
+        finally
+        {
+            renderTargetRoot.RemoveFromManagers();
+        }
+    }
+
+    /// <summary>
+    /// Renderable that records how many times the walk asked it to draw. Draws nothing itself —
+    /// the count is the observable, which is what separates "culled" from "drawn but scissored".
+    /// </summary>
+    private sealed class RenderCountingRenderable : InvisibleRenderable
+    {
+        public int RenderCallCount { get; private set; }
+
+        public void ResetRenderCallCount() => RenderCallCount = 0;
+
+        public override void Render(ISystemManagers managers) => RenderCallCount++;
+    }
+
+    /// <summary>
+    /// Runtime wrapper for <see cref="RenderCountingRenderable"/> so it can be positioned and
+    /// nested through normal Gum layout, following the standard Runtime-wraps-Renderable pattern.
+    /// </summary>
+    private sealed class RenderCountingRuntime : GraphicalUiElement
+    {
+        private readonly RenderCountingRenderable _renderable;
+
+        public RenderCountingRuntime() : base(new RenderCountingRenderable(), whatContainsThis: null)
+        {
+            _renderable = (RenderCountingRenderable)RenderableComponent;
+        }
+
+        public int RenderCallCount => _renderable.RenderCallCount;
+
+        public void ResetRenderCallCount() => _renderable.ResetRenderCallCount();
+    }
+
+    /// <summary>
+    /// Minimal Game host that initializes a fresh <see cref="GumService"/> per test so
+    /// <see cref="Renderer.Draw(SystemManagers)"/> can be invoked against a live device.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Gum.GumService.Default.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Gum.GumService.Default.IsInitialized)
+            {
+                Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/ClipWalkConformanceTests.cs
@@ -11,11 +11,12 @@ using static Raylib_cs.Raylib;
 namespace RaylibGum.Tests.Rendering;
 
 /// <summary>
-/// Real-frame conformance suite for raylib's <c>DrawGumRecursively</c> walk (issue #4155), the
-/// off-screen-cull / clip-walk counterpart to <see cref="RenderTargetTests"/>. raylib reimplements
-/// the cull and clip walk inline instead of routing through the shared
-/// <see cref="RenderingLibrary.Graphics.HierarchicalOrderer"/> (#4154), so it can silently diverge
-/// from MonoGame's behavior even when every MonoGame-side test is green (#4144). Covers the
+/// Real-frame conformance suite for raylib's clip/cull walk (issue #4155), the off-screen-cull /
+/// clip-walk counterpart to <see cref="RenderTargetTests"/>. raylib used to reimplement the cull
+/// and clip walk inline rather than routing through the shared
+/// <see cref="RenderingLibrary.Graphics.HierarchicalOrderer"/>, which is how it silently diverged
+/// from MonoGame's behavior while every MonoGame-side test stayed green (#4144); both the main pass
+/// and the render-target bake now go through that shared builder (#4154). Covers the
 /// off-screen cull at the clip edge and cull margin, nested-clip intersection, and one pinning
 /// test per divergence found auditing against <c>HierarchicalOrderer</c>: draw order relative to
 /// an element's own clip, non-<see cref="GraphicalUiElement"/> children, and top-level visibility.
@@ -275,7 +276,7 @@ public class ClipWalkConformanceTests : BaseTestClass
     }
 
     // Coverage for existing (correct) behavior: raylib's BeginScissorMode replaces rather than
-    // intersects, which is why DrawGumRecursively maintains its own _scissorStack. A nested clip
+    // intersects, which is why the Submit phase maintains its own _scissorStack. A nested clip
     // narrower than its ancestor must still be bounded by BOTH rectangles' intersection.
     [Fact]
     public void Draw_NestedClipContainers_IntersectRatherThanReplace()
@@ -333,7 +334,7 @@ public class ClipWalkConformanceTests : BaseTestClass
     }
 
     // #4154: a container that is both IsRenderTarget and ClipsChildren -- e.g. a scrolling panel
-    // rendered to a texture for group opacity. DrawGumRecursively checks IsRenderTarget and
+    // rendered to a texture for group opacity. The walk checks IsRenderTarget and
     // composites-then-returns BEFORE ever reaching the ClipsChildren scissor push, so the node's
     // own clip has no effect and its children are never walked outside the bake. Pinned here via a
     // sibling drawn immediately afterward in the SAME bake: if that ordering regressed (the scissor
@@ -343,11 +344,11 @@ public class ClipWalkConformanceTests : BaseTestClass
     // scissoring is a fragment-level test, not something that suppresses the draw call itself --
     // so this needs pixel readback.
     //
-    // This exercises the shared DrawGumRecursively walk (used by BakeRenderTarget's child loop),
-    // not Renderer.Submit's own IsRenderTarget guard: this harness has no way to read the actual
-    // screen framebuffer Submit draws to, only RenderTexture2D content populated by a bake, and any
-    // node nested under an IsRenderTarget ancestor is (by the orderer's own recursion gate) reached
-    // via the bake's DrawGumRecursively walk, never via Submit. Submit's matching guard -- applied
+    // This exercises the bake path (BakeRenderTarget builds its subtree through the shared orderer),
+    // not the main pass's own IsRenderTarget guard: this harness has no way to read the actual
+    // screen framebuffer the main pass draws to, only RenderTexture2D content populated by a bake,
+    // and any node nested under an IsRenderTarget ancestor is (by the orderer's own recursion gate)
+    // reached via the bake, never via the main pass. Submit's matching guard -- applied
     // uniformly across BeginClip/DrawRenderable/EndClip rather than gated by command kind -- is
     // covered by Draw_TopLevelRenderTargetContainerWithClipsChildren_
     // CompositesOnceWithoutDoubleDrawingChildren below (draw-call count) and by
@@ -434,8 +435,8 @@ public class ClipWalkConformanceTests : BaseTestClass
     }
 
     // #4154: raylib's Renderer.Submit (the migrated main-pass walk) special-cases IsRenderTarget
-    // uniformly for BeginClip/DrawRenderable/EndClip -- mirroring DrawGumRecursively's composite-
-    // then-return-before-ClipsChildren ordering -- so a TOP-LEVEL container that is both
+    // uniformly for BeginClip/DrawRenderable/EndClip -- keeping the composite-before-ClipsChildren
+    // ordering -- so a TOP-LEVEL container that is both
     // IsRenderTarget and ClipsChildren composites exactly once and never draws its children a
     // second time in the main pass (only once, inside the bake). Unlike the multi-child cull case,
     // draw-call count is reliable here: the bake and the main-pass composite land in different FBO


### PR DESCRIPTION
Closes #4154. Step 4 of the implementation order on the issue — the last remaining piece after PR #4165 landed steps 1-3.

## What changed

Both backends' render-target bakes ran their own recursive child walk. Both now build a `DrawCommand` list through `IRenderableOrderer`'s subtree overload and hand it to the existing Submit phase:

- **xnalike** — `RenderToRenderTarget`'s `Draw(..., forceRenderHierarchy: true, isPreRender: true)` is replaced by `SubmitBake`, which draws the container itself and then builds + submits its subtree. `forceRenderHierarchy`/`isPreRender` were the only reason those parameters existed, so the legacy recursive `Draw` sheds both and is now used solely by the GumBatch immediate-mode path.
- **raylib** — `BakeRenderTarget`'s child loop builds through the orderer with the RT-local scissor/cull mappings. `DrawGumRecursively` is deleted; raylib now has a single walk implementation.

## Behavior change (decision 2 on the issue)

The shared walk culls off-screen content whenever a clip is active, in the main pass and inside a bake alike. That was already raylib's behavior; **MonoGame's bake gains the cull it never had**. New MonoGame coverage in `RenderTargetBakeClipWalkTests` pins both that and clipped content baking correctly.

Two smaller semantic conversions fall out, both toward raylib/main-pass semantics: an invisible nested render-target container inside a bake is now skipped rather than composited, and the bake no longer applies the container's clip and blend in a single `BeginSpriteBatch` (clip first, then blend — same as the main pass already does).

## Bug fixed along the way

The bake snapped `Camera.X/Y` using `SpriteRenderer.CurrentZoom`, which is still `0` during `PreRender` — before the frame's first `BeginSpriteBatch`. On the first frame that pushed the bake camera to NaN, and any `ClipsChildren` content inside a render target threw `floatToRound cannot be NaN` from every world→screen scissor. Falls back to `Camera.Zoom`.

## Verification

- `RaylibGum.Tests` 569/569, `MonoGameGum.Tests` 2079/2079, `MonoGameGum.IntegrationTests` 78/79.
- The one integration failure is `DrawAllocationTests.IdleUpdateAndDraw_RepresentativeFormsScene_AllocationBaseline` (224 vs 120 bytes/frame). **Pre-existing** — reproduces identically with this branch's changes stashed, and that suite doesn't run in CI. Untouched here.
