### PR TITLE
Deduplicate the pooled-texture bookkeeping across the three PixelDataTextureApplier backends

### DIFF
--- a/GumCommon/Content/PixelDataTexturePool.cs
+++ b/GumCommon/Content/PixelDataTexturePool.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using Gum.Wireframe;
+using System;
+using System.Collections.Generic;
+
+namespace RenderingLibrary.Content;
+
+/// <summary>
+/// Pooled-texture bookkeeping shared by every backend's pixel-data texture applier. Each owner keeps
+/// its own texture while it is in the visual tree, and an entry whose owner has detached is recycled,
+/// so repeated create/destroy cycles never grow the pool. Backends supply the texture type and how it
+/// is allocated. This is the pooled counterpart to the shared, key-based caching in
+/// <see cref="LoaderManager"/>.
+/// </summary>
+/// <typeparam name="TTexture">The backend's texture type.</typeparam>
+public class PixelDataTexturePool<TTexture>
+{
+    private class PoolEntry
+    {
+        public PoolEntry(TTexture texture) => Texture = texture;
+        public TTexture Texture { get; }
+        public GraphicalUiElement? Owner { get; set; }
+    }
+
+    private readonly List<PoolEntry> _entries;
+
+    /// <summary>
+    /// Creates an empty pool. Backends hold one per pooled texture role.
+    /// </summary>
+    public PixelDataTexturePool()
+    {
+        _entries = new List<PoolEntry>();
+    }
+
+    /// <summary>
+    /// Returns the texture belonging to <paramref name="owner"/>, reusing the texture of an entry
+    /// whose owner has left the visual tree, or calling <paramref name="create"/> when neither is
+    /// available. The returned texture holds whatever pixels it was last given, so callers upload
+    /// their pixel data to it after this returns.
+    /// </summary>
+    /// <param name="owner">The element the texture is reserved for.</param>
+    /// <param name="create">Allocates a texture. Only called when nothing can be reused.</param>
+    public TTexture GetOrCreate(GraphicalUiElement owner, Func<TTexture> create)
+    {
+        PoolEntry? entry = null;
+        PoolEntry? reclaimable = null;
+        foreach (PoolEntry candidate in _entries)
+        {
+            if (candidate.Owner == owner)
+            {
+                entry = candidate;
+                break;
+            }
+            // An entry whose owner has left the visual tree (removed from root) can be reused.
+            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
+            {
+                reclaimable = candidate;
+            }
+        }
+
+        if (entry == null)
+        {
+            entry = reclaimable ?? AddEntry(create());
+            entry.Owner = owner;
+        }
+
+        return entry.Texture;
+    }
+
+    private PoolEntry AddEntry(TTexture texture)
+    {
+        PoolEntry entry = new PoolEntry(texture);
+        _entries.Add(entry);
+        return entry;
+    }
+}

