### PR TITLE
Fix Bubblegum theme's bundled Nunito Font values to include Fonts/ path segment

### DIFF
--- a/GumCommon/Bundle/FontReferenceCollector.cs
+++ b/GumCommon/Bundle/FontReferenceCollector.cs
@@ -346,7 +346,6 @@ public class FontReferenceCollector
 
         BmfcSave bmfcSave = new BmfcSave();
         bmfcSave.FontSize = fontSize.Value;
-        bmfcSave.FontName = fontValue;
         bmfcSave.OutlineThickness = outlineValue;
         bmfcSave.UseSmoothing = fontSmoothing;
         bmfcSave.IsItalic = isItalic;
@@ -354,6 +353,16 @@ public class FontReferenceCollector
         bmfcSave.Ranges = fontRanges;
         bmfcSave.SpacingHorizontal = spacingHorizontal;
         bmfcSave.SpacingVertical = spacingVertical;
+
+        if (BmfcSave.IsFontFilePath(fontValue))
+        {
+            bmfcSave.FontFile = fontValue;
+            bmfcSave.FontName = Path.GetFileNameWithoutExtension(fontValue);
+        }
+        else
+        {
+            bmfcSave.FontName = fontValue;
+        }
 
         return bmfcSave;
     }

--- a/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
@@ -400,6 +400,43 @@ public class BubblegumTemplateTests
         actualTextStyles.ShouldBe(expectedTextStyles.OrderBy(n => n, StringComparer.Ordinal).ToList());
     }
 
