### PR TITLE
Register file-watch ignores before writing Convert to JSON output

### DIFF
--- a/Gum/ConvertToJsonPlugin/MainConvertToJsonPlugin.cs
+++ b/Gum/ConvertToJsonPlugin/MainConvertToJsonPlugin.cs
@@ -1,4 +1,5 @@
 using Gum.Commands;
+using Gum.Logic.FileWatch;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.ProjectServices;
@@ -29,10 +30,11 @@ internal class MainConvertToJsonPlugin : WpfPluginBase
     public MainConvertToJsonPlugin(
         IProjectState projectState,
         IFileCommands fileCommands,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        IFileWatchIgnoreList fileWatchIgnoreList)
     {
         _convertToJsonLogic = new ConvertToJsonLogic(
-            projectState, new ConvertProjectToJsonService(), fileCommands, dialogService);
+            projectState, new ConvertProjectToJsonService(fileWatchIgnoreList), fileCommands, dialogService);
     }
 
     public override void StartUp()

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -855,6 +855,9 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
             batch.AddExportedValue<IProjectState>(Locator.GetRequiredService<IProjectState>());
             batch.AddExportedValue<IImportLogic>(Locator.GetRequiredService<IImportLogic>());
             batch.AddExportedValue<IFileWatchManager>(Locator.GetRequiredService<IFileWatchManager>());
+            // MainConvertToJsonPlugin (#4219): mutes the file watcher for each JSON file it writes
+            // during "Convert to JSON", the same way FileCommands/ProjectManager do for their saves.
+            batch.AddExportedValue<IFileWatchIgnoreList>(Locator.GetRequiredService<IFileWatchIgnoreList>());
 
             // MainInheritancePlugin (InheritanceLogic) and MainFavoriteComponentPlugin
             // (IFavoriteComponentManager) construction-time deps:

--- a/Tests/Gum.ProjectServices.Tests/ConvertProjectToJsonServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ConvertProjectToJsonServiceTests.cs
@@ -1,7 +1,9 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Serialization.Json;
+using Gum.Logic.FileWatch;
 using Gum.StateAnimation.SaveClasses;
+using Moq;
 using Shouldly;
 using ToolsUtilities;
 
