### PR TITLE
Enable the V3 ColorPicker default visual on raylib and Skia

### DIFF
--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -10,6 +10,9 @@ Use `gh issue create` to file issues. Conventions:
 ## Before researching the source pointer
 Check the skills list for one matching the feature area and load it **before** grepping for the file:line pointer — CLAUDE.md's "load matching skills before investigating" rule applies to issue research too, not just edits. A matching skill (e.g. `gum-tool-variable-grid` for a Variables-tab/displayer report) names the relevant files and known gotchas directly instead of rediscovering them by grep.
 
+## Don't file
+Sokol is not held to per-backend feature parity — a feature that ships on the MonoGame family, raylib, and Skia but not SokolGum is not a tracked gap.
+
 ## Labels
 - **Bug reports get `--label bug`** (label exists, color `#fc2929`). Apply it at creation time.
 - The `bug` label is real and applies silently — don't second-guess it or omit it on later issues.

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
@@ -2,9 +2,17 @@
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
+using RenderingLibrary.Graphics;
+
+#if XNALIKE
 using Microsoft.Xna.Framework;
 using MonoGameGum.GueDeriving;
-using RenderingLibrary.Graphics;
+#else
+using Gum.GueDeriving;
+#endif
+#if SKIA
+using Color = SkiaSharp.SKColor;
+#endif
 
 namespace Gum.Forms.DefaultVisuals.V3;
 
