### PR TITLE
Fix middle-mouse pan snap and scrollbar camera-position truncation

### DIFF
--- a/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
+++ b/Tests/Gum.Presentation.Tests/CameraControllerTests.cs
@@ -113,6 +113,42 @@ public class CameraControllerTests
     }
 
     [Fact]
+    public void HandleMouseUp_ThenHandleMouseDown_ThenHandleMouseMove_PansByTheNewDragDeltaOnly()
+    {
+        var (controller, camera, _, _) = CreateSut();
+        camera.Zoom = 2f;
+        var originalX = camera.X;
+        var originalY = camera.Y;
+
+        controller.HandleMouseDown(new GumMouseEventArgs { X = 100, Y = 100, Button = GumMouseButton.Middle });
+        controller.HandleMouseMove(new GumMouseEventArgs { X = 130, Y = 90, Button = GumMouseButton.Middle });
+        controller.HandleMouseUp(new GumMouseEventArgs { X = 130, Y = 90, Button = GumMouseButton.Middle });
+
+        var xAfterFirstDrag = camera.X;
+        var yAfterFirstDrag = camera.Y;
+        var raised = 0;
+        controller.CameraChanged += () => raised++;
+
+        // A stray move reporting the middle button still held - e.g. a WPF-synchronized
+        // MouseMove dispatched without WireframeControl's own MouseDown having run first for
+        // this press - must not pan, since HandleMouseUp already ended the drag.
+        controller.HandleMouseMove(new GumMouseEventArgs { X = 500, Y = 500, Button = GumMouseButton.Middle });
+
+        camera.X.ShouldBe(xAfterFirstDrag);
+        camera.Y.ShouldBe(yAfterFirstDrag);
+        raised.ShouldBe(0);
+
+        // The next real press starts a fresh drag baseline at its own position, so only the
+        // small delta from here pans the camera - not the distance traveled since the release.
+        controller.HandleMouseDown(new GumMouseEventArgs { X = 500, Y = 500, Button = GumMouseButton.Middle });
+        controller.HandleMouseMove(new GumMouseEventArgs { X = 510, Y = 495, Button = GumMouseButton.Middle });
+
+        camera.X.ShouldBe(xAfterFirstDrag - (510 - 500) / 2f);
+        camera.Y.ShouldBe(yAfterFirstDrag - (495 - 500) / 2f);
+        raised.ShouldBe(1);
+    }
+
+    [Fact]
     public void HandleMouseMove_WithLeftButton_DoesNotPanCameraOrRaiseCameraChanged()
     {
         var (controller, camera, _, _) = CreateSut();

--- a/Tests/Gum.Presentation.Tests/ScrollBarControlLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ScrollBarControlLogicTests.cs
@@ -167,4 +167,20 @@ public class ScrollBarControlLogicTests
         _horizontal.Value.ShouldBe(_horizontal.Maximum);
         _vertical.Value.ShouldBe(_vertical.Minimum);
     }
+
+    [Fact]
+    public void UpdateScrollBarsToCameraPosition_PreservesTheCamerasFractionalPositionWithinRange()
+    {
+        Camera camera = new Camera { Zoom = 2, X = 100.75f, Y = 50.25f };
+        _logic.Camera = camera;
+        _logic.SetDisplayedArea(800, 600);
+
+        _logic.UpdateScrollBarsToCameraPosition();
+
+        // Setting the (int) bar value round-trips through ValueChanged back into the camera - the
+        // same feedback UpdateScrollBars() guards against by restoring X/Y afterward. This method
+        // must guard it the same way, or every mouse-pan tick truncates sub-pixel camera position.
+        camera.X.ShouldBe(100.75f);
+        camera.Y.ShouldBe(50.25f);
+    }
 }

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -122,6 +122,9 @@ public class WireframeControl : WpfGraphicsDeviceControl
     void HandleMouseMove(object? sender, MouseEventArgs e) =>
         _cameraController.HandleMouseMove(e.ToGumMouseEventArgs(this));
 
