### PR TITLE
Fix ObjectFinder.GetElementSave cache-miss fallback

### DIFF
--- a/Gum/Managers/ObjectFinder.cs
+++ b/Gum/Managers/ObjectFinder.cs
@@ -354,6 +354,10 @@ public class ObjectFinder : IObjectFinder
             {
                 return cachedDictionary[elementName];
             }
+            else if(_fallbackStandardElements != null && _fallbackStandardElements.TryGetValue(elementName, out StandardElementSave? fallback))
+            {
+                return fallback;
+            }
         }
         else
         {

--- a/Tests/Gum.ProjectServices.Tests/ObjectFinderStandardElementFallbackTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ObjectFinderStandardElementFallbackTests.cs
@@ -64,4 +64,24 @@ public class ObjectFinderStandardElementFallbackTests : BaseTestClass
 
         result.ShouldBeSameAs(second);
     }
+
+    [Fact]
+    public void GetElementSave_WithCacheEnabledAndRegisteredFallback_ReturnsFallback()
+    {
+        ObjectFinder.Self.GumProjectSave = null;
+        StandardElementSave fallback = new StandardElementSave { Name = "NineSlice" };
+        ObjectFinder.Self.RegisterFallbackStandardElements(new[] { fallback });
+
+        ObjectFinder.Self.EnableCache();
+        try
+        {
+            ElementSave? result = ObjectFinder.Self.GetElementSave("NineSlice");
+
+            result.ShouldBeSameAs(fallback);
+        }
+        finally
+        {
+            ObjectFinder.Self.DisableCache();
+        }
+    }
 }


### PR DESCRIPTION
GetElementSave's cached-lookup branch returned null on a miss without checking `_fallbackStandardElements`, unlike GetStandardElement (which already falls through regardless of cache state). Cache-enabled and cache-disabled lookups now return the same result.

Closes #4252