### PR TITLE
Fix BitmapFont's space-character fallback throwing IndexOutOfRangeException

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -161,6 +161,45 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
         font.MeasureString("     ").ShouldBe(40 + 5 + 1);
     }
 
+    const string smallCharSetFontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=21 base=17 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""Font18Arial_0.png""
+chars count=1
+char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xadvance=5     page=0  chnl=15
+";
+
+    [Fact]
+    public void GetCharacterInfo_ShouldNotThrow_WhenFontIsSmallerThanSpaceCharacterIndex()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, smallCharSetFontData);
+
+        font.SetFontPattern(256, 256);
+
+        // The font's character array only extends to index 5 (its last defined char id),
+        // short of the space character's index (32). An out-of-range lookup falls back
+        // to the space character, which used to re-index the same too-short array and throw.
+        Should.NotThrow(() => font.GetCharacterInfo('A'));
+    }
+
+    [Fact]
+    public void GetCharacterInfo_ShouldFallBackToRealSpaceGlyphMetrics_NotPlaceholderMutatedByTabOrNewline()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+
+        font.SetFontPattern(256, 256);
+
+        // Codepoint 200 is out of range (the font only defines up to id 37) and falls back to
+        // the space character. SetFontPattern initially fills every array slot with a shared
+        // placeholder object, then mutates that same object in place for the tab/newline special
+        // cases, before finally overwriting index 32 with the font's real space glyph (id 32
+        // above). The fallback must reflect that real, final glyph -- not the placeholder, which
+        // by then has its texture coordinates zeroed out by the newline special-case.
+        BitmapCharacterInfo fallback = font.GetCharacterInfo((char)200);
+
+        fallback.TULeft.ShouldBe(206f / 256f);
+    }
+
     [Fact]
     public void MeasureString_ShouldIgnoreTrailingNewlines()
     {

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -41,6 +41,11 @@ public class BitmapFont : IDisposable
 
     BitmapCharacterInfo[] mCharacterInfo;
 
+    // The space character's info, used as the fallback for any out-of-range lookup.
+    // Cached directly instead of re-indexing mCharacterInfo[' '], since that index can
+    // itself be out of range for a font whose character table is smaller than 33 entries.
+    private BitmapCharacterInfo _defaultCharacterInfo;
+
     int mLineHeightInPixels;
 
     internal string mFontFile;
@@ -330,7 +335,7 @@ public class BitmapFont : IDisposable
         else
         {
             // Just return the coordinates for the space character
-            characterInfo = mCharacterInfo[' '];
+            characterInfo = _defaultCharacterInfo;
         }
 
         tVTop = characterInfo.TVTop;
@@ -350,7 +355,7 @@ public class BitmapFont : IDisposable
         }
         else
         {
-            characterInfo = mCharacterInfo[' '];
+            characterInfo = _defaultCharacterInfo;
         }
 
         return characterInfo.DistanceFromTopOfLine;
@@ -373,7 +378,7 @@ public class BitmapFont : IDisposable
         }
         else
         {
-            return mCharacterInfo[' '];
+            return _defaultCharacterInfo;
         }
     }
 
@@ -392,7 +397,7 @@ public class BitmapFont : IDisposable
         }
         else
         {
-            return mCharacterInfo[' '].ScaleY * 2;
+            return _defaultCharacterInfo.ScaleY * 2;
         }
     }
 
@@ -404,7 +409,7 @@ public class BitmapFont : IDisposable
         }
         else
         {
-            return mCharacterInfo[' '].ScaleX;
+            return _defaultCharacterInfo.ScaleX;
 
         }
     }
@@ -417,7 +422,7 @@ public class BitmapFont : IDisposable
         }
         else
         {
-            return mCharacterInfo[' '].Spacing;
+            return _defaultCharacterInfo.Spacing;
         }
     }
 
@@ -445,6 +450,7 @@ public class BitmapFont : IDisposable
 
         var charArraySize = (parsedData.Chars.LastOrDefault()?.Id + 1) ?? 0;
         mCharacterInfo = new BitmapCharacterInfo[charArraySize];
+        _defaultCharacterInfo = null;
         mLineHeightInPixels = parsedData.Common.LineHeight;
         BaselineY = parsedData.Common.Base;
 
@@ -472,11 +478,8 @@ public class BitmapFont : IDisposable
         // This used to cause a rendering crash. That was fixed but
         // even with it fixed we want to make sure we have a valid space
         // character since it's so common.
