### PR TITLE
Collapse Red/Green/Blue VariableReferences in FormsTemplate (Standard)

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonClose.gucx
@@ -170,9 +170,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Danger.FillRed</string>
-        <string>Green = Components/Styles.Danger.FillGreen</string>
-        <string>Blue = Components/Styles.Danger.FillBlue</string>
+        <string>Color = Components/Styles.Danger.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -182,9 +180,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -214,9 +210,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -244,9 +238,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -274,9 +266,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -304,9 +294,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -334,9 +322,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -364,9 +350,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -394,9 +378,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonConfirm.gucx
@@ -209,9 +209,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Success.FillRed</string>
-        <string>Green = Components/Styles.Success.FillGreen</string>
-        <string>Blue = Components/Styles.Success.FillBlue</string>
+        <string>Color = Components/Styles.Success.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -221,9 +219,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -233,9 +229,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -279,9 +273,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -291,9 +283,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -327,9 +317,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -339,9 +327,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -375,9 +361,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -387,9 +371,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -423,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -435,9 +415,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -471,9 +449,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +459,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -519,9 +493,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -531,9 +503,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -567,9 +537,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -579,9 +547,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonDeny.gucx
@@ -209,9 +209,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Danger.FillRed</string>
-        <string>Green = Components/Styles.Danger.FillGreen</string>
-        <string>Blue = Components/Styles.Danger.FillBlue</string>
+        <string>Color = Components/Styles.Danger.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -221,9 +219,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -233,9 +229,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -279,9 +273,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -291,9 +283,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -327,9 +317,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -339,9 +327,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -375,9 +361,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -387,9 +371,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -423,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -435,9 +415,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -471,9 +449,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +459,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -519,9 +493,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -531,9 +503,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -567,9 +537,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -579,9 +547,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonIcon.gucx
@@ -175,9 +175,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -187,9 +185,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -219,9 +215,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -249,9 +243,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -279,9 +271,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -309,9 +299,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -339,9 +327,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -369,9 +355,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -399,9 +383,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandard.gucx
@@ -212,9 +212,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -224,9 +222,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -236,9 +232,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -282,9 +276,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -294,9 +286,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -330,9 +320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -342,9 +330,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -378,9 +364,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -390,9 +374,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -426,9 +408,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -438,9 +418,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -474,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -486,9 +462,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -522,9 +496,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -534,9 +506,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -570,9 +540,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -582,9 +550,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonStandardIcon.gucx
@@ -205,9 +205,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -217,9 +215,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -229,9 +225,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -278,9 +272,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -290,9 +282,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -329,9 +319,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -341,9 +329,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -380,9 +366,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -392,9 +376,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -431,9 +413,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -443,9 +423,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -482,9 +460,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -494,9 +470,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -533,9 +507,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -545,9 +517,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -584,9 +554,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -596,9 +564,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ButtonTab.gucx
@@ -217,9 +217,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -229,9 +227,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -241,9 +237,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -287,9 +281,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -299,9 +291,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -335,9 +325,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -347,9 +335,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -383,9 +369,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -395,9 +379,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -431,9 +413,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -443,9 +423,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -479,9 +457,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -491,9 +467,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -527,9 +501,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -539,9 +511,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -575,9 +545,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -587,9 +555,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/CheckBox.gucx
@@ -230,9 +230,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -242,9 +240,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -254,9 +250,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -309,9 +303,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -321,9 +313,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -366,9 +356,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -378,9 +366,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -423,9 +409,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -435,9 +419,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -480,9 +462,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -492,9 +472,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -537,9 +515,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -549,9 +525,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -594,9 +568,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -606,9 +578,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -651,9 +621,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -663,9 +631,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -708,9 +674,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -720,9 +684,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -765,9 +727,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -777,9 +737,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -822,9 +780,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -834,9 +790,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -879,9 +833,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -891,9 +843,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -936,9 +886,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -948,9 +896,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -993,9 +939,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1005,9 +949,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1050,9 +992,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1062,9 +1002,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1107,9 +1045,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1119,9 +1055,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1164,9 +1098,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1176,9 +1108,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1221,9 +1151,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1233,9 +1161,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1278,9 +1204,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1290,9 +1214,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1335,9 +1257,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1347,9 +1267,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1392,9 +1310,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1404,9 +1320,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1449,9 +1363,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1461,9 +1373,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ComboBox.gucx
@@ -254,9 +254,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -266,9 +264,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -278,9 +274,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -318,9 +312,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -348,9 +340,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -378,9 +368,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -408,9 +396,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -438,9 +424,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -468,9 +452,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -498,9 +480,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/DialogBox.gucx
@@ -165,9 +165,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -177,9 +175,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ItemsControl.gucx
@@ -299,9 +299,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -311,9 +309,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/KeyboardKey.gucx
@@ -209,9 +209,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -221,9 +219,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -233,9 +229,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -279,9 +273,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -291,9 +283,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -327,9 +317,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -339,9 +327,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -375,9 +361,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -387,9 +371,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -423,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -435,9 +415,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -471,9 +449,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +459,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -519,9 +493,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -531,9 +503,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -567,9 +537,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -579,9 +547,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Label.gucx
@@ -57,9 +57,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBox.gucx
@@ -290,9 +290,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -302,9 +300,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ListBoxItem.gucx
@@ -212,9 +212,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -224,9 +222,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -236,9 +232,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -276,9 +270,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -306,9 +298,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -336,9 +326,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -366,9 +354,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Menu.gucx
@@ -143,9 +143,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/MenuItem.gucx
@@ -295,9 +295,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -307,9 +305,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -327,9 +323,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -370,9 +364,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -382,9 +374,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -415,9 +405,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -427,9 +415,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -460,9 +446,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -472,9 +456,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -505,9 +487,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -517,9 +497,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -550,9 +528,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -562,9 +538,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/PasswordBox.gucx
@@ -445,9 +445,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -457,9 +455,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -469,9 +465,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -481,9 +475,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -501,9 +493,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -513,9 +503,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -568,9 +556,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -580,9 +566,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -592,9 +576,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -637,9 +619,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -649,9 +629,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -661,9 +639,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -706,9 +682,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -718,9 +692,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -730,9 +702,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -775,9 +745,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -787,9 +755,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -799,9 +765,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/RadioButton.gucx
@@ -224,9 +224,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -236,9 +234,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -248,9 +244,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -300,9 +294,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -312,9 +304,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -354,9 +344,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -366,9 +354,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -408,9 +394,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -420,9 +404,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -462,9 +444,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -474,9 +454,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -516,9 +494,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -528,9 +504,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -570,9 +544,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -582,9 +554,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -624,9 +594,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -636,9 +604,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -678,9 +644,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -690,9 +654,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -732,9 +694,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -744,9 +704,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -786,9 +744,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -798,9 +754,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -840,9 +794,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -852,9 +804,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -894,9 +844,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -906,9 +854,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -948,9 +894,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -960,9 +904,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1002,9 +944,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -1014,9 +954,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollBar.gucx
@@ -173,9 +173,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ScrollViewer.gucx
@@ -238,9 +238,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -250,9 +248,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Slider.gucx
@@ -186,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -198,9 +196,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/SplitterStandard.gucx
@@ -92,9 +92,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TextBox.gucx
@@ -447,9 +447,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -459,9 +457,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -471,9 +467,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -483,9 +477,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -503,9 +495,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -515,9 +505,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -570,9 +558,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -582,9 +568,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -594,9 +578,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -639,9 +621,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -651,9 +631,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -663,9 +641,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -708,9 +684,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -720,9 +694,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -732,9 +704,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -777,9 +747,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -789,9 +757,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
       <VariableList xsi:type="VariableListSaveOfString">
