### PR TITLE
Graduate CullOffscreenWhenClipped from experimental status

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -56,9 +56,10 @@ public class Renderer : IRenderer
     /// the active clip rectangle, along with its subtree — avoiding draw and render-state work for
     /// scrolled-off content in ListBoxes, ScrollViewers, etc. (#2998).
     /// <para>
-    /// Treat as experimental until validated on real projects: set to false to render all clipped
-    /// content if a renderable's visuals intentionally bleed far past its own bounds. Forwards to
-    /// the backend-agnostic <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
+    /// Set to false to render all clipped content if a renderable's visuals intentionally bleed far
+    /// past its own bounds; this is a diagnostic escape hatch, not a routine toggle, so report cases
+    /// that need it. Forwards to the backend-agnostic
+    /// <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
     /// </para>
     /// </summary>
     public static bool CullOffscreenWhenClipped

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -23,9 +23,9 @@ public class Renderer : IRenderer
     /// <summary>
     /// When true (the default), the render walk skips any renderable that falls entirely outside
     /// the active clip rectangle, along with its subtree — avoiding draw work for scrolled-off
-    /// content in clipping containers (#2998). Experimental until validated on real projects; set
-    /// false to render all clipped content. Forwards to the backend-agnostic
-    /// <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
+    /// content in clipping containers (#2998). Set false to render all clipped content; this is a
+    /// diagnostic escape hatch, not a routine toggle, so report cases that need it. Forwards to the
+    /// backend-agnostic <see cref="CameraScissorExtensions.CullOffscreenWhenClipped"/>.
     /// </summary>
     public static bool CullOffscreenWhenClipped
     {

--- a/docs/code/performance-and-optimization/culling-offscreen-renderables.md
+++ b/docs/code/performance-and-optimization/culling-offscreen-renderables.md
@@ -35,7 +35,7 @@ The cull decides what to skip from each renderable's *own* bounds. That is corre
 In those cases an item sitting just past the edge of a scrolled region could be culled even though part of it should still be visible. If you see content disappear at the edge of a clipped area that should be on screen, either set `CullOffscreenWhenClipped` to `false`, or give the overflowing content a parent that clips it so its footprint stays within its bounds.
 
 {% hint style="info" %}
-**As of May 2026:** Off-screen culling is on by default but is still considered experimental while it is validated across real projects. If it causes incorrect clipping in your project, disable it with `Renderer.CullOffscreenWhenClipped = false` and please report the case.
+Setting `CullOffscreenWhenClipped` to `false` is a diagnostic step, not a long-term fix. If disabling it changes what's visible in your project, please [report it](https://github.com/vchelaru/Gum/issues) so the underlying cull bounds can be fixed.
 {% endhint %}
 
 Use [Measuring Draw Calls](lastframedrawstates.md) to confirm the reduction in draw states with the cull on versus off.


### PR DESCRIPTION
## Summary
Drops the "experimental until validated" wording for `CullOffscreenWhenClipped` and reframes it as a documented diagnostic escape hatch, not a provisional toggle.

## Why
It's been the shipped default across every backend and pass (raylib main pass + bake, MonoGame bake) since #4154, has conformance coverage (`ClipWalkConformanceTests`, `OffscreenCullRenderTests`, `OffscreenCullWrappedTextTests`, `RenderTargetBakeClipWalkTests`), and there's no report anywhere of a real project needing it disabled.

## Changes
- `RenderingLibrary/Graphics/Renderer.cs`, `Runtimes/RaylibGum/RenderingLibrary/Renderer.cs`: drop "experimental" doc comments, note the flag is a diagnostic escape hatch worth reporting if needed.
- `docs/code/performance-and-optimization/culling-offscreen-renderables.md`: same reframing, replacing the dated "as of May 2026" hint block.

No behavior change — the default stays `true`.

Closes #4201
