### PR TITLE
gumcli screenshot --background, gum-raylib-rendering skill, ui-decoupling-plan status

### DIFF
--- a/.claude/skills/gum-cli/SKILL.md
+++ b/.claude/skills/gum-cli/SKILL.md
@@ -23,7 +23,7 @@ description: GumCli — headless CLI for Gum projects. Triggers: gumcli commands
 | `gumcli codegen <project.gumx> [--element <name>...]` | Generate C# code. Requires `ProjectCodeSettings.codsj`. Per-element error check gates generation. |
 | `gumcli codegen-init <project.gumx> [--force] [--csproj <path>]` | Auto-detect `.csproj`, derive namespace and output library, write `ProjectCodeSettings.codsj`. Use `--csproj` when the Gum project is not inside the MonoGame project directory. |
 | `gumcli fonts <project.gumx>` | Generate missing bitmap font files (.fnt + .png). Windows-only (bmfont.exe). |
-| `gumcli screenshot <project.gumx> <element> [--output] [--width] [--height]` | Render a Screen or Component to a PNG via MonoGame DesktopGL. Pixel-accurate; cross-platform. |
+| `gumcli screenshot <project.gumx> <element> [--output] [--width] [--height] [--backend monogame\|raylib] [--background hex]` | Render a Screen or Component to a PNG via MonoGame DesktopGL (default) or raylib. Pixel-accurate; cross-platform. `--background` clears to an opaque RRGGBB/RRGGBBAA hex color instead of the default transparent, for a more representative visual comparison. |
 | `gumcli svg <project.gumx> <element> [--output] [--width] [--height]` | Render a Screen or Component to a vector SVG via SkiaGum's `SKSvgCanvas`. Bitmaps embed as base64. |
 
 **Exit codes:** 0 = success, 1 = errors found / generation blocked, 2 = load failure, bad args, or non-Windows (fonts).

--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -5,7 +5,7 @@ description: Gum's MonoGame rendering pipeline — Renderer/SpriteBatchStack/Gum
 
 # Gum's MonoGame Rendering Pipeline
 
-This skill covers the XNA-family backends only (MonoGame / KNI / FNA). Skia, Raylib, and Sokol have their own renderers and don't go through this code.
+This skill covers the XNA-family backends only (MonoGame / KNI / FNA). Skia, Raylib, and Sokol have their own renderers and don't go through this code — for raylib's blend-mode/render-target pipeline see [gum-raylib-rendering](../gum-raylib-rendering/SKILL.md).
 
 ## Two Entry Paths into Renderer
 