@@ -801,9 +767,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Toast.gucx
@@ -172,9 +172,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -184,9 +182,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeView.gucx
@@ -205,9 +205,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -217,9 +215,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/TreeViewToggle.gucx
@@ -97,9 +97,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -135,9 +133,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -171,9 +167,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -207,9 +201,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -243,9 +235,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -279,9 +269,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -315,9 +303,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -351,9 +337,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -387,9 +371,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/UserControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/UserControl.gucx
@@ -69,9 +69,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/Window.gucx
@@ -368,9 +368,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/CautionLines.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/CautionLines.gucx
@@ -71,9 +71,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Black.FillRed</string>
-          <string>Green = Components/Styles.Black.FillGreen</string>
-          <string>Blue = Components/Styles.Black.FillBlue</string>
+          <string>Color = Components/Styles.Black.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -95,9 +93,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -119,9 +115,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -143,9 +137,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -167,9 +159,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -191,9 +181,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -215,9 +203,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -239,9 +225,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -263,9 +247,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -287,9 +269,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -311,9 +291,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -335,9 +313,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/Divider.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/Divider.gucx
@@ -262,9 +262,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -274,9 +272,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -286,9 +282,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/DividerHorizontal.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/DividerHorizontal.gucx
@@ -171,9 +171,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -183,9 +181,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -195,9 +191,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/DividerVertical.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/DividerVertical.gucx
@@ -186,9 +186,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -198,9 +196,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -210,9 +206,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
       </Value>
     </VariableList>
   </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/Icon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/Icon.gucx