-        bool wasSpaceCreatedDynamically = false;
         if(spaceCharInfo == null)
         {
-            wasSpaceCreatedDynamically = true;
-
             var fontSize = 18;
 
             var absFontSize = System.Math.Abs(parsedData.Info.Size);
@@ -504,6 +507,9 @@ public class BitmapFont : IDisposable
         {
             var space = FillBitmapCharacterInfo(spaceCharInfo, textureWidth, textureHeight,
                 mLineHeightInPixels);
+            // Tentative fallback for a font too small to have an index 32 at all (see the
+            // final assignment below, which takes precedence once the array is fully populated).
+            _defaultCharacterInfo = space;
 
             for (int i = 0; i < charArraySize; i++)
             {
@@ -542,13 +548,11 @@ public class BitmapFont : IDisposable
                 textureHeight, mLineHeightInPixels);
         }
 
-        if(wasSpaceCreatedDynamically)
+        // Prefer the font's real space glyph (now in its final, non-placeholder form) if the
+        // array is large enough to hold it.
+        if (mCharacterInfo.Length > (int)' ')
         {
-            if(mCharacterInfo.Length > (int)' ')
-            {
-                mCharacterInfo[' '] = FillBitmapCharacterInfo(spaceCharInfo, textureWidth,
-                    textureHeight, mLineHeightInPixels);
-            }
+            _defaultCharacterInfo = mCharacterInfo[' '];
         }
 
         foreach (var kerning in parsedData.Kernings)
@@ -1169,16 +1173,7 @@ public class BitmapFont : IDisposable
         for (int i = 0; i < line.Length; i++)
         {
             char character = line[i];
-            BitmapCharacterInfo characterInfo = null;
-            try
-            {
-                characterInfo = GetCharacterInfo(character);
-            }
-            catch
-            {
-                // If we can't measure a character due to it missing, we shouldn't throw an exception here.
-                // By catching the exception, we allow Gum to work even if it's missing characters
-            }
+            BitmapCharacterInfo characterInfo = GetCharacterInfo(character);
 
             if (characterInfo != null)
             {


### PR DESCRIPTION
## Problem
`BitmapFont.GetCharacterInfo` (and 5 sibling methods: `AssignCharacterTextureCoordinates`, `DistanceFromTopOfLine`, `GetCharacterHeight`, `GetCharacterScaleX`, `GetCharacterSpacing`) fell back to `mCharacterInfo[' ']` for any out-of-range codepoint lookup. That index (32) can itself be out of bounds for a font whose character table has fewer than 33 entries, throwing `IndexOutOfRangeException`. `MeasureString` silently swallowed this per character via a `try`/`catch` -- expensive under a debugger, and the exact mechanism #4168 (previously titled around the Bubblegum-theme slowdown) hypothesized.

## Fix
- Cache the resolved space glyph in a new `_defaultCharacterInfo` field, set once `SetFontPattern` finishes populating the array, instead of re-indexing `mCharacterInfo[' ']` at every fallback call site.
- Removed `MeasureString`'s now-dead `try`/`catch` (`GetCharacterInfo` can no longer throw).
- Removed a redundant re-fill of `mCharacterInfo[' ']` in `SetFontPattern` that recomputed an already-identical value.

## A regression along the way
My first pass cached `_defaultCharacterInfo` too early -- before `SetFontPattern`'s per-character loop overwrites index 32 with the font's real, final space glyph (it starts from a shared placeholder object that the tab/newline special-casing also mutates in place). Two existing tests (`WrappedText_ShouldRemoveZeroWidthSpace_WhenBreakingAtIt`, `WrappedText_ShouldHandleMultipleZeroWidthSpaces_InSameWord`) caught this by going red. Fixed by moving the assignment to after that loop, and added a dedicated regression test (`GetCharacterInfo_ShouldFallBackToRealSpaceGlyphMetrics_NotPlaceholderMutatedByTabOrNewline`) pinning it.

## Testing
- `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` -- 2088 passed.
- New tests: reproduces the `IndexOutOfRangeException` for a small font (red before the fix), and pins the real-vs-placeholder space glyph regression (red without the post-loop reassignment).
- `RaylibGum.Tests` / `SkiaGum.Tests` build clean (0 errors) -- `BitmapFont.cs` is shared across these runtimes.

Manual test: not needed -- the observable behavior (fallback glyph metrics, wrapped line content) is pinned exactly by the unit tests above; a manual check would only approximate the same data by eye.

FRB canary: needed -- `BitmapFont.cs` is FRB1-shared via `GumCoreShared.projitems`. No platform `#if` or new BCL APIs touched, so risk is low, but will run once the primary checkout is free.

Closes #4168
