### PR TITLE
Tighten DrawAllocationTests' idle Update+Draw allocation ratchet

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -624,7 +624,7 @@ jobs:
         timeout-minutes: 15
         env:
           GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
-        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --filter "RequiresOpenGlShaderCompiler!=true" --logger "trx" --logger "console;verbosity=detailed" --results-directory "TestResults"
+        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --filter "RequiresOpenGlShaderCompiler!=true" --logger "trx" --results-directory "TestResults"
 
       - name: Publish Test Results
         if: always() && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -624,7 +624,7 @@ jobs:
         timeout-minutes: 15
         env:
           GALLIUM_DRIVER: llvmpipe   # force Mesa's software rasterizer (no GPU on the runners)
-        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --filter "RequiresOpenGlShaderCompiler!=true" --logger "trx" --results-directory "TestResults"
+        run: dotnet test "Tests/MonoGameGum.IntegrationTests" --configuration Release --no-build --filter "RequiresOpenGlShaderCompiler!=true" --logger "trx" --logger "console;verbosity=detailed" --results-directory "TestResults"
 
       - name: Publish Test Results
         if: always() && (github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true')

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -62,7 +62,13 @@ public class DrawAllocationTests : BaseTestClass
         // FormsUtilities.UpdateGamepads — framework-internal, not removable here. This guard owns the
         // idle-Update residual (separate from the text/full-relayout ratchets); set just above the
         // residual so re-introducing a removed allocation source fails the build.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(80);
+        //
+        // The measured value is also folded into the assertion message, not left solely in the
+        // _output.WriteLine above: xUnit only surfaces a test's stdout on failure, and CI loggers
+        // don't reliably capture ITestOutputHelper output either, so the Shouldly failure message is
+        // the one place a future regression's actual bytes/frame is guaranteed visible.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(80,
+            $"measured {result.BytesPerIteration:N0} bytes/frame");
     }
 
     [Fact]
@@ -101,14 +107,20 @@ public class DrawAllocationTests : BaseTestClass
         // no-op would make a low/zero allocation result meaningless.
         drawStateCount.ShouldBeGreaterThan(0);
 
-        // Ratchet (#1934): the idle Update/Draw walk over an unchanging Forms scene. The Draw walk
-        // itself is zero-alloc; the residual is the per-frame input/cursor pass in GumService.Update
-        // (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState), which the IdleUpdate
-        // ratchet above bounds on its own. Headroom over that residual is deliberate: it absorbs
-        // hosted-runner variance while still tripping on a real Draw-walk regression, which lands in
-        // the hundreds of bytes (#4190 reintroduced 160 B/frame and would fail here). Tighten toward
-        // the IdleUpdate bound once CI has established what this measures on a runner.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(120);
+        // Ratchet (#1934, tightened in #4199): the idle Update/Draw walk over an unchanging Forms
+        // scene. The Draw walk itself is zero-alloc; the residual is the per-frame input/cursor pass
+        // in GumService.Update (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState),
+        // which the IdleUpdate ratchet above bounds on its own. Headroom over the CI runner's measured
+        // residual is deliberate: it absorbs runner/JIT variance while still tripping on a real
+        // Draw-walk regression, which lands in the hundreds of bytes (#4190 reintroduced 160 B/frame
+        // and would fail here).
+        //
+        // The measured value is also folded into the assertion message, not left solely in the
+        // _output.WriteLine above: xUnit only surfaces a test's stdout on failure, and CI loggers
+        // don't reliably capture ITestOutputHelper output either, so the Shouldly failure message is
+        // the one place a future regression's actual bytes/frame is guaranteed visible.
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(120,
+            $"measured {result.BytesPerIteration:N0} bytes/frame");
     }
 
     private static void BuildScene()

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Performance/DrawAllocationTests.cs
@@ -110,16 +110,17 @@ public class DrawAllocationTests : BaseTestClass
         // Ratchet (#1934, tightened in #4199): the idle Update/Draw walk over an unchanging Forms
         // scene. The Draw walk itself is zero-alloc; the residual is the per-frame input/cursor pass
         // in GumService.Update (FormsUtilities.Update, dominated by MonoGame's GamePad.GetState),
-        // which the IdleUpdate ratchet above bounds on its own. Headroom over the CI runner's measured
-        // residual is deliberate: it absorbs runner/JIT variance while still tripping on a real
-        // Draw-walk regression, which lands in the hundreds of bytes (#4190 reintroduced 160 B/frame
-        // and would fail here).
+        // which the IdleUpdate ratchet above bounds on its own — the CI Windows runner measures the
+        // same 64 B/f residual as a dev machine, so this bound matches IdleUpdate's. Headroom over
+        // that residual absorbs runner/JIT variance while still tripping on a real Draw-walk
+        // regression, which lands in the hundreds of bytes (#4190 reintroduced 160 B/frame and would
+        // fail here).
         //
         // The measured value is also folded into the assertion message, not left solely in the
         // _output.WriteLine above: xUnit only surfaces a test's stdout on failure, and CI loggers
         // don't reliably capture ITestOutputHelper output either, so the Shouldly failure message is
         // the one place a future regression's actual bytes/frame is guaranteed visible.
-        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(120,
+        result.BytesPerIteration.ShouldBeLessThanOrEqualTo(80,
             $"measured {result.BytesPerIteration:N0} bytes/frame");
     }
 


### PR DESCRIPTION
Closes #4199.

`IdleUpdateAndDraw_RepresentativeFormsScene_AllocationBaseline` asserts `<= 120` bytes/frame with no real runner number behind it (dev machine measures 64). This PR:

1. Folds the measured bytes/frame into the Shouldly assertion message on both ratchets, so a future regression's actual value is visible directly in the failure output (not just `_output.WriteLine`, which xUnit only surfaces on failure and CI loggers don't reliably capture anyway).
2. Temporarily adds `--logger "console;verbosity=detailed"` to the CI step so this run's log reveals the Windows runner's real number. Will push a follow-up commit that reverts the verbosity flag and tightens the `120` bound to just above the measured value, mirroring `IdleUpdate`'s 80-over-64.

Manual test: not needed — this is CI/test plumbing with no runtime-visible behavior change.
