### PR TITLE
Stop the draw-list build allocating per frame, and run MonoGameGum.IntegrationTests in CI (#4190)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -611,12 +611,20 @@ jobs:
       # Real MonoGame Game + GraphicsDevice per test, on the same Mesa llvmpipe DLLs copied above
       # (#4190). Windows-only for the same reason RaylibGum.Tests is: the macOS runner's window
       # creation is main-thread-coupled via Cocoa, and Mesa is dropped in as Windows DLLs.
+      #
+      # RequiresOpenGlShaderCompiler is filtered out: those 7 RenderTargetEffectTests compile a .fx
+      # with ShadowDusk for PlatformTarget.OpenGL, which fails on the hosted runner even though the
+      # DirectX target succeeds there (Compile_GrayscaleShader_ForDirectXTarget_Succeeds is untagged
+      # and runs), so the HLSL front end loads and it is the GLSL back end that is missing. This is a
+      # toolchain gap unrelated to Mesa or the GraphicsDevice — the other 72 tests, render-target
+      # pixel readbacks included, all pass. They still run in full locally. Closing the gap (and
+      # dropping this filter) is #4195.
       - name: "MonoGameGum.IntegrationTests (Windows, #4190)"
         if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
         timeout-minutes: 15
         env:
           GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
-        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --filter "RequiresOpenGlShaderCompiler!=true" --logger "trx" --results-directory "TestResults"
 
       - name: Publish Test Results
         if: always() && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -425,6 +425,11 @@ jobs:
       #                                     raylib window/OpenGL context as
       #                                     RaylibGum.Tests above, needs the same
       #                                     Mesa llvmpipe DLLs. #4174)
+      #   - MonoGameGum.IntegrationTests   (real MonoGame Game + GraphicsDevice;
+      #                                     Windows-only, on the same Mesa llvmpipe
+      #                                     software GL as RaylibGum.Tests. Promoted
+      #                                     from Bucket D in #4190 — see the note
+      #                                     under that bucket below)
       #
       # Bucket B — DEFERRED, NEEDS INVESTIGATION (likely safe in part, but may
       # mix headless and graphics-using tests in the same project; would need
@@ -441,9 +446,26 @@ jobs:
       #
       # Bucket D — WILL NOT RUN IN CI (require a real graphics device / window;
       # do NOT add these even if they look tempting):
-      #   - MonoGameGum.IntegrationTests   (integration → real GraphicsDevice)
-      #   - MonoGameGum.Shapes.Tests       (shape rendering → GraphicsDevice)
-      #   - MonoGameFum.FromFile.Tests     (instantiates real visuals)
+      #   - MonoGameGum.Shapes.Tests       (shape rendering → GraphicsDevice.
+      #                                     Same MonoGame.Framework.DesktopGL as
+      #                                     MonoGameGum.IntegrationTests, so Mesa
+      #                                     llvmpipe likely covers it too — but it
+      #                                     renders through Apos.Shapes, which has
+      #                                     not been exercised on software GL. Needs
+      #                                     its own verification run before moving.)
+      #   - MonoGameFum.FromFile.Tests     (instantiates real visuals. References no
+      #                                     MonoGame package at all, so its exclusion
+      #                                     reason is something other than "needs a
+      #                                     GraphicsDevice" and needs its own look.)
+      #
+      # MonoGameGum.IntegrationTests graduated from Bucket D to Bucket A in #4190. Its
+      # "needs a real GraphicsDevice" exclusion predated Mesa llvmpipe (#3250) and was
+      # already contradicted by two jobs: Native-AOT-Smoke drives a real Game +
+      # GraphicsDevice + Texture2D upload on this runner, and Gum.Cli.Tests renders via
+      # MonoGame under `dotnet test` with the same Mesa DLLs. The suite uses the identical
+      # MonoGame.Framework.DesktopGL, and its MinimalGame hosts match the AOT harness's
+      # SmokeGame. The gap had a cost: a DrawAllocationTests ratchet went red for 129
+      # commits with nothing to catch it.
       # ---------------------------------------------------------------------
 
       # continue-on-error was removed from the Bucket-A suites below (#3233): a red
@@ -546,7 +568,8 @@ jobs:
           $dests = @(
             "Tests/RaylibGum.Tests/bin/Release/net8.0",
             "Tests/Gum.ProjectServices.Raylib.Tests/bin/Release/net8.0",
-            "Tests/Gum.Cli.Tests/bin/Release/net8.0"
+            "Tests/Gum.Cli.Tests/bin/Release/net8.0",
+            "Tests/MonoGameGum.IntegrationTests/bin/Release/net8.0"
           )
           foreach ($dest in $dests) {
             Copy-Item (Join-Path $opengl.Directory.FullName "*.dll") -Destination $dest -Force
@@ -584,6 +607,16 @@ jobs:
         env:
           GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
         run: dotnet test "Tests/Gum.ProjectServices.Raylib.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      # Real MonoGame Game + GraphicsDevice per test, on the same Mesa llvmpipe DLLs copied above
+      # (#4190). Windows-only for the same reason RaylibGum.Tests is: the macOS runner's window
+      # creation is main-thread-coupled via Cocoa, and Mesa is dropped in as Windows DLLs.
+      - name: "MonoGameGum.IntegrationTests (Windows, #4190)"
+        if: (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true') && runner.os == 'Windows'
+        timeout-minutes: 15
+        env:
+          GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
+        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Publish Test Results
         if: always() && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -278,8 +278,7 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         BatchKeyGroupedOrderer.Instance.BuildDrawList(
             new List<IRenderableIpso> { clipContainer },
             commands,
-            GetScissorRectangle,
-            GetCullTestBounds);
+            new ClipBoundsSource(GetScissorRectangle, GetCullTestBounds));
 
         Describe(commands).ShouldBe(new[]
         {

--- a/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/HierarchicalOrdererTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
+using MonoGameGum.TestsCommon;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -287,8 +288,7 @@ public class HierarchicalOrdererTests : BaseTestClass
         HierarchicalOrderer.Instance.BuildDrawList(
             new List<IRenderableIpso> { clipContainer },
             commands,
-            GetScissorRectangle,
-            GetCullTestBounds);
+            new ClipBoundsSource(GetScissorRectangle, GetCullTestBounds));
 
         Describe(commands).ShouldBe(new[]
         {
@@ -344,7 +344,7 @@ public class HierarchicalOrdererTests : BaseTestClass
         HierarchicalOrderer.Instance.BuildDrawList(
             new List<IRenderableIpso> { clipContainer },
             commands,
-            GetScissorRectangle);
+            new ClipBoundsSource(GetScissorRectangle));
 
         Describe(commands).ShouldBe(new[]
         {
@@ -420,6 +420,42 @@ public class HierarchicalOrdererTests : BaseTestClass
         HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera);
 
         Describe(commands).ShouldContain("DrawRenderable:scrolledText");
+    }
+
+    // Allocation guard (#4190): the render path rebuilds the draw list every frame, once per layer,
+    // so building it must not allocate. Synthesizing the camera/layer rectangle mappings as closures
+    // per call cost 160 B/frame (a display class plus two delegates) and went unnoticed because the
+    // only guard lived in a suite excluded from CI. This one runs headless, so CI catches it.
+    [Fact]
+    public void BuildDrawList_LayerOverloadWithCamera_DoesNotAllocate()
+    {
+        Camera camera = new Camera();
+        camera.ClientWidth = 800;
+        camera.ClientHeight = 600;
+        camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
+
+        FakeRenderable clipParent = new FakeRenderable("clipParent");
+        clipParent.ClipsChildren = true;
+        clipParent.Y = 300;
+        clipParent.Width = 200;
+        clipParent.Height = 200;
+
+        FakeRenderable child = AddChild(clipParent, "child");
+        child.Width = 190;
+        child.Height = 80;
+
+        Layer layer = BuildLayer(clipParent);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
+            () => HierarchicalOrderer.Instance.BuildDrawList(layer, commands, camera),
+            attempts: 3,
+            warmupIterations: 50,
+            measuredIterations: 500);
+
+        // Liveness: a build that emitted nothing would trivially allocate nothing.
+        Describe(commands).ShouldContain("DrawRenderable:child");
+        result.BytesPerIteration.ShouldBe(0);
     }
 
     [Fact]

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -37,31 +37,26 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     {
         destination.Clear();
 
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = camera != null
-            ? renderable => camera.GetScissorRectangleFor(layer, renderable)
-            : null;
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = camera != null
-            ? renderable => camera.GetCullTestBoundsFor(layer, renderable)
-            : null;
+        ClipBoundsSource clipBounds = camera != null
+            ? new ClipBoundsSource(camera, layer)
+            : default;
 
-        ProcessLayerTopLevel(layer, getScissorRectangle, getCullTestBounds, destination);
+        ProcessLayerTopLevel(layer, clipBounds, destination);
     }
 
     /// <inheritdoc/>
     public void BuildDrawList(
         IList<IRenderableIpso> roots,
         List<DrawCommand> destination,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null)
+        ClipBoundsSource clipBounds = default)
     {
         destination.Clear();
-        ProcessWindow(roots, getScissorRectangle, getCullTestBounds ?? getScissorRectangle, destination);
+        ProcessWindow(roots, clipBounds, destination);
     }
 
     private static void ProcessLayerTopLevel(
         Layer layer,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        ClipBoundsSource clipBounds,
         List<DrawCommand> destination)
     {
         ReadOnlyCollection<IRenderableIpso> top = layer.Renderables;
@@ -89,7 +84,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 List<Entry> window = new List<Entry>();
                 for (int i = runStart; i < runEnd; i++)
                 {
-                    ProcessRenderable(top[i], getScissorRectangle, getCullTestBounds, null, window, destination);
+                    ProcessRenderable(top[i], clipBounds, null, window, destination);
                 }
                 FlushWindow(window, destination);
 
@@ -98,14 +93,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         }
         else
         {
-            ProcessWindow(top, getScissorRectangle, getCullTestBounds, destination);
+            ProcessWindow(top, clipBounds, destination);
         }
     }
 
     private static void ProcessWindow(
         IList<IRenderableIpso> renderables,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        ClipBoundsSource clipBounds,
         List<DrawCommand> destination)
     {
         int count = renderables.Count;
@@ -117,15 +111,14 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         List<Entry> window = new List<Entry>();
         for (int i = 0; i < count; i++)
         {
-            ProcessRenderable(renderables[i], getScissorRectangle, getCullTestBounds, null, window, destination);
+            ProcessRenderable(renderables[i], clipBounds, null, window, destination);
         }
         FlushWindow(window, destination);
     }
 
     private static void ProcessRenderable(
         IRenderableIpso renderable,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        ClipBoundsSource clipBounds,
         System.Drawing.Rectangle? activeClip,
         List<Entry> currentWindow,
         List<DrawCommand> destination)
@@ -136,12 +129,12 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         }
 
         // #2998 off-screen cull: skip a renderable (and its subtree) fully outside the active
