### PR TITLE
Docs: add raylib render-target compositing guidance, split into its own page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -316,6 +316,7 @@
   * [Finding Elements](code/visual-tree/finding-elements.md)
 * [Rendering](code/rendering/README.md)
   * [GumBatch](code/rendering/gumbatch.md)
+  * [Render Targets](code/rendering/render-targets.md)
   * [Rendering Custom Graphics](code/rendering/rendering-custom-graphics.md)
   * [Texture Filtering](code/rendering/texture-filtering.md)
 * [Ordering, Layers, and Popups](code/ordering-layers-and-popups/README.md)

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -274,21 +274,4 @@ For a runnable example, see the `RenderTarget` screen in the Gum immediate-mode 
 
 {% embed url="https://github.com/vchelaru/Gum/tree/main/Samples/MonoGameGumImmediateMode" %}
 
-Note that if you are rendering multiple objects on a render target, the BlendState must be set as to add the transparency. Using the default BlendState may result in alpha being "removed" from the render target when new instances are drawn.
-
-The following shows how to create a BlendState for objects which have partial transparency and are to be drawn on RenderTargets:
-
-```csharp
-// Initialize
-var blendState = new BlendState();
-
-blendState.ColorSourceBlend = BlendState.NonPremultiplied.ColorSourceBlend;
-blendState.ColorDestinationBlend = BlendState.NonPremultiplied.ColorDestinationBlend;
-blendState.ColorBlendFunction = BlendState.NonPremultiplied.ColorBlendFunction;
-
-blendState.AlphaSourceBlend = Blend.SourceAlpha;
-blendState.AlphaDestinationBlend = Blend.DestinationAlpha;
-blendState.AlphaBlendFunction = BlendFunction.Add;
-
-halfTransparentRectangle.BlendState = blendState;
-```
+If you are rendering multiple translucent objects onto the render target, see [Render Targets](render-targets.md) for the `BlendState` needed to accumulate alpha correctly (the default `BlendState` can "remove" alpha from the render target when new instances are drawn on top of existing content). That page also covers the equivalent raylib pattern.

--- a/docs/code/rendering/render-targets.md
+++ b/docs/code/rendering/render-targets.md
@@ -94,7 +94,3 @@ Raylib.EndTextureMode();
 {% hint style="info" %}
 `Raylib.EndBlendMode` always resets to `BlendMode.Alpha`, it does not restore whatever blend mode was active before. If you are drawing a mix of translucent objects onto the same render target and need to change blend modes mid-bake, re-select `BlendMode.CustomSeparate` with these same factors after each `EndBlendMode` rather than assuming the accumulating alpha blend is still active.
 {% endhint %}
-
-{% hint style="warning" %}
-**As of August 2026:** `RaylibGum`'s own `IsRenderTarget` container baking has a known gap where this alpha-accumulating pass does not apply to the default `Blend.Normal`/`Additive` values, only to `Replace`/`ReplaceAlpha`/`SubtractAlpha`/`MinAlpha` ([#4204](https://github.com/vchelaru/Gum/issues/4204)). Until that is fixed, translucent content baked through Gum's own `IsRenderTarget` on raylib can show the same darkening symptom described above even though you are not managing the render target yourself. Manually managed `RenderTexture2D` compositing using the pattern on this page is not affected, since it does not go through that code path.
-{% endhint %}