--- a/MonoGameGum.Tests/GumCommon/PixelDataTexturePoolTests.cs
+++ b/MonoGameGum.Tests/GumCommon/PixelDataTexturePoolTests.cs
@@ -1,0 +1,66 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary.Content;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.GumCommon;
+
+/// <summary>
+/// Pins the pooled-texture bookkeeping shared by every backend's PixelDataTextureApplier: an owner
+/// keeps its own texture while it is in the visual tree, and an entry whose owner has detached is
+/// recycled instead of growing the pool. Issue #4247.
+/// </summary>
+public class PixelDataTexturePoolTests : BaseTestClass
+{
+    [Fact]
+    public void GetOrCreate_ReclaimsEntryWhoseOwnerLeftTheVisualTree()
+    {
+        object detachedOwnerTexture = new object();
+        object newlyCreatedTexture = new object();
+        ContainerRuntime root = new ContainerRuntime();
+        GraphicalUiElement detachedOwner = new GraphicalUiElement();
+        GraphicalUiElement newOwner = new GraphicalUiElement();
+        root.AddChild(newOwner);
+        PixelDataTexturePool<object> pool = new PixelDataTexturePool<object>();
+        pool.GetOrCreate(detachedOwner, () => detachedOwnerTexture);
+
+        object reclaimed = pool.GetOrCreate(newOwner, () => newlyCreatedTexture);
+
+        reclaimed.ShouldBeSameAs(detachedOwnerTexture);
+    }
+
+    [Fact]
+    public void GetOrCreate_SameOwner_ReturnsTheSameTexture()
+    {
+        object firstTexture = new object();
+        object secondTexture = new object();
+        ContainerRuntime root = new ContainerRuntime();
+        GraphicalUiElement owner = new GraphicalUiElement();
+        root.AddChild(owner);
+        PixelDataTexturePool<object> pool = new PixelDataTexturePool<object>();
+        pool.GetOrCreate(owner, () => firstTexture);
+
+        object second = pool.GetOrCreate(owner, () => secondTexture);
+
+        second.ShouldBeSameAs(firstTexture);
+    }
+
+    [Fact]
+    public void GetOrCreate_SecondOwnerInVisualTree_CreatesItsOwnTexture()
+    {
+        object firstTexture = new object();
+        object secondTexture = new object();
+        ContainerRuntime root = new ContainerRuntime();
+        GraphicalUiElement firstOwner = new GraphicalUiElement();
+        GraphicalUiElement secondOwner = new GraphicalUiElement();
+        root.AddChild(firstOwner);
+        root.AddChild(secondOwner);
+        PixelDataTexturePool<object> pool = new PixelDataTexturePool<object>();
+        pool.GetOrCreate(firstOwner, () => firstTexture);
+
+        object second = pool.GetOrCreate(secondOwner, () => secondTexture);
+
+        second.ShouldBeSameAs(secondTexture);
+    }
+}

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -472,14 +472,7 @@ public partial class SystemManagers : ISystemManagers
 /// </summary>
 internal static class PixelDataTextureApplier
 {
-    private class PoolEntry
-    {
-        public PoolEntry(Texture2D texture) => Texture = texture;
-        public Texture2D Texture { get; }
-        public GraphicalUiElement? Owner { get; set; }
-    }
-
-    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+    private static readonly PixelDataTexturePool<Texture2D> Pool = new PixelDataTexturePool<Texture2D>();
 
     public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
     {
@@ -518,37 +511,11 @@ internal static class PixelDataTextureApplier
             return;
         }
 
-        PoolEntry? entry = null;
-        PoolEntry? reclaimable = null;
-        foreach (PoolEntry candidate in Pool)
-        {
-            if (candidate.Owner == owner)
-            {
-                entry = candidate;
-                break;
-            }
-            // An entry whose owner has left the visual tree (removed from root) can be reused.
-            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
-            {
-                reclaimable = candidate;
-            }
-        }
+        Texture2D texture = Pool.GetOrCreate(owner,
+            () => new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color));
 
-        if (entry == null)
-        {
-            entry = reclaimable ?? AddPoolEntry(graphicsDevice, width, height);
-            entry.Owner = owner;
-        }
-
-        entry.Texture.SetData(rgba);
-        sprite.Texture = entry.Texture;
-    }
-
-    private static PoolEntry AddPoolEntry(GraphicsDevice graphicsDevice, int width, int height)
-    {
-        PoolEntry entry = new PoolEntry(new Texture2D(graphicsDevice, width, height, false, SurfaceFormat.Color));
-        Pool.Add(entry);
-        return entry;
+        texture.SetData(rgba);
+        sprite.Texture = texture;
     }
 }
 #endif

--- a/Runtimes/RaylibGum/RenderingLibrary/PixelDataTextureApplier.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/PixelDataTextureApplier.cs
@@ -1,7 +1,6 @@
 using Gum.Renderables;
 using Gum.Wireframe;
 using RenderingLibrary.Content;
-using System.Collections.Generic;
 using static Raylib_cs.Raylib;
 
 namespace RenderingLibrary;