-        // clip. Gated on a non-null mapping, mirroring HierarchicalOrderer — see its rationale.
-        if (getCullTestBounds != null
+        // clip. Gated on a resolvable mapping, mirroring HierarchicalOrderer — see its rationale.
+        if (clipBounds.CanResolveCullTestBounds
             && activeClip.HasValue
             && CameraScissorExtensions.CullOffscreenWhenClipped
             && CameraScissorExtensions.IsFullyOutside(
-                getCullTestBounds(renderable),
+                clipBounds.GetCullTestBounds(renderable),
                 activeClip.Value,
                 CameraScissorExtensions.OffscreenCullMarginInPixels))
         {
@@ -163,9 +156,9 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
             // Entering a clipper narrows the active clip for descendants (intersect).
             System.Drawing.Rectangle? childClip = activeClip;
-            if (getScissorRectangle != null)
+            if (clipBounds.CanResolveScissorRectangle)
             {
-                System.Drawing.Rectangle thisClip = getScissorRectangle(renderable);
+                System.Drawing.Rectangle thisClip = clipBounds.GetScissorRectangle(renderable);
                 childClip = activeClip.HasValue ? System.Drawing.Rectangle.Intersect(activeClip.Value, thisClip) : thisClip;
             }
 
@@ -177,7 +170,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], getScissorRectangle, getCullTestBounds, childClip, innerWindow, destination);
+                        ProcessRenderable(children[i], clipBounds, childClip, innerWindow, destination);
                     }
                 }
             }
