### PR TITLE
Include file extension in Load Recent display name

### DIFF
--- a/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/RecentFilesLogicTests.cs
@@ -66,6 +66,26 @@ public class RecentFilesLogicTests
     }
 
     [Fact]
+    public void GetDisplayedNameForGumxFilePath_IncludesExtension()
+    {
+        FilePath filePath = new(@"C:\NonExistentFolder12345\MyProject.gumx");
+
+        string name = RecentFilesLogic.GetDisplayedNameForGumxFilePath(filePath);
+
+        name.ShouldBe("MyProject.gumx");
+    }
+
+    [Fact]
+    public void GetDisplayedNameForGumxFilePath_Gumj_IncludesExtension()
+    {
+        FilePath filePath = new(@"C:\NonExistentFolder12345\MyProject.gumj");
+
+        string name = RecentFilesLogic.GetDisplayedNameForGumxFilePath(filePath);
+
+        name.ShouldBe("MyProject.gumj");
+    }
+
+    [Fact]
     public void LoadProject_DelegatesToFileCommands()
     {
         _logic.LoadProject(@"C:\SomeProject.gumx");

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/LoadRecentFilesPlugin/RecentFilesLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/LoadRecentFilesPlugin/RecentFilesLogic.cs
@@ -51,7 +51,7 @@ public class RecentFilesLogic
     /// </summary>
     public static string GetDisplayedNameForGumxFilePath(FilePath filePath)
     {
-        string name = filePath.RemoveExtension().FileNameNoPath;
+        string name = filePath.FileNameNoPath;
 
         // It's common to have lots of same-named projects so let's see if this is in a csproj somewhere:
         FilePath? parentDirectory = filePath.GetDirectoryContainingThis();


### PR DESCRIPTION
Closes #4223

`GetDisplayedNameForGumxFilePath` stripped the extension via `RemoveExtension()`, so `.gumx` and `.gumj` projects with the same name were indistinguishable in the Load Recent menu. Fixed by keeping the extension (`filePath.FileNameNoPath` instead of `filePath.RemoveExtension().FileNameNoPath`).

## Test plan
- [x] Added `RecentFilesLogicTests.GetDisplayedNameForGumxFilePath_IncludesExtension` / `_Gumj_IncludesExtension` (red before fix, green after)
- [x] `dotnet build GumFull.sln` — 0 errors
- [ ] Manual: open Load Recent menu, confirm entries show `.gumx`/`.gumj` extension