@@ -15,14 +14,7 @@ namespace RenderingLibrary;
 /// </summary>
 internal static class PixelDataTextureApplier
 {
-    private class PoolEntry
-    {
-        public PoolEntry(Texture2D texture) => Texture = texture;
-        public Texture2D Texture { get; }
-        public GraphicalUiElement? Owner { get; set; }
-    }
-
-    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+    private static readonly PixelDataTexturePool<Texture2D> Pool = new PixelDataTexturePool<Texture2D>();
 
     public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
     {
@@ -60,37 +52,10 @@ internal static class PixelDataTextureApplier
             return;
         }
 
-        PoolEntry? entry = null;
-        PoolEntry? reclaimable = null;
-        foreach (PoolEntry candidate in Pool)
-        {
-            if (candidate.Owner == owner)
-            {
-                entry = candidate;
-                break;
-            }
-            // An entry whose owner has left the visual tree (removed from root) can be reused.
-            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
-            {
-                reclaimable = candidate;
-            }
-        }
+        Texture2D texture = Pool.GetOrCreate(owner, () => CreateTexture(rgba, width, height));
 
-        if (entry == null)
-        {
-            entry = reclaimable ?? AddPoolEntry(rgba, width, height);
-            entry.Owner = owner;
-        }
-
-        UpdateTexture(entry.Texture, rgba);
-        sprite.Texture = entry.Texture;
-    }
-
-    private static PoolEntry AddPoolEntry(byte[] rgba, int width, int height)
-    {
-        PoolEntry entry = new PoolEntry(CreateTexture(rgba, width, height));
-        Pool.Add(entry);
-        return entry;
+        UpdateTexture(texture, rgba);
+        sprite.Texture = texture;
     }
 
     private static Texture2D CreateTexture(byte[] rgba, int width, int height)

--- a/Runtimes/SkiaGum/RenderingLibrary/PixelDataTextureApplier.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/PixelDataTextureApplier.cs
@@ -2,7 +2,6 @@ using Gum.Wireframe;
 using RenderingLibrary.Content;
 using SkiaGum.Renderables;
 using SkiaSharp;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace RenderingLibrary;
@@ -16,14 +15,7 @@ namespace RenderingLibrary;
 /// </summary>
 internal static class PixelDataTextureApplier
 {
-    private class PoolEntry
-    {
-        public PoolEntry(SKBitmap bitmap) => Bitmap = bitmap;
-        public SKBitmap Bitmap { get; }
-        public GraphicalUiElement? Owner { get; set; }
-    }
-
-    private static readonly List<PoolEntry> Pool = new List<PoolEntry>();
+    private static readonly PixelDataTexturePool<SKBitmap> Pool = new PixelDataTexturePool<SKBitmap>();
 
     public static void ApplyCached(GraphicalUiElement target, string cacheKey, byte[] rgba, int width, int height)
     {
@@ -50,37 +42,10 @@ internal static class PixelDataTextureApplier
             return;
         }
 
-        PoolEntry? entry = null;
-        PoolEntry? reclaimable = null;
-        foreach (PoolEntry candidate in Pool)
-        {
-            if (candidate.Owner == owner)
-            {
-                entry = candidate;
-                break;
-            }
-            // An entry whose owner has left the visual tree (removed from root) can be reused.
-            if (reclaimable == null && (candidate.Owner == null || candidate.Owner.Parent == null))
-            {
-                reclaimable = candidate;
-            }
-        }
+        SKBitmap bitmap = Pool.GetOrCreate(owner, () => CreateBitmap(rgba, width, height));
 
-        if (entry == null)
-        {
-            entry = reclaimable ?? AddPoolEntry(rgba, width, height);
-            entry.Owner = owner;
-        }
-
-        Upload(entry.Bitmap, rgba);
-        sprite.Texture = entry.Bitmap;
-    }
-
-    private static PoolEntry AddPoolEntry(byte[] rgba, int width, int height)
-    {
-        PoolEntry entry = new PoolEntry(CreateBitmap(rgba, width, height));
-        Pool.Add(entry);
-        return entry;
+        Upload(bitmap, rgba);
+        sprite.Texture = bitmap;
     }
 
     private static SKBitmap CreateBitmap(byte[] rgba, int width, int height)


### PR DESCRIPTION
The XNA-family, raylib, and Skia `PixelDataTextureApplier`s each carried a byte-identical owner-match/reclaim scan. That rule now lives once in `RenderingLibrary.Content.PixelDataTexturePool<TTexture>` (GumCommon), leaving each backend with only its allocate/upload code.

Homing the helper in GumCommon rather than a new `RenderingLibrary` file sidesteps the FRB friction the issue anticipated: the XNA applier already sits inside the `#if USE_GUMCOMMON` block, so no `GumCoreShared.projitems` entry and no new guard are needed, and the FRB-visible source is unchanged.

Pinned by new `PixelDataTexturePoolTests` (owner reuse, second live owner, reclaim of a detached owner — verified red by disabling the reclaim branch), plus the existing raylib/Skia ColorPicker texture tests.

Closes #4247