@@ -197,7 +190,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     int childCount = children.Count;
                     for (int i = 0; i < childCount; i++)
                     {
-                        ProcessRenderable(children[i], getScissorRectangle, getCullTestBounds, activeClip, currentWindow, destination);
+                        ProcessRenderable(children[i], clipBounds, activeClip, currentWindow, destination);
                     }
                 }
             }

--- a/RenderingLibrary/Graphics/HierarchicalOrderer.cs
+++ b/RenderingLibrary/Graphics/HierarchicalOrderer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -24,31 +23,26 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
     {
         destination.Clear();
 
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = camera != null
-            ? renderable => camera.GetScissorRectangleFor(layer, renderable)
-            : null;
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = camera != null
-            ? renderable => camera.GetCullTestBoundsFor(layer, renderable)
-            : null;
+        ClipBoundsSource clipBounds = camera != null
+            ? new ClipBoundsSource(camera, layer)
+            : default;
 
-        AppendRenderables(layer.Renderables, getScissorRectangle, getCullTestBounds, null, destination);
+        AppendRenderables(layer.Renderables, clipBounds, null, destination);
     }
 
     /// <inheritdoc/>
     public void BuildDrawList(
         IList<IRenderableIpso> roots,
         List<DrawCommand> destination,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null)
+        ClipBoundsSource clipBounds = default)
     {
         destination.Clear();
-        AppendRenderables(roots, getScissorRectangle, getCullTestBounds ?? getScissorRectangle, null, destination);
+        AppendRenderables(roots, clipBounds, null, destination);
     }
 
     private static void AppendRenderables(
         IList<IRenderableIpso> renderables,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds,
+        ClipBoundsSource clipBounds,
         System.Drawing.Rectangle? activeClip,
         List<DrawCommand> destination)
     {
@@ -62,13 +56,13 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
             }
 
             // #2998 off-screen cull: when a clip is active, skip this renderable and its whole