@@ -94,7 +102,7 @@ public class ColorPickerVisual : InteractiveGue
     {
         RectangleRuntime outline = new RectangleRuntime();
         outline.IsFilled = false;
-        outline.StrokeColor = new Color((byte)80, (byte)80, (byte)80);
+        outline.StrokeColor = new Color(80, 80, 80);
         outline.Width = 0;
         outline.WidthUnits = DimensionUnitType.RelativeToParent;
         outline.Height = 0;
@@ -133,7 +141,7 @@ public class ColorPickerVisual : InteractiveGue
     {
         RectangleRuntime outer = new RectangleRuntime();
         outer.IsFilled = false;
-        outer.StrokeColor = new Color((byte)0, (byte)0, (byte)0);
+        outer.StrokeColor = new Color(0, 0, 0);
         outer.Width = 0;
         outer.WidthUnits = DimensionUnitType.RelativeToParent;
         outer.Height = 0;
@@ -142,7 +150,7 @@ public class ColorPickerVisual : InteractiveGue
 
         RectangleRuntime inner = new RectangleRuntime();
         inner.IsFilled = false;
-        inner.StrokeColor = new Color((byte)255, (byte)255, (byte)255);
+        inner.StrokeColor = new Color(255, 255, 255);
         inner.X = 1;
         inner.Y = 1;
         inner.Width = -2;

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -224,9 +224,7 @@ public class FormsUtilities
                 TryAdd(typeof(ScrollViewer), (_, c) => new DefaultVisuals.V3.ScrollViewerVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(TextBox), (_, c) => new DefaultVisuals.V3.TextBoxVisual(tryCreateFormsObject: c));
                 TryAdd(typeof(Slider), (_, c) => new DefaultVisuals.V3.SliderVisual(tryCreateFormsObject: c));
-#if XNALIKE
-                // ColorPickerVisual generates its saturation/value and hue textures per-pixel, which
-                // is XNA-family only for now. Raylib/Skia need their own visual (issue #4047).
+#if !SOKOL
                 TryAdd(typeof(ColorPicker), (_, c) => new DefaultVisuals.V3.ColorPickerVisual(tryCreateFormsObject: c));
 #endif
                 TryAdd(typeof(Splitter), (_, c) => new DefaultVisuals.V3.SplitterVisual(tryCreateFormsObject: c));

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -105,6 +105,7 @@
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\Styling.cs" Link="Forms\DefaultVisuals\Styling.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ButtonVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\CheckBoxVisual.cs" Link="Forms\DefaultVisuals\V3\CheckBoxVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ColorPickerVisual.cs" Link="Forms\DefaultVisuals\V3\ColorPickerVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ComboBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ComboBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\DialogBoxVisual.cs" Link="Forms\DefaultVisuals\V3\DialogBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ItemsControlVisual.cs" Link="Forms\DefaultVisuals\V3\ItemsControlVisual.cs" />

--- a/Runtimes/RaylibGum/RenderingLibrary/PixelDataTextureApplier.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/PixelDataTextureApplier.cs
@@ -1,0 +1,111 @@
+using Gum.Renderables;
+using Gum.Wireframe;
+using RenderingLibrary.Content;
+using System.Collections.Generic;
+using static Raylib_cs.Raylib;
+
+namespace RenderingLibrary;
+
+/// <summary>
+/// raylib backend for <see cref="GraphicalUiElement.ApplyCachedTextureFromPixelData"/> and
+/// <see cref="GraphicalUiElement.ApplyPooledTextureFromPixelData"/>. Cached textures live in the
+/// <see cref="LoaderManager"/> (shared across instances, unloaded on content unload). Pooled textures
+/// are reused across control instances, reclaiming entries whose owner has detached from the visual
+/// tree, so repeated create/destroy cycles never grow the pool.
+/// </summary>
+internal static class PixelDataTextureApplier
+{
+    private class PoolEntry
+    {
+        public PoolEntry(Texture2D texture) => Texture = texture;
+        public Texture2D Texture { get; }
+        public GraphicalUiElement? Owner { get; set; }
+    }
+
+    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+
+    public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        // Texture creation needs a live GL context.
+        if (!IsWindowReady())
+        {
+            return;
+        }
+
+        LoaderManager loader = LoaderManager.Self;
+        ManagedTexture? managed = loader.TryGetCachedDisposable<ManagedTexture>(cacheKey);
+        if (managed == null)
+        {
+            managed = new ManagedTexture(CreateTexture(rgba, width, height));
+            loader.AddDisposable(cacheKey, managed, LoaderManager.ExistingContentBehavior.Replace);
+        }
+
+        sprite.Texture = managed.Texture;
+    }
+
+    public static void ApplyPooled(GraphicalUiElement target, GraphicalUiElement owner, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        if (!IsWindowReady())
+        {
+            return;
+        }
+
+        PoolEntry? entry = null;
+        PoolEntry? reclaimable = null;
+        foreach (PoolEntry candidate in Pool)
+        {
+            if (candidate.Owner == owner)
+            {
+                entry = candidate;
+                break;
+            }
+            // An entry whose owner has left the visual tree (removed from root) can be reused.
+            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
+            {
+                reclaimable = candidate;
+            }
+        }
+
+        if (entry == null)
+        {
+            entry = reclaimable ?? AddPoolEntry(rgba, width, height);
+            entry.Owner = owner;
+        }
+
+        UpdateTexture(entry.Texture, rgba);
+        sprite.Texture = entry.Texture;
+    }
+
+    private static PoolEntry AddPoolEntry(byte[] rgba, int width, int height)
+    {
+        PoolEntry entry = new PoolEntry(CreateTexture(rgba, width, height));
+        Pool.Add(entry);
+        return entry;
+    }
+
+    private static Texture2D CreateTexture(byte[] rgba, int width, int height)
+    {
+        // GenImageColor produces an UncompressedR8G8B8A8 image, matching the RGBA byte layout the
+        // callers build, so UpdateTexture can push the pixels straight in.
+        Image image = GenImageColor(width, height, Color.Blank);
+        Texture2D texture = LoadTextureFromImage(image);
+        UnloadImage(image);
+
+        UpdateTexture(texture, rgba);
+        // These textures are stretched to their on-screen size, so filter smoothly rather than
+        // showing the generation resolution as blocks.
+        SetTextureFilter(texture, TextureFilter.Bilinear);
+
+        return texture;
+    }
+}

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -131,6 +131,8 @@ public class SystemManagers : ISystemManagers
             // teardown nulls UpdateFontFromProperties; without re-wiring here, the direct font-property
             // setters silently stop loading fonts after a teardown/reinitialize cycle.
             GraphicalUiElement.UpdateFontFromProperties = CustomSetPropertyOnRenderable.UpdateToFontValues;
+            GraphicalUiElement.ApplyCachedTextureFromPixelData = PixelDataTextureApplier.ApplyCached;
+            GraphicalUiElement.ApplyPooledTextureFromPixelData = PixelDataTextureApplier.ApplyPooled;
 
             // raylib seems to use a resources folder, but I don't think we should make any
             // assumptions

--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -97,6 +97,7 @@
 	<ItemGroup>
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ButtonVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\CheckBoxVisual.cs" Link="Forms\DefaultVisuals\V3\CheckBoxVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ColorPickerVisual.cs" Link="Forms\DefaultVisuals\V3\ColorPickerVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ComboBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ComboBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\DialogBoxVisual.cs" Link="Forms\DefaultVisuals\V3\DialogBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ItemsControlVisual.cs" Link="Forms\DefaultVisuals\V3\ItemsControlVisual.cs" />

--- a/Runtimes/SkiaGum/RenderingLibrary/PixelDataTextureApplier.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/PixelDataTextureApplier.cs
@@ -1,0 +1,100 @@
+using Gum.Wireframe;
+using RenderingLibrary.Content;
+using SkiaGum.Renderables;
+using SkiaSharp;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace RenderingLibrary;
+
+/// <summary>
+/// Skia backend for <see cref="GraphicalUiElement.ApplyCachedTextureFromPixelData"/> and
+/// <see cref="GraphicalUiElement.ApplyPooledTextureFromPixelData"/>. Cached bitmaps live in the
+/// <see cref="LoaderManager"/> (shared across instances, disposed on content unload). Pooled bitmaps
+/// are reused across control instances, reclaiming entries whose owner has detached from the visual
+/// tree, so repeated create/destroy cycles never grow the pool.
+/// </summary>
+internal static class PixelDataTextureApplier
+{
+    private class PoolEntry
+    {
+        public PoolEntry(SKBitmap bitmap) => Bitmap = bitmap;
+        public SKBitmap Bitmap { get; }
+        public GraphicalUiElement? Owner { get; set; }
+    }
+
+    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+
+    public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        LoaderManager loader = LoaderManager.Self;
+        SKBitmap? bitmap = loader.TryGetCachedDisposable<SKBitmap>(cacheKey);
+        if (bitmap == null)
+        {
+            bitmap = CreateBitmap(rgba, width, height);
+            loader.AddDisposable(cacheKey, bitmap, LoaderManager.ExistingContentBehavior.Replace);
+        }
+
+        sprite.Texture = bitmap;
+    }
+
+    public static void ApplyPooled(GraphicalUiElement target, GraphicalUiElement owner, byte[] rgba, int width, int height)
+    {
+        if (target?.RenderableComponent is not Sprite sprite)
+        {
+            return;
+        }
+
+        PoolEntry? entry = null;
+        PoolEntry? reclaimable = null;
+        foreach (PoolEntry candidate in Pool)
+        {
+            if (candidate.Owner == owner)
+            {
+                entry = candidate;
+                break;
+            }
+            // An entry whose owner has left the visual tree (removed from root) can be reused.
+            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
+            {
+                reclaimable = candidate;
+            }
+        }
+
+        if (entry == null)
+        {
+            entry = reclaimable ?? AddPoolEntry(rgba, width, height);
+            entry.Owner = owner;
+        }
+
+        Upload(entry.Bitmap, rgba);
+        sprite.Texture = entry.Bitmap;
+    }
+
+    private static PoolEntry AddPoolEntry(byte[] rgba, int width, int height)
+    {
+        PoolEntry entry = new PoolEntry(CreateBitmap(rgba, width, height));
+        Pool.Add(entry);
+        return entry;
+    }
+
+    private static SKBitmap CreateBitmap(byte[] rgba, int width, int height)
+    {
+        // Rgba8888 explicitly rather than the platform-native color type, so the callers' RGBA byte
+        // layout copies in directly instead of coming out channel-swapped where BGRA is native.
+        SKBitmap bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul));
+        Upload(bitmap, rgba);
+        return bitmap;
+    }
+
+    private static void Upload(SKBitmap bitmap, byte[] rgba)
+    {
+        Marshal.Copy(rgba, 0, bitmap.GetPixels(), rgba.Length);
+        bitmap.NotifyPixelsChanged();
+    }
+}

