### PR TITLE
Ensure FontCache/ always exists and clear-font-cache preserves the folder

### DIFF
--- a/Gum/Services/Fonts/FontManager.cs
+++ b/Gum/Services/Fonts/FontManager.cs
@@ -35,11 +35,12 @@ public class FontManager : IFontManager
     }
 
     /// <summary>
-    /// Deletes the font cache folder for the current project.
+    /// Clears the font cache for the current project. The folder itself is left in place (rather
+    /// than deleted and later re-created) so it can always be watched from project load onward (#4259).
     /// </summary>
     public void DeleteFontCacheFolder()
     {
-        _fileCommands.DeleteDirectory(AbsoluteFontCacheFolder);
+        _fileCommands.ClearDirectoryContents(AbsoluteFontCacheFolder);
     }
 
     /// <summary>

--- a/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
+++ b/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
@@ -104,6 +104,40 @@ public class FileManagerTests : IDisposable
     }
 
     [Fact]
+    public void ClearDirectoryContents_ShouldDeleteFilesAndSubdirectories_ButKeepDirectoryItself()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "GumClearDirectoryContentsTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string subDirectory = Path.Combine(root, "SubDirectory");
+        Directory.CreateDirectory(subDirectory);
+        File.WriteAllText(Path.Combine(root, "file.txt"), "contents");
+        File.WriteAllText(Path.Combine(subDirectory, "nested.txt"), "contents");
+
+        try
+        {
+            FileManager.ClearDirectoryContents(root);
+
+            Directory.Exists(root).ShouldBeTrue();
+            Directory.GetFileSystemEntries(root).ShouldBeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ClearDirectoryContents_ShouldNotThrow_WhenDirectoryDoesNotExist()
+    {
+        string missingDirectory = Path.Combine(Path.GetTempPath(), "GumClearDirectoryContentsTests_Missing_" + Guid.NewGuid().ToString("N"));
+
+        Should.NotThrow(() => FileManager.ClearDirectoryContents(missingDirectory));
+    }
+
+    [Fact]
     public void GetMacOSBundleResourcesPath_ShouldResolveRealFile_WhenContentShippedInResources()
     {
         // Build a real .app directory layout in a temp dir: content physically in Resources, nothing

--- a/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileWatchManagerTests.cs
@@ -159,6 +159,27 @@ public class FileWatchManagerTests : IDisposable
     }
 
     [Fact]
+    public void EnableWithDirectories_ShouldCreateDirectory_WhenWatchedDirectoryDoesNotExistYet()
+    {
+        // Issue #4259: watching a directory that hasn't been created yet (e.g. FontCache/ before
+        // the first font is generated) used to throw and log a spurious error. The directory
+        // should simply be created so the watch can proceed.
+        string missingDirectory = Path.Combine(_tempDirectory, "FontCache");
+        FilePath watchedDirectory = new FilePath(missingDirectory + "/");
+        FileWatchManager sut = BuildSut(
+            out Mock<IGuiCommands> guiCommandsMock,
+            out _,
+            out _,
+            watchedDirectory);
+
+        sut.EnableWithDirectories(new HashSet<FilePath> { watchedDirectory });
+
+        Directory.Exists(missingDirectory).ShouldBeTrue();
+        sut.Enabled.ShouldBeTrue();
+        guiCommandsMock.Verify(g => g.PrintOutput(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
     public void IgnoreNextChangeUntil_ShouldSuppressQueuedChange_ForIgnoredFile()
     {
         FilePath watchedDirectory = new FilePath(_tempDirectory + "/");

--- a/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectCreatorTests.cs
@@ -41,6 +41,19 @@ public class ProjectCreatorTests : IDisposable
     }
 
     [Fact]
+    public void Create_ShouldCreateFontCacheFolder()
+    {
+        // FontCache/ should exist as soon as the project is created, even before any font has
+        // been generated - otherwise the file watcher errors trying to watch a folder that
+        // doesn't exist yet on a freshly-created project (#4259).
+        string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");
+
+        _sut.Create(filePath);
+
+        Directory.Exists(Path.Combine(_tempDirectory, "FontCache")).ShouldBeTrue();
+    }
+
+    [Fact]
     public void Create_ShouldProduceLoadableProject()
     {
         string filePath = Path.Combine(_tempDirectory, "TestProject.gumx");

--- a/Tool/Tests/GumToolUnitTests/Managers/FontManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/FontManagerTests.cs
@@ -99,6 +99,21 @@ public class FontManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void DeleteFontCacheFolder_ShouldClearContents_ButKeepFolderItself()
+    {
+        // The FontCache folder should always exist (#4259) so it can be watched from project load
+        // onward - clearing the cache must not delete the folder itself, only its contents.
+        string expectedFontCacheFolder = new FilePath(_fontManager.AbsoluteFontCacheFolder).FullPath;
+
+        _fontManager.DeleteFontCacheFolder();
+
+        _fileCommandsMock.Verify(f => f.ClearDirectoryContents(
+            It.Is<FilePath>(p => p.FullPath == expectedFontCacheFolder)),
+            Times.Once);
+        _fileCommandsMock.Verify(f => f.DeleteDirectory(It.IsAny<FilePath>()), Times.Never);
+    }
+
+    [Fact]
     public void GenerateMissingFontsForReferencingElements_ShouldDelegateToHeadlessService()
     {
         GumProjectSave gumProject = new GumProjectSave();

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
@@ -1010,6 +1010,7 @@ public class GumxImportServiceTests : IDisposable
         public bool TryAutoSaveProject(bool forceSaveContainedElements = false) => false;
         public void LoadProject(string fileName) { }
         public void DeleteDirectory(FilePath filePath) { }
+        public void ClearDirectoryContents(FilePath filePath) { }
         public void MoveToRecycleBin(FilePath filePath) { }
         public string[] GetFiles(string path) => Array.Empty<string>();
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => Array.Empty<string>();

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/ImportFromGumxViewModelTests.cs
@@ -498,6 +498,7 @@ public class ImportFromGumxViewModelTests
         public bool TryAutoSaveProject(bool forceSaveContainedElements = false) => false;
         public void LoadProject(string fileName) { }
         public void DeleteDirectory(FilePath filePath) { }
+        public void ClearDirectoryContents(FilePath filePath) { }
         public void MoveToRecycleBin(FilePath filePath) { }
         public string[] GetFiles(string path) => Array.Empty<string>();
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => Array.Empty<string>();

--- a/Tools/Gum.Presentation/Commands/FileCommands.cs
+++ b/Tools/Gum.Presentation/Commands/FileCommands.cs
@@ -68,6 +68,9 @@ public class FileCommands : IFileCommands
     public void DeleteDirectory(FilePath directory) =>
         FileManager.DeleteDirectory(directory.FullPath);
 
+    public void ClearDirectoryContents(FilePath directory) =>
+        FileManager.ClearDirectoryContents(directory.FullPath);
+
     public void MoveToRecycleBin(FilePath filePath) =>
         _recycleBinService.MoveToRecycleBin(filePath);
 

--- a/Tools/Gum.Presentation/Commands/IFileCommands.cs
+++ b/Tools/Gum.Presentation/Commands/IFileCommands.cs
@@ -17,6 +17,11 @@ public interface IFileCommands
     void DeleteDirectory(FilePath filePath);
 
     /// <summary>
+    /// Deletes everything inside <paramref name="directory"/> but leaves the directory itself in place.
+    /// </summary>
+    void ClearDirectoryContents(FilePath directory);
+
+    /// <summary>
     /// Moves a file to the recycle bin rather than permanently deleting it.
     /// Currently uses Microsoft.VisualBasic.FileIO (Windows-only). If Gum ever
     /// moves to a cross-platform UI, update the implementation here.

--- a/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
+++ b/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
@@ -89,6 +89,13 @@ public class FileWatchManager : IFileWatchManager
             var pathToAssign = filePathAsString.Substring(0, filePathAsString.Length - 1);
             try
             {
+                // The directory may not exist yet (e.g. FontCache/ before the first font has been
+                // generated) - create it rather than letting FileSystemWatcher throw (#4259).
+                if (!Directory.Exists(pathToAssign))
+                {
+                    Directory.CreateDirectory(pathToAssign);
+                }
+
                 fileWatcher.Path = pathToAssign;
                 fileWatcher.EnableRaisingEvents = true;
                 fileSystemWatchers.Add(fileWatcher);

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesChangeLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesChangeLogic.cs
@@ -184,7 +184,7 @@ public class ProjectPropertiesChangeLogic
                                 wasAbleToDelete = false;
 
                                 string message =
-                                    "Attempted to delete font cache folder to re-create it with the new font range values " +
+                                    "Attempted to clear the font cache to re-create it with the new font range values " +
                                     $"but was unable to do so:\n\n{exception}";
                                 _dialogService.ShowMessage(message);
                             }
@@ -242,7 +242,7 @@ public class ProjectPropertiesChangeLogic
                 catch (System.IO.IOException exception)
                 {
                     _dialogService.ShowMessage(
-                        "Attempted to delete font cache folder to re-create it with the new font generator " +
+                        "Attempted to clear the font cache to re-create it with the new font generator " +
                         $"but was unable to do so:\n\n{exception}");
                     break;
                 }

--- a/Tools/Gum.Presentation/Services/Fonts/IFontManager.cs
+++ b/Tools/Gum.Presentation/Services/Fonts/IFontManager.cs
@@ -25,7 +25,8 @@ public interface IFontManager : IRuntimeFontService
     string AbsoluteFontCacheFolder { get; }
 
     /// <summary>
-    /// Deletes the font cache folder for the current project.
+    /// Clears the font cache for the current project. The folder itself is left in place so it
+    /// can always be watched (#4259) - only its contents are deleted.
     /// </summary>
     void DeleteFontCacheFolder();
 

--- a/Tools/Gum.ProjectServices/ProjectCreator.cs
+++ b/Tools/Gum.ProjectServices/ProjectCreator.cs
@@ -13,7 +13,10 @@ public class ProjectCreator : IProjectCreator
         "Screens",
         "Components",
         "Standards",
-        "Behaviors"
+        "Behaviors",
+        // Created up front (rather than lazily on first font generation) so the file watcher
+        // never has to watch a directory that doesn't exist yet on a freshly-created project (#4259).
+        "FontCache"
     };
 
     // ColoredRectangle is intentionally omitted: the v3 Rectangle carries the full

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -1001,12 +1001,24 @@ namespace ToolsUtilities
 
         public static void DeleteDirectory(string dir)
         {
+            if (!System.IO.Directory.Exists(dir)) return;
+
+            ClearDirectoryContents(dir);
+
+            System.IO.Directory.Delete(dir);
+        }
+
+        /// <summary>
+        /// Deletes everything inside <paramref name="dir"/> but leaves the directory itself in place.
+        /// </summary>
+        public static void ClearDirectoryContents(string dir)
+        {
             System.IO.DirectoryInfo info = new System.IO.DirectoryInfo(dir);
             if (!info.Exists) return;
 
             // Set the folder to NORMAL so it doesn't retain READONLY or ARCHIVE attributes
             // This happens because of OneDrive
-            // Shouldn't matter if we change the attributes, we're going to delete the folder anyways
+            // Shouldn't matter if we change the attributes, we're going to delete the contents anyways
             info.Attributes = FileAttributes.Normal;
 
             string[] files = System.IO.Directory.GetFiles(dir);
@@ -1020,9 +1032,6 @@ namespace ToolsUtilities
             {
                 DeleteDirectory(dirs[i]);
             }
-
-
-            System.IO.Directory.Delete(dir);
         }
 
         private static bool DeleteTargetFileIfExists(string targetFileName)


### PR DESCRIPTION
Closes #4259

## Changes
- `ProjectCreator` now creates `FontCache/` alongside the other standard subfolders (Screens, Components, Standards, Behaviors) when a project is created, so it always exists - even before any font has been generated.
- `FileWatchManager.EnableWithDirectories` creates a watched directory if it doesn't already exist instead of throwing and logging an error. This covers projects created before this fix.
- `FontManager.DeleteFontCacheFolder` (the "Clear Font Cache" menu item, and font-range/font-generator changes) now clears the folder's *contents* instead of deleting the folder itself, via a new `FileManager.ClearDirectoryContents` / `IFileCommands.ClearDirectoryContents`. This keeps Explorer from losing its place when a user is iterating on font-cache bugs, and keeps the folder always present for the file watcher.

## Test plan
- [x] New/updated unit tests (`ProjectCreatorTests`, `FileWatchManagerTests`, `FileManagerTests`, `FontManagerTests`) - all green.
- [x] `dotnet build GumFull.sln` - 0 errors, no new warnings.

Manual test: needed (tool UI behavior).
1. Open `Gum.sln`, run the tool, create a new project.
2. Check the Output panel - no "Error trying to watch ... FontCache" message, and `FontCache/` exists on disk next to the `.gumx` immediately.
3. Add a Text instance and set a font so a font file generates. Content > Clear Font Cache. Confirm `FontCache/` still exists in Explorer (doesn't disappear/reappear) and is empty, then re-open the project (or trigger regeneration) to confirm fonts regenerate normally.