-            // subtree if its bounds fall entirely outside the clip. Gated on a non-null mapping
+            // subtree if its bounds fall entirely outside the clip. Gated on a resolvable mapping
             // (the render path) so the mapping-less order-only unit tests are unaffected.
-            if (getCullTestBounds != null
+            if (clipBounds.CanResolveCullTestBounds
                 && activeClip.HasValue
                 && CameraScissorExtensions.CullOffscreenWhenClipped
                 && CameraScissorExtensions.IsFullyOutside(
-                    getCullTestBounds(renderable),
+                    clipBounds.GetCullTestBounds(renderable),
                     activeClip.Value,
                     CameraScissorExtensions.OffscreenCullMarginInPixels))
             {
@@ -91,14 +85,14 @@ public sealed class HierarchicalOrderer : IRenderableOrderer
                     // Entering a clipper narrows the active clip for descendants (intersect, mirroring
                     // Renderer.AdjustRenderStates). Without a mapping we can't compute it, so leave it null.
                     System.Drawing.Rectangle? childClip = activeClip;
-                    if (clips && getScissorRectangle != null)
+                    if (clips && clipBounds.CanResolveScissorRectangle)
                     {
-                        System.Drawing.Rectangle thisClip = getScissorRectangle(renderable);
+                        System.Drawing.Rectangle thisClip = clipBounds.GetScissorRectangle(renderable);
                         childClip = activeClip.HasValue
                             ? System.Drawing.Rectangle.Intersect(activeClip.Value, thisClip)
                             : thisClip;
                     }
-                    AppendRenderables(children, getScissorRectangle, getCullTestBounds, childClip, destination);
+                    AppendRenderables(children, clipBounds, childClip, destination);
                 }
             }
 

--- a/RenderingLibrary/Graphics/IRenderableOrderer.cs
+++ b/RenderingLibrary/Graphics/IRenderableOrderer.cs
@@ -4,6 +4,96 @@ using System.Collections.Generic;
 namespace RenderingLibrary.Graphics;
 
 /// <summary>