@@ -1390,9 +1390,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Black.FillRed</string>
-          <string>Green = Components/Styles.Black.FillGreen</string>
-          <string>Blue = Components/Styles.Black.FillBlue</string>
+          <string>Color = Components/Styles.Black.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1414,9 +1412,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1438,9 +1434,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1462,9 +1456,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1486,9 +1478,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1510,9 +1500,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1534,9 +1522,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1558,9 +1544,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1582,9 +1566,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1606,9 +1588,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1630,9 +1610,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -1654,9 +1632,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBar.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBar.gucx
@@ -226,9 +226,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -238,9 +236,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Black.FillRed</string>
-        <string>Green = Components/Styles.Black.FillGreen</string>
-        <string>Blue = Components/Styles.Black.FillBlue</string>
+        <string>Color = Components/Styles.Black.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -294,9 +290,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Black.FillRed</string>
-          <string>Green = Components/Styles.Black.FillGreen</string>
-          <string>Blue = Components/Styles.Black.FillBlue</string>
+          <string>Color = Components/Styles.Black.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -318,9 +312,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -342,9 +334,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -366,9 +356,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -390,9 +378,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -414,9 +400,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -438,9 +422,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -462,9 +444,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -486,9 +466,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -510,9 +488,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -534,9 +510,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -558,9 +532,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBarIcon.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/PercentBarIcon.gucx
@@ -258,9 +258,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -270,9 +268,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Black.FillRed</string>
-        <string>Green = Components/Styles.Black.FillGreen</string>
-        <string>Blue = Components/Styles.Black.FillBlue</string>
+        <string>Color = Components/Styles.Black.FillColor</string>
       </Value>
     </VariableList>
   </State>
@@ -326,9 +322,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Black.FillRed</string>
-          <string>Green = Components/Styles.Black.FillGreen</string>
-          <string>Blue = Components/Styles.Black.FillBlue</string>
+          <string>Color = Components/Styles.Black.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -350,9 +344,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -374,9 +366,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -398,9 +388,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -422,9 +410,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -446,9 +432,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -470,9 +454,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -494,9 +476,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -518,9 +498,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -542,9 +520,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -566,9 +542,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -590,9 +564,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/VerticalLines.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Elements/VerticalLines.gucx
@@ -71,9 +71,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Black.FillRed</string>
-          <string>Green = Components/Styles.Black.FillGreen</string>
-          <string>Blue = Components/Styles.Black.FillBlue</string>
+          <string>Color = Components/Styles.Black.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -95,9 +93,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.DarkGray.FillRed</string>
-          <string>Green = Components/Styles.DarkGray.FillGreen</string>
-          <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+          <string>Color = Components/Styles.DarkGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -119,9 +115,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Gray.FillRed</string>
-          <string>Green = Components/Styles.Gray.FillGreen</string>
-          <string>Blue = Components/Styles.Gray.FillBlue</string>
+          <string>Color = Components/Styles.Gray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -143,9 +137,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.LightGray.FillRed</string>
-          <string>Green = Components/Styles.LightGray.FillGreen</string>
-          <string>Blue = Components/Styles.LightGray.FillBlue</string>
+          <string>Color = Components/Styles.LightGray.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -167,9 +159,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.White.FillRed</string>
-          <string>Green = Components/Styles.White.FillGreen</string>
-          <string>Blue = Components/Styles.White.FillBlue</string>
+          <string>Color = Components/Styles.White.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -191,9 +181,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-          <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -215,9 +203,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Primary.FillRed</string>
-          <string>Green = Components/Styles.Primary.FillGreen</string>
-          <string>Blue = Components/Styles.Primary.FillBlue</string>
+          <string>Color = Components/Styles.Primary.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -239,9 +225,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-          <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-          <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+          <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -263,9 +247,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Success.FillRed</string>
-          <string>Green = Components/Styles.Success.FillGreen</string>
-          <string>Blue = Components/Styles.Success.FillBlue</string>
+          <string>Color = Components/Styles.Success.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -287,9 +269,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Warning.FillRed</string>
-          <string>Green = Components/Styles.Warning.FillGreen</string>
-          <string>Blue = Components/Styles.Warning.FillBlue</string>
+          <string>Color = Components/Styles.Warning.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -311,9 +291,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Danger.FillRed</string>
-          <string>Green = Components/Styles.Danger.FillGreen</string>
-          <string>Blue = Components/Styles.Danger.FillBlue</string>
+          <string>Color = Components/Styles.Danger.FillColor</string>
         </Value>
       </VariableList>
     </State>