--- a/.claude/skills/gum-raylib-rendering/SKILL.md
+++ b/.claude/skills/gum-raylib-rendering/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: gum-raylib-rendering
+description: RaylibGum's rendering pipeline and blend-mode handling. Triggers: RaylibRenderer.cs, BatchDrawCallCounter, BlendModeExtensions.cs, Rlgl.SetBlendFactorsSeparate, RenderTexture2D compositing, IsRenderTarget on raylib, translucent-content-looks-darker-in-game-than-in-tool bugs.
+---
+
+# RaylibGum's Rendering Pipeline
+
+This skill covers the raylib backend only. MonoGame/KNI/FNA go through a different renderer entirely — see [gum-monogame-rendering](../gum-monogame-rendering/SKILL.md).
+
+## Architecture Seam: BatchDrawCallCounter
+
+`Renderer.Draw` routes every raylib scissor/blend/mode-2D/shader state change through `BatchDrawCallCounter` (`Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs`) rather than calling raylib directly, so draw-call stats stay accurate. Per-element renderables (`Sprite.cs`, `NineSlice.cs`, `Text.cs`) call `BatchDrawCallCounter.BeginBlendMode(Blend.Value)`/`EndBlendMode()` around their own draw **whenever `Blend.HasValue`** — and every Sprite/NineSlice gets `Blend = Blend.Normal` by default (`StandardElementsManager.AddBlendVariable`), so this fires for virtually all content, not just elements with an explicit non-default `Blend`.
+
+## Known Gap: `Blend.Normal`/`Additive` Bypass the Render-Target Premultiply Pass
+
+`BeginRenderTargetBlend()`/`_renderTargetBlendActive` (`BatchDrawCallCounter.cs`) exist so content baked into an offscreen render target composites back without a "double-blend dark fringe" — see `Renderer.cs`'s `BakeRenderTarget`/`CompositeRenderTarget`. But `BeginBlendMode(Blend blend)` calls `TryGetSimpleRaylibBlendMode` (`BlendModeExtensions.cs`) first, and that method maps `Blend.Normal`/`Additive` straight to a canned raylib `BlendMode` **without ever consulting `_renderTargetBlendActive`** — only `Replace`/`ReplaceAlpha`/`SubtractAlpha`/`MinAlpha` reach the ambient-aware custom-separate factors. So the premultiply-pass protection never actually engages for ordinary translucent content, which is the common case. Tracked in [#4204](https://github.com/vchelaru/Gum/issues/4204); fix that engages this path for Normal/Additive too, not a caller-side workaround.
+
+## The Underlying Alpha-Channel Gotcha
+
+Raylib's canned `BlendMode.Alpha` uses the **same** GL factors (`SrcAlpha`/`OneMinusSrcAlpha`) for the color *and* alpha channels. A single translucent draw over an opaque backdrop still computes the correct **color** (color blending doesn't depend on the backdrop's alpha), but the resulting **alpha** comes out short of 255 (`srcA² + dstA*(1-srcA)` instead of the correct `srcA + dstA*(1-srcA)`). That's invisible as long as nothing downstream reads the render target's own alpha again — but any consumer that composites that render target a *second* time (blits it onto another target, reads it back for export) re-multiplies by that leftover alpha and visibly darkens exactly the translucent regions.
+
+A host application that bakes Gum's draw output into its own render target and later composites that render target elsewhere (e.g. blitting it to the window) must not weight that second pass by the render target's own alpha — make it a straight replace-copy, or flatten the alpha first. [Airpig PR #200](https://github.com/profexorgeek/Airpig/pull/200) works through a concrete instance of this. `gumcli screenshot --backend raylib` and the Gum tool never hit it, since both do a single compositing pass and never re-consume that leftover alpha.
+
+**No user-facing docs exist for this yet** — MonoGame has an equivalent gotcha documented (`docs/code/rendering/gumbatch.md`'s "RenderTargets" section, with a corrected `BlendState`); raylib has no counterpart. Tracked in [#4205](https://github.com/vchelaru/Gum/issues/4205).

--- a/Direction/ui-decoupling-plan.md
+++ b/Direction/ui-decoupling-plan.md
@@ -423,12 +423,17 @@ this doc when scoping a new target; its own baselines and comments often already
 as in-scope vs. deferred.
 
 **Phase 4 — The two WinForms subsystems** (the real cost; multi-week each, can overlap).
-- *4a — Element tree:* decouple `ElementTreeViewManager` from `TreeNode`; the already-migrated
-  state tree is the proven template.
-- *4b — Rendering host:* formalize a host contract around `SystemManagers.Initialize(GraphicsDevice)`
-  plus pixel-buffer-out / input-in, and lift the cursor/keyboard off the WinForms control. The
-  `3218-skiasharp-host-model` work is the prototype. *Payoff (even on WPF):* lets the
-  `WindowsFormsHost` airspace/focus hacks be deleted.
+- *4a — Element tree:* **Done** (#3755/#3963) — `ElementTreeViewManager`/`MultiSelectTreeView`'s
+  business logic decoupled from `TreeNode` onto `ITreeNode`/`ITreeNodeMutable`, the already-migrated
+  state tree's template. The WinForms `MultiSelectTreeView` widget itself stays, per the scope
+  boundary above.
+- *4b — Rendering host:* tracked in #3756/#3833 (reopened). Host-contract formalization
+  (`IRenderDeviceHost`/`IInputHostControl`/`IRenderTargetPixelBufferWriter`) and WPF-native additive
+  infra (`WpfRenderSurfaceHost` — CPU-readback + `WriteableBitmap`, measured 45-60fps incl. 4K via
+  `CompositionTarget.Rendering`; `WpfInputHostAdapter`; `CursorKind`; a WPF drag/drop payload reader)
+  are merged but unwired. What's left is the actual `WireframeControl`/`ImageRegionSelectionControl`
+  base-class swap off `GraphicsDeviceControl`/`WindowsFormsHost` — see #3833 for the concrete
+  remaining steps.
   The wireframe canvas has taken this path end to end: `WpfGraphicsDeviceControl` draws into the
   shared device's render target, reads it back, and pushes the pixels into a `WriteableBitmap`, so
   the editor tab is `WindowsFormsHost`-free. Points worth carrying to the next host:

--- a/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
+++ b/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <!-- Decodes the raylib backend's rendered PNG to assert on pixel color in
+         Screenshot_WithBackgroundOption_RendersOpaqueBackground; already a transitive
+         dependency via Gum.Cli -> Gum.ProjectServices -> Gum.ImageDiff. -->
+    <PackageReference Include="SkiaSharp" VersionOverride="3.119.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Gum.Cli.Tests/ScreenshotCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/ScreenshotCommandTests.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.ProjectServices;
 using Shouldly;
+using SkiaSharp;
 
 namespace Gum.Cli.Tests;
 
@@ -53,6 +54,46 @@ public class ScreenshotCommandTests : IDisposable
 
         result.ExitCode.ShouldBe(2);
         result.StandardError.ShouldContain("Unknown backend");
+    }
+
+    // Windows-only for the same reason as Screenshot_WithRaylibBackend_WritesPngFile above:
+    // raylib's window creation hangs on macOS CI (GLFW/Cocoa main-thread requirement, #3233).
+    [Fact]
+    public void Screenshot_WithBackgroundOption_RendersOpaqueBackgroundColor()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        string projectPath = CreateProjectWithScreen();
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+
+        CliTestHelper result = CliTestHelper.Run(
+            "screenshot", projectPath, "Screen", "--output", outputPath,
+            "--backend", "raylib", "--background", "1E2A38");
+
+        result.ExitCode.ShouldBe(0, result.StandardError);
+
+        // The Screen has no content, so every pixel is the clear color.
+        using SKBitmap bitmap = SKBitmap.Decode(outputPath);
+        SKColor pixel = bitmap.GetPixel(0, 0);
+        pixel.Red.ShouldBe((byte)0x1E);
+        pixel.Green.ShouldBe((byte)0x2A);
+        pixel.Blue.ShouldBe((byte)0x38);
+        pixel.Alpha.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void Screenshot_WithInvalidBackgroundOption_ReturnsExitCode2()
+    {
+        string projectPath = CreateProjectWithScreen();
+
+        CliTestHelper result = CliTestHelper.Run(
+            "screenshot", projectPath, "Screen", "--background", "notacolor");
+
+        result.ExitCode.ShouldBe(2);
+        result.StandardError.ShouldContain("Invalid --background value");
     }
 
     private string CreateProjectWithScreen()

--- a/Tests/Gum.ProjectServices.Tests/ScreenshotAlphaFlattenerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenshotAlphaFlattenerTests.cs
@@ -1,0 +1,38 @@
+using Gum.ProjectServices.Screenshot;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScreenshotAlphaFlattener.FlattenToOpaque"/>, which guarantees a screenshot
+/// rendered against a requested opaque <c>--background</c> has no leftover partial transparency
+/// from translucent content blended over that background (#4172).
+/// </summary>
+public class ScreenshotAlphaFlattenerTests
+{
+    [Fact]
+    public void FlattenToOpaque_SetsEveryAlphaByteTo255_PreservingColorBytes()
+    {
+        byte[] rgba =
+        {
+            10, 20, 30, 40,     // pixel 0: partially transparent
+            50, 60, 70, 255,    // pixel 1: already opaque
+            80, 90, 100, 0,     // pixel 2: fully transparent
+        };
+
+        ScreenshotAlphaFlattener.FlattenToOpaque(rgba);
+
+        rgba.ShouldBe(new byte[]
+        {
+            10, 20, 30, 255,
+            50, 60, 70, 255,
+            80, 90, 100, 255,
+        });
+    }
+
+    [Fact]
+    public void FlattenToOpaque_WithEmptyBuffer_DoesNotThrow()
+    {
+        Should.NotThrow(() => ScreenshotAlphaFlattener.FlattenToOpaque(Array.Empty<byte>()));
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/ScreenshotColorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenshotColorTests.cs
@@ -1,0 +1,64 @@
+using Gum.ProjectServices.Screenshot;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="ScreenshotColor.TryParse"/>, which parses the <c>gumcli screenshot
+/// --background</c> option so screenshots can be rendered against an opaque backdrop instead of
+/// the default transparent one (#4172 - transparent vs. opaque compositing look very different,
+/// which made raylib-vs-tool comparisons misleading).
+/// </summary>
+public class ScreenshotColorTests
+{
+    [Fact]
+    public void TryParse_WithSixDigitHex_ReturnsOpaqueColor()
+    {
+        bool success = ScreenshotColor.TryParse("1E2A38", out ScreenshotColor color);
+
+        success.ShouldBeTrue();
+        color.R.ShouldBe((byte)0x1E);
+        color.G.ShouldBe((byte)0x2A);
+        color.B.ShouldBe((byte)0x38);
+        color.A.ShouldBe((byte)255);
+    }
+
+    [Fact]
+    public void TryParse_WithLeadingHash_StripsItAndParsesSameAsWithout()
+    {
+        ScreenshotColor.TryParse("#1E2A38", out ScreenshotColor withHash);
+        ScreenshotColor.TryParse("1E2A38", out ScreenshotColor withoutHash);
+
+        withHash.R.ShouldBe(withoutHash.R);
+        withHash.G.ShouldBe(withoutHash.G);
+        withHash.B.ShouldBe(withoutHash.B);
+        withHash.A.ShouldBe(withoutHash.A);
+    }
+
+    [Fact]
+    public void TryParse_WithEightDigitHex_ReturnsColorWithParsedAlpha()
+    {
+        bool success = ScreenshotColor.TryParse("1E2A3880", out ScreenshotColor color);
+
+        success.ShouldBeTrue();
+        color.R.ShouldBe((byte)0x1E);
+        color.G.ShouldBe((byte)0x2A);
+        color.B.ShouldBe((byte)0x38);
+        color.A.ShouldBe((byte)0x80);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1E2A3")]
+    [InlineData("1E2A388")]
+    [InlineData("GGHHII")]
+    public void TryParse_WithInvalidInput_ReturnsFalse(string? invalidHex)
+    {
+        bool success = ScreenshotColor.TryParse(invalidHex, out ScreenshotColor color);
+
+        success.ShouldBeFalse();
+        color.ShouldBe(default);
+    }
+}

--- a/Tools/Gum.Cli/Commands/ScreenshotCommand.cs
+++ b/Tools/Gum.Cli/Commands/ScreenshotCommand.cs
@@ -55,6 +55,11 @@ public static class ScreenshotCommand
             () => MonoGameBackend,
             $"Rendering backend to use: '{MonoGameBackend}' (default) or '{RaylibBackend}'.");
 
+        Option<string?> backgroundOption = new Option<string?>(
+            "--background",
+            "Background color to clear to before rendering, as 6-digit (RRGGBB) or 8-digit "
+                + "(RRGGBBAA) hex, with or without a leading '#'. Defaults to fully transparent.");
+
         Command command = new Command("screenshot", "Render a Gum Screen or Component to a PNG file.")
         {
             projectArgument,
@@ -63,6 +68,7 @@ public static class ScreenshotCommand
             widthOption,
             heightOption,
             backendOption,
+            backgroundOption,
         };
 
         command.SetHandler((InvocationContext context) =>
@@ -73,18 +79,34 @@ public static class ScreenshotCommand
             int? width = context.ParseResult.GetValueForOption(widthOption);
             int? height = context.ParseResult.GetValueForOption(heightOption);
             string backend = context.ParseResult.GetValueForOption(backendOption) ?? MonoGameBackend;
+            string? background = context.ParseResult.GetValueForOption(backgroundOption);
 
             string outputPath = output ?? $"{elementName}.png";
 
-            context.ExitCode = Execute(projectPath, elementName, outputPath, width, height, backend);
+            context.ExitCode = Execute(projectPath, elementName, outputPath, width, height, backend, background);
         });
 
         return command;
     }
 
     private static int Execute(
-        string projectPath, string elementName, string outputPath, int? width, int? height, string backend)
+        string projectPath, string elementName, string outputPath, int? width, int? height, string backend,
+        string? background)
     {
+        ScreenshotColor? backgroundColor = null;
+        if (background != null)
+        {
+            if (!ScreenshotColor.TryParse(background, out ScreenshotColor parsedColor))
+            {
+                Console.Error.WriteLine(
+                    $"error: Invalid --background value '{background}'. Expected 6-digit (RRGGBB) or "
+                        + "8-digit (RRGGBBAA) hex, with or without a leading '#'.");
+                return 2;
+            }
+
+            backgroundColor = parsedColor;
+        }
+
         string fullProjectPath = Path.GetFullPath(projectPath);
 
         if (!File.Exists(fullProjectPath))
@@ -115,6 +137,7 @@ public static class ScreenshotCommand
             OutputPath = outputPath,
             Width = width,
             Height = height,
+            BackgroundColor = backgroundColor,
         };
 
         ScreenshotResult result = service.TakeScreenshot(request);

--- a/Tools/Gum.ProjectServices.MonoGame/MonoGameScreenshotService.cs
+++ b/Tools/Gum.ProjectServices.MonoGame/MonoGameScreenshotService.cs
@@ -8,6 +8,7 @@ using RenderingLibrary;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Gum.ProjectServices.MonoGame;
 
@@ -94,9 +95,13 @@ public class MonoGameScreenshotService : IScreenshotService
                 element.AddToManagers(SystemManagers.Default);
                 element.UpdateLayout();
 
+                Color clearColor = _request.BackgroundColor is { } background
+                    ? new Color(background.R, background.G, background.B, background.A)
+                    : Color.Transparent;
+
                 using var renderTarget = new RenderTarget2D(GraphicsDevice, width, height);
                 GraphicsDevice.SetRenderTarget(renderTarget);
-                GraphicsDevice.Clear(Color.Transparent);
+                GraphicsDevice.Clear(clearColor);
 
                 gumService.Draw();
 
@@ -110,7 +115,25 @@ public class MonoGameScreenshotService : IScreenshotService
                 }
 
                 using var stream = File.OpenWrite(outputPath);
