### PR TITLE
Forward app-wide hotkeys (Undo/Redo) from the Texture Coordinate selector

### DIFF
--- a/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
+++ b/Gum/TextureCoordinateSelectionPlugin/Logic/ControlLogic.cs
@@ -4,6 +4,7 @@ using Gum;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Dialogs;
+using Gum.Input;
 using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
@@ -180,8 +181,19 @@ public class TextureCoordinateDisplayController : ITextureCoordinateDisplayContr
         };
     }
 
-    private void HandleKeyDown(object? sender, KeyEventArgs e)
+    internal void HandleKeyDown(object? sender, KeyEventArgs e)
     {
+        // This control is hosted via WindowsFormsHost, so it never sees MainWindow's WPF
+        // PreviewKeyDown tunnel - forward app-wide hotkeys (Undo/Redo/etc.) directly here, the
+        // same way WireframeControl.HandleKeyDown does for the wireframe canvas. Entire-app zoom
+        // stays disabled because Ctrl+=/Ctrl+- already zoom this control's own camera below.
+        var keyArgs = e.ToGumKeyEventArgs();
+        if (_hotkeyManager.PreviewKeyDownAppWide(keyArgs, enableEntireAppZoom: false))
+        {
+            e.Handled = keyArgs.Handled;
+            return;
+        }
+
         var camera = mainControl.InnerControl.SystemManagers.Renderer.Camera;
         if (_hotkeyManager.MoveCameraRight.IsPressed(e))
         {

--- a/Tool/Tests/GumToolUnitTests/Plugins/TextureCoordinateSelectionPlugin/TextureCoordinateDisplayControllerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/TextureCoordinateSelectionPlugin/TextureCoordinateDisplayControllerTests.cs
@@ -1,0 +1,56 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Gum.Commands;
+using Gum.Dialogs;
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+using System.Windows.Forms;
+using TextureCoordinateSelectionPlugin.Logic;
+
+namespace GumToolUnitTests.Plugins.TextureCoordinateSelectionPlugin;
+
+public class TextureCoordinateDisplayControllerTests
+{
+    private readonly Mock<IHotkeyManager> _hotkeyManagerMock;
+    private readonly TextureCoordinateDisplayController _sut;
+
+    public TextureCoordinateDisplayControllerTests()
+    {
+        _hotkeyManagerMock = new Mock<IHotkeyManager>();
+
+        _sut = new TextureCoordinateDisplayController(
+            new Mock<ISelectedState>().Object,
+            new Mock<IUndoManager>().Object,
+            new Mock<IGuiCommands>().Object,
+            new Mock<IFileCommands>().Object,
+            new Mock<ISetVariableLogic>().Object,
+            new Mock<ITabManager>().Object,
+            _hotkeyManagerMock.Object,
+            new ScrollBarLogicWpf(new ScrollBarLogic()),
+            new Mock<IMessenger>().Object,
+            new Mock<IThemingService>().Object);
+    }
+
+    [Fact]
+    public void HandleKeyDown_WhenAppWideHotkeyHandlesTheKey_ReturnsWithoutTouchingCamera()
+    {
+        // CreateControl() was never called, so the controller's inner WinForms/XNA control is
+        // uninitialized. If HandleKeyDown fell through to the camera-pan logic below the app-wide
+        // check, it would NullReferenceException here - reaching the assertion instead pins that
+        // an app-wide-handled key (e.g. Ctrl+Z) returns before that point.
+        _hotkeyManagerMock
+            .Setup(m => m.PreviewKeyDownAppWide(It.IsAny<GumKeyEventArgs>(), false))
+            .Callback<GumKeyEventArgs, bool>((args, _) => args.Handled = true)
+            .Returns(true);
+        var e = new KeyEventArgs(Keys.Control | Keys.Z);
+
+        _sut.HandleKeyDown(null, e);
+
+        e.Handled.ShouldBeTrue();
+        _hotkeyManagerMock.Verify(m => m.PreviewKeyDownAppWide(It.IsAny<GumKeyEventArgs>(), false), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #4217.

The Textures tab's coordinate selector is `WindowsFormsHost`-hosted, so it never sees `MainWindow`'s WPF `PreviewKeyDown` tunnel that wires up app-wide hotkeys (Undo/Redo/etc.) - the same class of gap `WireframeControl` already closed for the wireframe canvas.

`ControlLogic.HandleKeyDown` now forwards to `IHotkeyManager.PreviewKeyDownAppWide(keyArgs, enableEntireAppZoom: false)` first (same pattern/flag as `WireframeControl`, since this control has its own Ctrl+=/Ctrl+- camera zoom), returning early on a match before falling into the existing camera pan/zoom handling.

**Manual test:** run the tool, select a Sprite instance, open the Textures tab, drag the selection rectangle (giving the coordinate selector focus), then press Ctrl+Z without clicking elsewhere - should undo immediately.

FRB canary: not needed - change is tool-only (`Gum/TextureCoordinateSelectionPlugin`), not FRB1-shared source.