--- a/docs/code/rendering/render-targets.md
+++ b/docs/code/rendering/render-targets.md
@@ -1,0 +1,100 @@
+# Render Targets
+
+### Introduction
+
+Rendering translucent content onto an offscreen render target (MonoGame's `RenderTarget2D`, raylib's `RenderTexture2D`) and then compositing that target elsewhere is a common pattern, but it has a gotcha that does not show up when drawing straight to the screen: the render target's own alpha channel matters.
+
+When you draw straight to the screen, nothing reads the screen's alpha channel afterward, so a blend mode that leaves it in whatever state is harmless. A render target is different: its alpha channel gets read again the next time the target itself is composited onto something else. If drawing multiple translucent objects onto the target uses a blend mode that does not correctly accumulate that alpha, the target ends up with an alpha channel that is wrong even though the colors on screen look correct at the time. The most common symptom is content that appears fine while you are drawing to the target, but darkens, fades unevenly, or loses transparency where you did not expect it once the target itself is drawn somewhere else.
+
+The fix in every backend is the same idea: use blend factors that add to the target's alpha rather than ones designed for compositing straight onto an opaque screen. The exact code differs per backend.
+
+{% hint style="info" %}
+This page covers **manually managed** render targets, where you create the render target yourself and control the drawing and compositing (MonoGame `RenderTarget2D` via `GumBatch`/`SpriteBatch`, or raylib `RenderTexture2D` via raw raylib calls). If you want Gum to manage the render target for you, see [Is Render Target](../../gum-tool/gum-elements/container/is-render-target.md) and [RenderTargetTextureSource](../standard-visuals/spriteruntime/rendertargettexturesource.md), which bake a container's contents to a texture without you having to set blend factors yourself.
+{% endhint %}
+
+### MonoGame
+
+`GumBatch` can draw Gum objects onto a `RenderTarget2D` the same way a regular `SpriteBatch` can:
+
+```csharp
+// Draw
+// Assuming MyRenderTarget is a valid render target:
+GraphicsDevice.SetRenderTarget(MyRenderTarget);
+gumBatch.Begin();
+gumBatch.Draw(SomeGumObject);
+gumBatch.End();
+
+// now set the render target to null to draw it to screen:
+GraphicsDevice.SetRenderTarget(null);
+spriteBatch.Draw(MyRenderTarget, new Vector2(0, 0), Color.White);
+```
+
+{% hint style="info" %}
+Content drawn to a render target this way is not interactive by default, because the cursor is measured in window pixels while the content was drawn, and then scaled or offset, into the render target. To keep it clickable, map the cursor back into render-target space with [`HitTestTransformMatrix`](../events-and-interactivity/mouse-and-touch-screen-cursor.md#several-coordinate-spaces-at-once-hittesttransformmatrix).
+{% endhint %}
+
+{% hint style="warning" %}
+A container only ever drawn through `GumBatch` (never `AddToRoot`) has no `EffectiveManagers`, which breaks Forms controls that depend on it — most notably a `Menu`/`ComboBox` popup, which opens but never closes on an outside click. Call `container.AttachManagersOnly(SystemManagers.Default)` once after creating it so this works correctly.
+{% endhint %}
+
+For a runnable example, see the `RenderTarget` screen in the Gum immediate-mode sample. It draws a scaled, offset render target alongside a full-screen UI drawn at 1:1, both interactive in the same frame:
+
+{% embed url="https://github.com/vchelaru/Gum/tree/main/Samples/MonoGameGumImmediateMode" %}
+
+If you are rendering multiple translucent objects onto a render target, the `BlendState` must be set so that alpha accumulates rather than getting overwritten. The default `BlendState` can "remove" alpha from the render target when new instances are drawn on top of existing content.
+
+The following shows a `BlendState` for objects which have partial transparency and are drawn onto a render target, using separate alpha source/destination factors:
+
+```csharp
+// Initialize
+var blendState = new BlendState();
+
+blendState.ColorSourceBlend = BlendState.NonPremultiplied.ColorSourceBlend;
+blendState.ColorDestinationBlend = BlendState.NonPremultiplied.ColorDestinationBlend;
+blendState.ColorBlendFunction = BlendState.NonPremultiplied.ColorBlendFunction;
+
+blendState.AlphaSourceBlend = Blend.SourceAlpha;
+blendState.AlphaDestinationBlend = Blend.DestinationAlpha;
+blendState.AlphaBlendFunction = BlendFunction.Add;
+
+halfTransparentRectangle.BlendState = blendState;
+```
+
+### Raylib
+
+Raylib's canned `BlendMode.Alpha` uses the same source-alpha factor for both the color and alpha channels. That is correct for compositing onto an opaque screen, but drawing multiple translucent objects onto a `RenderTexture2D` with `BlendMode.Alpha` leaves the texture's alpha channel under 255 even when the colors look correct, because each draw multiplies the destination alpha down instead of accumulating it. Compositing that texture again elsewhere (for example, blitting it to the window) then darkens the result a second time using that leftover alpha.
+
+The fix is to set separate alpha blend factors with `Rlgl.SetBlendFactorsSeparate` instead of using the canned `BlendMode.Alpha`, then select `BlendMode.CustomSeparate`. Keep the color factors as a normal alpha blend, but set the alpha factors to accumulate (`GL_ONE`, `GL_ONE_MINUS_SRC_ALPHA`) instead of overwrite:
+
+```csharp
+// Draw
+// GL blend-factor / equation constants (OpenGL spec, not raylib-specific).
+const int GL_SRC_ALPHA = 0x0302;
+const int GL_ONE_MINUS_SRC_ALPHA = 0x0303;
+const int GL_ONE = 1;
+const int GL_FUNC_ADD = 0x8006;
+
+Raylib.BeginTextureMode(myRenderTexture);
+
+Rlgl.SetBlendFactorsSeparate(
+    glSrcRGB: GL_SRC_ALPHA,
+    glDstRGB: GL_ONE_MINUS_SRC_ALPHA,
+    glSrcAlpha: GL_ONE,
+    glDstAlpha: GL_ONE_MINUS_SRC_ALPHA,
+    glEqRGB: GL_FUNC_ADD,
+    glEqAlpha: GL_FUNC_ADD);
+Raylib.BeginBlendMode(BlendMode.CustomSeparate);
+
+// draw your translucent content here
+
+Raylib.EndBlendMode();
+Raylib.EndTextureMode();
+```
+
+{% hint style="info" %}
+`Raylib.EndBlendMode` always resets to `BlendMode.Alpha`, it does not restore whatever blend mode was active before. If you are drawing a mix of translucent objects onto the same render target and need to change blend modes mid-bake, re-select `BlendMode.CustomSeparate` with these same factors after each `EndBlendMode` rather than assuming the accumulating alpha blend is still active.
+{% endhint %}
+
+{% hint style="warning" %}
+**As of August 2026:** `RaylibGum`'s own `IsRenderTarget` container baking has a known gap where this alpha-accumulating pass does not apply to the default `Blend.Normal`/`Additive` values, only to `Replace`/`ReplaceAlpha`/`SubtractAlpha`/`MinAlpha` ([#4204](https://github.com/vchelaru/Gum/issues/4204)). Until that is fixed, translucent content baked through Gum's own `IsRenderTarget` on raylib can show the same darkening symptom described above even though you are not managing the render target yourself. Manually managed `RenderTexture2D` compositing using the pattern on this page is not affected, since it does not go through that code path.
+{% endhint %}

--- a/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
+++ b/docs/code/standard-visuals/spriteruntime/rendertargettexturesource.md
@@ -72,3 +72,5 @@ Currently the ListBox is not interactive because the original ListBox is invisib
 
 This limitation applies to Gum's own `IsRenderTarget` baking. If you instead draw a subtree into a `RenderTarget2D` yourself (for example with `GumBatch`), you can keep it interactive by mapping the cursor with [`HitTestTransformMatrix`](../../events-and-interactivity/mouse-and-touch-screen-cursor.md#several-coordinate-spaces-at-once-hittesttransformmatrix).
 {% endhint %}
+
+If you are managing a render target yourself instead of using `IsRenderTarget`, see [Render Targets](../../rendering/render-targets.md) for the blend-mode setup needed to composite translucent content correctly on MonoGame and raylib.

--- a/docs/gum-tool/gum-elements/container/is-render-target.md
+++ b/docs/gum-tool/gum-elements/container/is-render-target.md
@@ -32,3 +32,5 @@ Once a container is rendered to a render target, additional special effects can 
 
 For a step-by-step tool walkthrough of rotating and scaling a clipped container, see [Rotating and Scaling Clipped Contents](../../tutorials-and-examples/examples/rotating-and-scaling-clipped-contents.md). For the same pattern in code, see the [SpriteRuntime RenderTargetTextureSource](../../../code/standard-visuals/spriteruntime/rendertargettexturesource.md) documentation.
 
+If you are managing a render target yourself in code instead of using `Is Render Target`, see [Render Targets](../../../code/rendering/render-targets.md) for the blend-mode setup needed to composite translucent content correctly on MonoGame and raylib.
+


### PR DESCRIPTION
Closes #4205

Splits the alpha-blend-on-render-target gotcha out of `gumbatch.md`'s MonoGame-only RenderTargets section into a new cross-platform `docs/code/rendering/render-targets.md` page, with a MonoGame subsection (moved content) and a new raylib subsection (`Rlgl.SetBlendFactorsSeparate` pattern).

- `gumbatch.md` keeps just the GumBatch-specific mechanics (draw-to-target code, interactivity/`HitTestTransformMatrix`, `AttachManagersOnly` hints) and links out for the blend-mode gotcha.
- raylib section caveats the known `IsRenderTarget`/`Blend.Normal`/`Additive` gap (#4204, still open) in a hint block.
- Linked from `is-render-target.md` and `rendertargettexturesource.md`.
- Verified the raylib-cs API surface (`Rlgl.SetBlendFactorsSeparate`, `BlendMode.CustomSeparate`) against the public GitHub source, not decompiled.

Manual test: not needed — pure documentation content, no compiled/runtime code touched.
FRB canary: not needed — no FRB1-shared source touched.