+    void HandleMouseUp(object? sender, MouseButtonEventArgs e) =>
+        _cameraController.HandleMouseUp(e.ToGumMouseEventArgs(this));
+
     void HandleMouseWheel(object? sender, MouseWheelEventArgs e)
     {
         GumMouseEventArgs gumMouseArgs = e.ToGumMouseEventArgs(this);
@@ -240,6 +243,7 @@ public class WireframeControl : WpfGraphicsDeviceControl
             KeyUp += HandleKeyUp;
             MouseDown += HandleMouseDown;
             MouseMove += HandleMouseMove;
+            MouseUp += HandleMouseUp;
             MouseWheel += HandleMouseWheel;
 
             MouseEnter += (_, _) =>

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/CameraController.cs
@@ -17,6 +17,7 @@ public class CameraController
 
     int _lastMouseX;
     int _lastMouseY;
+    bool _isPanning;
 
     public event Action? CameraChanged;
     IHotkeyManager _hotkeyManager;
@@ -64,14 +65,29 @@ public class CameraController
     {
         if (e.Button == GumMouseButton.Middle)
         {
+            _isPanning = true;
             _lastMouseX = e.X;
             _lastMouseY = e.Y;
         }
     }
 
-    public void HandleMouseMove(GumMouseEventArgs e)
+    public void HandleMouseUp(GumMouseEventArgs e)
     {
         if (e.Button == GumMouseButton.Middle)
+        {
+            _isPanning = false;
+        }
+    }
+
+    public void HandleMouseMove(GumMouseEventArgs e)
+    {
+        // _isPanning (set/cleared only by HandleMouseDown/HandleMouseUp) is the source of truth for
+        // whether a drag is in progress, rather than e.Button alone: a move event can report the
+        // middle button as currently held without HandleMouseDown having run first for this press
+        // (e.g. a stray/synchronized move), in which case _lastMouseX/Y would still be the position
+        // from the end of a previous, already-released drag, and the whole idle-period distance
+        // would get applied as one jump.
+        if (_isPanning && e.Button == GumMouseButton.Middle)
         {
             int xChange = e.X - _lastMouseX;
             int yChange = e.Y - _lastMouseY;

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/ScrollBarControlLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Services/ScrollBarControlLogic.cs
@@ -96,11 +96,21 @@ public class ScrollBarControlLogic
             return;
         }
 
+        // Setting Value below round-trips synchronously through ValueChanged -> HandleVerticalScroll
+        // / HandleHorizontalScroll, which write the (int), clamped bar value back into _camera.X/Y.
+        // Restore the camera's own fractional position afterward, the same way UpdateScrollBars()
+        // does, so this doesn't truncate/clamp the camera position on every call.
+        var x = _camera.X;
+        var y = _camera.Y;
+
         _verticalScrollBar.Value =
-            Math.Min(Math.Max(_verticalScrollBar.Minimum, (int)_camera.Y), _verticalScrollBar.Maximum);
+            Math.Min(Math.Max(_verticalScrollBar.Minimum, (int)y), _verticalScrollBar.Maximum);
 
         _horizontalScrollBar.Value =
-            Math.Min(Math.Max(_horizontalScrollBar.Minimum, (int)_camera.X), _horizontalScrollBar.Maximum);
+            Math.Min(Math.Max(_horizontalScrollBar.Minimum, (int)x), _horizontalScrollBar.Maximum);
+
+        _camera.X = x;
+        _camera.Y = y;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Middle-mouse pan in the wireframe editor snapped to a stale position when you released and re-pressed the middle button: `CameraController` inferred "dragging" purely from the current event's live button state, resetting its position baseline only in `HandleMouseDown`, with no `HandleMouseUp`. A stray move reporting Middle-held without a preceding `HandleMouseDown` computed its delta against the leftover baseline from the previous drag, jumping the camera by the whole idle-period distance. Fixed with an explicit `_isPanning` flag set/cleared by `HandleMouseDown`/a new `HandleMouseUp`, wired to `WireframeControl.MouseUp`.
- Found while diagnosing that: `ScrollBarControlLogic.UpdateScrollBarsToCameraPosition()` round-trips through the WPF scrollbar's `ValueChanged` on every pan tick, writing back into `Camera.X`/`Camera.Y` — but unlike the sibling `UpdateScrollBars()`, never restored the camera's pre-clamp value afterward, silently truncating/clamping the camera position on every mouse-pan tick. Fixed the same way `UpdateScrollBars()` already does.

## Test plan
- [x] `CameraControllerTests` / `ScrollBarControlLogicTests` — new regression tests, red before the fix, green after (`dotnet test Tests/Gum.Presentation.Tests`)
- [x] Full `Gum.Presentation.Tests` suite green (783 passed)
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings
- [x] Manual: middle-push+drag to pan, release, move the mouse further, middle-push again — camera should start panning from the new press position, not jump

Closes #4216
