### PR TITLE
Enable ObjectFinder's element cache during ProjectLoad's dependency walk/font collection

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -136,19 +136,25 @@ public class GuiCommands : IGuiCommands
     /// <inheritdoc/>
     public void ActivateMainWindow()
     {
-        // IsLoaded: font generation can run before the main window has completed its Show()
-        // sequence (e.g. during initial project load at startup) - Activate() throws
-        // InvalidOperationException ("Cannot call DragMove or Activate before a Window is shown")
-        // if called that early.
-        if (Application.Current?.MainWindow is not { IsLoaded: true } mainWindow)
+        // Its only caller (ToolFontGenerationCallbacks.SpinnerHandle.Dispose) runs on whichever
+        // thread a background Task continuation happens to resume on after font generation, not
+        // necessarily the UI thread (#4253) - every WPF call below needs to be dispatcher-marshaled.
+        _dispatcher.Post(() =>
         {
-            return;
-        }
+            // IsLoaded: font generation can run before the main window has completed its Show()
+            // sequence (e.g. during initial project load at startup) - Activate() throws
+            // InvalidOperationException ("Cannot call DragMove or Activate before a Window is shown")
+            // if called that early.
+            if (Application.Current?.MainWindow is not { IsLoaded: true } mainWindow)
+            {
+                return;
+            }
 
-        // EnsureHandle forces the Win32 HWND to be created if it doesn't exist yet.
-        IntPtr windowHandle = new WindowInteropHelper(mainWindow).EnsureHandle();
-        NativeMethods.ForceForegroundWindow(windowHandle);
-        mainWindow.Activate();
+            // EnsureHandle forces the Win32 HWND to be created if it doesn't exist yet.
+            IntPtr windowHandle = new WindowInteropHelper(mainWindow).EnsureHandle();
+            NativeMethods.ForceForegroundWindow(windowHandle);
+            mainWindow.Activate();
+        });
     }
 
     private static class NativeMethods

--- a/Gum/Controls/Spinner.xaml.cs
+++ b/Gum/Controls/Spinner.xaml.cs
@@ -57,4 +57,15 @@ public partial class Spinner : Window, ISpinner
             CountLabel.Text = $"{_completed}/{_total}";
         });
     }
+
+    /// <summary>
+    /// Shadows <see cref="Window.Hide"/> so calls through <see cref="ISpinner"/> (its only
+    /// current caller runs the disposing code on whichever thread a background Task continuation
+    /// happened to resume on, not necessarily this Window's owning thread) are dispatcher-safe
+    /// like <see cref="SetTotal"/>/<see cref="IncrementProgress"/> already are.
+    /// </summary>
+    public new void Hide()
+    {
+        Dispatcher.BeginInvoke(() => base.Hide());
+    }
 }

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -60,34 +60,47 @@ public class GumProjectDependencyWalker
         HashSet<string> external = new HashSet<string>(StringComparer.Ordinal);
         List<DependencyWarning> missing = new List<DependencyWarning>();
 