@@ -14,13 +16,15 @@ namespace Gum.ProjectServices.Tests;
 public class ConvertProjectToJsonServiceTests : IDisposable
 {
     private readonly string _tempDirectory;
+    private readonly Mock<IFileWatchIgnoreList> _fileWatchIgnoreList;
     private readonly IConvertProjectToJsonService _service;
 
     public ConvertProjectToJsonServiceTests()
     {
         _tempDirectory = Path.Combine(Path.GetTempPath(), "GumConvertToJsonTests_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDirectory);
-        _service = new ConvertProjectToJsonService();
+        _fileWatchIgnoreList = new Mock<IFileWatchIgnoreList>();
+        _service = new ConvertProjectToJsonService(_fileWatchIgnoreList.Object);
     }
 
     public void Dispose()
@@ -89,6 +93,48 @@ public class ConvertProjectToJsonServiceTests : IDisposable
         File.ReadAllBytes(Path.Combine(_tempDirectory, "Components", "Button.gucx")).ShouldBe(componentXmlBytesBefore);
         File.ReadAllBytes(behaviorXmlPath).ShouldBe(behaviorXmlBytesBefore);
         File.ReadAllBytes(animationXmlPath).ShouldBe(animationXmlBytesBefore);
+    }
+
+    [Fact]
+    public void ConvertToJson_FullProject_RegistersFileWatchIgnoreForEveryJsonFileBeforeWritingIt()
+    {
+        string gumxPath = Path.Combine(_tempDirectory, "Project.gumx");
+        GumProjectSave project = new GumProjectSave { Version = GumProjectSave.NativeVersion, FullFileName = gumxPath.Replace('\\', '/') };
+        ComponentSave component = new ComponentSave { Name = "Button" };
+        project.Components.Add(component);
+        project.Behaviors.Add(new BehaviorSave { Name = "ButtonBehavior", DefaultImplementation = "Controls/Button" });
+        project.BehaviorReferences.Add(new BehaviorReference { Name = "ButtonBehavior" });
+        project.Save(gumxPath, saveElements: true);
+        string behaviorXmlPath = Path.Combine(_tempDirectory, "Behaviors", "ButtonBehavior.behx");
+        Directory.CreateDirectory(Path.GetDirectoryName(behaviorXmlPath)!);
+        project.Behaviors[0].Save(behaviorXmlPath);
+        string animationXmlPath = Path.Combine(_tempDirectory, "Components", "ButtonAnimations.ganx");
+        WriteAnimationXml(animationXmlPath, animationName: "FadeIn");
+
+        List<FilePath> ignoredBeforeGumjWritten = new List<FilePath>();
+        _fileWatchIgnoreList
+            .Setup(x => x.IgnoreNextChangeUntil(It.IsAny<FilePath>(), null))
+            .Callback<FilePath, DateTime?>((path, _) =>
+            {
+                if (!File.Exists(path.FullPath))
+                {
+                    ignoredBeforeGumjWritten.Add(path);
+                }
+            });
+
+        _service.ConvertToJson(project);
+
+        string gumjPath = Path.Combine(_tempDirectory, "Project.gumj");
+        string componentJsonPath = Path.Combine(_tempDirectory, "Components", "Button.gucj");
+        string behaviorJsonPath = Path.Combine(_tempDirectory, "Behaviors", "ButtonBehavior.behj");
+        string animationJsonPath = Path.Combine(_tempDirectory, "Components", "ButtonAnimations.ganj");
+
+        // Every path was ignored before its file existed on disk - i.e. before the write happened,
+        // not after (issue #4219: registering after the write is too late to mute the watcher).
+        ignoredBeforeGumjWritten.ShouldContain((FilePath)gumjPath);
+        ignoredBeforeGumjWritten.ShouldContain((FilePath)componentJsonPath);
+        ignoredBeforeGumjWritten.ShouldContain((FilePath)behaviorJsonPath);
+        ignoredBeforeGumjWritten.ShouldContain((FilePath)animationJsonPath);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -63,6 +63,7 @@ internal static class PluginBridgedServiceTypes
         typeof(IProjectState),
         typeof(IImportLogic),
         typeof(IFileWatchManager),
+        typeof(IFileWatchIgnoreList),
 
         typeof(InheritanceLogic),
         typeof(IFavoriteComponentManager),

--- a/Tools/Gum.Cli/Commands/ConvertToJsonCommand.cs
+++ b/Tools/Gum.Cli/Commands/ConvertToJsonCommand.cs
@@ -53,7 +53,7 @@ public static class ConvertToJsonCommand
         }
 
         GumProjectSave project = loadResult.Project!;
-        IConvertProjectToJsonService convertService = new ConvertProjectToJsonService();
+        IConvertProjectToJsonService convertService = new ConvertProjectToJsonService(new HeadlessFileWatchIgnoreList());
 
         ConvertProjectToJsonResult result;
         try

--- a/Tools/Gum.Cli/HeadlessFileWatchIgnoreList.cs
+++ b/Tools/Gum.Cli/HeadlessFileWatchIgnoreList.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using Gum.Logic.FileWatch;
+using ToolsUtilities;
+
+namespace Gum.Cli;
+
+/// <summary>
+/// No-op file watch ignore list for headless/CLI use. <c>gumcli</c> has no running file watcher to
+/// mute, so every member is a no-op.
+/// </summary>
+internal class HeadlessFileWatchIgnoreList : IFileWatchIgnoreList
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<FilePath, DateTime> TimedChangesToIgnore { get; } =
+        new Dictionary<FilePath, DateTime>();
+
+    /// <inheritdoc/>
+    public void IgnoreNextChangeUntil(FilePath filePath, DateTime? time = null) { }
+
+    /// <inheritdoc/>
+    public void ClearIgnoredFiles() { }
+
+    /// <inheritdoc/>
+    public bool TryGetIgnoreFileChange(FilePath fileName) => false;
+}

