### PR TITLE
Gate LocalizeText behind a new GumxVersions v4 slot

### DIFF
--- a/Gum/Managers/StandardElementsManager.cs
+++ b/Gum/Managers/StandardElementsManager.cs
@@ -169,7 +169,7 @@ public class StandardElementsManager
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "string", Value = "Hello", Name = "Text", Category = "Text" });
 
-            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "LocalizeText", Category = "Text" });
+            stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "bool", Value = true, Name = "LocalizeText", Category = "Text", MinimumGumxVersion = (int)GumProjectSave.GumxVersions.LocalizeTextExpansion });
 
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "HorizontalAlignment", Value = HorizontalAlignment.Left, Name = "HorizontalAlignment", Category = "Text" });
             stateSave.Variables.Add(new VariableSave { SetsValue = true, Type = "VerticalAlignment", Value = VerticalAlignment.Top, Name = "VerticalAlignment", Category = "Text" });

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -111,6 +111,18 @@ public class GumProjectSave
         /// than silently dropping the new variables (or mis-showing a stale Radius) on the next save.
         /// </summary>
         ShapeVariableExpansion = 3,
+
+        /// <summary>
+        /// Reserves a version slot for the Text standard element's <c>LocalizeText</c> variable
+        /// (#4133/#4134). Files saved at this version use the same XML format as
+        /// <see cref="ShapeVariableExpansion"/>; the bump exists purely so the back-fill gate
+        /// (<see cref="Gum.DataTypes.Variables.VariableSave.MinimumGumxVersion"/>) can tell a
+        /// pre-LocalizeText v3 project apart from one saved after LocalizeText existed, and skip
+        /// injecting it into the older one. Without this, opening a pre-#4134 v3 project would
+        /// silently back-fill LocalizeText and break its FRB1-generated runtime (issue #4222,
+        /// same failure mode as FRB #1881).
+        /// </summary>
+        LocalizeTextExpansion = 4,
     }
 
     /// <summary>
@@ -121,13 +133,13 @@ public class GumProjectSave
     /// The <see cref="GumProjectSave"/> constructor still defaults to
     /// <see cref="GumxVersions.AttributeVersion"/>, NOT this value. That ctor default is the
     /// fallback for deserialized files that lack a Version element — a legacy file must read
-    /// back as the older version so the variable-grid gate keeps hiding v3-only shape variables.
-    /// Brand-new projects are a different case: they seed the v3 shape variable surface up front,
+    /// back as the older version so the variable-grid gate keeps hiding newer-only variables.
+    /// Brand-new projects are a different case: they seed the latest variable surface up front,
     /// so the new-project factories (ProjectManager.CreateNewProject and ProjectCreator.Create)
-    /// explicitly stamp this version. Marking them v3 is honest — the project genuinely uses v3
-    /// features — and lets the gate show those variables on a fresh Circle/Rectangle.
+    /// explicitly stamp this version. Marking them at the native version is honest — the project
+    /// genuinely uses those features — and lets the gate show those variables immediately.
     /// </remarks>
-    public const int NativeVersion = (int)GumxVersions.ShapeVariableExpansion;
+    public const int NativeVersion = (int)GumxVersions.LocalizeTextExpansion;
 
     #region Fields
 

--- a/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
@@ -349,14 +349,14 @@ public class GumProjectSaveTests : BaseTestClass
     }
 
     [Fact]
