### PR TITLE
Clear tree-view selection when editing a standard's defaults

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -1373,14 +1373,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     {
         if (IsInUiInitiatedSelection) return;
 
-        // When the Standards palette is on, standard elements have no visible tree node (the "Standard"
-        // folder is detached from the tree). Selecting one as data is valid — the variable grid loads
-        // its defaults via the selection cascade — but selecting a detached node in the tree would
-        // leave a selection the user cannot see. Skip the visual sync in that case.
-        if (treeNode != null && !IsInTree(treeNode))
-        {
-            return;
-        }
+        treeNode = ResolveNodeToSelect(treeNode, ObjectTreeView.Nodes);
 
         if (ObjectTreeView.SelectedNode != treeNode)
         {
@@ -1401,10 +1394,22 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
     }
 
     /// <summary>
-    /// Whether a node is still reachable from the tree's roots. A node detached during a rebuild -
-    /// or never attached, as standard elements are while the Standards palette is on - is not.
+    /// Resolves the node that should actually be selected. A node detached from the tree - never
+    /// attached, as standard elements are while the Standards palette is on, or detached during a
+    /// rebuild - has no visible row to select, so it resolves to null (clearing any prior selection)
+    /// rather than being selected outright.
     /// </summary>
-    private bool IsInTree(GumTreeNode node)
+    internal static GumTreeNode? ResolveNodeToSelect(GumTreeNode? treeNode, GumTreeNodeCollection rootNodes)
+    {
+        if (treeNode != null && !IsInTree(treeNode, rootNodes))
+        {
+            return null;
+        }
+
+        return treeNode;
+    }
+
+    private static bool IsInTree(GumTreeNode node, GumTreeNodeCollection rootNodes)
     {
         GumTreeNode root = node;
         while (root.Parent is { } parent)
@@ -1412,7 +1417,7 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
             root = parent;
         }
 
-        return ObjectTreeView.Nodes.Contains(root);
+        return rootNodes.Contains(root);
     }
 
     private void Select(List<GumTreeNode> treeNodes)

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerSelectionTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerSelectionTests.cs
@@ -63,4 +63,55 @@ public class ElementTreeViewManagerSelectionTests : BaseTestClass
 
         result.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void ResolveNodeToSelect_NodeAttachedToTree_ReturnsSameNode()
+    {
+        GumTreeNodeCollection rootNodes = new GumTreeNodeCollection();
+        GumTreeNode attached = new GumTreeNode { Tag = new InstanceSave() };
+        rootNodes.Add(attached);
+
+        GumTreeNode? result = ElementTreeViewManager.ResolveNodeToSelect(attached, rootNodes);
+
+        result.ShouldBeSameAs(attached);
+    }
+
+    [Fact]
+    public void ResolveNodeToSelect_NodeDetachedFromTree_ReturnsNull()
+    {
+        // Issue #4267: editing a standard's defaults (via the Standards palette) left the
+        // previously-selected instance's node highlighted in the tree. The standard element's
+        // node isn't attached to the tree (the palette is a separate control), and selection
+        // used to bail out entirely on a detached node instead of clearing the old selection.
+        GumTreeNodeCollection rootNodes = new GumTreeNodeCollection();
+        GumTreeNode detached = new GumTreeNode { Tag = new StandardElementSave() };
+
+        GumTreeNode? result = ElementTreeViewManager.ResolveNodeToSelect(detached, rootNodes);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ResolveNodeToSelect_NodeNestedUnderAttachedRoot_ReturnsSameNode()
+    {
+        GumTreeNodeCollection rootNodes = new GumTreeNodeCollection();
+        GumTreeNode root = new GumTreeNode { Tag = new InstanceSave { Name = "Root" } };
+        rootNodes.Add(root);
+        GumTreeNode child = new GumTreeNode { Tag = new InstanceSave { Name = "Child" } };
+        root.AddChild(child);
+
+        GumTreeNode? result = ElementTreeViewManager.ResolveNodeToSelect(child, rootNodes);
+
+        result.ShouldBeSameAs(child);
+    }
+
+    [Fact]
+    public void ResolveNodeToSelect_NullNode_ReturnsNull()
+    {
+        GumTreeNodeCollection rootNodes = new GumTreeNodeCollection();
+
+        GumTreeNode? result = ElementTreeViewManager.ResolveNodeToSelect(null, rootNodes);
+
+        result.ShouldBeNull();
+    }
 }


### PR DESCRIPTION
## Summary
Editing a standard's defaults (right-click a Standards-palette chip → Edit) left the previously-selected instance's node highlighted in the main tree view, since standard elements have no node in that tree (the palette is a separate control) and the selection sync used to bail out early on a detached node instead of clearing the old selection.

Fix: `ElementTreeViewManager.Select(GumTreeNode?)` now resolves a detached target node to `null` (clearing the prior selection) instead of returning early. The decision logic is extracted into a testable static `ResolveNodeToSelect`.

Closes #4267

## Test plan
- [x] New unit tests in `ElementTreeViewManagerSelectionTests.cs` (`ResolveNodeToSelect_*`), confirmed red before the fix
- [x] Full `GumToolUnitTests` suite green (1205 passed)
- [ ] Manual: select an instance in the tree, then edit a standard's defaults via the Standards palette — the instance's tree node should no longer stay highlighted

Manual test: needed (tool UI selection behavior).
FRB canary: not needed — change is tool-side (`Gum/Plugins/InternalPlugins/TreeView`), not FRB1-shared source.
