### PR TITLE
Remove dead FRB/platform #if branches from FormsUtilities and RangeBase

### DIFF
--- a/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
@@ -324,27 +324,11 @@ public abstract class RangeBase :
 
     private void AssignExplicitTrack()
     {
-        // Vic says
-        // It seems FRB
-        // tolerates a missing
-        // track, but MonoGame requires
-        // it. Not sure why...perhaps to
-        // not break old FRB projects?
+        // A missing or non-InteractiveGue TrackInstance surfaces as an InvalidCastException on the
+        // cast below. A FULL_DIAGNOSTICS check used to explain it, but it was guarded on a
+        // combination no build satisfies once this file moved to GumCommon -- see #4238 for
+        // whether it should come back live.
         var trackLocal = this.Visual.GetGraphicalUiElementByName("TrackInstance");
-#if MONOGAME && !FRB
-
-#if FULL_DIAGNOSTICS
-        if (trackLocal == null)
-        {
-            throw new Exception($"Could not find a child named TrackInstance when creating a {this.GetType()}");
-        }
-        else if (!(trackLocal is InteractiveGue))
-        {
-            throw new Exception("Found a TrackInstance, but it is not an InteractiveGue");
-        }
-#endif
-
-#endif
         explicitTrack = (InteractiveGue)trackLocal;
         if (trackLocal is InteractiveGue trackAsInteractive)
         {

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -30,11 +30,10 @@ using Gum.GueDeriving;
 // so this shared file compiles on backends without those types (e.g. Skia). GamePad is used only as
 // the fully-qualified platform-neutral Gum.Input.GamePad holder.
 
-#if FRB
-namespace MonoGameGum.Forms;
-#else
+// Unlike the Forms *control* files, this one is never compiled by FlatRedBall: FRB's
+// FlatRedBall.Forms.Shared.projitems does not reference it and FRB has no FormsUtilities of
+// its own. So FRB is never defined here and `#if FRB` branches are dead -- don't add any.
 namespace Gum.Forms;
-#endif
 
 /// <summary>
 /// The version to use for default visuals in a code-only project.
@@ -140,13 +139,12 @@ public class FormsUtilities
                 "You must call this method after initializing SystemManagers.Default, or you must explicitly specify a SystemsManager instance");
         }
 
-#if XNALIKE
-        Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
-#elif RAYLIB
+        // Written as an exclusion rather than an enumeration of every backend so a new runtime
+        // linking this file gets a compiling default instead of an undeclared-variable error:
+        // raylib alone returns a nullable value type here, everything else a nullable reference.
+#if RAYLIB
         Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png").Value;
-#elif SOKOL
-        Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
-#elif SKIA
+#else
         Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
 #endif
 
@@ -182,13 +180,13 @@ public class FormsUtilities
                 TryAdd(typeof(Button), (_, c) => new DefaultVisuals.ButtonVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(CheckBox), (_, c) => new DefaultVisuals.CheckBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ComboBox), (_, c) => new DefaultVisuals.ComboBoxVisual(tryCreateFormsObject: c));
-#if XNALIKE || FRB
+#if XNALIKE
                 TryAdd(typeof(ItemsControl), (_, c) => new DefaultVisuals.ItemsControlVisual(tryCreateFormsObject: c));
 #endif
                 TryAdd(typeof(Label), (_, c) => new DefaultVisuals.LabelVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ListBox), (_, c) => new DefaultVisuals.ListBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ListBoxItem), (_, c) => new DefaultVisuals.ListBoxItemVisual(tryCreateFormsObject: c));
-#if XNALIKE || FRB
+#if XNALIKE
                 TryAdd(typeof(Menu), (_, c) => new DefaultVisuals.MenuVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(MenuItem), (_, c) => new DefaultVisuals.MenuItemVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(PasswordBox), (_, c) => new DefaultVisuals.PasswordBoxVisual(tryCreateFormsObject: c));
