### PR TITLE
Restore RangeBase TrackInstance FULL_DIAGNOSTICS check

### DIFF
--- a/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
+++ b/MonoGameGum/Forms/Controls/Primitives/RangeBase.cs
@@ -324,11 +324,21 @@ public abstract class RangeBase :
 
     private void AssignExplicitTrack()
     {
-        // A missing or non-InteractiveGue TrackInstance surfaces as an InvalidCastException on the
-        // cast below. A FULL_DIAGNOSTICS check used to explain it, but it was guarded on a
-        // combination no build satisfies once this file moved to GumCommon -- see #4238 for
-        // whether it should come back live.
         var trackLocal = this.Visual.GetGraphicalUiElementByName("TrackInstance");
+
+#if FULL_DIAGNOSTICS
+        if (trackLocal == null)
+        {
+            throw new InvalidOperationException(
+                $"Could not find a child named TrackInstance when creating a {this.GetType()}");
+        }
+        else if (trackLocal is not InteractiveGue)
+        {
+            throw new InvalidOperationException(
+                $"Found a TrackInstance in {this.GetType()}, but it is not an InteractiveGue");
+        }
+#endif
+
         explicitTrack = (InteractiveGue)trackLocal;
         if (trackLocal is InteractiveGue trackAsInteractive)
         {

--- a/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/SliderVisualTests.cs
@@ -16,6 +16,24 @@ namespace MonoGameGum.Tests.V3;
 public class SliderVisualTests
 {
     [Fact]
+    public void Constructor_ShouldThrow_WhenVisualHasNoTrackInstance()
+    {
+        ContainerRuntime visual = new();
+
+        Should.Throw<InvalidOperationException>(() => new Slider(visual));
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenTrackInstanceIsNotInteractiveGue()
+    {
+        ContainerRuntime visual = new();
+        SpriteRuntime nonInteractiveTrack = new() { Name = "TrackInstance" };
+        visual.Children.Add(nonInteractiveTrack);
+
+        Should.Throw<InvalidOperationException>(() => new Slider(visual));
+    }
+
+    [Fact]
     public void BackgroundColor_Property_ShouldNotExist()
     {
         PropertyInfo? property = typeof(SliderVisual).GetProperty("BackgroundColor");


### PR DESCRIPTION
Restores the `RangeBase.AssignExplicitTrack` diagnostic that went dead when `RangeBase.cs` moved to GumCommon (#3543's dead-`#if` sweep deleted the block after it was already unreachable).

The check now lives under `#if FULL_DIAGNOSTICS` only (dropping the `MONOGAME && !FRB` guard, which no build satisfies since GumCommon compiles this file and FRB doesn't define `FULL_DIAGNOSTICS`). A missing or wrong-typed `TrackInstance` now throws a clear `InvalidOperationException` instead of an unexplained `InvalidCastException`/`NullReferenceException`.

Only `Slider` is affected — `ScrollBar` overrides `RefreshInternalVisualReferences` and never calls `AssignExplicitTrack` (see the WARNING comment on that method).

Manual test: not needed — the two new unit tests assert the exact exception behavior; no visible change to the working (valid-`TrackInstance`) path.

FRB canary: pass — 0 errors on both main (baseline) and this branch (FlatRedBall.Forms.DesktopGlNet6.csproj).

Closes #4238