@@ -335,9 +313,7 @@
         <IsFile>false</IsFile>
         <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
         <Value>
-          <string>Red = Components/Styles.Accent.FillRed</string>
-          <string>Green = Components/Styles.Accent.FillGreen</string>
-          <string>Blue = Components/Styles.Accent.FillBlue</string>
+          <string>Color = Components/Styles.Accent.FillColor</string>
         </Value>
       </VariableList>
     </State>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/DemoScreenGum.gusx
@@ -1218,9 +1218,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -1230,9 +1228,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -1242,9 +1238,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -1254,9 +1248,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
         <string>Font = Components/Styles.Title.Font</string>
         <string>FontSize = Components/Styles.Title.FontSize</string>
         <string>IsBold = Components/Styles.Title.IsBold</string>
@@ -1274,9 +1266,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
         <string>Font = Components/Styles.Title.Font</string>
         <string>FontSize = Components/Styles.Title.FontSize</string>
         <string>IsBold = Components/Styles.Title.IsBold</string>
@@ -1294,9 +1284,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
         <string>Font = Components/Styles.Title.Font</string>
         <string>FontSize = Components/Styles.Title.FontSize</string>
         <string>IsBold = Components/Styles.Title.IsBold</string>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/StylesScreen.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Screens/StylesScreen.gusx
@@ -2090,9 +2090,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2102,9 +2100,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2114,9 +2110,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2126,9 +2120,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2138,9 +2130,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2150,9 +2140,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2162,9 +2150,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2174,9 +2160,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2186,9 +2170,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
       </Value>
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
@@ -2198,9 +2180,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Accent.FillRed</string>
-        <string>Green = Components/Styles.Accent.FillGreen</string>
-        <string>Blue = Components/Styles.Accent.FillBlue</string>
+        <string>Color = Components/Styles.Accent.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2218,9 +2198,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Black.FillRed</string>
-        <string>Green = Components/Styles.Black.FillGreen</string>
-        <string>Blue = Components/Styles.Black.FillBlue</string>
+        <string>Color = Components/Styles.Black.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2238,9 +2216,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.DarkGray.FillRed</string>
-        <string>Green = Components/Styles.DarkGray.FillGreen</string>
-        <string>Blue = Components/Styles.DarkGray.FillBlue</string>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2258,9 +2234,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Emphasis.Font</string>
         <string>FontSize = Components/Styles.Emphasis.FontSize</string>
         <string>IsBold = Components/Styles.Emphasis.IsBold</string>
@@ -2278,9 +2252,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Gray.FillRed</string>
-        <string>Green = Components/Styles.Gray.FillGreen</string>
-        <string>Blue = Components/Styles.Gray.FillBlue</string>
+        <string>Color = Components/Styles.Gray.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2298,9 +2270,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.H1.Font</string>
         <string>FontSize = Components/Styles.H1.FontSize</string>
         <string>IsBold = Components/Styles.H1.IsBold</string>
@@ -2318,9 +2288,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.H2.Font</string>
         <string>FontSize = Components/Styles.H2.FontSize</string>
         <string>IsBold = Components/Styles.H2.IsBold</string>
@@ -2338,9 +2306,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.H3.Font</string>
         <string>FontSize = Components/Styles.H3.FontSize</string>
         <string>IsBold = Components/Styles.H3.IsBold</string>