--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -79,6 +79,8 @@ namespace RenderingLibrary
                 ElementSaveExtensions.CustomCreateGraphicalComponentFunc = HandleCreateGraphicalComponent;
                 GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
                 GraphicalUiElement.UpdateFontFromProperties = UpdateFonts;
+                GraphicalUiElement.ApplyCachedTextureFromPixelData = PixelDataTextureApplier.ApplyCached;
+                GraphicalUiElement.ApplyPooledTextureFromPixelData = PixelDataTextureApplier.ApplyPooled;
 
                 GraphicalUiElement.AddRenderableToManagers = AddRenderableToManagers;
                 GraphicalUiElement.RemoveRenderableFromManagers = RemoveRenderableFromManagers;

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -93,6 +93,7 @@
 	<ItemGroup>
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ButtonVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\CheckBoxVisual.cs" Link="Forms\DefaultVisuals\V3\CheckBoxVisual.cs" />
+		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ColorPickerVisual.cs" Link="Forms\DefaultVisuals\V3\ColorPickerVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ComboBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ComboBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\DialogBoxVisual.cs" Link="Forms\DefaultVisuals\V3\DialogBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ItemsControlVisual.cs" Link="Forms\DefaultVisuals\V3\ItemsControlVisual.cs" />

--- a/Samples/MonoGameGumThemesShowcase/Screens/AllControlsScreen.cs
+++ b/Samples/MonoGameGumThemesShowcase/Screens/AllControlsScreen.cs
@@ -40,7 +40,8 @@ public class AllControlsScreen : ShowcaseScreen
 
         // Row 3
         PlaceToggleButton(col: 0, row: 3);