+    [Fact]
+    public void AllBundledFontVariables_ShouldIncludeFontsPathSegment()
+    {
+        // ResolveFontFilePath resolves a non-rooted .ttf Font value against the project root
+        // (the .gumx's own directory), not the Fonts/ folder specifically - a bare filename
+        // (e.g. "Nunito-Regular.ttf") looks for the ttf directly in the project root and fails
+        // to find it there, even though the file is bundled at Fonts/Nunito-Regular.ttf (#4255).
+        GumProjectSave project = LoadBubblegum();
+
+        List<string> offenders = new();
+        foreach (ElementSave element in project.AllElements)
+        {
+            foreach (StateSave state in element.AllStates)
+            {
+                foreach (VariableSave variable in state.Variables)
+                {
+                    if (variable.SetsValue != true || variable.Value is not string fontValue)
+                    {
+                        continue;
+                    }
+
+                    if (!fontValue.EndsWith(".ttf", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (!fontValue.StartsWith("Fonts/", StringComparison.Ordinal))
+                    {
+                        offenders.Add($"{element.Name} [{state.Name}]: {variable.Name} = {fontValue}");
+                    }
+                }
+            }
+        }
+
+        offenders.ShouldBeEmpty();
+    }
+
     private static string GetLastNameSegment(string variableName)
     {
         int lastDotIndex = variableName.LastIndexOf('.');

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -711,6 +711,34 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
         result.Values.ShouldContain(f => f.FontName == "Verdana" && f.FontSize == 24);
     }
 
+    [Fact]
+    public void CollectRequiredFonts_ShouldSetFontFile_WhenNestedTextInComponentUsesTtfPath()
+    {
+        // Component "MyButton" has a Text instance "Label" with Font="Fonts/Custom.ttf" - a
+        // bundled .ttf file reference, not a system font family name (#4255's Bubblegum bug is
+        // exactly this shape: a themed control's nested TextInstance.Font pointing at a bundled
+        // .ttf). Screen has an instance of MyButton, so collection goes through the nested-Text
+        // resolution path (TryGetBmfcSaveFromStack), not the direct-instance path (BuildBmfcSave).
+        // Both paths must treat a .ttf Font value as a file reference: FontFile set (so the
+        // generator loads the file instead of doing a system-font lookup) and FontName reduced to
+        // the bare name (matching BuildBmfcSave's behavior for a direct instance).
+        ComponentSave component = new ComponentSave { Name = "MyButton", BaseType = "Container" };
+        StateSave componentState = AddState(component, "Default");
+        AddTextInstance(component, "Label");
+        SetVar(componentState, "Label.Font", "Fonts/Custom.ttf");
+        SetVar(componentState, "Label.FontSize", 18);
+        Project.Components.Add(component);
+
+        ScreenSave screen = new ScreenSave { Name = "MainScreen" };
+        StateSave screenState = AddState(screen, "Default");
+        screen.Instances.Add(new InstanceSave { Name = "ButtonInstance", BaseType = "MyButton" });
+        Project.Screens.Add(screen);
+
+        Dictionary<string, BmfcSave> result = _sut.CollectRequiredFonts(Project, new[] { screen });
+
+        result.Values.ShouldContain(f => f.FontName == "Custom" && f.FontFile == "Fonts/Custom.ttf");
+    }
+
     #endregion
 
     // -------------------------------------------------------------------------

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Button.gucx
@@ -145,7 +145,7 @@
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/CheckBox.gucx
@@ -282,7 +282,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ComboBox.gucx
@@ -247,7 +247,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/DialogBox.gucx
@@ -138,7 +138,7 @@
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Label.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Label.gucx
@@ -8,7 +8,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
@@ -55,7 +55,7 @@
     <State>
       <Name>Normal</Name>
       <Variable IsFont="true" Type="string" Name="Font" SetsValue="true">
-        <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+        <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
       </Variable>
       <Variable Type="int" Name="FontSize" SetsValue="true">
         <Value xsi:type="xsd:int">14</Value>
@@ -83,7 +83,7 @@
     <State>
       <Name>Strong</Name>
       <Variable IsFont="true" Type="string" Name="Font" SetsValue="true">
-        <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+        <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
       </Variable>
       <Variable Type="int" Name="FontSize" SetsValue="true">
         <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ListBoxItem.gucx
@@ -67,7 +67,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/MenuItem.gucx
@@ -109,7 +109,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="SubmenuIndicatorInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="SubmenuIndicatorInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
@@ -166,7 +166,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/PasswordBox.gucx
@@ -248,7 +248,7 @@
       <Value xsi:type="xsd:int">217</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="PlaceholderTextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="PlaceholderTextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
@@ -345,7 +345,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/RadioButton.gucx
@@ -173,7 +173,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/TextBox.gucx
@@ -250,7 +250,7 @@
       <Value xsi:type="xsd:int">217</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="PlaceholderTextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="PlaceholderTextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
@@ -342,7 +342,7 @@
       <Value xsi:type="xsd:int">85</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Toast.gucx
@@ -90,7 +90,7 @@
       <Value xsi:type="xsd:int">255</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Styles.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Styles.gucx
@@ -242,7 +242,7 @@
       <Value xsi:type="xsd:float">0</Value>
     </Variable>
     <Variable Type="string" Name="Normal.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Regular.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
     </Variable>
     <Variable Type="int" Name="Normal.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>
@@ -275,7 +275,7 @@
       <Value xsi:type="xsd:string">Default</Value>
     </Variable>
     <Variable Type="string" Name="Strong.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="Strong.FontSize" SetsValue="true">
       <Value xsi:type="xsd:int">14</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Screens/Bubblegum/DemoScreenGum.gusx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Screens/Bubblegum/DemoScreenGum.gusx
@@ -630,10 +630,10 @@
       <Value xsi:type="xsd:int">157</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TitleText.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TitleText.FontSize" SetsValue="true">
-      <Value xsi:type="xsd:int">28</Value>
+      <Value xsi:type="xsd:int">14</Value>
     </Variable>
     <Variable Type="int" Name="TitleText.Green" SetsValue="true">
       <Value xsi:type="xsd:int">107</Value>
@@ -657,10 +657,10 @@
       <Value xsi:type="xsd:int">157</Value>
     </Variable>
     <Variable IsFont="true" Type="string" Name="TitleText1.Font" SetsValue="true">
-      <Value xsi:type="xsd:string">Nunito-Bold.ttf</Value>
+      <Value xsi:type="xsd:string">Fonts/Nunito-Bold.ttf</Value>
     </Variable>
     <Variable Type="int" Name="TitleText1.FontSize" SetsValue="true">
-      <Value xsi:type="xsd:int">28</Value>
+      <Value xsi:type="xsd:int">14</Value>
     </Variable>
     <Variable Type="int" Name="TitleText1.Green" SetsValue="true">
       <Value xsi:type="xsd:int">107</Value>


### PR DESCRIPTION
## Problem
Bubblegum theme's `Font` values for the bundled Nunito font referenced bare filenames (`Nunito-Regular.ttf`, `Nunito-Bold.ttf`) instead of `Fonts/Nunito-Regular.ttf` / `Fonts/Nunito-Bold.ttf`. `ResolveFontFilePath` resolves a non-rooted `.ttf` path against the project root, not the `Fonts/` folder, so generation failed to find the file and spammed KernSmith errors on every state/instance referencing it.

## Fix 1: theme content path
- Fixed the two values in `Components/Bubblegum/Styles.gucx` (the single source of truth for `Normal.Font`/`Strong.Font`).
- Cascaded the fix to every control/screen that references those swatches via `VariableReferences` using `ThemeRecolorHelper` (`ApplyAllVariableReferences` + re-save) — 12 control files + the demo screen.
- Added `BubblegumTemplateTests.AllBundledFontVariables_ShouldIncludeFontsPathSegment`, a pinning test scanning every `.ttf`-valued `Font` variable across all elements for the `Fonts/` prefix.

## Fix 2: a second, distinct bug surfaced by manual verification
Manually testing fix 1 (New Project → Add Forms → Bubblegum → open demo screen) still showed `KernSmith error: System font 'Fonts/Nunito-Regular.ttf' not found` alongside a *successful* generation of the same conceptual font. Root cause: `FontReferenceCollector.TryGetBmfcSaveFromStack` (`GumCommon/Bundle/FontReferenceCollector.cs`) — used when collecting fonts from a Text instance nested inside a component (e.g. a themed control's `TextInstance`) — never checked `BmfcSave.IsFontFilePath`, unlike the direct-instance path (`BuildBmfcSave`) right above it in the same file. A `.ttf`-valued `Font` resolved through this path got `FontName` set to the raw path string with `FontFile` left null, so the generator fell back to a system-font lookup and failed, while a second, correctly-built `BmfcSave` for the same font (from the direct-instance collection path) succeeded — producing both a spurious error and a duplicate cache entry for the same font.

Fixed with a pinning unit test (`CollectRequiredFonts_ShouldSetFontFile_WhenNestedTextInComponentUsesTtfPath`) reproducing the exact shape (nested Text-in-component `.ttf` Font), red before the fix, green after.

## Verification
- `gumcli check`/`check-references`/`diff-standards`: all clean.
- Real `GumProjectFontGenerator` run against a scratch copy: `Font14Nunito-Regular_ttf.fnt`/`.png` and `Font14Nunito-Bold_ttf_Bold.fnt`/`.png` generate successfully.
- Fix confirmed present in the staged build output (`Gum/bin/Debug/Content/FormsThemes/Bubblegum/...`) after a full `GumFull.sln` rebuild.
- Full `Gum.ProjectServices.Tests`/`Gum.Bundle.Tests` suites green, no regressions.

Manual test: needed — retest New Project → Add Forms → Bubblegum → open `DemoScreenGum.gusx`, confirm the Tool Output panel has no KernSmith errors.

Closes #4255