-                renderTarget.SaveAsPng(stream, width, height);
+
+                if (_request.BackgroundColor.HasValue)
+                {
+                    // Translucent content blended onto the opaque clear color above does not
+                    // itself flatten the render target's own alpha channel back to 255 - force it
+                    // so the exported PNG is genuinely opaque, not just visually opaque against
+                    // the background it happened to be rendered with.
+                    Color[] pixels = new Color[width * height];
+                    renderTarget.GetData(pixels);
+                    ScreenshotAlphaFlattener.FlattenToOpaque(MemoryMarshal.AsBytes(pixels.AsSpan()));
+
+                    using var flattenedTexture = new Texture2D(GraphicsDevice, width, height);
+                    flattenedTexture.SetData(pixels);
+                    flattenedTexture.SaveAsPng(stream, width, height);
+                }
+                else
+                {
+                    renderTarget.SaveAsPng(stream, width, height);
+                }
 
                 Result = ScreenshotResult.Succeeded(outputPath);
             }

--- a/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
+++ b/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
+    <!-- RaylibScreenshotService flattens Image.Data's alpha channel in place when a screenshot
+         background color is requested (#4172); raylib's Image only exposes its pixel buffer as
+         an unmanaged pointer. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
+++ b/Tools/Gum.ProjectServices.Raylib/RaylibScreenshotService.cs
@@ -72,11 +72,15 @@ public class RaylibScreenshotService : IScreenshotService
             element.AddToManagers(SystemManagers.Default);
             element.UpdateLayout();
 
+            Color clearColor = request.BackgroundColor is { } background
+                ? new Color(background.R, background.G, background.B, background.A)
+                : new Color((byte)0, (byte)0, (byte)0, (byte)0);
+
             RenderTexture2D renderTexture = Raylib_cs.Raylib.LoadRenderTexture(width, height);
             try
             {
                 Raylib_cs.Raylib.BeginTextureMode(renderTexture);
-                Raylib_cs.Raylib.ClearBackground(new Color((byte)0, (byte)0, (byte)0, (byte)0));
+                Raylib_cs.Raylib.ClearBackground(clearColor);
                 gumService.Draw();
                 Raylib_cs.Raylib.EndTextureMode();
 
@@ -86,6 +90,19 @@ public class RaylibScreenshotService : IScreenshotService
                     // Render textures are stored bottom-up in GL; flip so the exported PNG reads
                     // right-side-up like any other screenshot.
                     Raylib_cs.Raylib.ImageFlipVertical(ref image);
+
+                    if (request.BackgroundColor.HasValue)
+                    {
+                        // Translucent content blended onto the opaque clear color above does not
+                        // itself flatten the render target's own alpha channel back to 255 - force
+                        // it so the exported PNG is genuinely opaque, not just visually opaque
+                        // against the background it happened to be rendered with.
+                        unsafe
+                        {
+                            var pixelBytes = new Span<byte>((void*)image.Data, image.Width * image.Height * 4);
+                            ScreenshotAlphaFlattener.FlattenToOpaque(pixelBytes);
+                        }
+                    }
 
                     string outputPath = Path.GetFullPath(request.OutputPath);
                     string? outputDir = Path.GetDirectoryName(outputPath);

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotAlphaFlattener.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotAlphaFlattener.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// Forces every pixel's alpha byte to fully opaque in an RGBA8-packed pixel buffer (4 bytes per
+/// pixel, alpha last). A screenshot rendered against a requested <see
+/// cref="ScreenshotRequest.BackgroundColor"/> should be fully opaque everywhere, but blending
+/// translucent content (e.g. a semi-transparent panel) onto that opaque background does not
+/// itself flatten the render target's alpha channel back to 255 - both the MonoGame and raylib
+/// screenshot backends leave leftover partial alpha in those regions. That leftover alpha is
+/// invisible when the PNG is only ever composited against the same background color it was
+/// rendered with, but any other viewer or further compositing pass blends its own backdrop
+/// through instead, making the requested background appear not to be there at all (#4172).
+/// </summary>
+public static class ScreenshotAlphaFlattener
+{
+    public static void FlattenToOpaque(Span<byte> rgba)
+    {
+        for (int i = 3; i < rgba.Length; i += 4)
+        {
+            rgba[i] = 255;
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotColor.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotColor.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Globalization;
+
+namespace Gum.ProjectServices.Screenshot;
+
+/// <summary>
+/// An RGBA color for <see cref="ScreenshotRequest.BackgroundColor"/>, parsed from a hex string so
+/// a screenshot can be rendered against an opaque backdrop instead of the default transparent one.
+/// Transparent vs. opaque compositing look very different once viewed, which made raylib-vs-tool
+/// screenshot comparisons misleading (#4172).
+/// </summary>
+public readonly struct ScreenshotColor
+{
+    public byte R { get; }
+    public byte G { get; }
+    public byte B { get; }
+    public byte A { get; }
+
+    public ScreenshotColor(byte r, byte g, byte b, byte a)
+    {
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+    }
+
+    /// <summary>
+    /// Parses a hex color string: 6-digit RRGGBB (alpha defaults to fully opaque) or 8-digit
+    /// RRGGBBAA, with or without a leading '#'.
+    /// </summary>
+    public static bool TryParse(string? hex, out ScreenshotColor color)
+    {
+        color = default;
+
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return false;
+        }
+
+        string trimmed = hex.Trim();
+        if (trimmed.StartsWith("#"))
+        {
+            trimmed = trimmed.Substring(1);
+        }
+
+        if (trimmed.Length != 6 && trimmed.Length != 8)
+        {
+            return false;
+        }
+
+        if (!TryParseComponent(trimmed, 0, out byte r) ||
+            !TryParseComponent(trimmed, 2, out byte g) ||
+            !TryParseComponent(trimmed, 4, out byte b))
+        {
+            return false;
+        }
+
+        byte a = 255;
+        if (trimmed.Length == 8 && !TryParseComponent(trimmed, 6, out a))
+        {
+            return false;
+        }
+
+        color = new ScreenshotColor(r, g, b, a);
+        return true;
+    }
+
+    private static bool TryParseComponent(string hex, int start, out byte value) =>
+        byte.TryParse(hex.AsSpan(start, 2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture, out value);
+}

--- a/Tools/Gum.ProjectServices/Screenshot/ScreenshotRequest.cs
+++ b/Tools/Gum.ProjectServices/Screenshot/ScreenshotRequest.cs
@@ -29,4 +29,9 @@ public class ScreenshotRequest
     /// Height of the output image in pixels. Defaults to the project canvas height.
     /// </summary>
     public int? Height { get; init; }
+
+    /// <summary>
+    /// Background color to clear to before rendering. Defaults to fully transparent when null.
+    /// </summary>
+    public ScreenshotColor? BackgroundColor { get; init; }
 }

--- a/docs/cli/screenshot.md
+++ b/docs/cli/screenshot.md
@@ -1,7 +1,7 @@
 # screenshot
 
 ```
-gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>] [--backend <name>]
+gumcli screenshot <project.gumx> <element> [--output <path>] [--width <px>] [--height <px>] [--backend <name>] [--background <hex>]
 ```
 
 Renders a Gum Screen or Component to a PNG file. The element is laid out and drawn using the same backend a shipped game would use, so the output is pixel-accurate and suitable for visual regression testing, documentation screenshots, or asset pipelines.
@@ -17,6 +17,7 @@ Renders a Gum Screen or Component to a PNG file. The element is laid out and dra
 - `--width` — Width of the output image in pixels. Defaults to the project canvas width.
 - `--height` — Height of the output image in pixels. Defaults to the project canvas height.
 - `--backend` — Rendering backend to use: `monogame` (default, DesktopGL) or `raylib`.
+- `--background` — Background color to clear to before rendering, as 6-digit (`RRGGBB`) or 8-digit (`RRGGBBAA`) hex, with or without a leading `#`. Defaults to fully transparent.
 
 ## Examples
 
@@ -25,6 +26,7 @@ gumcli screenshot MyProject/MyProject.gumx MainMenu
 gumcli screenshot MyProject/MyProject.gumx Controls/Button --output button.png
 gumcli screenshot MyProject/MyProject.gumx MainMenu --width 1920 --height 1080
 gumcli screenshot MyProject/MyProject.gumx MainMenu --backend raylib
+gumcli screenshot MyProject/MyProject.gumx MainMenu --background 1E2A38
 ```
 
 Output on success:
@@ -39,6 +41,7 @@ Screenshot written to: /full/path/to/MainMenu.png
 - Any fonts referenced by the element must already exist in the project's `FontCache/` folder. Run [`gumcli fonts`](fonts.md) first if fonts are missing.
 - Bitmap content (sprites, nine-slices, text) is rasterized into the PNG at the requested resolution.
 - To compare the two backends' output for every element in a project at once, see [`diff-screenshots`](diff-screenshots.md).
+- Rendering against the default transparent background can make some visual differences (a semi-transparent panel or border, for example) hard to see once the image is opened in isolation. Use `--background` to composite against an opaque color, ideally the same clear color your game actually uses, for a more representative comparison.
 
 ## Exit Codes
 
@@ -46,4 +49,4 @@ Screenshot written to: /full/path/to/MainMenu.png
 |------|---------|
 | 0 | Screenshot written successfully |
 | 1 | Rendering failed (for example, the named element does not exist) |
-| 2 | Project file not found, or `--backend` is not `monogame` or `raylib` |
+| 2 | Project file not found, `--backend` is not `monogame` or `raylib`, or `--background` is not a valid hex color |


### PR DESCRIPTION
## Summary
- `gumcli screenshot --background <hex>` renders against an opaque backdrop instead of the default transparent one, for a more representative MonoGame-vs-raylib comparison (#4172). Surfaced and fixed a real defect: exported PNGs carried leftover partial alpha in translucent regions even when a background was requested - `ScreenshotAlphaFlattener` now forces the exported alpha to 255 in both backends.
- New `gum-raylib-rendering` skill capturing what the #4172 investigation found: `BatchDrawCallCounter`'s per-element blend dispatch, the `Blend.Normal`/`Additive` gap that bypasses the render-target premultiply pass (#4204), and the alpha-channel gotcha for anything compositing a raylib render target a second time.
- `Direction/ui-decoupling-plan.md` status update (Phase 4a done, 4b tracking) - unrelated cleanup that was sitting in the working tree.

## Test plan
- [x] `dotnet build` on affected projects
- [x] `Gum.Cli.Tests` (65 passed) and `Gum.ProjectServices.Tests` (450 passed) green
- [x] Manually verified `--background` produces byte-exact opaque output on both MonoGame and raylib backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)