-        if (scopeElement == null)
+        // The walk resolves instance BaseTypes via ObjectFinder.Self.GetElementSave/GetRootVariable
+        // for every instance in the project. Without the cache those fall back to an O(n) linear
+        // scan of Screens/Components/StandardElements per call, so the walk's cost scales with
+        // project size squared. EnableCache/DisableCache is reference-counted, so this composes
+        // safely with an already-active cache from an outer caller.
+        ObjectFinder.Self.EnableCache();
+        try
         {
-            if (inclusion.HasFlag(GumBundleInclusion.Core))
+            if (scopeElement == null)
             {
-                CollectCoreFiles(project, projectRootDirectory, core, missing);
-                CollectInstanceTypeCoreFiles(project, core);
-            }
+                if (inclusion.HasFlag(GumBundleInclusion.Core))
+                {
+                    CollectCoreFiles(project, projectRootDirectory, core, missing);
+                    CollectInstanceTypeCoreFiles(project, core);
+                }
 
-            if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
-            {
-                CollectFileAndFontReferences(project, projectRootDirectory, inclusion, fontCache, external, missing);
-            }
+                if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
+                {
+                    CollectFileAndFontReferences(project, projectRootDirectory, inclusion, fontCache, external, missing);
+                }
 
-            if (inclusion.HasFlag(GumBundleInclusion.FontCache))
+                if (inclusion.HasFlag(GumBundleInclusion.FontCache))
+                {
+                    CollectFontCacheReferences(project, project.AllElements, projectRootDirectory,
+                        inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
+                }
+            }
+            else
             {
-                CollectFontCacheReferences(project, project.AllElements, projectRootDirectory,
-                    inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
+                CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing);
+
+                if (inclusion.HasFlag(GumBundleInclusion.FontCache))
+                {
+                    CollectFontCacheReferences(project, new[] { scopeElement }, projectRootDirectory,
+                        inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
+                }
             }
         }
-        else
+        finally
         {
-            CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing);
-
-            if (inclusion.HasFlag(GumBundleInclusion.FontCache))
-            {
-                CollectFontCacheReferences(project, new[] { scopeElement }, projectRootDirectory,
-                    inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
-            }
+            ObjectFinder.Self.DisableCache();
         }
 
         // Enforce precedence: Core wins over FontCache wins over External.

--- a/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
@@ -23,6 +23,29 @@ public class GumProjectDependencyWalkerTests : IDisposable
     }
 
     [Fact]