-    public void NativeVersion_MatchesShapeVariableExpansion()
+    public void NativeVersion_MatchesLocalizeTextExpansion()
     {
-        // The v3 slot is reserved for the expanded Circle/Rectangle variable surface
-        // landing in #2925/#2927 follow-up PRs. Files saved at v3 use the same XML
-        // format as AttributeVersion; the bump only changes the rejection ceiling so
-        // tool builds without the new variable definitions refuse to silently drop them.
-        GumProjectSave.NativeVersion.ShouldBe((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
-        ((int)GumProjectSave.GumxVersions.ShapeVariableExpansion).ShouldBe(3);
+        // The v4 slot is reserved for the Text standard element's LocalizeText variable
+        // (#4133/#4134). Files saved at v4 use the same XML format as ShapeVariableExpansion;
+        // the bump only changes the rejection ceiling and the back-fill gate so tool builds
+        // without the new variable definition refuse to silently drop/back-fill it.
+        GumProjectSave.NativeVersion.ShouldBe((int)GumProjectSave.GumxVersions.LocalizeTextExpansion);
+        ((int)GumProjectSave.GumxVersions.LocalizeTextExpansion).ShouldBe(4);
     }
 
     [Fact]

--- a/Tests/CodeGen_Maui_FullCodegen/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Maui_FullCodegen/StandardElements.Generated.cs
@@ -1621,9 +1621,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_ByReference/StandardElements.Generated.cs
@@ -1894,9 +1894,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_FullCodegen/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_FullCodegen/StandardElements.Generated.cs
@@ -2286,9 +2286,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGameForms_Localization_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGameForms_Localization_ByReference/StandardElements.Generated.cs
@@ -1891,9 +1891,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_MonoGame_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_MonoGame_ByReference/StandardElements.Generated.cs
@@ -1894,9 +1894,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_Raylib_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Raylib_ByReference/StandardElements.Generated.cs
@@ -888,9 +888,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/CodeGen_Skia_ByReference/StandardElements.Generated.cs
+++ b/Tests/CodeGen_Skia_ByReference/StandardElements.Generated.cs
@@ -888,9 +888,6 @@ internal static class StandardElementsCodeGenRegistration
       <Variable Type=""float"" Name=""LineHeightMultiplier"" Category=""Text"" SetsValue=""true"">
         <Value xsi:type=""xsd:float"">1</Value>
       </Variable>
-      <Variable Type=""bool"" Name=""LocalizeText"" Category=""Text"" SetsValue=""true"">
-        <Value xsi:type=""xsd:boolean"">true</Value>
-      </Variable>
       <Variable Type=""float?"" Name=""MaxHeight"" Category=""Dimensions"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxLettersToShow"" Category=""Text"" SetsValue=""true"" />
       <Variable Type=""int?"" Name=""MaxNumberOfLines"" Category=""Text"" SetsValue=""true"" />

--- a/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
@@ -120,27 +120,27 @@ public class ProjectCreatorTests : IDisposable
     }
 
     [Fact]
-    public void Create_ShouldDefaultVersionToShapeVariableExpansion()
+    public void Create_ShouldDefaultVersionToNativeVersion()
     {
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
 
         GumProjectSave project = _sut.Create(filePath);
 
-        // New projects seed the v3 shape variable surface (Fill/Dropshadow/Gradient) on the
-        // standard Circle/Rectangle, so they must be stamped at the matching version. Otherwise
-        // the variable-grid version gate hides those variables on a brand-new project.
-        project.Version.ShouldBe((int)GumProjectSave.GumxVersions.ShapeVariableExpansion);
+        // New projects seed the latest standard-element variable surface (Fill/Dropshadow/
+        // Gradient, LocalizeText, etc.), so they must be stamped at the matching version.
+        // Otherwise the variable-grid version gate hides those variables on a brand-new project.
+        project.Version.ShouldBe(GumProjectSave.NativeVersion);
     }
 
     [Fact]
-    public void Create_ShouldPersistShapeVariableExpansionVersionToDisk()
+    public void Create_ShouldPersistNativeVersionToDisk()
     {
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
 
         _sut.Create(filePath);
 
         string gumxContent = File.ReadAllText(filePath);
-        gumxContent.ShouldContain($"<Version>{(int)GumProjectSave.GumxVersions.ShapeVariableExpansion}</Version>");
+        gumxContent.ShouldContain($"<Version>{GumProjectSave.NativeVersion}</Version>");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/StandardElementBackfillVersionGateTests.cs
@@ -23,6 +23,7 @@ public class StandardElementBackfillVersionGateTests : BaseTestClass
 {
     private const int PreV3 = (int)GumProjectSave.GumxVersions.AttributeVersion;     // 2
     private const int V3 = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;  // 3
+    private const int V4 = (int)GumProjectSave.GumxVersions.LocalizeTextExpansion;   // 4
 
     // Variables added to the plain Circle / Rectangle in the v3 shape-variable expansion
     // (#2929/#2931/#2950). None existed on a pre-v3 shape, and none exist on the older FRB-pinned
@@ -320,6 +321,41 @@ public class StandardElementBackfillVersionGateTests : BaseTestClass
             .Variables.FirstOrDefault(v => v.Name == variableName);
         preserved.ShouldNotBeNull();
         preserved.Value.ShouldBe(value);
+    }
+
+    // LocalizeText (#4133/#4134) was added to the Text standard element's default state without a
+    // MinimumGumxVersion tag, so it back-filled into every project regardless of version — including
+    // v3 projects saved before LocalizeText existed, breaking their FRB1-generated runtime the same
+    // way the v3 shape surface did pre-v3 projects (issue #4222).
+    [Fact]
+    public void Initialize_DoesNotInjectLocalizeText_IntoPreV4TextStandard()
+    {
+        var project = MakeProjectWithBareStandard("Text", V3, "Width", "Height", "Visible", "Text");
+
+        var textDefault = DefaultStateAfterInitialize(project, "Text");
+
+        textDefault.Variables.Any(v => v.Name == "LocalizeText").ShouldBeFalse(
+            "A pre-v4 project (including one already at v3) must not have LocalizeText back-filled into its Text standard.");
+    }
+
+    [Fact]
+    public void Initialize_InjectsLocalizeText_IntoV4TextStandard()
+    {
+        var project = MakeProjectWithBareStandard("Text", V4, "Width", "Height", "Visible", "Text");
+
+        var textDefault = DefaultStateAfterInitialize(project, "Text");
+
+        textDefault.Variables.Any(v => v.Name == "LocalizeText").ShouldBeTrue(
+            "A v4 project should get LocalizeText back-filled into its Text standard.");
+    }
+
+    [Fact]
+    public void DefaultState_TagsLocalizeText_WithV4MinimumGumxVersion()
+    {
+        StateSave defaultState = StandardElementsManager.Self.DefaultStates["Text"];
+
+        VariableSave variable = defaultState.Variables.First(v => v.Name == "LocalizeText");
+        variable.MinimumGumxVersion.ShouldBe(V4);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGateTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGateTests.cs
@@ -9,6 +9,7 @@ public class ShapeVariableVersionGateTests
 {
     private const int OlderThanV3 = (int)GumProjectSave.GumxVersions.AttributeVersion;
     private const int V3 = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+    private const int V4 = (int)GumProjectSave.GumxVersions.LocalizeTextExpansion;
 
     private readonly ShapeVariableVersionGate _gate = new();
 
@@ -121,5 +122,21 @@ public class ShapeVariableVersionGateTests
     public void GetIfHidden_HandlesNullRootStandardTypeName()
     {
         _gate.GetIfHiddenForProjectVersion("FillRed", null, OlderThanV3).ShouldBeFalse();
+    }
+
+    [Theory]
+    // LocalizeText (issue #4222) is gated at v4, a version past the rest of the map, so a v3
+    // project (which already clears the v3 dropshadow gate above) must still hide it.
+    [InlineData(OlderThanV3)]
+    [InlineData(V3)]
+    public void GetIfHidden_HidesLocalizeText_OnPreV4Text(int projectVersion)
+    {
+        _gate.GetIfHiddenForProjectVersion("LocalizeText", "Text", projectVersion).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetIfHidden_KeepsLocalizeText_OnV4Text()
+    {
+        _gate.GetIfHiddenForProjectVersion("LocalizeText", "Text", V4).ShouldBeFalse();
     }
 }

--- a/Tools/Gum.Presentation/Managers/ProjectManager.cs
+++ b/Tools/Gum.Presentation/Managers/ProjectManager.cs
@@ -211,11 +211,12 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
         _gumProjectSave = new GumProjectSave
         {
             FontGenerator = FontGeneratorType.KernSmith,
-            // PopulateProjectWithDefaultStandards (below) seeds the v3 shape variable surface
-            // on the standard Circle/Rectangle, so stamp the project at the matching version
-            // rather than the GumProjectSave ctor default. Without this, the variable-grid
-            // version gate hides Fill/Dropshadow/Gradient on a brand-new project.
-            Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion
+            // PopulateProjectWithDefaultStandards (below) seeds the latest variable surface
+            // on the standard elements, so stamp the project at the matching version rather
+            // than the GumProjectSave ctor default. Without this, the variable-grid version
+            // gate hides newer-only variables (Fill/Dropshadow/Gradient, LocalizeText, etc.)
+            // on a brand-new project.
+            Version = GumProjectSave.NativeVersion
         };
         ObjectFinder.Self.GumProjectSave = _gumProjectSave;
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGate.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/ShapeVariableVersionGate.cs
@@ -4,21 +4,23 @@ using Gum.DataTypes;
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
 /// <summary>
-/// Pure decision logic for hiding the fill / dropshadow / gradient variables that were added to
+/// Pure decision logic for hiding standard-element variables that were added to a project version
+/// later than the one currently loaded (e.g. the fill / dropshadow / gradient variables added to
 /// the plain <c>Circle</c> and <c>Rectangle</c> standard elements in the
 /// <see cref="GumProjectSave.GumxVersions.ShapeVariableExpansion"/> (version 3) surface
-/// expansion. When an older project is loaded these variables are hidden in the variable grid so
-/// the tool doesn't surface variables the project's runtime won't honor. Kept free of services
-/// (the caller supplies the resolved project version and root standard type name) so it can be
-/// unit tested without a loaded project or selection state.
+/// expansion, or Text's <c>LocalizeText</c> variable added in version 4). When an older project is
+/// loaded these variables are hidden in the variable grid so the tool doesn't surface variables the
+/// project's runtime won't honor. Kept free of services (the caller supplies the resolved project
+/// version and root standard type name) so it can be unit tested without a loaded project or
+/// selection state.
 /// </summary>
 internal class ShapeVariableVersionGate
 {
     // Only the plain Circle / Rectangle standard elements are gated. The legacy Skia shapes
     // (ColoredCircle / RoundedRectangle / Arc) carried gradient / dropshadow / fill long before
-    // v3, so they must stay visible on older projects. Text's dropshadow surface (issue #4005) is
-    // new in the same v3 surface, so it is gated here too — the fill/gradient names below don't
-    // apply to Text, but V3OnlyVariableNames.Contains still only matches the dropshadow names.
+    // v3, so they must stay visible on older projects. Text's dropshadow surface (issue #4005) and
+    // LocalizeText (issue #4222) are gated here too — the fill/gradient names in the map below
+    // don't apply to Text, but the per-variable lookup still only matches Text's own gated names.
     private static readonly HashSet<string> GatedStandardTypeNames = new()
     {
         "Circle",
@@ -26,77 +28,89 @@ internal class ShapeVariableVersionGate
         "Text",
     };
 
-    // Fill / dropshadow / gradient variable names added to plain Circle / Rectangle in v3
+    // Gated variable names mapped to the minimum project version that unlocks them. Most are the
+    // fill / dropshadow / gradient variables added to plain Circle / Rectangle in v3
     // (StandardElementsManager.AddFillAndStrokeVariables fill section, AddDropshadowVariables,
-    // AddGradientVariables). Stroke is intentionally excluded — it is the always-present surface
-    // on these shapes (gated implicitly by StrokeWidth = 0, not by version). Phase 0 decision: a
-    // hardcoded name list here rather than a per-variable MinProjectVersion attribute. Keep in
-    // sync with GumxVersions.ShapeVariableExpansion and the StandardElementsManager helpers.
-    private static readonly HashSet<string> V3OnlyVariableNames = new()
+    // AddGradientVariables); LocalizeText (issue #4222) is the first entry gated at a different
+    // version, which is why this is a per-variable map rather than a single global cutoff. Stroke
+    // is intentionally excluded — it is the always-present surface on these shapes (gated
+    // implicitly by StrokeWidth = 0, not by version). Phase 0 decision: a hardcoded name list here
+    // rather than reading VariableSave.MinimumGumxVersion directly. Keep in sync with the
+    // StandardElementsManager helpers and their MinimumGumxVersion tags.
+    private static readonly Dictionary<string, int> GatedVariableMinimumVersions = BuildGatedVariableMinimumVersions();
+
+    private static Dictionary<string, int> BuildGatedVariableMinimumVersions()
     {
-        // Fill
-        "IsFilled",
-        "FillRed",
-        "FillGreen",
-        "FillBlue",
-        "FillAlpha",
-        // Dropshadow
-        "HasDropshadow",
-        "DropshadowOffsetX",
-        "DropshadowOffsetY",
-        "DropshadowBlur",
-        "DropshadowAlpha",
-        "DropshadowRed",
-        "DropshadowGreen",
-        "DropshadowBlue",
-        // Gradient
-        "UseGradient",
-        "GradientType",
-        "GradientX1",
-        "GradientX1Units",
-        "GradientY1",
-        "GradientY1Units",
-        "GradientX2",
-        "GradientX2Units",
-        "GradientY2",
-        "GradientY2Units",
-        "GradientInnerRadius",
-        "GradientInnerRadiusUnits",
-        "GradientOuterRadius",
-        "GradientOuterRadiusUnits",
-        // Rounded corners (Rectangle only — absorbed from the retired RoundedRectangle standard)
-        "CornerRadius",
-        // Issue #3617 — per-corner CornerRadius overrides, added alongside CornerRadius itself.
-        "CustomRadiusTopLeft",
-        "CustomRadiusTopRight",
-        "CustomRadiusBottomLeft",
-        "CustomRadiusBottomRight",
-        // Issue #3009 — Circle/Rectangle no longer expose the standalone gradient start
-        // (Red1/Green1/Blue1/Alpha1); the start is the active body color, so there is no such
-        // variable to gate. Color2 (Red2/Green2/Blue2/Alpha2) remains the standalone second stop.
-        "Red2",
-        "Green2",
-        "Blue2",
-        "Alpha2",
-    };
+        int v3 = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion;
+
+        return new Dictionary<string, int>
+        {
+            // Fill
+            ["IsFilled"] = v3,
+            ["FillRed"] = v3,
+            ["FillGreen"] = v3,
+            ["FillBlue"] = v3,
+            ["FillAlpha"] = v3,
+            // Dropshadow
+            ["HasDropshadow"] = v3,
+            ["DropshadowOffsetX"] = v3,
+            ["DropshadowOffsetY"] = v3,
+            ["DropshadowBlur"] = v3,
+            ["DropshadowAlpha"] = v3,
+            ["DropshadowRed"] = v3,
+            ["DropshadowGreen"] = v3,
+            ["DropshadowBlue"] = v3,
+            // Gradient
+            ["UseGradient"] = v3,
+            ["GradientType"] = v3,
+            ["GradientX1"] = v3,
+            ["GradientX1Units"] = v3,
+            ["GradientY1"] = v3,
+            ["GradientY1Units"] = v3,
+            ["GradientX2"] = v3,
+            ["GradientX2Units"] = v3,
+            ["GradientY2"] = v3,
+            ["GradientY2Units"] = v3,
+            ["GradientInnerRadius"] = v3,
+            ["GradientInnerRadiusUnits"] = v3,
+            ["GradientOuterRadius"] = v3,
+            ["GradientOuterRadiusUnits"] = v3,
+            // Rounded corners (Rectangle only — absorbed from the retired RoundedRectangle standard)
+            ["CornerRadius"] = v3,
+            // Issue #3617 — per-corner CornerRadius overrides, added alongside CornerRadius itself.
+            ["CustomRadiusTopLeft"] = v3,
+            ["CustomRadiusTopRight"] = v3,
+            ["CustomRadiusBottomLeft"] = v3,
+            ["CustomRadiusBottomRight"] = v3,
+            // Issue #3009 — Circle/Rectangle no longer expose the standalone gradient start
+            // (Red1/Green1/Blue1/Alpha1); the start is the active body color, so there is no such
+            // variable to gate. Color2 (Red2/Green2/Blue2/Alpha2) remains the standalone second stop.
+            ["Red2"] = v3,
+            ["Green2"] = v3,
+            ["Blue2"] = v3,
+            ["Alpha2"] = v3,
+            // Issue #4222 — Text's LocalizeText variable, gated at v4 (a version past the rest of
+            // this list, which is why a per-variable map is needed instead of one cutoff).
+            ["LocalizeText"] = (int)GumProjectSave.GumxVersions.LocalizeTextExpansion,
+        };
+    }
 
     /// <summary>
-    /// Returns true when the given variable (identified by its root name) should be hidden in
-    /// the variable grid because it is a v3-only fill / dropshadow / gradient variable on a plain
-    /// Circle / Rectangle and the loaded project predates v3.
+    /// Returns true when the given variable (identified by its root name) should be hidden in the
+    /// variable grid because the loaded project predates the version that unlocked it.
     /// </summary>
     public bool GetIfHiddenForProjectVersion(string rootName, string? rootStandardTypeName, int projectVersion)
     {
-        if (projectVersion >= (int)GumProjectSave.GumxVersions.ShapeVariableExpansion)
-        {
-            return false;
-        }
-
         if (rootStandardTypeName == null || !GatedStandardTypeNames.Contains(rootStandardTypeName))
         {
             return false;
         }
 
-        return V3OnlyVariableNames.Contains(rootName);
+        if (!GatedVariableMinimumVersions.TryGetValue(rootName, out int minimumVersion))
+        {
+            return false;
+        }
+
+        return projectVersion < minimumVersion;
     }
 }

--- a/Tools/Gum.ProjectServices/ProjectCreator.cs
+++ b/Tools/Gum.ProjectServices/ProjectCreator.cs
@@ -49,9 +49,9 @@ public class ProjectCreator : IProjectCreator
         {
             FontGenerator = FontGeneratorType.KernSmith,
             FullFileName = filePath,
-            // The default standard elements seed the v3 shape variable surface, so stamp the
+            // The default standard elements seed the latest variable surface, so stamp the
             // project at the matching version rather than the GumProjectSave ctor default.
-            Version = (int)GumProjectSave.GumxVersions.ShapeVariableExpansion
+            Version = GumProjectSave.NativeVersion
         };
 
         foreach (var name in StandardElementNames)

--- a/Tools/Gum.ProjectServices/Templates/Default/CliTemplate.gumx
+++ b/Tools/Gum.ProjectServices/Templates/Default/CliTemplate.gumx
@@ -6,7 +6,7 @@
   <FontSpacingHorizontal>1</FontSpacingHorizontal>
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
-  <Version>3</Version>
+  <Version>4</Version>
   <DefaultCanvasWidth>800</DefaultCanvasWidth>
   <DefaultCanvasHeight>600</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/Tools/Gum.ProjectServices/Templates/Default/Standards/Text.gutx
+++ b/Tools/Gum.ProjectServices/Templates/Default/Standards/Text.gutx
@@ -51,6 +51,9 @@
     <Variable Type="float" Name="LineHeightMultiplier" Category="Text" SetsValue="true">
       <Value xsi:type="xsd:float">1</Value>
     </Variable>
+    <Variable Type="bool" Name="LocalizeText" Category="Text" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
     <Variable Type="float?" Name="MaxHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="int?" Name="MaxLettersToShow" Category="Text" SetsValue="true" />
     <Variable Type="int?" Name="MaxNumberOfLines" Category="Text" SetsValue="true" />

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
@@ -6,7 +6,7 @@
   <FontSpacingHorizontal>1</FontSpacingHorizontal>
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
-  <Version>3</Version>
+  <Version>4</Version>
   <DefaultCanvasWidth>1024</DefaultCanvasWidth>
   <DefaultCanvasHeight>768</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Text.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Standards/Text.gutx
@@ -51,6 +51,9 @@
     <Variable Type="float" Name="LineHeightMultiplier" Category="Text" SetsValue="true">
       <Value xsi:type="xsd:float">1</Value>
     </Variable>
+    <Variable Type="bool" Name="LocalizeText" Category="Text" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
     <Variable Type="float?" Name="MaxHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="int?" Name="MaxLettersToShow" Category="Text" SetsValue="true" />
     <Variable Type="int?" Name="MaxNumberOfLines" Category="Text" SetsValue="true" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
@@ -7,7 +7,7 @@
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
   <FontGenerator>KernSmith</FontGenerator>
-  <Version>3</Version>
+  <Version>4</Version>
   <DefaultCanvasWidth>1024</DefaultCanvasWidth>
   <DefaultCanvasHeight>768</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Text.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Standards/Text.gutx
@@ -51,6 +51,9 @@
     <Variable Type="float" Name="LineHeightMultiplier" Category="Text" SetsValue="true">
       <Value xsi:type="xsd:float">1</Value>
     </Variable>
+    <Variable Type="bool" Name="LocalizeText" Category="Text" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
     <Variable Type="float?" Name="MaxHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="int?" Name="MaxLettersToShow" Category="Text" SetsValue="true" />
     <Variable Type="int?" Name="MaxNumberOfLines" Category="Text" SetsValue="true" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
@@ -7,7 +7,7 @@
   <UseFontCharacterFile>false</UseFontCharacterFile>
   <AutoSizeFontOutputs>false</AutoSizeFontOutputs>
   <FontGenerator>KernSmith</FontGenerator>
-  <Version>3</Version>
+  <Version>4</Version>
   <DefaultCanvasWidth>1024</DefaultCanvasWidth>
   <DefaultCanvasHeight>768</DefaultCanvasHeight>
   <CustomCanvasSizes>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Standards/Text.gutx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Standards/Text.gutx
@@ -51,6 +51,9 @@
     <Variable Type="float" Name="LineHeightMultiplier" Category="Text" SetsValue="true">
       <Value xsi:type="xsd:float">1</Value>
     </Variable>
+    <Variable Type="bool" Name="LocalizeText" Category="Text" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
     <Variable Type="float?" Name="MaxHeight" Category="Dimensions" SetsValue="true" />
     <Variable Type="int?" Name="MaxLettersToShow" Category="Text" SetsValue="true" />
     <Variable Type="int?" Name="MaxNumberOfLines" Category="Text" SetsValue="true" />

--- a/docs/gum-tool/upgrading/upgrading-file-gumx-version.md
+++ b/docs/gum-tool/upgrading/upgrading-file-gumx-version.md
@@ -89,3 +89,19 @@ Unlike Version 2, which is a real XML-format change requiring a **File** -> **Sa
 {% hint style="info" %}
 New projects created with the 2026 May tool (or later) are stamped Version 3 automatically. Only projects created before this release need the manual bump.
 {% endhint %}
+
+## Version 4
+
+**Required Gum Tool Version**: 2026 July (or later)
+
+This version unlocks the `Localize Text` variable on the **Text** standard element, which controls whether that instance's text is translated when a localization database is loaded. The tool only shows and back-fills this variable for projects at version 4 or later, so a project still at version 3 keeps it hidden even on a tool build that supports it.
+
+✅No manual changes are needed to your project beyond changing the version number.
+
+Version 4 uses the **same XML format** as Version 3. The version bump exists only to unlock the new variable and to make older tool builds refuse the file rather than silently dropping it on the next save. There is **no format conversion or Save All step**, you only change the `<Version>` number.
+
+❗Be sure that your entire team is using the new version of Gum (2026 July or later) before making this upgrade. As with previous versions, mixing tool versions across a team can produce a "hybrid" file which can break a project.
+
+{% hint style="info" %}
+New projects created with the 2026 July tool (or later) are stamped Version 4 automatically. Only projects created before this release need the manual bump.
+{% endhint %}


### PR DESCRIPTION
Closes #4222

`LocalizeText` (#4133/#4134) was added to the Text standard element's default state without a `MinimumGumxVersion` tag. `Initialize()` back-fills every untagged default-state variable into loaded projects regardless of saved version — so opening a pre-#4134 v3 project silently injected `LocalizeText`, and its FRB1-generated runtime doesn't have that property (same failure mode as FRB #1881).

## Changes
- Reserves `GumxVersions.LocalizeTextExpansion = 4`, tags `LocalizeText`'s `VariableSave` with it, bumps `NativeVersion`.
- `ProjectCreator.Create` / `ProjectManager`'s new-project path now stamp `GumProjectSave.NativeVersion` instead of the old hardcoded `ShapeVariableExpansion` literal, so future version bumps don't require touching these call sites again.
- `ShapeVariableVersionGate` (the separate variable-grid display gate) previously supported only a single global v3 cutoff — generalized to a per-variable minimum-version map so it can gate `LocalizeText` at v4 alongside the existing v3 entries.
- Synced the four bundled Forms/theme `.gumx` templates (Default, FormsTemplate, Bubblegum, Hazard): added `LocalizeText` to their `Text.gutx` and bumped `Version` to 4, so they don't drift from `StandardElementsManager`'s canonical defaults (`Create_ShouldNotDriftFromDefaultStandards` caught this).
- Added a "Version 4" section to the gumx-version upgrade doc.

Manual test: needed (file load/save + variable-grid visibility are tool-observable). Steps in the PR thread / from the agent.

FRB canary: needed — this change touches `GumDataTypes/GumProjectSave.cs` and `Gum/Managers/StandardElementsManager.cs`, both shared into FRB1 via `GumCoreShared.projitems`. Will run once the primary checkout is confirmed free (per repo process, this must run from the primary checkout, not a worktree).