+/// Resolves the clip rectangle a <see cref="IRenderableIpso.ClipsChildren"/> renderable establishes,
+/// and the bounds the off-screen cull (#2998) tests against, for one draw-list build.
+/// <para>
+/// A struct rather than an interface, deliberately: the render path rebuilds the draw list every
+/// frame, so this must not allocate — an interface would mean either a per-call implementation
+/// object or boxing. Declared here rather than in its own file so the type travels with
+/// <see cref="IRenderableOrderer"/> through the per-consumer <c>Compile Include</c> links that
+/// already carry it (RaylibGum, FRB), matching why <c>CameraScissorExtensions</c> lives in
+/// <c>Camera.cs</c>.
+/// </para>
+/// <para>
+/// Two forms. A <see cref="Camera"/> plus optional <see cref="Layer"/> covers the main pass and the
+/// xnalike render-target bake, whose camera is already rebased into target-local space. A pair of
+/// caller-supplied delegates covers a caller that maps rectangles itself — raylib's bake, which
+/// rebases into render-target-local pixels from its own bake origin. The default value supplies no
+/// mapping at all: no clip narrowing and no culling, which is what order-only unit tests want.
+/// </para>
+/// </summary>
+public readonly struct ClipBoundsSource
+{
+    private readonly Camera? _camera;
+    private readonly Layer? _layer;
+    private readonly Func<IRenderableIpso, System.Drawing.Rectangle>? _getScissorRectangle;
+    private readonly Func<IRenderableIpso, System.Drawing.Rectangle>? _getCullTestBounds;
+
+    /// <summary>
+    /// Maps through <paramref name="camera"/>, in the coordinate space that camera currently
+    /// describes. <paramref name="layer"/> is honored for its <c>LayerCameraSettings</c> when
+    /// supplied.
+    /// </summary>
+    public ClipBoundsSource(Camera camera, Layer? layer = null)
+    {
+        _camera = camera;
+        _layer = layer;
+        _getScissorRectangle = null;
+        _getCullTestBounds = null;
+    }
+
+    /// <summary>
+    /// Maps through caller-supplied delegates, for a caller drawing in a space no
+    /// <see cref="Camera"/> describes. <paramref name="getCullTestBounds"/> is optional and falls
+    /// back to <paramref name="getScissorRectangle"/>; supply it separately only when the drawn
+    /// extent can exceed the declared bounds (wrapped text, #4144).
+    /// <para>
+    /// Callers on the render path should cache the delegates rather than passing lambdas inline,
+    /// which allocates a closure per call.
+    /// </para>
+    /// </summary>
+    public ClipBoundsSource(
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle,
+        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null)
+    {
+        _camera = null;
+        _layer = null;
+        _getScissorRectangle = getScissorRectangle;
+        _getCullTestBounds = getCullTestBounds ?? getScissorRectangle;
+    }
+
+    /// <summary>
+    /// Whether a clip rectangle can be resolved. When false the walk cannot narrow the active clip
+    /// for descendants, so it leaves it unchanged.
+    /// </summary>
+    public bool CanResolveScissorRectangle => _camera != null || _getScissorRectangle != null;
+
+    /// <summary>
+    /// Whether cull-test bounds can be resolved. When false the off-screen cull is skipped entirely
+    /// and the full walk is emitted.
+    /// </summary>
+    public bool CanResolveCullTestBounds => _camera != null || _getCullTestBounds != null;
+
+    /// <summary>
+    /// The clip rectangle <paramref name="renderable"/> establishes. Only call when
+    /// <see cref="CanResolveScissorRectangle"/> is true.
+    /// </summary>
+    public System.Drawing.Rectangle GetScissorRectangle(IRenderableIpso renderable) =>
+        _camera != null
+            ? _camera.GetScissorRectangleFor(_layer, renderable)
+            : _getScissorRectangle!(renderable);
+
+    /// <summary>
+    /// The bounds the off-screen cull tests against for <paramref name="renderable"/>. Only call
+    /// when <see cref="CanResolveCullTestBounds"/> is true.
+    /// </summary>
+    public System.Drawing.Rectangle GetCullTestBounds(IRenderableIpso renderable) =>
+        _camera != null
+            ? _camera.GetCullTestBoundsFor(_layer, renderable)
+            : _getCullTestBounds!(renderable);
+}
+
+/// <summary>
 /// Produces the flat <see cref="DrawCommand"/> sequence for a render pass. Pluggable so that
 /// alternative orderings (e.g. batch-grouped) can be swapped in without touching the renderer's
 /// submit phase. The default implementation is <see cref="HierarchicalOrderer"/>, which
@@ -31,29 +121,17 @@ public interface IRenderableOrderer
     /// <see cref="Layer"/>'s top-level renderables. Lets a caller outside the main render pass
     /// reuse the same visibility / off-screen-cull / <see cref="IRenderableIpso.ClipsChildren"/> /
     /// hierarchy-traversal semantics as <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/>
-    /// without requiring a <see cref="Layer"/> or a screen-space <see cref="Camera"/> — the caller
-    /// supplies the renderable-to-rectangle mappings directly, in whatever coordinate space it is
-    /// drawing into (screen space for the main pass, render-target-local space for a bake).
+    /// without requiring a <see cref="Layer"/>, in whatever coordinate space it is drawing into.
     /// </summary>
     /// <param name="roots">The top-level renderables of the subtree to flatten.</param>
     /// <param name="destination">Caller-owned buffer; cleared, then filled with the ordered commands.</param>
