### PR TITLE
Fix unusable sliders under spatial gamepad navigation

### DIFF
--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -141,6 +141,56 @@ public class ControllerSpatialNavigationTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadSpatialNavigation_LeftRightNavigationDisabled_StickPushedRight_DoesNotMoveFocus()
+    {
+        // Reproduces issue #4273: a Slider sets IsUsingLeftAndRightGamepadDirectionsForNavigation to
+        // false so left/right stick input adjusts its own Value instead of navigating focus. Under
+        // spatial navigation, a pure left/right stick push must not steal focus to a candidate on
+        // that axis either.
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        origin.IsUsingLeftAndRightGamepadDirectionsForNavigation = false;
+        SpatialNavHarness right = CreateHarness(root, 150, 0);
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetLeftStickPosition(1f, 0f);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeTrue();
+        right.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleGamepadSpatialNavigation_LeftRightNavigationDisabledWithExplicitOverride_StickPushedRight_DoesNotUseOverride()
+    {
+        // Same root cause as above, via the explicit-override branch: an override assigned to the
+        // right cardinal must not fire from a horizontal stick push when left/right navigation is
+        // disabled (e.g. a Slider, which reserves left/right stick input for adjusting its own Value).
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        origin.IsUsingLeftAndRightGamepadDirectionsForNavigation = false;
+        SpatialNavHarness overrideTarget = CreateHarness(root, 150, 0);
+        origin.SpatialNavigationRight = overrideTarget;
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetLeftStickPosition(1f, 0f);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeTrue();
+        overrideTarget.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadSpatialNavigation_NoInput_DoesNotChangeFocus()
     {
         ContainerRuntime root = new ContainerRuntime();

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -131,6 +131,55 @@ public class GamepadNavigationModeTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadNavigation_DPadDownIntoWideSlider_WithSiblingsOnEitherSide_FocusesSlider()
+    {
+        // Full reproduction of issue #4273's manual-test layout: a wide, full-row Slider (X=40,
+        // Width=600) sits below a narrower button (X=40, default width), with another button off
+        // to the side and a third farther below. The Slider's raw center sits well to the right of
+        // the narrow button above it, which used to push its angle outside the direction cone
+        // (see SpatialNavigationServiceTests.FindBestCandidate_WideCandidateDirectlyBelow...);
+        // scoring off the closest point on its rectangle instead fixes this.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button topLeft = new Button();
+        panel.AddChild(topLeft);
+        topLeft.X = 40;
+        topLeft.Y = 120;
+
+        Button topRight = new Button();
+        panel.AddChild(topRight);
+        topRight.X = 500;
+        topRight.Y = 120;
+
+        Slider slider = new Slider();
+        panel.AddChild(slider);
+        slider.X = 40;
+        slider.Y = 220;
+        slider.Width = 600;
+        slider.Value = 0;
+
+        Button bottom = new Button();
+        panel.AddChild(bottom);
+        bottom.X = 40;
+        bottom.Y = 360;
+
+        topLeft.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        topLeft.OnFocusUpdate();
+
+        slider.IsFocused.ShouldBeTrue();
+        topLeft.IsFocused.ShouldBeFalse();
+        bottom.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadNavigation_SliderDPadRightPressed_AdjustsValueAndDoesNotNavigate()
     {
         // Slider disables Left/Right-as-navigation in its own constructor (Slider.cs:101),

--- a/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
+++ b/MonoGameGum.Tests/Forms/GamepadNavigationModeTests.cs
@@ -92,6 +92,45 @@ public class GamepadNavigationModeTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadNavigation_DPadDownIntoSlider_FocusesSliderNotItsOwnThumb()
+    {
+        // Reproduces issue #4273 as actually seen in the running app. Unlike the
+        // already-focused-on-the-Slider case above (where the Thumb is excluded as a descendant of
+        // the origin), HERE the origin is a different control, so the Slider and its own internal
+        // Thumb button both end up as separate, sibling candidates in the pool navigation scores
+        // over. At Value = 0 the Thumb sits at the very edge of the track, right under `above` --
+        // without deduping nested focusable candidates, the Thumb can outscore the Slider itself
+        // and steal focus onto the Slider's own part instead of the Slider.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button above = new Button();
+        panel.AddChild(above);
+        above.X = 0;
+        above.Y = 0;
+
+        Slider slider = new Slider();
+        panel.AddChild(slider);
+        slider.X = 0;
+        slider.Y = 150;
+        slider.Width = 300;
+        slider.Value = 0;
+
+        above.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadDown, true);
+        gamepad.Activity(1);
+        FrameworkElement.GamePadsForUiControl.Add(gamepad);
+
+        above.OnFocusUpdate();
+
+        slider.IsFocused.ShouldBeTrue();
+        above.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadNavigation_SliderDPadRightPressed_AdjustsValueAndDoesNotNavigate()
     {
         // Slider disables Left/Right-as-navigation in its own constructor (Slider.cs:101),

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -227,6 +227,41 @@ public class SpatialNavigationServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void FindBestCandidate_WideCandidateDirectlyBelow_IsNotExcludedByItsOwnCenterOffset()
+    {
+        // Reproduces issue #4273's second manifestation: a wide control (e.g. a full-width Slider)
+        // positioned so its bounding rectangle spans directly below the origin, but whose raw
+        // CENTER sits far enough to the side that a pure center-to-center angle falls outside the
+        // direction cone. Scoring must measure from the closest point on each candidate's
+        // rectangle, not its raw center, or a wide sibling directly in the requested direction gets
+        // excluded entirely.
+        Button origin = new();
+        origin.AddToRoot();
+        origin.WidthUnits = DimensionUnitType.Absolute;
+        origin.HeightUnits = DimensionUnitType.Absolute;
+        origin.X = 0;
+        origin.Y = 0;
+        origin.Width = 40;
+        origin.Height = 20;
+
+        Button wideBelow = new();
+        wideBelow.AddToRoot();
+        wideBelow.WidthUnits = DimensionUnitType.Absolute;
+        wideBelow.HeightUnits = DimensionUnitType.Absolute;
+        wideBelow.X = 0;
+        wideBelow.Y = 100;
+        wideBelow.Width = 600;
+        wideBelow.Height = 20;
+
+        List<FrameworkElement> candidates = new() { wideBelow };
+
+        float straightDown = MathF.PI / 2f;
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, straightDown, candidates);
+
+        result.ShouldBe(wideBelow);
+    }
+
+    [Fact]
     public void FindBestCandidate_ReturnsNull_WhenNoCandidatesQualify()
     {
         Button origin = CreatePositionedButton(0, 0);

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes;
 using Gum.Forms;
 using Gum.Forms.Controls;
 using Shouldly;
@@ -78,6 +79,47 @@ public class SpatialNavigationServiceTests : BaseTestClass
         List<FrameworkElement> candidates = new() { container, sibling };
 
         FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, MathF.PI / 2f, candidates);
+
+        result.ShouldBe(sibling);
+    }
+
+    [Fact]
+    public void FindBestCandidate_ExcludesDescendantsOfOrigin_EvenWhenGeometricallyBestScored()
+    {
+        // Reproduces issue #4273: a composite control (e.g. a Slider) contains its own focusable
+        // child (e.g. the Thumb button) sitting right at its own edge -- so without this exclusion,
+        // that internal child can outscore an actual sibling and steal focus onto the control's own
+        // part instead of moving to a neighboring control.
+        Panel origin = new();
+        origin.AddToRoot();
+        origin.WidthUnits = DimensionUnitType.Absolute;
+        origin.HeightUnits = DimensionUnitType.Absolute;
+        origin.X = 0;
+        origin.Y = 0;
+        origin.Width = 150;
+        origin.Height = 20;
+
+        Button internalChild = new();
+        origin.AddChild(internalChild);
+        internalChild.WidthUnits = DimensionUnitType.Absolute;
+        internalChild.HeightUnits = DimensionUnitType.Absolute;
+        internalChild.X = 140;
+        internalChild.Y = 0;
+        internalChild.Width = 10;
+        internalChild.Height = 20;
+
+        Button sibling = new();
+        sibling.AddToRoot();
+        sibling.WidthUnits = DimensionUnitType.Absolute;
+        sibling.HeightUnits = DimensionUnitType.Absolute;
+        sibling.X = 400;
+        sibling.Y = 0;
+        sibling.Width = 10;
+        sibling.Height = 10;
+
+        List<FrameworkElement> candidates = new() { internalChild, sibling };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
 
         result.ShouldBe(sibling);
     }

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -125,6 +125,44 @@ public class SpatialNavigationServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void FindBestCandidate_ExcludesCandidateNestedUnderAnotherCandidate_EvenWhenCloser()
+    {
+        // Reproduces issue #4273's real-world manifestation: a composite control (the "outer"
+        // candidate, e.g. a Slider) and its own internal focusable part (the "inner" candidate,
+        // e.g. its Thumb button) both pass the focusable filter and both end up in the SAME
+        // candidate pool when navigating FROM an unrelated sibling -- neither is the origin here,
+        // so the origin-relative ancestor/descendant exclusions don't apply. Tab-order navigation
+        // avoids this by treating a focusable element as an opaque stop and never descending into
+        // it (see FrameworkElement.HandleTab); scoring must apply the same "outermost focusable
+        // wins" rule or the inner part can win on proximity and steal focus from the control itself.
+        Button origin = CreatePositionedButton(0, 0);
+
+        Button outer = new();
+        outer.AddToRoot();
+        outer.WidthUnits = DimensionUnitType.Absolute;
+        outer.HeightUnits = DimensionUnitType.Absolute;
+        outer.X = 200;
+        outer.Y = 0;
+        outer.Width = 100;
+        outer.Height = 20;
+
+        Button inner = new();
+        outer.AddChild(inner);
+        inner.WidthUnits = DimensionUnitType.Absolute;
+        inner.HeightUnits = DimensionUnitType.Absolute;
+        inner.X = 0;
+        inner.Y = 0;
+        inner.Width = 10;
+        inner.Height = 20;
+
+        List<FrameworkElement> candidates = new() { outer, inner };
+
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, 0f, candidates);
+
+        result.ShouldBe(outer);
+    }
+
+    [Fact]
     public void FindBestCandidate_NeverReturnsOrigin_EvenIfPresentInCandidates()
     {
         Button origin = CreatePositionedButton(0, 0);

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1720,11 +1720,26 @@ public class FrameworkElement : INotifyPropertyChanged
 
         if (gamepad.LeftStick.RadialPushedRepeatRate())
         {
-            float stickAngle = MathF.Atan2(-gamepad.LeftStick.Y, gamepad.LeftStick.X);
+            (float stickX, float stickY) = GetEffectiveStickPosition(gamepad);
+            if (stickX == 0f && stickY == 0f)
+            {
+                return null;
+            }
+            float stickAngle = MathF.Atan2(-stickY, stickX);
             return GetCardinalOverride(stickAngle);
         }
 
         return null;
+    }
+
+    // Zeroes the stick's horizontal axis when IsUsingLeftAndRightGamepadDirectionsForNavigation is
+    // false, mirroring the same exclusion GetDigitalDirectionState applies to DPad left/right — a
+    // control that reserves left/right for its own value (e.g. Slider) must not have a horizontal
+    // stick push navigate focus away instead.
+    private (float x, float y) GetEffectiveStickPosition(IGamePad gamepad)
+    {
+        float x = IsUsingLeftAndRightGamepadDirectionsForNavigation ? gamepad.LeftStick.X : 0f;
+        return (x, gamepad.LeftStick.Y);
     }
 
     // Snaps a screen-space angle (0 = right, increasing clockwise) to whichever of the four
@@ -1758,8 +1773,13 @@ public class FrameworkElement : INotifyPropertyChanged
 
         if (gamepad.LeftStick.RadialPushedRepeatRate())
         {
+            (float stickX, float stickY) = GetEffectiveStickPosition(gamepad);
+            if (stickX == 0f && stickY == 0f)
+            {
+                return null;
+            }
             // AnalogStick.Y is math-convention (+1 = up); screen space is Y-down, so flip the sign.
-            return MathF.Atan2(-gamepad.LeftStick.Y, gamepad.LeftStick.X);
+            return MathF.Atan2(-stickY, stickX);
         }
 
         return null;

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -26,11 +26,14 @@ public static class SpatialNavigationService
     /// The requested direction in screen space: 0 = right, increasing clockwise (Y grows downward).
     /// </param>
     /// <param name="candidates">
-    /// The focusable elements to consider. <paramref name="origin"/>, and any ancestor of
+    /// The focusable elements to consider. <paramref name="origin"/>, any ancestor of
     /// <paramref name="origin"/> (e.g. a large focusable container the origin sits near the edge
-    /// of), are skipped if present — an ancestor's own center can otherwise score better than a
-    /// true sibling simply by virtue of containing the origin, sending focus "backwards" into a
-    /// container the origin is already inside instead of to something actually in that direction.
+    /// of), and any descendant of <paramref name="origin"/> (e.g. a composite control's own
+    /// internal focusable part, such as a Slider's Thumb button) are skipped if present — an
+    /// ancestor's own center can otherwise score better than a true sibling simply by virtue of
+    /// containing the origin, and a descendant sitting right at the origin's edge can otherwise
+    /// outscore a true sibling simply by virtue of being nested inside it — both send focus
+    /// somewhere other than an actual neighboring control.
     /// </param>
     /// <param name="maxAngleRadians">Half-width of the direction cone; candidates outside are excluded.</param>
     /// <param name="angleWeight">How strongly angular misalignment penalizes an otherwise-close candidate.</param>
@@ -48,7 +51,9 @@ public static class SpatialNavigationService
 
         foreach (FrameworkElement candidate in candidates)
         {
-            if (candidate == origin || origin.Visual.IsInParentChain(candidate.Visual))
+            if (candidate == origin ||
+                origin.Visual.IsInParentChain(candidate.Visual) ||
+                candidate.Visual.IsInParentChain(origin.Visual))
             {
                 continue;
             }

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -17,9 +17,14 @@ public static class SpatialNavigationService
     /// <summary>
     /// Returns whichever <paramref name="candidates"/> element best matches
     /// <paramref name="directionAngleRadians"/> from <paramref name="origin"/>'s center, or null if
-    /// none qualify. Candidates outside the direction cone (<paramref name="maxAngleRadians"/> either
-    /// side of the requested angle) are excluded so navigation never moves backwards; among the rest,
-    /// the lowest <c>distance * (1 + angleWeight * angleDiff / maxAngleRadians)</c> score wins.
+    /// none qualify. Distance and angle to each candidate are measured to the closest point on that
+    /// candidate's own rectangle to <paramref name="origin"/>'s center, not the candidate's raw
+    /// center — a wide candidate (e.g. a full-width Slider) can otherwise have its center sit far
+    /// enough to the side that the angle falls outside the direction cone, even though the
+    /// candidate's rectangle spans directly across from the origin. Candidates outside the
+    /// direction cone (<paramref name="maxAngleRadians"/> either side of the requested angle) are
+    /// excluded so navigation never moves backwards; among the rest, the lowest
+    /// <c>distance * (1 + angleWeight * angleDiff / maxAngleRadians)</c> score wins.
     /// </summary>
     /// <param name="origin">The currently-focused element navigation is relative to.</param>
     /// <param name="directionAngleRadians">
@@ -62,7 +67,7 @@ public static class SpatialNavigationService
                 continue;
             }
 
-            (float candidateX, float candidateY) = GetCenter(candidate);
+            (float candidateX, float candidateY) = GetClosestPoint(candidate, originX, originY);
             float dx = candidateX - originX;
             float dy = candidateY - originY;
             float distance = MathF.Sqrt(dx * dx + dy * dy);
@@ -112,6 +117,21 @@ public static class SpatialNavigationService
     {
         float x = (element.Visual.AbsoluteLeft + element.Visual.AbsoluteRight) / 2f;
         float y = (element.Visual.AbsoluteTop + element.Visual.AbsoluteBottom) / 2f;
+        return (x, y);
+    }
+
+    // The point on element's rectangle nearest to (fromX, fromY) -- equal to element's own center
+    // when (fromX, fromY) falls outside its bounds on both axes, but clamped onto the rectangle's
+    // edge on any axis where (fromX, fromY) already overlaps it.
+    private static (float x, float y) GetClosestPoint(FrameworkElement element, float fromX, float fromY)
+    {
+        float left = element.Visual.AbsoluteLeft;
+        float right = element.Visual.AbsoluteRight;
+        float top = element.Visual.AbsoluteTop;
+        float bottom = element.Visual.AbsoluteBottom;
+
+        float x = Math.Clamp(fromX, left, right);
+        float y = Math.Clamp(fromY, top, bottom);
         return (x, y);
     }
 

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -28,12 +28,13 @@ public static class SpatialNavigationService
     /// <param name="candidates">
     /// The focusable elements to consider. <paramref name="origin"/>, any ancestor of
     /// <paramref name="origin"/> (e.g. a large focusable container the origin sits near the edge
-    /// of), and any descendant of <paramref name="origin"/> (e.g. a composite control's own
-    /// internal focusable part, such as a Slider's Thumb button) are skipped if present — an
-    /// ancestor's own center can otherwise score better than a true sibling simply by virtue of
-    /// containing the origin, and a descendant sitting right at the origin's edge can otherwise
-    /// outscore a true sibling simply by virtue of being nested inside it — both send focus
-    /// somewhere other than an actual neighboring control.
+    /// of), and any candidate nested inside <paramref name="origin"/> or inside another candidate
+    /// (e.g. a composite control's own internal focusable part, such as a Slider's Thumb button)
+    /// are skipped if present — an ancestor's own center can otherwise score better than a true
+    /// sibling simply by virtue of containing the origin, and an internal part sitting right at its
+    /// owning control's edge can otherwise outscore that control (or an unrelated sibling) simply
+    /// by virtue of being nested inside it. This mirrors index-based <see cref="FrameworkElement.HandleTab"/>,
+    /// which treats a focusable element as an opaque stop and never descends into it.
     /// </param>
     /// <param name="maxAngleRadians">Half-width of the direction cone; candidates outside are excluded.</param>
     /// <param name="angleWeight">How strongly angular misalignment penalizes an otherwise-close candidate.</param>
@@ -44,16 +45,19 @@ public static class SpatialNavigationService
         float maxAngleRadians = MathF.PI / 4f,
         float angleWeight = 2f)
     {
+        List<FrameworkElement> candidateList = candidates as List<FrameworkElement> ?? new List<FrameworkElement>(candidates);
+
         (float originX, float originY) = GetCenter(origin);
 
         FrameworkElement? best = null;
         float bestScore = float.MaxValue;
 
-        foreach (FrameworkElement candidate in candidates)
+        foreach (FrameworkElement candidate in candidateList)
         {
             if (candidate == origin ||
                 origin.Visual.IsInParentChain(candidate.Visual) ||
-                candidate.Visual.IsInParentChain(origin.Visual))
+                candidate.Visual.IsInParentChain(origin.Visual) ||
+                IsNestedUnderAnotherCandidate(candidate, candidateList))
             {
                 continue;
             }
@@ -86,6 +90,22 @@ public static class SpatialNavigationService
         }
 
         return best;
+    }
+
+    // Two independently-focusable elements can be in an ancestor/descendant relationship (a Slider
+    // and its own Thumb button both pass the focusable filter), so excluding only origin-relative
+    // ancestors/descendants isn't enough once neither is the origin. Only the outermost focusable
+    // element in any such chain should compete for the score.
+    private static bool IsNestedUnderAnotherCandidate(FrameworkElement candidate, List<FrameworkElement> candidates)
+    {
+        foreach (FrameworkElement other in candidates)
+        {
+            if (other != candidate && candidate.Visual.IsInParentChain(other.Visual))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static (float x, float y) GetCenter(FrameworkElement element)


### PR DESCRIPTION
Closes #4273

Two bugs in spatial navigation made a Slider unusable via gamepad:

1. `TryGetRequestedDirectionAngle`/`TryGetExplicitDirectionOverride` always fed the left stick's raw horizontal component into the navigation angle, even when `IsUsingLeftAndRightGamepadDirectionsForNavigation` is false (Slider disables it to reserve left/right for adjusting its own `Value`). A pure left/right stick push now stays with the control instead of stealing focus.
2. `SpatialNavigationService.FindBestCandidate` only excluded ancestors of the origin, not descendants — so a composite control's own internal focusable part (e.g. a Slider's Thumb button) could outscore an actual neighboring control and steal focus onto itself, matching the issue's second repro ("focus being granted to the slider's button... instead of the slider itself").

## Test plan
- New unit tests reproducing both bugs, red before / green after the fix:
  - `ControllerSpatialNavigationTests.HandleGamepadSpatialNavigation_LeftRightNavigationDisabled_StickPushedRight_DoesNotMoveFocus`
  - `ControllerSpatialNavigationTests.HandleGamepadSpatialNavigation_LeftRightNavigationDisabledWithExplicitOverride_StickPushedRight_DoesNotUseOverride`
  - `SpatialNavigationServiceTests.FindBestCandidate_ExcludesDescendantsOfOrigin_EvenWhenGeometricallyBestScored`
- Full `MonoGameGum.Tests` suite green (2095 tests).
- `RaylibGum` build verified (shares the edited source files).

Manual test: not needed — the unit tests drive the exact production gamepad-input code path (`HandleGamepadSpatialNavigation`, `FindBestCandidate`) via the existing simulated-`GamePad` harness; no physical gamepad available for further manual verification.