@@ -2358,9 +2324,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.LightGray.FillRed</string>
-        <string>Green = Components/Styles.LightGray.FillGreen</string>
-        <string>Blue = Components/Styles.LightGray.FillBlue</string>
+        <string>Color = Components/Styles.LightGray.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2378,9 +2342,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2398,9 +2360,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Primary.FillRed</string>
-        <string>Green = Components/Styles.Primary.FillGreen</string>
-        <string>Blue = Components/Styles.Primary.FillBlue</string>
+        <string>Color = Components/Styles.Primary.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2418,9 +2378,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.PrimaryDark.FillRed</string>
-        <string>Green = Components/Styles.PrimaryDark.FillGreen</string>
-        <string>Blue = Components/Styles.PrimaryDark.FillBlue</string>
+        <string>Color = Components/Styles.PrimaryDark.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2438,9 +2396,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.PrimaryLight.FillRed</string>
-        <string>Green = Components/Styles.PrimaryLight.FillGreen</string>
-        <string>Blue = Components/Styles.PrimaryLight.FillBlue</string>
+        <string>Color = Components/Styles.PrimaryLight.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2458,9 +2414,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Small.Font</string>
         <string>FontSize = Components/Styles.Small.FontSize</string>
         <string>IsBold = Components/Styles.Small.IsBold</string>
@@ -2478,9 +2432,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Strong.Font</string>
         <string>FontSize = Components/Styles.Strong.FontSize</string>
         <string>IsBold = Components/Styles.Strong.IsBold</string>
@@ -2498,9 +2450,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Success.FillRed</string>
-        <string>Green = Components/Styles.Success.FillGreen</string>
-        <string>Blue = Components/Styles.Success.FillBlue</string>
+        <string>Color = Components/Styles.Success.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2518,9 +2468,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Tiny.Font</string>
         <string>FontSize = Components/Styles.Tiny.FontSize</string>
         <string>IsBold = Components/Styles.Tiny.IsBold</string>
@@ -2538,9 +2486,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Title.Font</string>
         <string>FontSize = Components/Styles.Title.FontSize</string>
         <string>IsBold = Components/Styles.Title.IsBold</string>
@@ -2558,9 +2504,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Warning.FillRed</string>
-        <string>Green = Components/Styles.Warning.FillGreen</string>
-        <string>Blue = Components/Styles.Warning.FillBlue</string>
+        <string>Color = Components/Styles.Warning.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2578,9 +2522,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.Danger.FillRed</string>
-        <string>Green = Components/Styles.Danger.FillGreen</string>
-        <string>Blue = Components/Styles.Danger.FillBlue</string>
+        <string>Color = Components/Styles.Danger.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>
@@ -2598,9 +2540,7 @@
       <IsFile>false</IsFile>
       <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
       <Value>
-        <string>Red = Components/Styles.White.FillRed</string>
-        <string>Green = Components/Styles.White.FillGreen</string>
-        <string>Blue = Components/Styles.White.FillBlue</string>
+        <string>Color = Components/Styles.White.FillColor</string>
         <string>Font = Components/Styles.Normal.Font</string>
         <string>FontSize = Components/Styles.Normal.FontSize</string>
         <string>IsBold = Components/Styles.Normal.IsBold</string>


### PR DESCRIPTION
## Summary

Collapses the 400 `Red`/`Green`/`Blue` `VariableReferences` triples in FormsTemplate (Standard) into single `Color = X.FillColor` lines, now that cross-named composite references are supported (#4160/#4167). 1200 reference lines become 400. Same recipe as #4188's Bubblegum/Hazard sweep — no instance retyping or engine changes needed, contrary to this issue's original suggestion.

## Verification

- Dumped every materialized variable value across all Components/Screens after `ApplyAllVariableReferences`, before and after the change: **byte-identical** (throwaway test, deleted after confirming).
- `gumcli check` / `check-references` / `diff-standards` — all clean.
- `dotnet test Tests/Gum.ProjectServices.Tests` — 450 passed, 3 skipped.
- `dotnet build GumFull.sln` — 0 errors; staged `Gum/bin/Debug/Content/FormsThemes/Standard/*` confirmed reflects the collapse (postbuild re-ran).

Closes #4158
