### PR TITLE
Document Click's per-device activation timing on Button and related controls

### DIFF
--- a/MonoGameGum/Forms/Controls/ListBoxItem.cs
+++ b/MonoGameGum/Forms/Controls/ListBoxItem.cs
@@ -75,6 +75,11 @@ public class ListBoxItem :
     #region Events
 
     public event EventHandler Selected;
+    /// <summary>
+    /// Event raised when the item is clicked by a cursor or touch (press, then release
+    /// over the item). Unlike ButtonBase.Click, this is not raised by keyboard or gamepad
+    /// activation.
+    /// </summary>
     public event EventHandler Clicked;
     public event EventHandler Pushed;
 

--- a/MonoGameGum/Forms/Controls/MenuItem.cs
+++ b/MonoGameGum/Forms/Controls/MenuItem.cs
@@ -156,6 +156,11 @@ public class MenuItem : ItemsControl
     #region Events
 
     public event EventHandler Selected;
+    /// <summary>
+    /// Event raised when the item is activated by a cursor or touch. With a mouse, this
+    /// fires on push, matching WPF menu behavior; with touch, it fires on release. Unlike
+    /// ButtonBase.Click, this is not raised by keyboard or gamepad activation.
+    /// </summary>
     public event EventHandler Clicked;
 
     #endregion

--- a/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/ButtonBase.cs
@@ -62,10 +62,12 @@ public class ButtonBase :
     #region Events
 
     /// <summary>
-    /// Event raised when the user pushes, then releases the control.
-    /// This means the cursor is over the button, the button was originally pushed,
-    /// the primary button was pressed last frame, but is no longer pressed this frame.
-    /// The "click" terminology comes from the Cursor's PrimaryClick property.
+    /// Event raised when the control is activated. Click, not Push, is the primary event
+    /// for reacting to button activation, but its timing differs by input device:
+    /// with a mouse or touch, Click fires on release, after a matching push over the same
+    /// control (the cursor may leave and return before releasing; see Push).
+    /// With keyboard or gamepad, Click fires immediately when the activation key/button is
+    /// pressed, with no release-based confirmation.
     /// </summary>
     public event EventHandler Click;
 

--- a/docs/code/controls/button.md
+++ b/docs/code/controls/button.md
@@ -4,6 +4,11 @@
 
 The Button control providing an event for handling clicks.
 
+`Click`, not `Push`, is the primary event for reacting to button activation. Its timing depends on the input device:
+
+* **Mouse or touch** - `Click` fires on release, after a matching push over the same button. The cursor can leave and return before releasing; see [Click](../gum-code-reference/interactivegue/click.md) for details.
+* **Keyboard or gamepad** - `Click` fires immediately when the activation key or button is pressed, with no release-based confirmation.
+
 ## Code Example: Adding a Button
 
 The following code adds a button which increments every time it is clicked:

--- a/docs/code/gum-code-reference/interactivegue/click.md
+++ b/docs/code/gum-code-reference/interactivegue/click.md
@@ -6,6 +6,10 @@ A Click event is raised when an InteractiveGue is first pressed, then released. 
 
 The Click event is used by most Gum Forms controls to raise their own Click event, and to update visual state.
 
+{% hint style="info" %}
+Forms controls that derive from `ButtonBase` (such as `Button`) also raise their own `Click` for keyboard and gamepad activation, bypassing this InteractiveGue-level, cursor-only `Click`. That means `ButtonBase.Click` fires immediately on key/button press for keyboard and gamepad, with no release-based confirmation, unlike the press-then-release timing described here. See the [Button](../../controls/button.md) page for details.
+{% endhint %}
+
 ## Click Definition
 
 A click occurs when the following happens:


### PR DESCRIPTION
## Summary
Click is the primary/canonical activation event for Forms buttons, but the name and old docs implied mouse-only push-then-release semantics. Rather than rename (too disruptive, `Click` is entrenched terminology), this documents the actual behavior:

- `ButtonBase.Click` timing differs by device: mouse/touch fires on release after a matching push; keyboard/gamepad fires immediately on press, no release-based confirmation.
- `ListBoxItem.Clicked` / `MenuItem.Clicked` had no XML docs at all, and behave differently from `ButtonBase.Click` (cursor/touch only, no keyboard/gamepad path) — added docs noting that.
- Updated `docs/code/controls/button.md` and `docs/code/gum-code-reference/interactivegue/click.md` to match.

No behavior changes.

Closes #4193

## Test plan
- [x] `dotnet build MonoGameGum/MonoGameGum.csproj` - clean, 0 errors
- Manual test: not needed - doc/XML-comment only change, no runtime-observable behavior
