### PR TITLE
Cache failed font generation attempts to avoid retry storms

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -4,6 +4,7 @@ using Gum.Managers;
 using Gum.ProjectServices.FontGeneration;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -913,6 +914,67 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
     #endregion
 
     // -------------------------------------------------------------------------
+    // Failure cooldown cache (#4254)
+    // -------------------------------------------------------------------------
+
+    #region Failure cooldown cache
+
+    [Fact]
+    public void CreateFontIfNecessary_ShouldNotRetryGeneration_WhenPreviousAttemptFailedWithinCooldown()
+    {
+        ControllableFontFileGenerator generator = new() { ShouldFail = true };
+        HeadlessFontGenerationService service = new(generator);
+
+        BmfcSave bmfcSave = new() { FontName = "Nunito-Regular", FontSize = 14 };
+
+        service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+        GeneralResponse second = service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+
+        generator.GenerateFontCallCount.ShouldBe(1);
+        second.Succeeded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CreateFontIfNecessary_ShouldRetryGeneration_WhenCooldownHasElapsed()
+    {
+        ControllableFontFileGenerator generator = new() { ShouldFail = true };
+        TestableHeadlessFontGenerationService service = new(generator);
+
+        BmfcSave bmfcSave = new() { FontName = "Nunito-Regular", FontSize = 14 };
+
+        service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+        service.UtcNowOverride += TestableHeadlessFontGenerationService.FailureCooldownForTests + TimeSpan.FromSeconds(1);
+        service.CreateFontIfNecessary(bmfcSave, projectDirectory: "/tmp/test", autoSizeFontOutputs: false);
+
+        generator.GenerateFontCallCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task CreateAllMissingFontFiles_ShouldBypassCooldown_WhenForceRecreateRequested()
+    {
+        ControllableFontFileGenerator generator = new() { ShouldFail = true };
+        HeadlessFontGenerationService service = new(generator);
+
+        ScreenSave screen = new() { Name = "Screen" };
+        StateSave state = AddState(screen);
+        SetVar(state, "Font", "Nunito-Regular");
+        SetVar(state, "FontSize", 14);
+        Project.Screens.Add(screen);
+
+        await service.CreateAllMissingFontFiles(Project, "/tmp/test", forceRecreate: false);
+        int callsAfterFirstPass = generator.GenerateFontCallCount;
+
+        // A second, non-forced pass would be suppressed by the cooldown for every font that
+        // just failed. forceRecreate: true must bypass that and regenerate everything again —
+        // i.e. add exactly as many calls as the first pass made, not zero.
+        await service.CreateAllMissingFontFiles(Project, "/tmp/test", forceRecreate: true);
+
+        (generator.GenerateFontCallCount - callsAfterFirstPass).ShouldBe(callsAfterFirstPass);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
     // Windows gate (BmFontExeFileGenerator)
     // -------------------------------------------------------------------------
 
@@ -953,5 +1015,40 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
             GeneralResponse response = GeneralResponse.SuccessfulResponse;
             return Task.FromResult(response);
         }
+    }
+
+    /// <summary>
+    /// A font file generator whose success/failure and call count are controllable, for
+    /// exercising the failure-cooldown cache (#4254).
+    /// </summary>
+    private sealed class ControllableFontFileGenerator : IFontFileGenerator
+    {
+        public bool RequiresSizeEstimation { get; init; } = false;
+        public bool ShouldFail { get; init; }
+        public int GenerateFontCallCount { get; private set; }
+
+        public Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
+        {
+            GenerateFontCallCount++;
+            GeneralResponse response = ShouldFail
+                ? GeneralResponse.UnsuccessfulWith("Simulated failure")
+                : GeneralResponse.SuccessfulResponse;
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>
+    /// Exposes a settable clock so the failure cooldown can be advanced without a real wait.
+    /// </summary>
+    private sealed class TestableHeadlessFontGenerationService : HeadlessFontGenerationService
+    {
+        public static readonly TimeSpan FailureCooldownForTests = FailureCooldown;
+
+        public TimeSpan UtcNowOverride = TimeSpan.Zero;
+
+        public TestableHeadlessFontGenerationService(IFontFileGenerator fontFileGenerator)
+            : base(fontFileGenerator) { }
+
+        internal override DateTime UtcNow => base.UtcNow + UtcNowOverride;
     }
 }

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes.Variables;
 using Gum.Managers;
 using RenderingLibrary.Graphics.Fonts;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -37,6 +38,23 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
 
     private readonly IFontFileGenerator _fontFileGenerator;
     private readonly IFontGenerationCallbacks _callbacks;
+
+    /// <summary>
+    /// How long a failed generation attempt is remembered before the next request for the same
+    /// font (by <see cref="BmfcSave.FontCacheFileName"/>) is allowed to retry for real. Without
+    /// this, a single bad font reference (missing file, unresolvable system font) turns into a
+    /// full generation attempt — and exception/log line — per state/instance that references it
+    /// (#4254). A cooldown rather than a session-sticky cache lets an external fix (e.g. installing
+    /// a missing font) self-heal without requiring a project reload.
+    /// </summary>
+    internal static readonly TimeSpan FailureCooldown = TimeSpan.FromSeconds(30);
+
+    private readonly ConcurrentDictionary<string, DateTime> _recentFailures = new();
+
+    /// <summary>
+    /// Test seam — overridden by a test subclass to advance the clock without a real wait.
+    /// </summary>
+    internal virtual DateTime UtcNow => DateTime.UtcNow;
 
     /// <summary>
     /// Initializes a new instance of <see cref="HeadlessFontGenerationService"/>.
@@ -359,6 +377,15 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
     private async Task<GeneralResponse> TryCreateFontFor(BmfcSave bmfcSave, bool force, bool showSpinner,
         bool createTask, string projectDirectory, bool iterativelyDetermineSize)
     {
+        string cacheKey = bmfcSave.FontCacheFileName;
+
+        if (!force && _recentFailures.TryGetValue(cacheKey, out DateTime failedAt)
+            && UtcNow - failedAt < FailureCooldown)
+        {
+            return GeneralResponse.UnsuccessfulWith(
+                $"Skipping retry for font {bmfcSave.FontName} size {bmfcSave.FontSize} — a previous attempt failed recently.");
+        }
+
         if ((force || GetFilePath(bmfcSave, destinationDirectory: null, projectDirectory).Exists() == false)
             && _fontFileGenerator.RequiresSizeEstimation)
         {
@@ -371,6 +398,8 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
 
         if (response.Succeeded == false)
         {
+            _recentFailures[cacheKey] = UtcNow;
+
             string prefix = "Error creating font " + bmfcSave.FontName + " size " + bmfcSave.FontSize + ". ";
 
             if (!string.IsNullOrEmpty(response.Message))
@@ -381,6 +410,10 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
             {
                 _callbacks.OnOutput($"{prefix}Unknown error.");
             }
+        }
+        else
+        {
+            _recentFailures.TryRemove(cacheKey, out _);
         }
 
         return response;


### PR DESCRIPTION
## Summary
- `HeadlessFontGenerationService` now caches a failed font-generation attempt for 30s (keyed by `BmfcSave.FontCacheFileName`) and short-circuits repeat requests within that window instead of re-invoking the font generator and re-logging to the Output panel.
- `forceRecreate`/`force` (already the existing bulk-regenerate parameter) always bypasses the cooldown.
- On success, any cached failure for that font is cleared.

## Why
A single bad font reference (missing `.ttf`, unresolvable system font) previously caused a full generation attempt — and an Output-panel log line — per state/instance that referenced it, not once per unique font. On a real project (Bubblegum theme's demo screen, see #4255) this meant dozens of repeated KernSmith exceptions for the same two fonts, visibly slowing screen load. A cooldown (not a session-sticky cache) means an external fix — e.g. installing a missing system font — self-heals within seconds instead of requiring a project reload.

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 456 passed, 3 pre-existing skips.
- [x] New tests cover: cooldown suppresses an immediate retry, cooldown expiring allows a real retry (via an injectable clock seam), and `forceRecreate: true` bypasses the cooldown.
- [x] Red-first: confirmed the new tests fail without the seam (compile error), and confirmed disabling the cooldown branch turns the suppression test red.

Closes #4254