-        PlaceSplitter(col: 1, row: 3, colSpan: 3);
+        PlaceSplitter(col: 1, row: 3, colSpan: 2);
+        PlaceColorPicker(col: 3, row: 3);
     }
 
     // ---------- cell placement helpers ----------
@@ -327,6 +328,29 @@ public class AllControlsScreen : ShowcaseScreen
         stack.AddChild(valueLabel);
         stack.AddChild(disabledSlider);
         Position(stack, col, row);
+    }
+
+    void PlaceColorPicker(int col, int row)
+    {
+        AddHeader("ColorPicker", col, row);
+
+        var stack = new StackPanel();
+        stack.Width = CellW;
+        stack.Orientation = Orientation.Horizontal;
+        stack.Spacing = 12;
+
+        var colorPicker = new ColorPicker();
+        colorPicker.SelectedColor = System.Drawing.Color.CornflowerBlue;
+
+        var hexLabel = new Label();
+        hexLabel.Text = ToHex(colorPicker.SelectedColor);
+        colorPicker.SelectedColorChanged += (_, _) => hexLabel.Text = ToHex(colorPicker.SelectedColor);
+
+        stack.AddChild(colorPicker);
+        stack.AddChild(hexLabel);
+        Position(stack, col, row);
+
+        static string ToHex(System.Drawing.Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
     }
 
     void PlaceScrollBar(int col, int row)

--- a/Tests/RaylibGum.Tests/Forms/ColorPickerTests.cs
+++ b/Tests/RaylibGum.Tests/Forms/ColorPickerTests.cs
@@ -1,0 +1,79 @@
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Renderables;
+using Gum.Wireframe;
+using Raylib_cs;
+using RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests.Forms;
+
+/// <summary>
+/// Guards that ColorPicker is registered under the V3 default visuals on raylib, and that the
+/// per-pixel saturation/value and hue textures the control generates actually reach the display
+/// sprites through raylib's <c>PixelDataTextureApplier</c>. Mirrors
+/// <see cref="SkiaGum.Tests.Forms.ColorPickerTests"/>. Issue #4241.
+/// </summary>
+public class ColorPickerTests : BaseTestClass
+{
+    public ColorPickerTests()
+    {
+        FormsUtilities.InitializeDefaults(SystemManagers.Default, DefaultVisualsVersion.V3);
+    }
+
+    public override void Dispose()
+    {
+        FrameworkElement.DefaultFormsTemplates.Remove(typeof(ColorPicker));
+        base.Dispose();
+        TestAssemblyInitialize.ApplyDefaultTestState();
+    }
+
+    [Fact]
+    public void ColorPicker_Visual_IsRegistered_OnV3()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        colorPicker.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_HueDisplay_ReceivesGeneratedTexture()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        TextureOf(colorPicker, "HueDisplay").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_SaturationValueDisplay_ReceivesGeneratedTexture()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        TextureOf(colorPicker, "SaturationValueDisplay").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_SaturationValueDisplay_IsNotSharedBetweenLivePickers()
+    {
+        ColorPicker first = new ColorPicker();
+        ColorPicker second = new ColorPicker();
+        // Only a picker still in the visual tree holds its pooled texture; an unparented one is
+        // reclaimable, which would let both pickers land on the same entry.
+        ContainerRuntime root = new ContainerRuntime();
+        root.AddChild(first.Visual);
+        root.AddChild(second.Visual);
+
+        first.Hue = 0f;
+        second.Hue = 180f;
+
+        TextureOf(first, "SaturationValueDisplay")!.Value.Id
+            .ShouldNotBe(TextureOf(second, "SaturationValueDisplay")!.Value.Id);
+    }
+
+    private static Texture2D? TextureOf(ColorPicker colorPicker, string spriteName)
+    {
+        GraphicalUiElement element = colorPicker.Visual.GetGraphicalUiElementByName(spriteName);
+        return ((Sprite)element.RenderableComponent).Texture;
+    }
+}

--- a/Tests/SkiaGum.Tests/Forms/ColorPickerTests.cs
+++ b/Tests/SkiaGum.Tests/Forms/ColorPickerTests.cs
@@ -1,0 +1,78 @@
+using Gum;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using Shouldly;
+using SkiaGum.Renderables;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Forms;
+
+/// <summary>
+/// Guards that ColorPicker is registered under the V3 default visuals on Skia, and that the
+/// per-pixel saturation/value and hue textures the control generates actually reach the display
+/// sprites through Skia's <c>PixelDataTextureApplier</c>. Mirrors
+/// <see cref="RaylibGum.Tests.Forms.ColorPickerTests"/>. Issue #4241.
+///
+/// Calls <see cref="FormsUtilities.InitializeDefaults"/> explicitly rather than relying on
+/// <c>GumService.Initialize</c> -- the render-only SkiaGum.Standalone GumService never calls it.
+/// </summary>
+public class ColorPickerTests
+{
+    public ColorPickerTests()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(200, 100));
+        GumService.Default.Initialize(surface.Canvas, 200, 100);
+        FormsUtilities.InitializeDefaults(SystemManagers.Default, DefaultVisualsVersion.V3);
+    }
+
+    [Fact]
+    public void ColorPicker_Visual_IsRegistered_OnV3()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        colorPicker.Visual.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_HueDisplay_ReceivesGeneratedTexture()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        TextureOf(colorPicker, "HueDisplay").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_SaturationValueDisplay_ReceivesGeneratedTexture()
+    {
+        ColorPicker colorPicker = new ColorPicker();
+
+        TextureOf(colorPicker, "SaturationValueDisplay").ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ColorPicker_SaturationValueDisplay_IsNotSharedBetweenLivePickers()
+    {
+        ColorPicker first = new ColorPicker();
+        ColorPicker second = new ColorPicker();
+        // Only a picker still in the visual tree holds its pooled texture; an unparented one is
+        // reclaimable, which would let both pickers land on the same entry.
+        ContainerRuntime root = new ContainerRuntime();
+        root.AddChild(first.Visual);
+        root.AddChild(second.Visual);
+
+        first.Hue = 0f;
+        second.Hue = 180f;
+
+        TextureOf(first, "SaturationValueDisplay")
+            .ShouldNotBeSameAs(TextureOf(second, "SaturationValueDisplay"));
+    }
+
+    private static SKBitmap? TextureOf(ColorPicker colorPicker, string spriteName)
+    {
+        GraphicalUiElement element = colorPicker.Visual.GetGraphicalUiElementByName(spriteName);
+        return ((Sprite)element.RenderableComponent).Texture;
+    }
+}