@@ -198,7 +196,7 @@ public class FormsUtilities
                 TryAdd(typeof(ScrollViewer), (_, c) => new DefaultVisuals.ScrollViewerVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Slider), (_, c) => new DefaultVisuals.SliderVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Splitter), (_, c) => new DefaultVisuals.SplitterVisual(tryCreateFormsObject: c));
-#if XNALIKE || FRB
+#if XNALIKE
                 TryAdd(typeof(TextBox), (_, c) => new DefaultVisuals.TextBoxVisual(tryCreateFormsObject: c));
 #endif
                 TryAdd(typeof(Window), (_, c) => new DefaultVisuals.WindowVisual(tryCreateFormsObject: c));
@@ -210,9 +208,7 @@ public class FormsUtilities
             case DefaultVisualsVersion.V3:
                 TryAdd(typeof(Button), (_, c) => new DefaultVisuals.V3.ButtonVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(CheckBox), (_, c) => new DefaultVisuals.V3.CheckBoxVisual(tryCreateFormsObject: c));
-#if !FRB
                 TryAdd(typeof(Gum.Forms.Controls.Games.DialogBox), (_, c) => new DefaultVisuals.V3.DialogBoxVisual(tryCreateFormsObject: c));
-#endif
                 TryAdd(typeof(ComboBox), (_, c) => new DefaultVisuals.V3.ComboBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(ItemsControl), (_, c) => new DefaultVisuals.V3.ItemsControlVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Label), (_, c) => new DefaultVisuals.V3.LabelVisual(tryCreateFormsObject: c));
@@ -277,11 +273,9 @@ public class FormsUtilities
         IGumService service = IGumService.Default!;
         cursor = service.CreateCursor()!;
 
-#if !FRB
         // This was added to MonoGame/raylib on 1/22/2026 to support
         // simplified behavior.
         ICursor.VisualOverBehavior = VisualOverBehavior.IfHasEventsIsTrue;
-#endif
 
         keyboard = service.CreateKeyboard()!;
 


### PR DESCRIPTION
Part of #3543 (item 1 — dead platform `#if` reduction; and a slice of item 2). Deliberately no closing keyword: items 2 and 3 have leftovers, see the issue comment.

## The finding

`MonoGameGum/Forms/FormsUtilities.cs` is **not** compiled by FlatRedBall — it's absent from `FlatRedBall.Forms.Shared.projitems` and FRB has no `FormsUtilities` of its own (verified against the local FRB checkout). Its only compilers are MonoGameGum/KniGum/FnaGum/RaylibGum/SkiaGum/SokolGum/SilkNetGum, none of which define `FRB`. So every FRB-conditional branch in that file was dead — the same class of dead branch #3541 collapsed in the control files, just in the file item 2 is about.

## Changes

- **FormsUtilities** — collapsed the namespace selection, three `#if XNALIKE || FRB` V2 registration gates, the `#if !FRB` DialogBox V3 registration, and the `#if !FRB` `VisualOverBehavior` assignment. Header comment records the compile ownership so they don't come back.
- **FormsUtilities** — the `uiSpriteSheet` load was `#if XNALIKE / #elif RAYLIB / #elif SOKOL / #elif SKIA` with no `#else`, so a new backend linking this file failed with an undeclared variable. Rewritten as `#if RAYLIB / #else` (raylib is the only backend whose `LoadEmbeddedTexture2d` returns a nullable value type).
- **RangeBase** — the `TrackInstance` `FULL_DIAGNOSTICS` check was guarded `#if MONOGAME && !FRB`, which no build satisfies since the file became GumCommon-owned (GumCommon defines `FULL_DIAGNOSTICS` but not `MONOGAME`; MonoGameGum `<Compile Remove>`s it; FRB fails `!FRB`). Dead block removed; #4238 tracks whether the diagnostic should come back live.

Behavior-preserving throughout — no branch removed was reachable in any build, so no test accompanies it (dead-code exemption).

## Verification

`MonoGameGum.Tests` 2083/2083 pass. Clean builds of `MonoGameGum.Tests` (covers GumCommon + MonoGameGum), `KniGum`, `RaylibGum`, `SkiaGum`, `SilkNetGum`. No new warnings.
