### PR TITLE
Add menu item to open the global settings folder

### DIFF
--- a/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
+++ b/Gum/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManager.cs
@@ -13,6 +13,7 @@ using Gum.Dialogs;
 using Gum.Messages;
 using Gum.Services.Dialogs;
 using CommunityToolkit.Mvvm.Messaging;
+using ToolsUtilities;
 
 namespace Gum.Managers
 {
@@ -51,6 +52,7 @@ namespace Gum.Managers
         private MenuItem _undoMenuItem;
         private MenuItem _redoMenuItem;
         private MenuItem _standardsPaletteMenuItem;
+        private MenuItem _openSettingsFolderMenuItem;
 
         #endregion
 
@@ -246,11 +248,24 @@ namespace Gum.Managers
             _viewMenuItem.Header = "View";
 
 
+            _openSettingsFolderMenuItem = new MenuItem();
+            _openSettingsFolderMenuItem.Header = "Open Settings Folder...";
+            _openSettingsFolderMenuItem.ToolTip = "Open the folder containing Gum's global settings files";
+            _openSettingsFolderMenuItem.Click += (_, _) =>
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = FileManager.UserApplicationDataForThisApplication,
+                    UseShellExecute = true
+                });
+            };
+
             _helpMenuItem = new MenuItem();
             _helpMenuItem.Header = "Help";
             _helpMenuItem.Items.Add(_aboutMenuItem);
             _helpMenuItem.Items.Add(_thirdPartyLicensesMenuItem);
             _helpMenuItem.Items.Add(_documentationMenuItem);
+            _helpMenuItem.Items.Add(_openSettingsFolderMenuItem);
 
 
             _fileMenuItem = new MenuItem();

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/MenuStripPlugin/MenuStripManagerTests.cs
@@ -149,6 +149,18 @@ public class MenuStripManagerTests : BaseTestClass
     }
 
     [StaFact]
+    public void PopulateMenu_ShouldAddOpenSettingsFolderItemToHelpMenu()
+    {
+        var menu = new Menu();
+
+        _menuStripManager.PopulateMenu(menu);
+
+        var helpMenu = (MenuItem)menu.Items[5];
+        helpMenu.Items.OfType<MenuItem>()
+            .ShouldContain(mi => mi.Header as string == "Open Settings Folder...");
+    }
+
+    [StaFact]
     public void GetItem_ShouldReturnNull_WhenItemDoesNotExist()
     {
         var menu = new Menu();


### PR DESCRIPTION
Closes #4261

Adds a "Open Settings Folder..." item under Help that opens `%AppData%\Gum\` in Explorer, so users can find/back up `appsettings.json` and `GeneralSettings.xml` without knowing the path.

## Test plan
- `MenuStripManagerTests.PopulateMenu_ShouldAddOpenSettingsFolderItemToHelpMenu` (new, was red before the fix)
- Full `MenuStripManagerTests` suite green (17/17)
- `dotnet build GumFull.sln` clean