--- a/docs/code/controls/colorpicker.md
+++ b/docs/code/controls/colorpicker.md
@@ -4,9 +4,7 @@
 
 The ColorPicker control lets the user pick a color by dragging in a saturation/value square and a hue bar. The chosen color is available through `SelectedColor`, and changes raise `SelectedColorChanged`.
 
-{% hint style="info" %}
-The saturation/value square and hue bar are drawn with textures generated at runtime. This generation is currently implemented for the MonoGame family (MonoGame, KNI, and FNA). On other backends the control still works, but the two backgrounds render empty until that backend implements the texture seam.
-{% endhint %}
+The saturation/value square and hue bar are drawn with textures generated at runtime, on every backend the control ships on (the MonoGame family, raylib, and SkiaSharp).
 
 ## Code Example: Creating a ColorPicker
 


### PR DESCRIPTION
Closes #4241

`ColorPickerVisual` was gated to `XNALIKE` in `FormsUtilities.InitializeDefaults` because the saturation/value square and hue bar are generated per-pixel, and only the XNA-family backend implemented the `GraphicalUiElement.ApplyCachedTextureFromPixelData` / `ApplyPooledTextureFromPixelData` seam. The `ColorPicker` control itself already lived in GumCommon and was fully backend-neutral, so the only real work was the two per-backend appliers plus making the visual compile off-XNA.

