### PR TITLE
Dispatch the inline soft keyboard at runtime instead of #if ANDROID

### DIFF
--- a/GumRuntime/InteractiveGue.cs
+++ b/GumRuntime/InteractiveGue.cs
@@ -1153,6 +1153,14 @@ public interface IInputReceiverKeyboard
     IEnumerable<Gum.Forms.Input.Keys> KeysTyped { get; }
 
     /// <summary>
+    /// Whether this keyboard can surface an inline soft keyboard through
+    /// <see cref="ShowKeyboard"/> / <see cref="HideKeyboard"/>. When true, text controls use
+    /// it instead of the modal <c>INativeTextInput</c> dialog, because typed characters arrive
+    /// through the normal input pipeline. Defaults to false.
+    /// </summary>
+    bool SupportsInlineKeyboard => false;
+
+    /// <summary>
     /// Default no-op. Runtimes with soft-keyboard / IME support (e.g. Android) override
     /// this to surface the native on-screen keyboard.
     /// </summary>

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1452,34 +1452,32 @@ public abstract class TextBoxBase :
 
     /// <summary>
     /// Brings up the platform's native text-input UI on behalf of this control, if one is
-    /// available. The Android path uses the inline soft keyboard via
-    /// <c>FrameworkElement.MainKeyboard</c>; everywhere else the call is delegated to the
+    /// available. Keyboards reporting <see cref="IInputReceiverKeyboard.SupportsInlineKeyboard"/>
+    /// (Android) show the inline soft keyboard; everywhere else the call is delegated to the
     /// <see cref="INativeTextInput"/> registered on <c>IGumService.Default.NativeTextInput</c>
     /// — runtimes without a native dialog leave that property null and the call no-ops.
     /// Internal so tests can drive the focus-show flow directly.
     /// </summary>
     internal void TryShowNativeKeyboard()
     {
-#if !FRB && !RAYLIB && !FNA && !SOKOL
+#if !FRB
         if (!ShowNativeKeyboardOnFocus)
         {
             return;
         }
 
-#if ANDROID
-        // On Android we use an inline soft keyboard (ported from FRB's Keyboard.Android.cs).
-        // Typed characters flow through the normal InputReceiver pipeline via
-        // Keyboard.GetStringTyped / KeysTyped — no modal dialog, no deferred-queue marshaling
-        // needed because all input arrives on the UI thread and is drained by
-        // ProcessAndroidKeys each frame.
-        //
-        // IsAndroidVersionAtLeast(21) is required by CA1416 — see TryHideNativeKeyboard.
-        if (OperatingSystem.IsAndroidVersionAtLeast(21))
+        // Platforms with an inline soft keyboard (Android) surface it through MainKeyboard.
+        // Typed characters then flow through the normal InputReceiver pipeline via
+        // GetStringTyped / KeysTyped — no modal dialog, and no deferred-queue marshaling
+        // because the input already arrives on the game loop thread.
+        var keyboard = global::Gum.Forms.Controls.FrameworkElement.MainKeyboard;
+        if (keyboard?.SupportsInlineKeyboard == true)
         {
-            global::Gum.Forms.Controls.FrameworkElement.MainKeyboard?.ShowKeyboard();
+            keyboard.ShowKeyboard();
+            return;
         }
-#else
-        // iOS (and any future platform without an inline implementation) falls back to the
+
+        // iOS (and any platform without an inline implementation) falls back to the
         // runtime's INativeTextInput. Runtimes that don't register one (e.g. Raylib, FNA,
         // browser) leave NativeTextInput null and we no-op here.
         var service = global::RenderingLibrary.IGumService.Default;
@@ -1513,23 +1511,18 @@ public abstract class TextBoxBase :
             });
         });
 #endif
-#endif
     }
 
-    private void TryHideNativeKeyboard()
+    /// <summary>
+    /// Dismisses the inline soft keyboard when this control loses focus, so users aren't left
+    /// staring at an IME over un-focused UI. Only keyboards that supply one do anything here —
+    /// the modal <see cref="INativeTextInput"/> dialog dismisses itself.
+    /// Internal so tests can drive the focus-loss flow directly.
+    /// </summary>
+    internal void TryHideNativeKeyboard()
     {
-#if ANDROID && !FRB && !RAYLIB
-        // Dismiss the soft keyboard when the TextBox loses focus so users aren't left
-        // staring at an IME over an un-focused UI. Only meaningful on Android — iOS's
-        // modal KeyboardInput.Show dismisses itself.
-        //
-        // The IsAndroidVersionAtLeast guard is redundant at runtime (the whole block is
-        // inside #if ANDROID) but is required by the CA1416 platform-compatibility analyzer,
-        // which does not track #if directives — only runtime OS checks.
-        if (OperatingSystem.IsAndroidVersionAtLeast(21))
-        {
-            global::Gum.Forms.Controls.FrameworkElement.MainKeyboard?.HideKeyboard();
-        }
+#if !FRB
+        global::Gum.Forms.Controls.FrameworkElement.MainKeyboard?.HideKeyboard();
 #endif
     }
 

