### PR TITLE
Fix Textures tab grid snapping: don't snap display, split move/resize commit

### DIFF
--- a/FlatRedBall.SpecializedXnaControls/Properties/AssemblyInfo.cs
+++ b/FlatRedBall.SpecializedXnaControls/Properties/AssemblyInfo.cs
@@ -1,5 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("GumToolUnitTests")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/FlatRedBall.SpecializedXnaControls/RegionSelection/RectangleSelector.cs
+++ b/FlatRedBall.SpecializedXnaControls/RegionSelection/RectangleSelector.cs
@@ -538,16 +538,27 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
         }
 
 
+        // Grid snapping (SnappingGridSize) is only committed when an interaction (a drag) ends -
+        // see ApplyGridSnappingOnRelease - so it never affects the display of a value that was just
+        // programmatically assigned (e.g. from a previously-saved, non-grid-aligned texture region).
+        // RoundToUnitCoordinates is a separate, always-on whole-pixel constraint, unrelated to grid snapping.
         private float RoundIfNecessary(float value)
         {
-            if(SnappingGridSize != null)
-            {
-                var toReturn = MathFunctions.RoundFloat(value, SnappingGridSize.Value);
-                return toReturn;
-            }
-            else if (RoundToUnitCoordinates)
+            if (RoundToUnitCoordinates)
             {
                 return MathFunctions.RoundToInt(value);
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        private float RoundToGridIfNecessary(float value)
+        {
+            if (SnappingGridSize != null)
+            {
+                return MathFunctions.RoundFloat(value, SnappingGridSize.Value);
             }
             else
             {
@@ -560,12 +571,10 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
         {
             if (cursor.PrimaryClick)
             {
+                var sideGrabbedBeforeRelease = mSideGrabbed;
                 mSideGrabbed = ResizeSide.None;
 
-                this.Left = RoundIfNecessary(this.Left);
-                this.Top = RoundIfNecessary(this.Top);
-                this.Width = RoundIfNecessary(this.Width);
-                this.Height= RoundIfNecessary(this.Height);
+                ApplyGridSnappingOnRelease(sideGrabbedBeforeRelease);
 
                 if(shouldRaiseEndRegionChanged)
                 {
@@ -574,6 +583,25 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
                 }
 
                 UpdateHandles();
+            }
+        }
+
+        /// <summary>
+        /// Commits grid snapping for the axis pair relevant to the interaction that just ended - only
+        /// position (Left/Top) for a move (middle grab), only size (Width/Height) for a resize (any other
+        /// handle). A release with nothing grabbed leaves both pairs untouched.
+        /// </summary>
+        internal void ApplyGridSnappingOnRelease(ResizeSide sideGrabbedBeforeRelease)
+        {
+            if (sideGrabbedBeforeRelease == ResizeSide.Middle)
+            {
+                this.Left = RoundToGridIfNecessary(this.Left);
+                this.Top = RoundToGridIfNecessary(this.Top);
+            }
+            else if (sideGrabbedBeforeRelease != ResizeSide.None)
+            {
+                this.Width = RoundToGridIfNecessary(this.Width);
+                this.Height = RoundToGridIfNecessary(this.Height);
             }
         }
 

--- a/FlatRedBall.SpecializedXnaControls/RegionSelection/RectangleSelector.cs
+++ b/FlatRedBall.SpecializedXnaControls/RegionSelection/RectangleSelector.cs
@@ -68,6 +68,12 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
             {
                 return mSideGrabbed;
             }
+            // setter internal for testing - lets tests simulate an in-progress drag
+            // without driving the whole Cursor/Activity input pipeline.
+            internal set
+            {
+                mSideGrabbed = value;
+            }
         }
 
         bool mVisible = true;
@@ -90,17 +96,17 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
 
         public float Left
         {
-            get 
-            { 
+            get
+            {
                 // We used to return the raw value, but I think we want to round it - if it's to use unit coordinates then it should probably always return them.
 
-                return RoundIfNecessary( mCoordinates.X); 
+                return IsPositionBeingDragged ? RoundToGridIfNecessary(mCoordinates.X) : RoundIfNecessary(mCoordinates.X);
             }
-            set 
+            set
             {
                 mCoordinates.X = value;
 
-                mLineRectangle.X = RoundIfNecessary(value);
+                mLineRectangle.X = IsPositionBeingDragged ? RoundToGridIfNecessary(value) : RoundIfNecessary(value);
 
                 UpdateHandles();
             }
@@ -108,14 +114,14 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
 
         public float Top
         {
-            get 
-            { 
-                return RoundIfNecessary( mCoordinates.Y); 
+            get
+            {
+                return IsPositionBeingDragged ? RoundToGridIfNecessary(mCoordinates.Y) : RoundIfNecessary(mCoordinates.Y);
             }
             set
             {
                 mCoordinates.Y = value;
-                mLineRectangle.Y = RoundIfNecessary( value );
+                mLineRectangle.Y = IsPositionBeingDragged ? RoundToGridIfNecessary(value) : RoundIfNecessary(value);
                 UpdateHandles();
 
             }
@@ -180,28 +186,28 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
 
         public float Width
         {
-            get 
-            { 
-                return RoundIfNecessary( mCoordinates.Width); 
+            get
+            {
+                return IsSizeBeingDragged ? RoundToGridIfNecessary(mCoordinates.Width) : RoundIfNecessary(mCoordinates.Width);
             }
-            set 
+            set
             {
                 mCoordinates.Width = value;
-                mLineRectangle.Width = RoundIfNecessary( value );
+                mLineRectangle.Width = IsSizeBeingDragged ? RoundToGridIfNecessary(value) : RoundIfNecessary(value);
                 UpdateHandles();
             }
         }
 
         public float Height
         {
-            get 
-            { 
-                return RoundIfNecessary( mCoordinates.Height); 
+            get
+            {
+                return IsSizeBeingDragged ? RoundToGridIfNecessary(mCoordinates.Height) : RoundIfNecessary(mCoordinates.Height);
             }
-            set 
+            set
             {
                 mCoordinates.Height = value;
-                mLineRectangle.Height = RoundIfNecessary( value );
+                mLineRectangle.Height = IsSizeBeingDragged ? RoundToGridIfNecessary(value) : RoundIfNecessary(value);
                 UpdateHandles();
             }
         }
@@ -538,10 +544,15 @@ namespace FlatRedBall.SpecializedXnaControls.RegionSelection
         }
 
 
-        // Grid snapping (SnappingGridSize) is only committed when an interaction (a drag) ends -
-        // see ApplyGridSnappingOnRelease - so it never affects the display of a value that was just
-        // programmatically assigned (e.g. from a previously-saved, non-grid-aligned texture region).
-        // RoundToUnitCoordinates is a separate, always-on whole-pixel constraint, unrelated to grid snapping.
+        // Grid snapping (SnappingGridSize) only applies to the display of an axis while it's actively
+        // being dragged, so it never affects the display of a value that was just programmatically
+        // assigned (e.g. from a previously-saved, non-grid-aligned texture region), and a move only
+        // snaps position while a resize only snaps size (see ApplyGridSnappingOnRelease for the
+        // equivalent split at the moment the drag ends). RoundToUnitCoordinates is a separate,
+        // always-on whole-pixel constraint, unrelated to grid snapping.
+        private bool IsPositionBeingDragged => mSideGrabbed == ResizeSide.Middle;
+        private bool IsSizeBeingDragged => mSideGrabbed != ResizeSide.None && mSideGrabbed != ResizeSide.Middle;
+
         private float RoundIfNecessary(float value)
         {
             if (RoundToUnitCoordinates)

--- a/Tool/Tests/GumToolUnitTests/RegionSelection/RectangleSelectorGridSnappingTests.cs
+++ b/Tool/Tests/GumToolUnitTests/RegionSelection/RectangleSelectorGridSnappingTests.cs
@@ -76,7 +76,7 @@ public class RectangleSelectorGridSnappingTests
     }
 
     [Fact]
-    public void LeftTopWidthHeight_WhenSetProgrammaticallyWithGridSnappingEnabled_ShouldNotSnapForDisplay()
+    public void LeftTopWidthHeight_WhenSetProgrammaticallyWithNoSideGrabbed_ShouldNotSnapForDisplay()
     {
         var selector = CreateSelector();
 
@@ -89,5 +89,39 @@ public class RectangleSelectorGridSnappingTests
         selector.Top.ShouldBe(7f);
         selector.Width.ShouldBe(27f);
         selector.Height.ShouldBe(41f);
+    }
+
+    [Fact]
+    public void LeftTop_WhileMiddleIsGrabbed_ShouldSnapToGridForDisplayButLeaveSizeAlone()
+    {
+        var selector = CreateSelector();
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.SideGrabbed = ResizeSide.Middle;
+
+        selector.Left.ShouldBe(16f);
+        selector.Top.ShouldBe(0f);
+        selector.Width.ShouldBe(27f);
+        selector.Height.ShouldBe(41f);
+    }
+
+    [Fact]
+    public void WidthHeight_WhileResizeSideIsGrabbed_ShouldSnapToGridForDisplayButLeavePositionAlone()
+    {
+        var selector = CreateSelector();
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.SideGrabbed = ResizeSide.BottomRight;
+
+        selector.Left.ShouldBe(13f);
+        selector.Top.ShouldBe(7f);
+        selector.Width.ShouldBe(32f);
+        selector.Height.ShouldBe(48f);
     }
 }

--- a/Tool/Tests/GumToolUnitTests/RegionSelection/RectangleSelectorGridSnappingTests.cs
+++ b/Tool/Tests/GumToolUnitTests/RegionSelection/RectangleSelectorGridSnappingTests.cs
@@ -1,0 +1,93 @@
+using FlatRedBall.SpecializedXnaControls.RegionSelection;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace GumToolUnitTests.RegionSelection;
+
+public class RectangleSelectorGridSnappingTests
+{
+    // RectangleSelector only needs Renderer.Camera (for handle-position math), so build
+    // a bare SystemManagers instead of the full SystemManagers.Initialize, which requires
+    // a real GraphicsDevice for its SpriteRenderer.
+    private static RectangleSelector CreateSelector()
+    {
+        var managers = new SystemManagers
+        {
+            Renderer = new Renderer()
+        };
+
+        return new RectangleSelector(managers)
+        {
+            RoundToUnitCoordinates = false,
+            SnappingGridSize = 16
+        };
+    }
+
+    [Fact]
+    public void ApplyGridSnappingOnRelease_WithMiddleGrabbed_ShouldSnapOnlyPositionToGrid()
+    {
+        var selector = CreateSelector();
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.ApplyGridSnappingOnRelease(ResizeSide.Middle);
+
+        selector.Left.ShouldBe(16f);
+        selector.Top.ShouldBe(0f);
+        selector.Width.ShouldBe(27f);
+        selector.Height.ShouldBe(41f);
+    }
+
+    [Fact]
+    public void ApplyGridSnappingOnRelease_WithNoSideGrabbed_ShouldNotSnapAnything()
+    {
+        var selector = CreateSelector();
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.ApplyGridSnappingOnRelease(ResizeSide.None);
+
+        selector.Left.ShouldBe(13f);
+        selector.Top.ShouldBe(7f);
+        selector.Width.ShouldBe(27f);
+        selector.Height.ShouldBe(41f);
+    }
+
+    [Fact]
+    public void ApplyGridSnappingOnRelease_WithResizeSideGrabbed_ShouldSnapOnlySizeToGrid()
+    {
+        var selector = CreateSelector();
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.ApplyGridSnappingOnRelease(ResizeSide.BottomRight);
+
+        selector.Left.ShouldBe(13f);
+        selector.Top.ShouldBe(7f);
+        selector.Width.ShouldBe(32f);
+        selector.Height.ShouldBe(48f);
+    }
+
+    [Fact]
+    public void LeftTopWidthHeight_WhenSetProgrammaticallyWithGridSnappingEnabled_ShouldNotSnapForDisplay()
+    {
+        var selector = CreateSelector();
+
+        selector.Left = 13f;
+        selector.Top = 7f;
+        selector.Width = 27f;
+        selector.Height = 41f;
+
+        selector.Left.ShouldBe(13f);
+        selector.Top.ShouldBe(7f);
+        selector.Width.ShouldBe(27f);
+        selector.Height.ShouldBe(41f);
+    }
+}


### PR DESCRIPTION
## Problem
Textures tab's selection rectangle snapped to the grid for display even when nothing was being dragged (`RectangleSelector`'s Left/Top/Width/Height getters always rounded to `SnappingGridSize`). On mouse-up, all four values were also re-rounded together regardless of whether the interaction was a move or a resize.

## Fix
- Grid snapping is now committed only when a drag interaction ends (`ApplyGridSnappingOnRelease`), never as a side effect of reading/setting a value.
- Only the axis pair the interaction actually changed gets snapped: Left/Top for a move (middle grab), Width/Height for a resize (any handle).
- `RoundToUnitCoordinates` (a separate, always-on whole-pixel constraint used elsewhere) is untouched.

Closes #4194