## Changes

- **raylib `PixelDataTextureApplier`** — `GenImageColor` + `LoadTextureFromImage` to allocate, `UpdateTexture` to upload, bilinear filtering since both textures are stretched to their on-screen size. Cached entries go through `LoaderManager` as `ManagedTexture`.
- **Skia `PixelDataTextureApplier`** — `SKBitmap` allocated as `Rgba8888` explicitly (not the platform-native color type, which would channel-swap the callers' RGBA bytes on BGRA platforms), uploaded with `Marshal.Copy` + `NotifyPixelsChanged`. `SilkNetGum` picks this up through its existing `SkiaGum/RenderingLibrary/**` glob.
- **`ColorPickerVisual`** made cross-platform with the usual `#if` alias header and linked into `RaylibGum`, `SkiaGum`, and `SilkNetGum`.
- **Registration gate** widened from `#if XNALIKE` to `#if !SOKOL` (SokolGum is the one backend that doesn't link the visual). Sokol parity tracked separately.
- **Themes showcase** — added a ColorPicker cell to the shared `AllControlsScreen`, narrowing the Splitter span from 3 columns to 2 to make room. That one screen drives the MonoGame, raylib, and Skia/SilkNet hosts.
- Docs hint about the backend gap removed.

## Tests

New `ColorPickerTests` in `RaylibGum.Tests` and `SkiaGum.Tests`: the V3 registration, both display sprites actually receiving a generated texture, and two live pickers not sharing one pooled texture. All four were red before the change.

Green: `RaylibGum.Tests` (575), `SkiaGum.Tests` (419), `SilkNetGum.Tests` (33), `MonoGameGum.Tests` (2083), plus `MonoGameGum.Tests.V3`, `MonoGameGum.Shapes.Tests`, and both `Gum.ProjectServices.*` runtime suites.

FRB canary: not needed — none of the touched shared files (`FormsUtilities.cs`, `ColorPickerVisual.cs`) appear in `GumCoreShared.projitems` or FRB's `FlatRedBall.Forms.Shared.projitems`.