--- a/MonoGameGum/Input/Keyboard.Android.cs
+++ b/MonoGameGum/Input/Keyboard.Android.cs
@@ -3,6 +3,7 @@ using Android.Content;
 using Android.Views;
 using Android.Views.InputMethods;
 using Microsoft.Xna.Framework.Input;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
 
@@ -46,6 +47,14 @@ public partial class Keyboard
 
     readonly object _androidActionListLock = new();
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Gated on API 21 to match the <c>[SupportedOSPlatform]</c> annotations on the IME calls
+    /// below. Callers reach those through <c>IInputReceiverKeyboard</c>, where CA1416 cannot
+    /// see the attributes, so the floor is enforced here instead.
+    /// </remarks>
+    public bool SupportsInlineKeyboard => OperatingSystem.IsAndroidVersionAtLeast(21);
+
     /// <summary>
     /// Requests the Android soft keyboard to appear. Safe to call every frame — the IME
     /// subscription is established only on the first call. The game view is fetched from
@@ -60,7 +69,7 @@ public partial class Keyboard
 
         view.RequestFocus();
 
-        if (view.Context.GetSystemService(Context.InputMethodService) is InputMethodManager imm)
+        if (view.Context?.GetSystemService(Context.InputMethodService) is InputMethodManager imm)
         {
             imm.ShowSoftInput(view, ShowFlags.Forced);
             imm.ToggleSoftInput(ShowFlags.Forced, HideSoftInputFlags.ImplicitOnly);
@@ -83,7 +92,7 @@ public partial class Keyboard
         var view = _game?.Services.GetService(typeof(View)) as View;
         if (view == null) return;
 
-        if (view.Context.GetSystemService(Context.InputMethodService) is InputMethodManager imm)
+        if (view.Context?.GetSystemService(Context.InputMethodService) is InputMethodManager imm)
         {
             imm.HideSoftInputFromWindow(view.WindowToken, HideSoftInputFlags.None);
         }

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -287,10 +287,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="..\..\MonoGameGum\Forms\Controls\TextBoxBase.cs" Link="Forms\Controls\TextBoxBase.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<EmbeddedResource Include="ILLink.Descriptors.xml">
 			<LogicalName>ILLink.Descriptors.xml</LogicalName>
 		</EmbeddedResource>

--- a/Tests/MonoGameGum.Tests.V2/TextBoxBaseNativeKeyboardTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/TextBoxBaseNativeKeyboardTests.cs
@@ -4,16 +4,19 @@ using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MonoGameGum.Tests.V2;
 
 /// <summary>
-/// Behavior tests for TextBoxBase's interaction with the platform-agnostic
-/// <see cref="INativeTextInput"/> abstraction. These verify that the iOS / generic
-/// modal-keyboard path on TextBoxBase delegates to whatever
-/// <see cref="IGumService.NativeTextInput"/> is registered, rather than calling
-/// MonoGame's <c>KeyboardInput.Show</c> directly.
+/// Behavior tests for TextBoxBase's two native-keyboard paths: the inline soft keyboard
+/// surfaced through <see cref="FrameworkElement.MainKeyboard"/> (Android), and the modal
+/// <see cref="INativeTextInput"/> dialog registered on
+/// <see cref="IGumService.NativeTextInput"/> (iOS and anything else that supplies one).
+/// Which path is taken is decided at runtime by
+/// <see cref="IInputReceiverKeyboard.SupportsInlineKeyboard"/>, so both are reachable from
+/// this desktop test assembly.
 /// </summary>
 public class TextBoxBaseNativeKeyboardTests
 {
@@ -22,8 +25,11 @@ public class TextBoxBaseNativeKeyboardTests
     {
         StubNativeTextInput stubInput = new StubNativeTextInput();
         StubGumService stubService = new StubGumService { NativeTextInput = stubInput };
+        StubKeyboard stubKeyboard = new StubKeyboard { SupportsInlineKeyboard = false };
         IGumService? prior = IGumService.Default;
+        IInputReceiverKeyboard? priorKeyboard = FrameworkElement.MainKeyboard;
         IGumService.Default = stubService;
+        FrameworkElement.MainKeyboard = stubKeyboard;
         try
         {
             TextBox textBox = new TextBox();
@@ -39,10 +45,59 @@ public class TextBoxBaseNativeKeyboardTests
             stubInput.LastDescription.ShouldBe("DESC");
             stubInput.LastInitialText.ShouldBe("INIT");
             stubInput.LastIsPassword.ShouldBe(false);
+            stubKeyboard.ShowCallCount.ShouldBe(0);
         }
         finally
         {
             IGumService.Default = prior;
+            FrameworkElement.MainKeyboard = priorKeyboard;
+        }
+    }
+
+    [Fact]
+    public void TryShowNativeKeyboard_WhenMainKeyboardSupportsInline_ShowsInlineKeyboardInsteadOfDialog()
+    {
+        StubNativeTextInput stubInput = new StubNativeTextInput();
+        StubGumService stubService = new StubGumService { NativeTextInput = stubInput };
+        StubKeyboard stubKeyboard = new StubKeyboard { SupportsInlineKeyboard = true };
+        IGumService? prior = IGumService.Default;
+        IInputReceiverKeyboard? priorKeyboard = FrameworkElement.MainKeyboard;
+        IGumService.Default = stubService;
+        FrameworkElement.MainKeyboard = stubKeyboard;
+        try
+        {
+            TextBox textBox = new TextBox();
+            textBox.ShowNativeKeyboardOnFocus = true;
+
+            textBox.TryShowNativeKeyboard();
+
+            stubKeyboard.ShowCallCount.ShouldBe(1);
+            stubInput.CallCount.ShouldBe(0);
+        }
+        finally
+        {
+            IGumService.Default = prior;
+            FrameworkElement.MainKeyboard = priorKeyboard;
+        }
+    }
+
+    [Fact]
+    public void TryHideNativeKeyboard_WhenMainKeyboardSupportsInline_HidesInlineKeyboard()
+    {
+        StubKeyboard stubKeyboard = new StubKeyboard { SupportsInlineKeyboard = true };
+        IInputReceiverKeyboard? priorKeyboard = FrameworkElement.MainKeyboard;
+        FrameworkElement.MainKeyboard = stubKeyboard;
+        try
+        {
+            TextBox textBox = new TextBox();
+
+            textBox.TryHideNativeKeyboard();
+
+            stubKeyboard.HideCallCount.ShouldBe(1);
+        }
+        finally
+        {
+            FrameworkElement.MainKeyboard = priorKeyboard;
         }
     }
 
@@ -85,6 +140,28 @@ public class TextBoxBaseNativeKeyboardTests
         {
             IGumService.Default = prior;
         }
+    }
+
+    private class StubKeyboard : IInputReceiverKeyboard
+    {
+        public bool SupportsInlineKeyboard { get; set; }
+        public int ShowCallCount { get; private set; }
+        public int HideCallCount { get; private set; }
+
+        public bool IsShiftDown => false;
+        public bool IsCtrlDown => false;
+        public bool IsAltDown => false;
+        public IEnumerable<Gum.Forms.Input.Keys> KeysTyped => System.Array.Empty<Gum.Forms.Input.Keys>();
+
+        public void ShowKeyboard() => ShowCallCount++;
+        public void HideKeyboard() => HideCallCount++;
+
+        public string GetStringTyped() => string.Empty;
+        public void Activity(double gameTime) { }
+        public bool KeyDown(Gum.Forms.Input.Keys key) => false;
+        public bool KeyPushed(Gum.Forms.Input.Keys key) => false;
+        public bool KeyReleased(Gum.Forms.Input.Keys key) => false;
+        public bool KeyTyped(Gum.Forms.Input.Keys key) => false;
     }
 
     private class StubNativeTextInput : INativeTextInput


### PR DESCRIPTION
Closes #4240.

`TextBoxBase.cs` compiles only into `GumCommon` (`net8.0`) and FRB, so `ANDROID` was never defined there. The inline soft-keyboard branch was dead, Android silently fell through to the modal `INativeTextInput` dialog, and `TryHideNativeKeyboard` was dead on every platform.

The call site never needed a compile-time gate: `ShowKeyboard`/`HideKeyboard` are default interface methods on `IInputReceiverKeyboard`, so virtual dispatch already picks the right implementation and the modal-vs-inline decision only needs a capability flag.

- `IInputReceiverKeyboard.SupportsInlineKeyboard`, default `false`, overridden to `OperatingSystem.IsAndroidVersionAtLeast(21)` on the Android `Keyboard` partial. The version floor moves here because callers reach the IME methods through the interface, where CA1416 cannot see their `[SupportedOSPlatform]` attributes.
- `TryShowNativeKeyboard` picks inline when the keyboard reports it, otherwise falls back to `INativeTextInput`. `TryHideNativeKeyboard` is now unconditional and live everywhere.
- `Keyboard.Android.cs` stays `#if ANDROID`. It references `Android.*` types and lives in `MonoGameGum`, which does have the android TFM, so that gate is correct.

Drive-bys: dropped the dead `!RAYLIB`/`!FNA`/`!SOKOL` clauses (none of those projects compile this file), removed a no-op `Compile Update` in `RaylibGum.csproj` for a file it already `Compile Remove`s, fixed two CS8602 warnings on `view.Context`.

Three tests in `TextBoxBaseNativeKeyboardTests` cover the fork: inline wins when supported, modal is used when it isn't, hide reaches the keyboard. All reachable from the desktop test assembly now that the branch is runtime-selected.

Verified: `MonoGameGum` builds clean on `net9.0-android`; `MonoGameGum.Tests` (2083), `MonoGameGum.Tests.V2` (144), `RaylibGum.Tests` (571) all green; `RaylibGum`, `KniGum`, `SkiaGum` build clean.

Manual test still needed on an actual Android build (inline keyboard on focus, dismiss on focus loss). Desktop behavior is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
