### PR TITLE
Fix RaylibGum's Normal/Additive blend never getting render-target premultiply protection

### DIFF
--- a/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
+++ b/Runtimes/RaylibGum/Renderables/BlendModeExtensions.cs
@@ -97,10 +97,21 @@ internal static class BlendModeExtensions
             : (ToGlBlendFactor(blendState.ColorSourceBlend), ToGlBlendFactor(blendState.ColorDestinationBlend),
                 ToGlBlendEquation(blendState.ColorBlendFunction));
 
+        // Normal/Additive's straight-storage alpha factor reuses the same SrcAlpha factor as color
+        // (ToBlendState's 2-arg constructor sets AlphaSourceBlend = ColorSourceBlend), which squares
+        // the source alpha once written into premultiplied render-target storage. The other four
+        // values already use an alpha source factor of One (see BlendState.cs), so their alpha
+        // already accumulates correctly as coverage and needs no context-dependent override — only
+        // Normal/Additive need it (issue #4204).
+        int alphaSrc = isPremultiplyingContext && blend is global::Gum.RenderingLibrary.Blend.Normal
+            or global::Gum.RenderingLibrary.Blend.Additive
+            ? GlOne
+            : ToGlBlendFactor(blendState.AlphaSourceBlend);
+
         return (
             colorSrc,
             colorDst,
-            ToGlBlendFactor(blendState.AlphaSourceBlend),
+            alphaSrc,
             ToGlBlendFactor(blendState.AlphaDestinationBlend),
             colorFunc,
             ToGlBlendEquation(blendState.AlphaBlendFunction));
@@ -121,6 +132,15 @@ internal static class BlendModeExtensions
     // wrong-color leak.
     private static (int colorSrc, int colorDst, int colorFunc) ToPremultipliedConsistentColorFactors(global::Gum.RenderingLibrary.Blend blend) => blend switch
     {
+        // Standard "over" compositing, premultiplying the incoming color by its own alpha on the fly
+        // (Src*SrcAlpha) rather than leaving it raw (Src*One) — same color factors raylib's canned
+        // BlendMode.Alpha already uses; only the alpha factor (see ToGlBlendFactorsSeparate) needs to
+        // change to avoid squaring (issue #4204).
+        global::Gum.RenderingLibrary.Blend.Normal => (GlSrcAlpha, GlOneMinusSrcAlpha, GlFuncAdd),
+        // Adds the incoming color premultiplied by its own alpha without attenuating the destination
+        // — same color factors raylib's canned BlendMode.Additive already uses; only the alpha factor
+        // needs to change to avoid squaring (issue #4204).
+        global::Gum.RenderingLibrary.Blend.Additive => (GlSrcAlpha, GlOne, GlFuncAdd),
         // Fully replaces the destination, so premultiply the incoming color by its own alpha
         // (Src*SrcAlpha) rather than writing it raw (Src*One) — fully general, no destination
         // assumption needed since Replace discards the destination outright.

--- a/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/BatchDrawCallCounter.cs
@@ -142,7 +142,10 @@ public sealed unsafe class BatchDrawCallCounter
     {
         Bank();
 
-        if (blend.TryGetSimpleRaylibBlendMode(out BlendMode mode))
+        // raylib's canned Normal/Additive modes square the source alpha when written into
+        // premultiplied render-target storage (issue #4204), so skip them while a bake is active and
+        // fall through to the premultiply-consistent custom-separate factors below instead.
+        if (!_renderTargetBlendActive && blend.TryGetSimpleRaylibBlendMode(out BlendMode mode))
         {
             Raylib.BeginBlendMode(mode);
             return;

--- a/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/BlendModeRenderTests.cs
@@ -195,4 +195,44 @@ public class BlendModeRenderTests : BaseTestClass
         outer.R.ShouldBeInRange((byte)40, (byte)120);
         outer.B.ShouldBeGreaterThan((byte)120);
     }
+
+    [Fact]
+    public void Draw_NormalBlendSprite_ComposesAlphaAsCoverageOverOpaqueBackground()
+    {
+        // Normal is the default Blend, which took the fast path straight to raylib's canned
+        // BlendMode.Alpha regardless of _renderTargetBlendActive (issue #4204) — that canned mode's
+        // alpha factors square the source alpha (AlphaSourceBlend == ColorSourceBlend == SrcAlpha),
+        // instead of accumulating it as coverage (SrcAlpha + Dst*(1-SrcAlpha)) the way premultiplied
+        // render-target storage requires. Drawing a half-alpha masker over an already-opaque
+        // background isolates the difference: coverage keeps the result fully opaque (1.0), while
+        // the squared factor leaves it only ~0.75 opaque.
+        (Color cell, Color outer) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)255, (byte)0, (byte)0, (byte)255),
+            maskerTextureColor: new Color((byte)0, (byte)255, (byte)0, (byte)128),
+            maskerBlend: Blend.Normal);
+
+        cell.A.ShouldBeGreaterThan((byte)240);
+
+        // Composited over blue: a fully opaque cell must not let any of the outer blue background
+        // bleed through (the bug's ~0.75 opacity would let roughly a quarter of it show).
+        outer.B.ShouldBeLessThan((byte)40);
+    }
+
+    [Fact]
+    public void Draw_AdditiveBlendSprite_ComposesAlphaAsCoverageNotSquared()
+    {
+        // Mirrors the Normal case above but for Additive, which shares the same squared-alpha bug
+        // (raylib's canned BlendMode.Additive also sets AlphaSourceBlend == ColorSourceBlend ==
+        // SrcAlpha). A fully transparent background isolates the masker's own alpha contribution,
+        // since additive alpha would otherwise clamp to opaque once the background reaches 1.0.
+        (Color cell, Color _) = DrawMaskedCellOverBlueBackground(
+            32,
+            backgroundColor: new Color((byte)0, (byte)0, (byte)0, (byte)0),
+            maskerTextureColor: new Color((byte)0, (byte)255, (byte)0, (byte)128),
+            maskerBlend: Blend.Additive);
+
+        // Coverage keeps the masker's own ~50% alpha (~128); the squared bug halves it again (~64).
+        cell.A.ShouldBeGreaterThan((byte)100);
+    }
 }


### PR DESCRIPTION
## Problem
`BatchDrawCallCounter.BeginBlendMode(Blend)` took a fast path straight to raylib's canned `BlendMode.Alpha`/`Additive` whenever it could, regardless of `_renderTargetBlendActive` — so `Blend.Normal` (the default) and `Blend.Additive` never got the premultiply-consistent alpha accumulation the render-target bake pass exists to provide. Their canned modes square the source alpha instead of accumulating it as coverage, so a render target containing ordinary translucent content ends up under-opaque, corrupting any further composite of that bake.

## Fix
Skip the canned-mode fast path while `_renderTargetBlendActive` is true, and give `Normal`/`Additive` a premultiply-consistent alpha source factor (`One` instead of `SrcAlpha`) alongside their existing (already-correct) color factors.

## Tests
Added two pixel-readback tests to `BlendModeRenderTests` following the existing Replace/ReplaceAlpha/SubtractAlpha/MinAlpha pattern — both reproduced the exact squared-alpha values predicted by hand (191/255 for Normal, 64/255 for Additive) before the fix, and pass after it. Full `RaylibGum.Tests` suite (571 tests) is green.

Closes #4204