### PR TITLE
Sort STANDARDS palette chips alphabetically

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -555,7 +555,18 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 .Select(standard => standard.Name)
                 .ToList();
 
-        _viewCreator.StandardsPalette.RefreshChips(typeNames);
+        _viewCreator.StandardsPalette.RefreshChips(SortStandardTypeNamesForPalette(typeNames));
+    }
+
+    /// <summary>
+    /// Alphabetizes standard type names for the palette, matching the ordering the classic
+    /// "Standard" tree folder applies via <c>SortByName</c> -- the palette otherwise inherits
+    /// <see cref="GumProjectSave.StandardElements"/>'s dictionary-insertion order, which has no
+    /// relation to display order.
+    /// </summary>
+    internal static List<string> SortStandardTypeNamesForPalette(IReadOnlyList<string> typeNames)
+    {
+        return typeNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private void AddStandardInstanceToCurrentElement(string typeName)

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerStandardsPaletteTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerStandardsPaletteTests.cs
@@ -1,0 +1,27 @@
+using Gum.Managers;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+public class ElementTreeViewManagerStandardsPaletteTests : BaseTestClass
+{
+    [Fact]
+    public void SortStandardTypeNamesForPalette_UnsortedNames_ReturnsAlphabeticalOrder()
+    {
+        List<string> typeNames = new List<string> { "Text", "Sprite", "Container", "Circle", "Rectangle", "Polygon", "NineSlice" };
+
+        List<string> result = ElementTreeViewManager.SortStandardTypeNamesForPalette(typeNames);
+
+        result.ShouldBe(new[] { "Circle", "Container", "NineSlice", "Polygon", "Rectangle", "Sprite", "Text" });
+    }
+
+    [Fact]
+    public void SortStandardTypeNamesForPalette_EmptyInput_ReturnsEmpty()
+    {
+        List<string> result = ElementTreeViewManager.SortStandardTypeNamesForPalette(new List<string>());
+
+        result.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- The STANDARDS chip palette listed types in `StandardElementsManager.Initialize()`'s dictionary-insertion order (Text, Sprite, Container, Circle, Rectangle, Polygon, NineSlice), an implementation detail with no relation to display order.
- The classic "Standard" tree folder already alphabetizes via `SortByName`; applied the same ordering to the palette via a new `ElementTreeViewManager.SortStandardTypeNamesForPalette` helper.

## Test plan
- [x] New unit tests in `ElementTreeViewManagerStandardsPaletteTests.cs`
- [x] Full `GumToolUnitTests` suite green (1199 passed, 2 pre-existing skips)
- [x] `dotnet build GumFull.sln` clean, no new warnings

Closes #4264
