### PR TITLE
Report accurate font-generation summary when fonts are cache hits

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -6,6 +6,7 @@ using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ToolsUtilities;
@@ -1021,6 +1022,84 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
     #endregion
 
     // -------------------------------------------------------------------------
+    // Generation summary message (#4266): "Created font files" was shown even
+    // when every font was already cached and nothing was actually generated.
+    // -------------------------------------------------------------------------
+
+    #region Generation summary message
+
+    [Fact]
+    public void BuildFontGenerationSummaryMessage_ShouldReportAllUpToDate_WhenNothingWasAttempted()
+    {
+        string message = HeadlessFontGenerationService.BuildFontGenerationSummaryMessage(
+            totalFontCount: 3, attemptedCount: 0, elapsedTime: TimeSpan.FromSeconds(0.4));
+
+        message.ShouldBe("All 3 font files already up to date");
+    }
+
+    [Fact]
+    public void BuildFontGenerationSummaryMessage_ShouldReportCreatedOnly_WhenEveryFontWasAttempted()
+    {
+        string message = HeadlessFontGenerationService.BuildFontGenerationSummaryMessage(
+            totalFontCount: 3, attemptedCount: 3, elapsedTime: TimeSpan.FromSeconds(0.4));
+
+        message.ShouldBe("Created 3 font files in 0.4 seconds");
+    }
+
+    [Fact]
+    public void BuildFontGenerationSummaryMessage_ShouldReportBothCounts_WhenOnlySomeFontsWereAttempted()
+    {
+        string message = HeadlessFontGenerationService.BuildFontGenerationSummaryMessage(
+            totalFontCount: 3, attemptedCount: 1, elapsedTime: TimeSpan.FromSeconds(0.4));
+
+        message.ShouldBe("Created 1 font files (2 already up to date) in 0.4 seconds");
+    }
+
+    [Fact]
+    public async Task CreateAllMissingFontFiles_ShouldReportAlreadyUpToDate_WhenFontFileAlreadyExistsOnDisk()
+    {
+        // Regression guard for #4266: a cache hit (font file already on disk, nothing
+        // generated) must not be reported as "Created font files".
+        string projectDirectory = Path.Combine(Path.GetTempPath(), "GumFontGenTest_" + Guid.NewGuid()) + Path.DirectorySeparatorChar;
+        Directory.CreateDirectory(projectDirectory);
+        try
+        {
+            ScreenSave screen = new ScreenSave { Name = "Screen" };
+            StateSave state = AddState(screen);
+            SetVar(state, "Font", "Arial");
+            SetVar(state, "FontSize", 14);
+            Project.Screens.Add(screen);
+
+            // project.AllElements (walked internally by CreateAllMissingFontFiles) includes the
+            // Text standard element itself, whose Default state has its own Font/FontSize
+            // (Arial@18, set in this class's constructor) — so 2 fonts are required in total, not 1.
+            foreach (BmfcSave requiredFont in new[]
+                     {
+                         new BmfcSave { FontName = "Arial", FontSize = 14 },
+                         new BmfcSave { FontName = "Arial", FontSize = 18 }
+                     })
+            {
+                string cachedFntPath = Path.Combine(projectDirectory, requiredFont.FontCacheFileName);
+                Directory.CreateDirectory(Path.GetDirectoryName(cachedFntPath)!);
+                File.WriteAllText(cachedFntPath, "cached");
+            }
+
+            RecordingFontGenerationCallbacks callbacks = new();
+            HeadlessFontGenerationService service = new(new NoOpFontFileGenerator(), callbacks);
+
+            await service.CreateAllMissingFontFiles(Project, projectDirectory, forceRecreate: false);
+
+            callbacks.Messages.ShouldContain("All 2 font files already up to date");
+        }
+        finally
+        {
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
     // Windows gate (BmFontExeFileGenerator)
     // -------------------------------------------------------------------------
 
@@ -1081,6 +1160,16 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
                 : GeneralResponse.SuccessfulResponse;
             return Task.FromResult(response);
         }
+    }
+
+    /// <summary>
+    /// Captures <see cref="IFontGenerationCallbacks.OnOutput"/> messages for assertions.
+    /// </summary>
+    private sealed class RecordingFontGenerationCallbacks : IFontGenerationCallbacks
+    {
+        public List<string> Messages { get; } = new();
+
+        public void OnOutput(string message) => Messages.Add(message);
     }
 
     /// <summary>

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ToolsUtilities;
@@ -352,6 +353,7 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
         }
 
         List<Task> tasks = new List<Task>();
