### PR TITLE
Fix inaccurate spatial navigation by tightening the direction cone

### DIFF
--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -186,6 +186,34 @@ public class ControllerSpatialNavigationTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadSpatialNavigation_StickPushedNearLeft_HonorsSpatialNavigationLeftOverride()
+    {
+        // Issue #4274: explicit per-direction overrides only ever consulted the DPad, so a
+        // developer-set SpatialNavigationLeft was silently ignored when the player used the left
+        // stick instead -- scoring ran and could pick a different (wrong) candidate even with an
+        // override in place. A near-left stick push should snap to the Left cardinal and honor it.
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness nearestByScore = CreateHarness(root, -90, -20);
+        SpatialNavHarness overrideTarget = CreateHarness(root, -400, 0);
+
+        origin.SpatialNavigationLeft = overrideTarget;
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        // AnalogStick.Y is +1 = up; a small upward wobble keeps this short of straight-left.
+        gamepad.SetLeftStickPosition(-0.98f, 0.05f);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeFalse();
+        overrideTarget.IsFocused.ShouldBeTrue();
+        nearestByScore.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadSpatialNavigation_StickPushedOffAxis_MovesFocusUsingContinuousAngle()
     {
         ContainerRuntime root = new ContainerRuntime();

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -126,6 +126,27 @@ public class SpatialNavigationServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void FindBestCandidate_ExcludesNearPerpendicularCandidate_EvenWhenMuchCloserThanAlignedCandidate()
+    {
+        // Reproduces issue #4274: a vertically-stacked button list ("Settings" focused, with
+        // "Customize ship" above and "Leaderboard" below) sitting right next to a well-aligned but
+        // farther-away button ("Click me") off to the left. A Left request must not resolve to the
+        // above/below neighbors just because they are much closer -- they contribute ~zero actual
+        // progress in the requested direction.
+        Button origin = CreatePositionedButton(0, 0);
+        Button above = CreatePositionedButton(0, -75);
+        Button below = CreatePositionedButton(0, 75);
+        Button aligned = CreatePositionedButton(-400, 0);
+
+        List<FrameworkElement> candidates = new() { above, below, aligned };
+
+        float leftDirection = MathF.PI;
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, leftDirection, candidates);
+
+        result.ShouldBe(aligned);
+    }
+
+    [Fact]
     public void FindBestCandidate_ReturnsNull_WhenNoCandidatesQualify()
     {
         Button origin = CreatePositionedButton(0, 0);

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1189,9 +1189,10 @@ public class FrameworkElement : INotifyPropertyChanged
 
     /// <summary>
     /// Explicit per-direction focus overrides (Unity/UWP-style escape hatch): if set, a clean
-    /// single-direction D-pad press in that direction moves focus straight to the assigned element,
-    /// skipping <see cref="Gum.Forms.SpatialNavigationService"/> scoring entirely. Not consulted for
-    /// diagonal presses or analog stick input, which have no single well-defined cardinal to key off.
+    /// single-direction D-pad press — or a left-stick push snapped to its nearest cardinal — in that
+    /// direction moves focus straight to the assigned element, skipping
+    /// <see cref="Gum.Forms.SpatialNavigationService"/> scoring entirely. Not consulted for diagonal
+    /// D-pad presses (two held), which have no single well-defined cardinal to key off.
     /// Only meaningful while resolved <see cref="GamepadNavigationMode"/> is
     /// <see cref="Controls.GamepadNavigationMode.Spatial"/>.
     /// </summary>
@@ -1683,39 +1684,66 @@ public class FrameworkElement : INotifyPropertyChanged
         return new DigitalDirectionState(right, left, down, up, shouldFire);
     }
 
-    // Only a clean single held direction has one well-defined cardinal to key an override off of —
-    // a diagonal (two held) or stick-driven request falls through to SpatialNavigationService instead.
+    // A clean single held DPad direction has one well-defined cardinal to key an override off of —
+    // a diagonal (two held) falls through to SpatialNavigationService instead. A stick push with no
+    // DPad direction held is snapped to its nearest cardinal (see GetCardinalOverride) so overrides
+    // help stick-driven navigation the same way they help the DPad.
     private FrameworkElement? TryGetExplicitDirectionOverride(IGamePad gamepad)
     {
         DigitalDirectionState state = GetDigitalDirectionState(gamepad);
-        if (!state.ShouldFire)
+        if (state.ShouldFire)
         {
+            int heldCount = (state.Right ? 1 : 0) + (state.Left ? 1 : 0) + (state.Down ? 1 : 0) + (state.Up ? 1 : 0);
+            if (heldCount != 1)
+            {
+                return null;
+            }
+
+            if (state.Right)
+            {
+                return SpatialNavigationRight;
+            }
+            if (state.Left)
+            {
+                return SpatialNavigationLeft;
+            }
+            if (state.Down)
+            {
+                return SpatialNavigationDown;
+            }
+            if (state.Up)
+            {
+                return SpatialNavigationUp;
+            }
             return null;
         }
 
-        int heldCount = (state.Right ? 1 : 0) + (state.Left ? 1 : 0) + (state.Down ? 1 : 0) + (state.Up ? 1 : 0);
-        if (heldCount != 1)
+        if (gamepad.LeftStick.RadialPushedRepeatRate())
         {
-            return null;
+            float stickAngle = MathF.Atan2(-gamepad.LeftStick.Y, gamepad.LeftStick.X);
+            return GetCardinalOverride(stickAngle);
         }
 
-        if (state.Right)
-        {
-            return SpatialNavigationRight;
-        }
-        if (state.Left)
-        {
-            return SpatialNavigationLeft;
-        }
-        if (state.Down)
-        {
-            return SpatialNavigationDown;
-        }
-        if (state.Up)
-        {
-            return SpatialNavigationUp;
-        }
         return null;
+    }
+
+    // Snaps a screen-space angle (0 = right, increasing clockwise) to whichever of the four
+    // SpatialNavigation overrides is nearest, so an analog stick push can honor the same explicit
+    // overrides a clean DPad press does.
+    private FrameworkElement? GetCardinalOverride(float angleRadians)
+    {
+        float twoPi = MathF.PI * 2f;
+        float normalized = ((angleRadians % twoPi) + twoPi) % twoPi;
+        int cardinal = (int)MathF.Round(normalized / (MathF.PI / 2f)) % 4;
+
+        return cardinal switch
+        {
+            0 => SpatialNavigationRight,
+            1 => SpatialNavigationDown,
+            2 => SpatialNavigationLeft,
+            3 => SpatialNavigationUp,
+            _ => null,
+        };
     }
 
     private float? TryGetRequestedDirectionAngle(IGamePad gamepad)

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -38,7 +38,7 @@ public static class SpatialNavigationService
         FrameworkElement origin,
         float directionAngleRadians,
         IEnumerable<FrameworkElement> candidates,
-        float maxAngleRadians = MathF.PI / 2f,
+        float maxAngleRadians = MathF.PI / 4f,
         float angleWeight = 2f)
     {
         (float originX, float originY) = GetCenter(origin);


### PR DESCRIPTION
Closes #4274

## Problem
Spatial navigation's candidate cone was a full 90° hemisphere either side of the requested direction. A close-but-perpendicular candidate (directly above/below when pressing Left) can outscore a far-but-well-aligned one, since the multiplicative distance-based score doesn't penalize being at the very edge of the cone strongly enough relative to raw distance. In the reported layout, pressing DPad-Left and pushing the stick left landed on different (both wrong) neighbors because the two perpendicular candidates were nearly tied.

## Fix
- Tightened the default cone from 90° to 45° (`SpatialNavigationService.FindBestCandidate`). At 45°, a candidate can only be selected for a given direction if it's closer to that cardinal than to any other — this structurally rules out "left" resolving to something that's actually above/below.
- `SpatialNavigationUp/Down/Left/Right` explicit overrides previously only fired for a clean single-direction DPad press. A left-stick push now snaps to its nearest cardinal so the same overrides apply to stick-driven navigation too.

Keyboard-driven spatial navigation (also mentioned in the issue) is a separate, larger feature already tracked in #4272.

## Testing
- New unit test reproducing the exact button layout from the issue screenshot (measured from the attached image) — confirms the aligned-but-farther button wins over the close perpendicular ones.
- New unit test confirming a stick push near a cardinal honors the matching `SpatialNavigation*` override.
- Full `MonoGameGum.Tests` suite green (2093 tests). `RaylibGum` builds clean (shares the same source via GumCommon).

Manual test: opened a MonoGame scratch project reproducing the issue's exact layout (Settings focused, Customize ship above, Leaderboard below, Click Me off to the left) with `GamepadNavigationMode.Spatial` — ready for a physical-gamepad DPad/stick check.
