### PR TITLE
Fix ButtonBase: raise Push alongside Click on keyboard/gamepad activation

### DIFF
--- a/MonoGameGum.Tests/Forms/ButtonTests.cs
+++ b/MonoGameGum.Tests/Forms/ButtonTests.cs
@@ -3,7 +3,9 @@ using Gum.Wireframe;
 using Gum.Forms.Controls;
 using Gum.Forms.DefaultVisuals;
 using Gum.GueDeriving;
+using Microsoft.Xna.Framework.Input;
 using MonoGameGum.Input;
+using MonoGameGum.Tests.Input;
 using Gum.Input;
 using Moq;
 using Shouldly;
@@ -14,6 +16,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using GamePad = Gum.Input.GamePad;
 
 namespace MonoGameGum.Tests.Forms;
 public class ButtonTests : BaseTestClass
@@ -146,6 +149,59 @@ public class ButtonTests : BaseTestClass
         button.OnFocusUpdate();
 
         wasClicked.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OnFocusUpdate_ShouldPushOnEnter()
+    {
+        Button button = new();
+        var wasPushed = false;
+        button.Push += (sender, args) => wasPushed = true;
+        FrameworkElement.KeyboardsForUiControl.Clear();
+
+        var mockKeyboard = new Mock<IInputReceiverKeyboardMonoGame>();
+        mockKeyboard
+            .Setup(k => k.KeyPushed(Microsoft.Xna.Framework.Input.Keys.Enter))
+            .Returns(true);
+        mockKeyboard.As<Gum.Wireframe.IInputReceiverKeyboard>()
+            .Setup(k => k.KeyPushed(Gum.Forms.Input.Keys.Enter))
+            .Returns(true);
+
+        FrameworkElement.KeyboardsForUiControl.Add(mockKeyboard.Object);
+
+        button.OnFocusUpdate();
+
+        wasPushed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OnFocusUpdate_ShouldPushOnGamepadClickButton()
+    {
+        Button button = new();
+        button.IsFocused = true;
+        var wasPushed = false;
+        button.Push += (sender, args) => wasPushed = true;
+
+        GamePad gamepad = new();
+        gamepad.Activity(new GamePadState(), 0);
+
+        var pressedState = new GamePadState(
+            new GamePadThumbSticks(new Microsoft.Xna.Framework.Vector2(0, 0), new Microsoft.Xna.Framework.Vector2(0, 0)),
+            new GamePadTriggers(0, 0),
+            new GamePadButtons(Buttons.A),
+            new GamePadDPad(
+                ButtonState.Released,
+                ButtonState.Released,
+                ButtonState.Released,
+                ButtonState.Released));
+
+        InteractiveGue.CurrentGameTime = 1;
+        gamepad.Activity(pressedState, 1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        button.OnFocusUpdate();
+
+        wasPushed.ShouldBeTrue();
     }
 
     [Fact]

--- a/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
@@ -206,7 +206,7 @@ public class ButtonBase :
                 IsEnabled)
             {
                 wasPushedOnCurrentHold = true;
-                //this.HandlePush(null);
+                this.HandlePush(this, EventArgs.Empty);
                 this.HandleClick(this, new InputEventArgs() { InputDevice = gamepad });
 
             }
@@ -252,8 +252,8 @@ public class ButtonBase :
 
             if ((gamepad as IInputDevice).DefaultConfirmInput.WasJustPressed && IsEnabled)
             {
-                //this.HandlePush(null);
                 wasPushedOnCurrentHold = true;
+                this.HandlePush(this, EventArgs.Empty);
                 this.HandleClick(this, EventArgs.Empty);
             }
 
@@ -276,8 +276,8 @@ public class ButtonBase :
 
             if (inputDevice.DefaultConfirmInput.WasJustPressed && IsEnabled)
             {
-                //this.HandlePush(null);
                 wasPushedOnCurrentHold = true;
+                this.HandlePush(this, EventArgs.Empty);
                 this.HandleClick(this, EventArgs.Empty);
             }
         }
@@ -310,6 +310,7 @@ public class ButtonBase :
 
                 wasPushedOnCurrentHold = true;
 
+                this.HandlePush(this, EventArgs.Empty);
                 this.HandleClick(this, new InputEventArgs() { InputDevice = keyboard });
 
                 UpdateState();


### PR DESCRIPTION
## Summary
Mouse interaction on a Button fires both `Push` (on press) and `Click` (on release-while-over), but keyboard/gamepad activation only fired `Click` — `Push` never fired. Wires up the previously commented-out `HandlePush` calls at all four activation call sites in `ButtonBase.cs` (non-FRB gamepad, non-FRB keyboard, and the two FRB gamepad/input-device paths), calling `HandlePush` immediately before `HandleClick`.

Whether the click should fire on key-down vs. release is out of scope per the issue — this only adds the missing `Push` event.

## Test plan
- Added `OnFocusUpdate_ShouldPushOnEnter` and `OnFocusUpdate_ShouldPushOnGamepadClickButton` to `ButtonTests.cs`; both reproduced the bug (red) before the fix and pass after.
- `dotnet test MonoGameGum.Tests --filter "FullyQualifiedName~Forms"` — 682/682 passed, no regressions.
- FRB canary: pass (built `FlatRedBall.Forms.DesktopGlNet6.csproj` from the primary checkout with the fix patched in, 0 errors — matches the baseline error count).
- Manual test: not needed — the only observable effect is the `Push`/`ControllerButtonPushed`-style C# event firing; no rendering/layout change, fully covered by the unit tests above.

Closes #4191