--- a/Tools/Gum.ProjectServices/ConvertProjectToJsonService.cs
+++ b/Tools/Gum.ProjectServices/ConvertProjectToJsonService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Serialization.Json;
+using Gum.Logic.FileWatch;
 using Gum.StateAnimation.SaveClasses;
 using ToolsUtilities;
 
@@ -11,6 +12,13 @@ namespace Gum.ProjectServices;
 /// <inheritdoc/>
 public class ConvertProjectToJsonService : IConvertProjectToJsonService
 {
+    private readonly IFileWatchIgnoreList _fileWatchIgnoreList;
+
+    public ConvertProjectToJsonService(IFileWatchIgnoreList fileWatchIgnoreList)
+    {
+        _fileWatchIgnoreList = fileWatchIgnoreList;
+    }
+
     /// <inheritdoc/>
     public ConvertProjectToJsonResult ConvertToJson(GumProjectSave project)
     {
@@ -35,6 +43,13 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
         // cascades to every Screen/Component/StandardElement (skipping IsSourceFileMissing stubs -
         // issue #3369). It does NOT cascade to Behaviors or element animations - those aren't part
         // of the project's own referenced-element save cascade, so this method converts them below.
+        //
+        // Every one of those cascaded writes must be registered with IgnoreNextChangeUntil first
+        // (issue #4219) - otherwise the file watcher reacts to each write as an external change and
+        // triggers a full element reload + tree-view refresh per file, mirroring the pattern already
+        // used by FileCommands/ProjectManager when they save.
+        IgnoreUpcomingElementWrites(project, projectDirectory);
+        _fileWatchIgnoreList.IgnoreNextChangeUntil(jsonProjectPath);
         project.Save(jsonProjectPath, saveElements: true);
 
         return new ConvertProjectToJsonResult
@@ -48,7 +63,34 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
         };
     }
 
-    private static int ConvertBehaviors(GumProjectSave project, string projectDirectory)
+    private void IgnoreUpcomingElementWrites(GumProjectSave project, string projectDirectory)
+    {
+        foreach (ScreenSave screen in project.Screens)
+        {
+            IgnoreElementJsonWrite(screen, projectDirectory);
+        }
+        foreach (ComponentSave component in project.Components)
+        {
+            IgnoreElementJsonWrite(component, projectDirectory);
+        }
+        foreach (StandardElementSave standard in project.StandardElements)
+        {
+            IgnoreElementJsonWrite(standard, projectDirectory);
+        }
+    }
+
+    private void IgnoreElementJsonWrite(ElementSave element, string projectDirectory)
+    {
+        if (element.IsSourceFileMissing)
+        {
+            return;
+        }
+
+        string elementXmlPath = GetElementXmlPath(element, projectDirectory);
+        _fileWatchIgnoreList.IgnoreNextChangeUntil(ToJsonSiblingPath(elementXmlPath));
+    }
+
+    private int ConvertBehaviors(GumProjectSave project, string projectDirectory)
     {
         int count = 0;
 
@@ -67,14 +109,16 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
             }
 
             string xmlPath = projectDirectory + reference.GetRelativeFilePath(isJsonFormat: false);
-            behavior.Save(ToJsonSiblingPath(xmlPath));
+            string jsonPath = ToJsonSiblingPath(xmlPath);
+            _fileWatchIgnoreList.IgnoreNextChangeUntil(jsonPath);
+            behavior.Save(jsonPath);
             count++;
         }
 
         return count;
     }
 