-    /// <param name="getScissorRectangle">
-    /// Maps a renderable to the clip/scissor rectangle it establishes when it has
-    /// <see cref="IRenderableIpso.ClipsChildren"/> set — used to narrow the active clip for its
-    /// descendants. Optional — when null, no off-screen culling or clip narrowing is performed
-    /// (e.g. order-only unit tests), matching the <c>camera == null</c> behavior of the
-    /// <see cref="Layer"/> overload.
-    /// </param>
-    /// <param name="getCullTestBounds">
-    /// Maps a renderable to the bounds used for the off-screen cull (#2998) — separate from
-    /// <paramref name="getScissorRectangle"/> so a caller can widen the cull test for content whose
-    /// actual drawn extent exceeds its declared bounds (e.g. wrapped text, #4144) without changing
-    /// what is actually clipped. Optional — when null but <paramref name="getScissorRectangle"/>
-    /// is supplied, falls back to <paramref name="getScissorRectangle"/> for the cull test.
+    /// <param name="clipBounds">
+    /// How to resolve clip and cull-test rectangles for this subtree. Defaults to no mapping, which
+    /// performs no clip narrowing and no culling — matching the <c>camera == null</c> behavior of
+    /// the <see cref="Layer"/> overload.
     /// </param>
     void BuildDrawList(
         IList<IRenderableIpso> roots,
         List<DrawCommand> destination,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getScissorRectangle = null,
-        Func<IRenderableIpso, System.Drawing.Rectangle>? getCullTestBounds = null);
+        ClipBoundsSource clipBounds = default);
 }

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1020,11 +1020,7 @@ public class Renderer : IRenderer
         var children = container.Children;
         if (children != null && children.Count > 0)
         {
-            SiblingOrdering.BuildDrawList(
-                children,
-                _bakeCommands,
-                renderable => Camera.GetScissorRectangleFor(layer, renderable),
-                renderable => Camera.GetCullTestBoundsFor(layer, renderable));
+            SiblingOrdering.BuildDrawList(children, _bakeCommands, new ClipBoundsSource(Camera, layer));
             Submit(_bakeCommands, managers, layer);
         }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -72,6 +72,14 @@ public class Renderer : IRenderer
     // serves all of them.
     readonly List<DrawCommand> _bakeCommands = new();
 
+    // Cached bake rectangle mappings and the layer they read. Allocated once rather than as
+    // per-bake lambdas: a closure per BuildDrawList call is exactly the per-frame allocation the
+    // main pass was fixed for (#4190). Only read while a bake is running, which is never
+    // re-entrant, so a single layer field is enough.
+    readonly Func<IRenderableIpso, System.Drawing.Rectangle> _bakeScissorRectangleMapping;
+    readonly Func<IRenderableIpso, System.Drawing.Rectangle> _bakeCullTestBoundsMapping;
+    Layer? _bakeLayer;
+
     // Set during the PreRender walk (which already traverses the whole visible tree) when any
     // render-target container is present, so the bake pre-pass is skipped entirely for the common
     // case of screens with no render targets — no extra full traversal.
@@ -182,6 +190,8 @@ public class Renderer : IRenderer
         ColorTextureAlphaShader = new Gum.Renderables.ColorTextureAlphaShader();
         RenderStateChangeStatistics = new RenderStateChangeStatistics();
         BatchDrawCallCounter = new BatchDrawCallCounter();
+        _bakeScissorRectangleMapping = renderable => GetScissorRectangleFor(_bakeLayer, renderable);
+        _bakeCullTestBoundsMapping = renderable => GetCullTestBoundsFor(_bakeLayer, renderable);
     }
 
 
@@ -460,7 +470,7 @@ public class Renderer : IRenderer
     // BeginScissorMode takes top-left coordinates and applies its own Y flip; passing the RT-local
     // top-left rect directly clips the correct rows on both hardware GL and software GL (Mesa
     // llvmpipe) — no screen-height compensation is needed (that was the #3436 mistake, #3440).