+        ConcurrentBag<bool> didAttemptFlags = new();
 
         int completed = 0;
         _callbacks.OnFontProgress(0, bitmapFonts.Count);
@@ -361,8 +363,13 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
             System.Diagnostics.Debug.WriteLine($"Starting {item.Key}");
             Task task = TryCreateFontFor(item.Value, forceRecreate, showSpinner: false, createTask: true,
                 projectDirectory, project.AutoSizeFontOutputs)
-                .ContinueWith(_ =>
+                .ContinueWith(t =>
                 {
+                    if (t.Status == TaskStatus.RanToCompletion && t.Result is OptionallyAttemptedGeneralResponse response)
+                    {
+                        didAttemptFlags.Add(response.DidAttempt);
+                    }
+
                     int current = Interlocked.Increment(ref completed);
                     _callbacks.OnFontProgress(current, bitmapFonts.Count);
                 });
@@ -383,8 +390,30 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
         TimeSpan time = end - start;
         if (bitmapFonts.Count > 0)
         {
-            _callbacks.OnOutput($"Created font files in {time.TotalSeconds:F1} seconds");
+            int attemptedCount = didAttemptFlags.Count(didAttempt => didAttempt);
+            _callbacks.OnOutput(BuildFontGenerationSummaryMessage(bitmapFonts.Count, attemptedCount, time));
         }
+    }
+
+    /// <summary>
+    /// Builds the summary message shown after a font-generation pass. <paramref name="attemptedCount"/>
+    /// is how many of the <paramref name="totalFontCount"/> fonts actually needed (re)generation — the
+    /// rest were already cached on disk. Reported separately so a cache-hit run (#4266) doesn't claim
+    /// "Created" when nothing was actually created.
+    /// </summary>
+    internal static string BuildFontGenerationSummaryMessage(int totalFontCount, int attemptedCount, TimeSpan elapsedTime)
+    {
+        if (attemptedCount == 0)
+        {
+            return $"All {totalFontCount} font files already up to date";
+        }
+
+        if (attemptedCount == totalFontCount)
+        {
+            return $"Created {totalFontCount} font files in {elapsedTime.TotalSeconds:F1} seconds";
+        }
+
+        return $"Created {attemptedCount} font files ({totalFontCount - attemptedCount} already up to date) in {elapsedTime.TotalSeconds:F1} seconds";
     }
 
     private async Task<GeneralResponse> TryCreateFontFor(BmfcSave bmfcSave, bool force, bool showSpinner,
@@ -395,8 +424,12 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
         if (!force && _recentFailures.TryGetValue(cacheKey, out DateTime failedAt)
             && UtcNow - failedAt < FailureCooldown)
         {
-            return GeneralResponse.UnsuccessfulWith(
-                $"Skipping retry for font {bmfcSave.FontName} size {bmfcSave.FontSize} — a previous attempt failed recently.");
+            return new OptionallyAttemptedGeneralResponse
+            {
+                Succeeded = false,
+                DidAttempt = false,
+                Message = $"Skipping retry for font {bmfcSave.FontName} size {bmfcSave.FontSize} — a previous attempt failed recently."
+            };
         }
 
         if ((force || GetFilePath(bmfcSave, destinationDirectory: null, projectDirectory).Exists() == false)
@@ -476,6 +509,7 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
                 GeneralResponse generateResponse = await _fontFileGenerator.GenerateFont(
                     bmfcSave, desiredFntFile.FullPath, createTask);
 
+                toReturn.DidAttempt = true;
                 toReturn.Succeeded = generateResponse.Succeeded;
                 toReturn.Message = generateResponse.Message;
             }


### PR DESCRIPTION
## Summary
- `HeadlessFontGenerationService` always reported "Created font files in X seconds" even when every font was already cached on disk and nothing was generated.
- Root cause: `OptionallyAttemptedGeneralResponse.DidAttempt` was meant to distinguish a real generation attempt from a cache hit, but the real-generation code path never set it to `true` — so it was silently always `false`.
- Fixed `DidAttempt` and added `BuildFontGenerationSummaryMessage` to report "All N font files already up to date" (nothing attempted), a mixed count, or the original "Created N font files" message (everything attempted) as appropriate.

## Test plan
- [x] `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj` — 465 passed, 3 skipped (unrelated helper tests)
- [x] `dotnet build GumFull.sln` — clean

Manual test: not needed — the new integration test exercises the real service end-to-end (real cache file on disk, real callback) and asserts the exact output string a manual check would only approximate by eye.

FRB canary: not needed — change is isolated to `Tools/Gum.ProjectServices`, no FRB-shared source touched.

Closes #4266
