### PR TITLE
Coalesce per-element tree refresh during Forms/gumx import (#4231)

### DIFF
--- a/.claude/skills/gum-tool-tree-view/SKILL.md
+++ b/.claude/skills/gum-tool-tree-view/SKILL.md
@@ -21,6 +21,7 @@ inside an open element. A native WPF `TreeView`.
 | `Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs` | Builds, refreshes and selects nodes |
 | `MainTreeViewPlugin.cs` | Wires plugin events to `RefreshUi(...)` and error-indicator updates |
 | `TreeViewStateService.cs`, `CollapseToggleService.cs` | Expansion state: persisted across sessions, and the collapse-button toggle |
+| `Tools/Gum.Presentation/Services/RefreshCoalescer.cs` | Collapses N `RequestRefresh()` calls in one synchronous burst into a single `IDispatcher`-posted refresh |
 
 `ElementTreeViewManager` and its `RightClick` partial speak `ITreeNode`/`ITreeNodeMutable`, delegating
 to headless twins in `Tools/Gum.Presentation/Managers/` (`TreeNodeImageLogic`, the `TreeNode*Extensions`
@@ -54,6 +55,10 @@ headless `TreeNodeImageLogic`) to a pack URI plus a theme color key; `TreeNodeIc
 
 `Tag` distinguishes node kinds: folder/container nodes have `Tag == null`; element nodes carry an
 `ElementSave`/`BehaviorSave`; instance nodes an `InstanceSave`.
+
+`MainTreeViewPlugin.HandleElementImported` requests a refresh through a `RefreshCoalescer` rather than
+calling `RefreshUi()` directly, so importing N elements in one batch (Forms theme, `.gumx` import)
+produces one refresh instead of N.
 
 ## Gotchas
 

--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -30,6 +30,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
     private readonly IMessenger _messenger;
     private readonly IErrorChecker _errorChecker;
     private readonly IProjectState _projectState;
+    private readonly IRefreshCoalescer _elementImportRefreshCoalescer;
 
     [ImportingConstructor]
     public MainTreeViewPlugin(
@@ -39,7 +40,8 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         IMessenger messenger,
         IOutputManager outputManager,
         IErrorChecker errorChecker,
-        IProjectState projectState)
+        IProjectState projectState,
+        IDispatcher dispatcher)
     {
         _selectedState = selectedState;
         _elementTreeViewManager = elementTreeViewManager;
@@ -51,6 +53,15 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
 
         _errorChecker = errorChecker;
         _projectState = projectState;
+
+        // Forms import fires ElementImported once per element (issue #4231) - without coalescing,
+        // a multi-element import triggers one full RefreshUi() + error re-check per element instead
+        // of once for the whole batch.
+        _elementImportRefreshCoalescer = new RefreshCoalescer(dispatcher, () =>
+        {
+            _elementTreeViewManager.RefreshUi();
+            RefreshErrorIndicatorsForAllElements();
+        });
 
         // Register to receive ApplicationTeardownMessage
         _messenger.RegisterAll(this);
@@ -198,8 +209,7 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
 
     private void HandleElementImported(ElementSave save)
     {
-        _elementTreeViewManager.RefreshUi();
-        RefreshErrorIndicatorsForAllElements();
+        _elementImportRefreshCoalescer.RequestRefresh();
     }
 
     private void HandleBehaviorCreated(BehaviorSave save)

--- a/Tests/Gum.Presentation.Tests/RefreshCoalescerTests.cs
+++ b/Tests/Gum.Presentation.Tests/RefreshCoalescerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Gum.Services;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class RefreshCoalescerTests
+{
+    private readonly Mock<IDispatcher> _dispatcherMock;
+    private Action? _postedAction;
+    private int _refreshCallCount;
+    private readonly RefreshCoalescer _sut;
+
+    public RefreshCoalescerTests()
+    {
+        _dispatcherMock = new Mock<IDispatcher>();
+        _dispatcherMock.Setup(d => d.Post(It.IsAny<Action>()))
+            .Callback<Action>(action => _postedAction = action);
+
+        _sut = new RefreshCoalescer(_dispatcherMock.Object, () => _refreshCallCount++);
+    }
+
+    [Fact]
+    public void RequestRefresh_CalledOnce_PostsAndDoesNotRunRefreshSynchronously()
+    {
+        _sut.RequestRefresh();
+
+        _dispatcherMock.Verify(d => d.Post(It.IsAny<Action>()), Times.Once);
+        _refreshCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RequestRefresh_CalledRepeatedlyBeforePostedActionRuns_PostsOnlyOnce()
+    {
+        _sut.RequestRefresh();
+        _sut.RequestRefresh();
+        _sut.RequestRefresh();
+
+        _dispatcherMock.Verify(d => d.Post(It.IsAny<Action>()), Times.Once);
+    }
+
+    [Fact]
+    public void RequestRefresh_WhenPostedActionRuns_InvokesRefreshExactlyOnce()
+    {
+        _sut.RequestRefresh();
+        _sut.RequestRefresh();
+        _sut.RequestRefresh();
+
+        _postedAction!.Invoke();
+
+        _refreshCallCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RequestRefresh_AfterPostedActionRuns_SchedulesAgain()
+    {
+        _sut.RequestRefresh();
+        _postedAction!.Invoke();
+
+        _sut.RequestRefresh();
+
+        _dispatcherMock.Verify(d => d.Post(It.IsAny<Action>()), Times.Exactly(2));
+    }
+}

--- a/Tools/Gum.Presentation/Services/IRefreshCoalescer.cs
+++ b/Tools/Gum.Presentation/Services/IRefreshCoalescer.cs
@@ -1,0 +1,14 @@
+namespace Gum.Services;
+
+/// <summary>
+/// Coalesces repeated refresh requests raised within the same synchronous burst into a single
+/// deferred invocation.
+/// </summary>
+public interface IRefreshCoalescer
+{
+    /// <summary>
+    /// Requests a refresh. If a refresh is already pending (a prior call has not yet run), this is a
+    /// no-op; otherwise the refresh action is posted via <see cref="IDispatcher"/> to run once.
+    /// </summary>
+    void RequestRefresh();
+}

--- a/Tools/Gum.Presentation/Services/RefreshCoalescer.cs
+++ b/Tools/Gum.Presentation/Services/RefreshCoalescer.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Gum.Services;
+
+/// <inheritdoc cref="IRefreshCoalescer"/>
+public class RefreshCoalescer : IRefreshCoalescer
+{
+    private readonly IDispatcher _dispatcher;
+    private readonly Action _refresh;
+    private bool _isPending;
+
+    public RefreshCoalescer(IDispatcher dispatcher, Action refresh)
+    {
+        _dispatcher = dispatcher;
+        _refresh = refresh;
+    }
+
+    public void RequestRefresh()
+    {
+        if (_isPending)
+        {
+            return;
+        }
+
+        _isPending = true;
+        _dispatcher.Post(() =>
+        {
+            _isPending = false;
+            _refresh();
+        });
+    }
+}


### PR DESCRIPTION
Closes #4231.

`MainTreeViewPlugin.HandleElementImported` did a full `RefreshUi()` + all-elements error re-check on every `ElementImported` event. Forms theme import and `.gumx` import both fire that event once per element, so importing N elements did N full tree rebuilds for one logical import.

`HandleElementImported` now calls `RefreshCoalescer.RequestRefresh()` (new, `Tools/Gum.Presentation/Services/`). The first call in a synchronous burst posts one deferred refresh via `IDispatcher`; further calls before it runs are no-ops. Result: N imported elements → 1 refresh.

## #4233 (batch mode for `GumTreeNodeCollection`) — measured, not implemented

Measured on the ported tree: one coalesced `RefreshUi()` + error refresh for a ~30-element Forms theme import took **82 ms**, once, on the Add Forms action - not a hot/repeated path. Not worth the complexity of adding suppress/resume batching to `GumTreeNodeCollection` for. Closing #4233 with this number.

## Testing

- `Tests/Gum.Presentation.Tests/RefreshCoalescerTests.cs` (new, TDD) — coalescing behavior in isolation via a fake `IDispatcher` that captures the posted action.
- `AllPluginsCompositionTests` — confirms `MainTreeViewPlugin` still composes with the added `IDispatcher` import (already bridged in `PluginManager.LoadPlugins`, no bridge-list change needed).
- Full `GumToolUnitTests` (1195 passed) and `Gum.Presentation.Tests` (789 passed) suites green.

Manual test: done by the user - confirmed the Add Forms import completes with a single coalesced refresh (no wall of per-element `MainTreeViewPlugin took Xms` warnings) and captured the 82 ms number above via a temporary file-logged Stopwatch (since removed).