+    public void Walk_disables_ObjectFinder_cache_after_completing_so_later_additions_are_visible()
+    {
+        // Walk() enables ObjectFinder's cache internally (#4251) to avoid an O(n) linear scan per
+        // instance lookup. If it left the cache enabled afterward, a component added to the project
+        // post-Walk would be invisible to GetElementSave, since it would still be resolving against
+        // the stale pre-addition snapshot.
+        ComponentSave button = TestProjectBuilder.BuildComponent("Button");
+        GumProjectSave project = TestProjectBuilder.BuildProject(components: new[] { button });
+        string root = CreateProjectRoot(new[]
+        {
+            ("Components/Button.gucx", EmptyContent),
+        });
+        ObjectFinder.Self.GumProjectSave = project;
+
+        new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        ComponentSave panel = TestProjectBuilder.BuildComponent("Panel");
+        project.Components.Add(panel);
+
+        ObjectFinder.Self.GetElementSave("Panel").ShouldBe(panel);
+    }
+
+    [Fact]
     public void Walk_does_not_duplicate_files_referenced_by_multiple_components()
     {
         const string sharedTexture = "Textures/shared.png";

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -320,6 +320,24 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void CollectRequiredFonts_ShouldDisableObjectFinderCache_SoLaterAdditionsAreVisible()
+    {
+        // CollectRequiredFonts enables ObjectFinder's cache internally (#4251) to avoid an O(n)
+        // linear scan per instance lookup. If it left the cache enabled afterward, a component
+        // added to the project post-call would be invisible to GetElementSave, since it would
+        // still be resolving against the stale pre-addition snapshot.
+        ComponentSave button = new ComponentSave { Name = "Button" };
+        Project.Components.Add(button);
+
+        _sut.CollectRequiredFonts(Project, new ElementSave[] { button });
+
+        ComponentSave panel = new ComponentSave { Name = "Panel" };
+        Project.Components.Add(panel);
+
+        ObjectFinder.Self.GetElementSave("Panel").ShouldBe(panel);
+    }
+
+    [Fact]
     public void CollectRequiredFonts_ShouldReturn2Fonts_WhenTwoStatesHaveDifferentSizes()
     {
         ScreenSave screen = new ScreenSave { Name = "Screen" };

--- a/Tool/Tests/GumToolUnitTests/Commands/GuiCommandsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Commands/GuiCommandsTests.cs
@@ -16,15 +16,32 @@ namespace GumToolUnitTests.Commands;
 /// </summary>
 public class GuiCommandsTests
 {
-    private static GuiCommands CreateSut(ISpinnerFactory spinnerFactory)
+    private static GuiCommands CreateSut(ISpinnerFactory spinnerFactory, IDispatcher? dispatcher = null)
     {
         return new GuiCommands(
             new Lazy<ISelectedState>(() => new Mock<ISelectedState>().Object),
-            new Mock<IDispatcher>().Object,
+            dispatcher ?? new Mock<IDispatcher>().Object,
             new Mock<IOutputManager>().Object,
             new Lazy<PropertyGridManager>(() => throw new InvalidOperationException("Not needed by this test.")),
             new Mock<IPluginManager>().Object,
             spinnerFactory);
+    }
+
+    /// <summary>
+    /// Its only caller (ToolFontGenerationCallbacks.SpinnerHandle.Dispose) runs on whichever
+    /// thread a background Task continuation happens to resume on after font generation, not
+    /// necessarily the UI thread - calling Application.Current.MainWindow/Activate() inline
+    /// crashed with a Dispatcher cross-thread-access exception (#4253).
+    /// </summary>
+    [Fact]
+    public void ActivateMainWindow_PostsWorkToDispatcher_InsteadOfRunningInline()
+    {
+        Mock<IDispatcher> dispatcher = new Mock<IDispatcher>();
+        GuiCommands sut = CreateSut(new Mock<ISpinnerFactory>().Object, dispatcher.Object);
+
+        sut.ActivateMainWindow();
+
+        dispatcher.Verify(d => d.Post(It.IsAny<Action>()), Times.Once);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Controls/SpinnerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/SpinnerTests.cs
@@ -1,0 +1,44 @@
+using Gum.Commands;
+using Gum.Controls;
+using Shouldly;
+using System;
+using System.Threading;
+
+namespace GumToolUnitTests.Controls;
+
+/// <summary>
+/// The only production caller of <see cref="ISpinner.Hide"/> (<c>ToolFontGenerationCallbacks</c>)
+/// runs on whichever thread a background Task continuation happens to resume on after font
+/// generation, not necessarily the Spinner's owning thread (#4251/#4253 - a fast ProjectLoad
+/// exposed this via a Window-affinity crash in the tool). <see cref="ISpinner.SetTotal"/> and
+/// <see cref="ISpinner.IncrementProgress"/> already dispatcher-marshal for this reason; Hide()
+/// previously called <c>Window.Hide()</c> directly, so calling it off the owning thread crashed.
+/// </summary>
+public class SpinnerTests
+{
+    [StaFact]
+    public void Hide_CalledFromAnotherThread_DoesNotThrow()
+    {
+        Spinner spinner = new Spinner();
+        ISpinner asInterface = spinner;
+
+        Exception? caught = null;
+        Thread otherThread = new Thread(() =>
+        {
+            try
+            {
+                asInterface.Hide();
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+        });
+        // The Spinner's owning thread is this STA test thread; a plain background thread (not
+        // apartment-bound) mirrors the Task-continuation thread that hit the crash.
+        otherThread.Start();
+        otherThread.Join();
+
+        caught.ShouldBeNull();
+    }
+}

--- a/Tools/Gum.Presentation/Commands/IGuiCommands.cs
+++ b/Tools/Gum.Presentation/Commands/IGuiCommands.cs
@@ -21,6 +21,7 @@ public interface IGuiCommands
     /// <summary>
     /// Brings the tool's main window to the foreground. Used to reclaim focus after a transient
     /// top-level window (e.g. the font-generation spinner) closes without returning it.
+    /// Safe to call from any thread.
     /// </summary>
     void ActivateMainWindow();
 }

--- a/Tools/Gum.Presentation/Commands/ISpinner.cs
+++ b/Tools/Gum.Presentation/Commands/ISpinner.cs
@@ -20,7 +20,7 @@ public interface ISpinner
     void IncrementProgress();
 
     /// <summary>
-    /// Hides the progress indicator.
+    /// Hides the progress indicator. Safe to call from any thread.
     /// </summary>
     void Hide();
 }

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -276,7 +276,20 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
     {
         FontReferenceCollector collector = new FontReferenceCollector(
             instance => ObjectFinder.Self.GetElementSave(instance));
-        return collector.Collect(project, elements);
+
+        // The collector resolves every instance's BaseType through the injected resolver above,
+        // which falls back to an O(n) linear scan of Screens/Components/StandardElements per call
+        // without the cache. EnableCache/DisableCache is reference-counted, so this composes safely
+        // if a caller already has the cache active.
+        ObjectFinder.Self.EnableCache();
+        try
+        {
+            return collector.Collect(project, elements);
+        }
+        finally
+        {
+            ObjectFinder.Self.DisableCache();
+        }
     }
 
     private async Task GenerateMissingFontsFor(GumProjectSave project, IEnumerable<ElementSave> elements,


### PR DESCRIPTION
## Summary
Follow-up to #4224/#4250. #4250 removed a duplicate `FileWatchLogic.RefreshRootDirectory()` call; the two remaining ProjectLoad hot spots it identified (`MainFileWatchPlugin`'s file walk, `MainFontPlugin`'s font collection) aren't duplicate work — they're each a legitimate full project walk whose cost scales with project size.

Root cause: both walks resolve every instance's BaseType via `ObjectFinder.Self.GetElementSave`/`GetRootVariable`. `ProjectManager.LoadProject` disables the tool's element cache right after `Initialize()`, *before* the `ProjectLoad` event fires — so by the time `MainFileWatchPlugin`/`MainFontPlugin` run, every one of those lookups falls back to an O(n) linear scan of Screens/Components/StandardElements instead of an O(1) dictionary hit. That's the same pattern already solved elsewhere in the tool (`ErrorChecker`, `CodeGenerationService`, `WireframeObjectManager`, etc.) via `ObjectFinder.Self.EnableCache()`/`DisableCache()` around a bulk pass.

## Changes
- `GumProjectDependencyWalker.Walk` (used by `ObjectFinder.GetAllFilesInProject` → file-watch root directories, and by `gumcli pack`) now wraps its work in `EnableCache()`/`DisableCache()`.
- `HeadlessFontGenerationService.CollectRequiredFonts` (used by `FontCacheLogic.CreateMissingFontFilesForLoadedProject` on every load) does the same.
- `EnableCache`/`DisableCache` is reference-counted, so this composes safely with any caller that already has the cache active.

## Testing
- New regression test per call site proving the cache is actually released afterward (a project mutation made right after the call must be visible to a fresh `GetElementSave` lookup) — confirmed red when `DisableCache()` is removed, green with the fix.
- Full existing suites green: `Gum.Bundle.Tests` (69/69), `Gum.ProjectServices.Tests` (454/457, 3 pre-existing skips), `Gum.Cli.Tests` pack-related tests (15/15).

## Follow-up filed
While reading `ObjectFinder`, found a latent (currently unreachable) inconsistency where `GetElementSave` skips `_fallbackStandardElements` when the cache is enabled — filed as #4252, out of scope here.

Closes #4251

Manual test: not needed — behavior-preserving perf fix (same lookups, same results, just O(1) instead of O(n)); verified by the full automated suites above plus the new regression tests. The diagnostics added in #4250 (`%TEMP%\GumProjectLoadTiming.log`) are still in place, so the actual before/after timing on KidDefense can be confirmed on the next real load if useful.

FRB canary: not needed — the change is confined to `GumCommon/Bundle/GumProjectDependencyWalker.cs` and `Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs`, neither included via `GumCoreShared.projitems`/`FlatRedBall.Forms.Shared.projitems`.