-    private System.Drawing.Rectangle GetScissorRectangleFor(Layer layer, IRenderableIpso element)
+    private System.Drawing.Rectangle GetScissorRectangleFor(Layer? layer, IRenderableIpso element)
     {
         if (!_isBakingRenderTarget)
         {
@@ -485,7 +495,7 @@ public class Renderer : IRenderer
     // widens the world Top/Bottom before either the camera or bake-local transform below. Used only
     // for the off-screen cull decision above (#4144); GetScissorRectangleFor itself is unchanged and
     // still drives the actual scissor/clip application.
-    private System.Drawing.Rectangle GetCullTestBoundsFor(Layer layer, IRenderableIpso element)
+    private System.Drawing.Rectangle GetCullTestBoundsFor(Layer? layer, IRenderableIpso element)
     {
         if (!_isBakingRenderTarget)
         {
@@ -620,13 +630,13 @@ public class Renderer : IRenderer
         if (children != null && children.Count > 0)
         {
             // Same shared builder the main pass uses, entered at this container's subtree instead of
-            // at a Layer (#4154). The RT-local scissor / cull-bounds mappings below are what let the
-            // bake express its own coordinate space through the shared walk.
+            // at a Layer (#4154). The RT-local scissor / cull-bounds mappings are what let the bake
+            // express its own coordinate space through the shared walk.
+            _bakeLayer = layer;
             HierarchicalOrderer.Instance.BuildDrawList(
                 children,
                 _bakeCommands,
-                renderable => GetScissorRectangleFor(layer, renderable),
-                renderable => GetCullTestBoundsFor(layer, renderable));
+                new ClipBoundsSource(_bakeScissorRectangleMapping, _bakeCullTestBoundsMapping));
             Submit(_bakeCommands, layer);
         }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -78,12 +78,16 @@ public class DrawAllocationTests : BaseTestClass
         // only the Update/Draw walk itself.
         GameTime gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(1.0 / 60.0));
 
-        AllocationResult result = AllocationMeasurer.Measure(
+        // MeasureMinimum, matching IdleUpdate above: this suite runs on a shared CI runner, where a
+        // single measured window can catch unrelated GC/JIT work and red the build spuriously.
+        // Taking the best of several attempts keeps the ratchet honest without making it flaky.
+        AllocationResult result = AllocationMeasurer.MeasureMinimum(
             () =>
             {
                 global::Gum.GumService.Default.Update(gameTime);
                 global::Gum.GumService.Default.Draw();
             },
+            attempts: 3,
             warmupIterations: 50,
             measuredIterations: 500);
 
@@ -99,8 +103,11 @@ public class DrawAllocationTests : BaseTestClass
 
         // Ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene. The Draw walk
         // itself is zero-alloc; the residual is the per-frame input/cursor pass in GumService.Update
-        // (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState). Bound sits just above
-        // that residual with headroom for JIT/runner variance.
+        // (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState), which the IdleUpdate
+        // ratchet above bounds on its own. Headroom over that residual is deliberate: it absorbs
+        // hosted-runner variance while still tripping on a real Draw-walk regression, which lands in
+        // the hundreds of bytes (#4190 reintroduced 160 B/frame and would fail here). Tighten toward
+        // the IdleUpdate bound once CI has established what this measures on a runner.
         result.BytesPerIteration.ShouldBeLessThanOrEqualTo(120);
     }
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetEffectTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/RenderTargetEffectTests.cs
@@ -20,6 +20,15 @@ namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
 /// bound to the SpriteBatch when the container's cached texture is blitted back to the screen
 /// (issue #816). A real <see cref="BasicEffect"/> stands in for a user post-process shader so the
 /// binding can be verified without shipping a compiled .fx in the test project.
+/// <para>
+/// Tests carrying the <c>RequiresOpenGlShaderCompiler</c> trait compile the sample <c>.fx</c> with
+/// ShadowDusk for <see cref="PlatformTarget.OpenGL"/>. That target fails on GitHub's hosted Windows
+/// runner while <see cref="PlatformTarget.DirectX"/> succeeds there (see
+/// <see cref="Compile_GrayscaleShader_ForDirectXTarget_Succeeds"/>, which is deliberately untagged),
+/// so the HLSL front end loads fine and it is the GLSL back end that is unavailable. CI filters the
+/// trait out; these run in full locally. Making the OpenGL target work on a hosted runner is #4195 —
+/// do not weaken these assertions to make them pass there.
+/// </para>
 /// </summary>
 public class RenderTargetEffectTests : BaseTestClass
 {
@@ -146,6 +155,7 @@ technique SpriteDrawing
 ";
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void RenderTargetEffect_GrayscaleShader_ActuallyGraysThePixels()
     {
         using MinimalGame game = new();
@@ -204,6 +214,7 @@ technique SpriteDrawing
     }
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void RenderTargetEffect_GrayscaleShader_GraysThePixels_UnderCameraZoom()
     {
         using MinimalGame game = new();
@@ -249,6 +260,7 @@ technique SpriteDrawing
     }
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void RenderTargetEffect_GrayscaleShader_GraysThePixels_WhenDeeplyNested()
     {
         using MinimalGame game = new();
@@ -324,6 +336,7 @@ technique SpriteDrawing
     }
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void SourceShaderFile_CompilesOnce_WhenReferencedByMultipleContainers()
     {
         using MinimalGame game = new();
@@ -360,6 +373,7 @@ technique SpriteDrawing
     }
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void SourceShaderFile_GraysThePixels_WhenDeeplyNested()
     {
         using MinimalGame game = new();
@@ -416,6 +430,7 @@ technique SpriteDrawing
     }
 
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void SourceShaderFile_GraysThePixels_WhenResolverRegistered()
     {
         using MinimalGame game = new();
@@ -467,6 +482,7 @@ technique SpriteDrawing
     // IRenderTargetRenderable interface that both implement. Mirror the editor's setup here: a GUE
     // whose contained renderable is a LineRectangle, made a render target with a SourceShaderFile.
     [Fact]
+    [Trait("RequiresOpenGlShaderCompiler", "true")]
     public void SourceShaderFile_GraysThePixels_WhenContainerRenderableIsLineRectangle()
     {
         using MinimalGame game = new();


### PR DESCRIPTION
Closes #4190. All three steps in one PR, in dependency order.

## 1. The allocation

`HierarchicalOrderer.BuildDrawList(Layer, ...)` synthesized two closures per call to map renderables to clip/cull rectangles — one display class capturing `camera` + `layer`, plus two `Func` delegates. That is **160 bytes per layer per frame** on the default render path, introduced by #4165 and pinned by `git bisect`.

Replaced with a `ClipBoundsSource` readonly struct carrying *either* a `Camera` + `Layer` *or* a delegate pair, passed down the recursion. `BatchKeyGroupedOrderer` follows the same shape (interface conformance; its own per-flush list allocations are untouched — it is opt-in and not on the default path).

Both render-target bakes are fixed the same way: MonoGame's uses the camera form outright, since `RenderToRenderTarget` already rebases the camera into target-local space; raylib's genuinely needs delegates for its RT-local rebasing, so those are cached as fields instead of built per bake.

A struct, not an interface, is deliberate here — an interface would mean a per-call implementation object or boxing, which is the thing being removed. No mutable state was added to `HierarchicalOrderer.Instance`, which is documented as shared and stateless.

## 2. The ratchet

`IdleUpdateAndDraw_RepresentativeFormsScene_AllocationBaseline` used single-shot `AllocationMeasurer.Measure` while its sibling `IdleUpdate` used `MeasureMinimum(attempts: 3)` specifically to absorb GC/JIT noise. On a shared runner the single-shot form would produce false reds, so it now matches its sibling. The bound stays at 120 with its headroom documented rather than tightened to the measured 64 — tighten it once CI has established what this actually measures on a runner, not on a dev machine.

Also adds a headless zero-allocation guard to `HierarchicalOrdererTests`. That matters independently of step 3: `MonoGameGum.Tests` already runs in CI, so this regression class is now caught there directly rather than only by an integration suite.

## 3. The CI gap

`MonoGameGum.IntegrationTests` was excluded as Bucket D, "requires a real graphics device / window". That rationale predated Mesa llvmpipe (#3250) and was already contradicted by two jobs on the same runner: `Native-AOT-Smoke` drives a real `Game` + `GraphicsDevice` + `Texture2D` upload, and `Gum.Cli.Tests` renders via MonoGame under `dotnet test` with the same Mesa DLLs. The suite uses the identical `MonoGame.Framework.DesktopGL 3.8.4.1`, and its `MinimalGame` hosts are structurally identical to the AOT harness's `SmokeGame`.

It now runs Windows-only with `GALLIUM_DRIVER: llvmpipe`, with its bin directory added to the Mesa copy step. It is already built by the existing `AllLibraries.sln` build, so `--no-build` resolves.

The other two Bucket D entries are deliberately **not** swept in — `MonoGameGum.Shapes.Tests` renders through Apos.Shapes, which has not been exercised on software GL, and `MonoGameFum.FromFile.Tests` references no MonoGame package at all, so its exclusion reason is something else. Both now carry that reasoning inline instead of a blanket "do NOT add these".

## Verification

- New guard verified red-first at exactly **160 B**, matching the integration-suite delta.
- `MonoGameGum.Tests` 2080/2080 · `RaylibGum.Tests` 569/569 · `MonoGameGum.IntegrationTests` **79/79** (Debug and Release) — the ratchet that had been red since #4165 is green.
- `KniGum` builds clean; no new warnings in any touched file.
- FRB canary (`GumCore.DesktopGlNet6`, net6.0 + net8.0): pass, identical to the `main` baseline. Relevant here because this changes a public interface signature in FRB1-shared source.