-    private static int ConvertAnimations(GumProjectSave project, string projectDirectory)
+    private int ConvertAnimations(GumProjectSave project, string projectDirectory)
     {
         int count = 0;
 
@@ -99,14 +143,14 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
     /// <c>{ElementName}Animations.ganj</c> (see <c>GumService.LoadAnimationsFromProvider</c> for the
     /// same naming convention) when that file exists. Returns 1 when converted, 0 otherwise.
     /// </summary>
-    private static int ConvertAnimationIfPresent(ElementSave element, string projectDirectory)
+    private int ConvertAnimationIfPresent(ElementSave element, string projectDirectory)
     {
         if (element.IsSourceFileMissing)
         {
             return 0;
         }
 
-        string elementXmlPath = projectDirectory + element.Subfolder + "/" + element.Name + "." + element.FileExtension;
+        string elementXmlPath = GetElementXmlPath(element, projectDirectory);
         string animationXmlPath = FileManager.RemoveExtension(elementXmlPath) + "Animations.ganx";
 
         if (!FileManager.FileExists(animationXmlPath))
@@ -116,16 +160,20 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
 
         ElementAnimationsSave animations = FileManager.XmlDeserialize<ElementAnimationsSave>(animationXmlPath);
         string animationJsonPath = FileManager.RemoveExtension(elementXmlPath) + "Animations.ganj";
+        _fileWatchIgnoreList.IgnoreNextChangeUntil(animationJsonPath);
         GumJsonFileSerializer.WriteToFile(animationJsonPath, GumAnimationJsonFileSerializer.SerializeElementAnimations(animations));
 
         return 1;
     }
+
+    private string GetElementXmlPath(ElementSave element, string projectDirectory) =>
+        projectDirectory + element.Subfolder + "/" + element.Name + "." + element.FileExtension;
 
     /// <summary>
     /// Every JSON sibling extension in this format is its XML counterpart with the trailing "x"
     /// swapped for "j" (behx-&gt;behj), matching the convention used throughout
     /// <see cref="GumJsonFileSerializer"/>/<see cref="BehaviorSave.Save"/>.
     /// </summary>
-    private static string ToJsonSiblingPath(string xmlPath) =>
+    private string ToJsonSiblingPath(string xmlPath) =>
         xmlPath.Substring(0, xmlPath.Length - 1) + "j";
 }

--- a/Tools/Gum.ProjectServices/FileWatch/IFileWatchIgnoreList.cs
+++ b/Tools/Gum.ProjectServices/FileWatch/IFileWatchIgnoreList.cs
@@ -9,7 +9,10 @@ namespace Gum.Logic.FileWatch;
 /// the file watcher. Extracted from FileWatchManager so that components
 /// which only need to mute the watcher (e.g. FileCommands when saving an
 /// element) can depend on this small surface without introducing a DI
-/// cycle through FileWatchManager.
+/// cycle through FileWatchManager. Lives in Gum.ProjectServices (rather
+/// than Gum.Presentation, its original home) so lower-layer services like
+/// ConvertProjectToJsonService can also depend on it without an upward
+/// project reference.
 /// </summary>
 public interface IFileWatchIgnoreList
 {


### PR DESCRIPTION
## Summary
- `ConvertProjectToJsonService` now registers each `.gumj`/`.gusj`/`.gucj`/`.gutj`/`.behj`/`.ganj` path with `IFileWatchIgnoreList.IgnoreNextChangeUntil` before writing it, mirroring `FileCommands`/`ProjectManager`. The file watcher no longer treats each converted file as an external change, so "Convert to JSON" no longer triggers a full element reload + tree-view refresh per file.
- `IFileWatchIgnoreList` moved from `Gum.Presentation` to `Gum.ProjectServices` (namespace unchanged) so the lower-layer conversion service can depend on it without an upward project reference.
- Added a no-op `HeadlessFileWatchIgnoreList` for `gumcli`'s headless convert-to-json path, which has no running file watcher.

## Test plan
- [x] `Gum.ProjectServices.Tests` (new test asserts every JSON path is ignored before the file exists on disk)
- [x] `GumToolUnitTests` (plugin composition, including `AllPluginsCompositionTests`)
- [x] `Gum.Presentation.Tests`
- [x] `Gum.Cli.Tests`
- [x] `dotnet build GumFull.sln`

Manual test: needed — see PR comment.

Closes #4219
