### PR TITLE
Add opt-in keyboard arrow-key focus navigation

### DIFF
--- a/MonoGameGum.Tests/BaseTestClass.cs
+++ b/MonoGameGum.Tests/BaseTestClass.cs
@@ -74,6 +74,12 @@ public class BaseTestClass : IDisposable
             IsTriggeredOnRepeat = true
         });
 
+        // Empty is the true default (opt-in, unlike Tab/Click above) -- just clear, don't re-seed.
+        FrameworkElement.UpKeyCombos.Clear();
+        FrameworkElement.DownKeyCombos.Clear();
+        FrameworkElement.LeftKeyCombos.Clear();
+        FrameworkElement.RightKeyCombos.Clear();
+
         // just to remove any mocks:
         FrameworkElement.MainCursor = new Cursor(null);
 

--- a/MonoGameGum.Tests/Forms/KeyboardDirectionalNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/KeyboardDirectionalNavigationTests.cs
@@ -1,0 +1,204 @@
+using Gum.Forms.Controls;
+using Gum.Input;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+using Keys = Gum.Forms.Input.Keys;
+
+namespace MonoGameGum.Tests.Forms;
+
+/// <summary>
+/// Tests for issue #4272: keyboard arrow-key focus navigation reusing the same
+/// <see cref="FrameworkElement.GamepadNavigationMode"/> resolution (TabOrder or Spatial, see
+/// <see cref="Gum.Forms.SpatialNavigationService"/>) and <see cref="FrameworkElement.SpatialNavigationUp"/>-style
+/// overrides that gamepad D-pad/stick navigation already has. Driven by
+/// <see cref="FrameworkElement.UpKeyCombos"/>/<see cref="FrameworkElement.DownKeyCombos"/>/
+/// <see cref="FrameworkElement.LeftKeyCombos"/>/<see cref="FrameworkElement.RightKeyCombos"/>, which are
+/// empty by default (opt-in) since several stock controls already claim arrow keys for their own
+/// value/selection/caret behavior. Mirrors <see cref="GamepadNavigationModeTests"/>.
+/// </summary>
+public class KeyboardDirectionalNavigationTests : BaseTestClass
+{
+    private static Mock<IInputReceiverKeyboardMonoGame> CreateKeyboardMock(Keys key)
+    {
+        Mock<IInputReceiverKeyboardMonoGame> keyboard = new Mock<IInputReceiverKeyboardMonoGame>();
+        keyboard.As<IInputReceiverKeyboard>().Setup(k => k.KeyDown(key)).Returns(true);
+        keyboard.As<IInputReceiverKeyboard>().Setup(k => k.KeyPushed(key)).Returns(true);
+        keyboard.As<IInputReceiverKeyboard>().Setup(k => k.KeyTyped(key)).Returns(true);
+        keyboard.As<IInputReceiverKeyboard>().Setup(k => k.KeysTyped).Returns(new List<Keys>());
+        return keyboard;
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_DownKeyComboConfigured_TabOrderMode_MovesFocusToNextFocusableSibling()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        // GamepadNavigationMode left unset -- defaults to TabOrder, same as the gamepad counterpart.
+
+        Button first = new Button();
+        panel.AddChild(first);
+        Button second = new Button();
+        panel.AddChild(second);
+
+        first.IsFocused = true;
+
+        FrameworkElement.DownKeyCombos.Add(new KeyCombo { PushedKey = Keys.Down });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Down).Object);
+
+        first.OnFocusUpdate();
+
+        first.IsFocused.ShouldBeFalse();
+        second.IsFocused.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_ExplicitSpatialNavigationRightOverride_TakesPrecedenceOverScoring()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button nearestByScore = new Button();
+        panel.AddChild(nearestByScore);
+        nearestByScore.X = 50;
+        nearestByScore.Y = 0;
+
+        Button overrideTarget = new Button();
+        panel.AddChild(overrideTarget);
+        overrideTarget.X = 500;
+        overrideTarget.Y = 0;
+
+        origin.SpatialNavigationRight = overrideTarget;
+        origin.IsFocused = true;
+
+        FrameworkElement.RightKeyCombos.Add(new KeyCombo { PushedKey = Keys.Right });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Right).Object);
+
+        origin.OnFocusUpdate();
+
+        overrideTarget.IsFocused.ShouldBeTrue();
+        nearestByScore.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_NoKeyCombosConfigured_DownKeyPressDoesNotNavigate()
+    {
+        // Pins the opt-in default: UpKeyCombos/DownKeyCombos/LeftKeyCombos/RightKeyCombos start
+        // empty, so a raw Down key press does nothing until a project configures a combo for it.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        Button below = new Button();
+        panel.AddChild(below);
+
+        origin.IsFocused = true;
+
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Down).Object);
+
+        origin.OnFocusUpdate();
+
+        origin.IsFocused.ShouldBeTrue();
+        below.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_RightKeyComboConfigured_SpatialMode_MovesFocusToCandidateOnRight()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button right = new Button();
+        panel.AddChild(right);
+        right.X = 150;
+        right.Y = 0;
+
+        Button above = new Button();
+        panel.AddChild(above);
+        above.X = 0;
+        above.Y = -150;
+
+        origin.IsFocused = true;
+
+        FrameworkElement.RightKeyCombos.Add(new KeyCombo { PushedKey = Keys.Right });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Right).Object);
+
+        origin.OnFocusUpdate();
+
+        origin.IsFocused.ShouldBeFalse();
+        right.IsFocused.ShouldBeTrue();
+        above.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_SliderRightKeyComboConfigured_SpatialMode_AdjustsValueAndDoesNotNavigate()
+    {
+        // Slider disables Left/Right-as-navigation in its own constructor
+        // (IsUsingLeftAndRightGamepadDirectionsForNavigation = false) so it can use Left/Right for
+        // its own value instead -- the new keyboard path reuses that same flag rather than adding a
+        // parallel one, so this guard should protect keyboard Right exactly like it already
+        // protects gamepad D-pad/stick Right (see GamepadNavigationModeTests's companion test).
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Slider slider = new Slider();
+        panel.AddChild(slider);
+        slider.X = 0;
+        slider.Y = 0;
+        slider.Value = 50;
+
+        Button right = new Button();
+        panel.AddChild(right);
+        right.X = 150;
+        right.Y = 0;
+
+        slider.IsFocused = true;
+
+        FrameworkElement.RightKeyCombos.Add(new KeyCombo { PushedKey = Keys.Right });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Right).Object);
+
+        slider.OnFocusUpdate();
+
+        slider.Value.ShouldBeGreaterThan(50);
+        slider.IsFocused.ShouldBeTrue();
+        right.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HandleKeyboardFocusUpdate_UpKeyComboConfigured_TabOrderMode_MovesFocusToPreviousFocusableSibling()
+    {
+        Panel panel = new Panel();
+        panel.AddToRoot();
+
+        Button first = new Button();
+        panel.AddChild(first);
+        Button second = new Button();
+        panel.AddChild(second);
+
+        second.IsFocused = true;
+
+        FrameworkElement.UpKeyCombos.Add(new KeyCombo { PushedKey = Keys.Up });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Up).Object);
+
+        second.OnFocusUpdate();
+
+        second.IsFocused.ShouldBeFalse();
+        first.IsFocused.ShouldBeTrue();
+    }
+}

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1183,7 +1183,8 @@ public class FrameworkElement : INotifyPropertyChanged
     /// An unset element inherits the nearest ancestor's value (an explicit
     /// <see cref="Controls.GamepadNavigationMode.TabOrder"/> on a nested element opts back out of an
     /// outer <see cref="Controls.GamepadNavigationMode.Spatial"/> zone); the root default is TabOrder.
-    /// Does not affect keyboard Tab, which is always index-based.
+    /// Also resolved for keyboard arrow-key navigation (<see cref="UpKeyCombos"/> etc.) — but never
+    /// for keyboard Tab/Shift+Tab, which is always index-based regardless of this setting.
     /// </summary>
     public GamepadNavigationMode? GamepadNavigationMode { get; set; }
 
@@ -1325,6 +1326,32 @@ public class FrameworkElement : INotifyPropertyChanged
         new KeyCombo { PushedKey = Keys.Space },
     };
 
+    /// <summary>
+    /// List of key combinations that request focus navigation toward whatever the resolved
+    /// <see cref="Controls.GamepadNavigationMode"/> considers "up" — the previous element in
+    /// <see cref="Controls.GamepadNavigationMode.TabOrder"/> mode, or the nearest candidate above
+    /// in <see cref="Controls.GamepadNavigationMode.Spatial"/> mode (see
+    /// <see cref="Gum.Forms.SpatialNavigationService"/>). Empty by default: unlike
+    /// <see cref="TabKeyCombos"/>, arrow keys are already claimed by several stock controls for
+    /// their own value/selection/caret behavior (Slider, ListBox, TextBox), so wiring them up is
+    /// opt-in per project rather than a default that could silently change existing behavior.
+    /// </summary>
+    public static List<KeyCombo> UpKeyCombos { get; set; } = new ();
+
+    /// <inheritdoc cref="UpKeyCombos"/>
+    public static List<KeyCombo> DownKeyCombos { get; set; } = new ();
+
+    /// <summary>
+    /// <inheritdoc cref="UpKeyCombos"/>
+    /// Only consulted while <see cref="IsUsingLeftAndRightGamepadDirectionsForNavigation"/> is true —
+    /// the same flag that already gates gamepad D-pad/stick Left/Right from double-firing against a
+    /// control (e.g. Slider) that uses Left/Right for its own value instead.
+    /// </summary>
+    public static List<KeyCombo> LeftKeyCombos { get; set; } = new ();
+
+    /// <inheritdoc cref="LeftKeyCombos"/>
+    public static List<KeyCombo> RightKeyCombos { get; set; } = new ();
+
     protected void HandleKeyboardFocusUpdate()
     {
         foreach (var keyboard in KeyboardsForUiControl)
@@ -1355,6 +1382,8 @@ public class FrameworkElement : INotifyPropertyChanged
                 }
             }
         }
+
+        HandleKeyboardDirectionalNavigation();
     }
 #endif
 
@@ -1684,38 +1713,48 @@ public class FrameworkElement : INotifyPropertyChanged
         return new DigitalDirectionState(right, left, down, up, shouldFire);
     }
 
-    // A clean single held DPad direction has one well-defined cardinal to key an override off of —
-    // a diagonal (two held) falls through to SpatialNavigationService instead. A stick push with no
-    // DPad direction held is snapped to its nearest cardinal (see GetCardinalOverride) so overrides
-    // help stick-driven navigation the same way they help the DPad.
+    // A clean single held direction has one well-defined cardinal to key an override off of — a
+    // diagonal (two held) falls through to SpatialNavigationService instead.
+    private FrameworkElement? GetExplicitDirectionOverride(DigitalDirectionState state)
+    {
+        if (!state.ShouldFire)
+        {
+            return null;
+        }
+
+        int heldCount = (state.Right ? 1 : 0) + (state.Left ? 1 : 0) + (state.Down ? 1 : 0) + (state.Up ? 1 : 0);
+        if (heldCount != 1)
+        {
+            return null;
+        }
+
+        if (state.Right)
+        {
+            return SpatialNavigationRight;
+        }
+        if (state.Left)
+        {
+            return SpatialNavigationLeft;
+        }
+        if (state.Down)
+        {
+            return SpatialNavigationDown;
+        }
+        if (state.Up)
+        {
+            return SpatialNavigationUp;
+        }
+        return null;
+    }
+
+    // A stick push with no DPad direction held is snapped to its nearest cardinal (see
+    // GetCardinalOverride) so overrides help stick-driven navigation the same way they help the DPad.
     private FrameworkElement? TryGetExplicitDirectionOverride(IGamePad gamepad)
     {
         DigitalDirectionState state = GetDigitalDirectionState(gamepad);
         if (state.ShouldFire)
         {
-            int heldCount = (state.Right ? 1 : 0) + (state.Left ? 1 : 0) + (state.Down ? 1 : 0) + (state.Up ? 1 : 0);
-            if (heldCount != 1)
-            {
-                return null;
-            }
-
-            if (state.Right)
-            {
-                return SpatialNavigationRight;
-            }
-            if (state.Left)
-            {
-                return SpatialNavigationLeft;
-            }
-            if (state.Down)
-            {
-                return SpatialNavigationDown;
-            }
-            if (state.Up)
-            {
-                return SpatialNavigationUp;
-            }
-            return null;
+            return GetExplicitDirectionOverride(state);
         }
 
         if (gamepad.LeftStick.RadialPushedRepeatRate())
@@ -1746,14 +1785,24 @@ public class FrameworkElement : INotifyPropertyChanged
         };
     }
 
+    private float? GetRequestedDirectionAngle(DigitalDirectionState state)
+    {
+        if (!state.ShouldFire)
+        {
+            return null;
+        }
+
+        float x = (state.Right ? 1f : 0f) - (state.Left ? 1f : 0f);
+        float y = (state.Down ? 1f : 0f) - (state.Up ? 1f : 0f);
+        return MathF.Atan2(y, x);
+    }
+
     private float? TryGetRequestedDirectionAngle(IGamePad gamepad)
     {
         DigitalDirectionState state = GetDigitalDirectionState(gamepad);
         if (state.ShouldFire)
         {
-            float x = (state.Right ? 1f : 0f) - (state.Left ? 1f : 0f);
-            float y = (state.Down ? 1f : 0f) - (state.Up ? 1f : 0f);
-            return MathF.Atan2(y, x);
+            return GetRequestedDirectionAngle(state);
         }
 
         if (gamepad.LeftStick.RadialPushedRepeatRate())
@@ -1763,6 +1812,107 @@ public class FrameworkElement : INotifyPropertyChanged
         }
 
         return null;
+    }
+
+    // Mirrors GetDigitalDirectionState(IGamePad) for the new keyboard arrow-key navigation path
+    // (issue #4272): "held" comes from IsComboDown (KeyDown-based, the keyboard analogue of
+    // ButtonDown) and "fired" from IsComboPushed (the same repeat-rate-aware check TabKeyCombos
+    // already uses), so a held combo only triggers on its own push/repeat pulses. Right/Left reuse
+    // IsUsingLeftAndRightGamepadDirectionsForNavigation -- the same flag a control like Slider
+    // already sets false to keep Left/Right for its own value instead of navigation.
+    private DigitalDirectionState GetDigitalDirectionStateFromKeyCombos()
+    {
+        bool right = IsUsingLeftAndRightGamepadDirectionsForNavigation && AnyComboDown(RightKeyCombos);
+        bool left = IsUsingLeftAndRightGamepadDirectionsForNavigation && AnyComboDown(LeftKeyCombos);
+        bool down = AnyComboDown(DownKeyCombos);
+        bool up = AnyComboDown(UpKeyCombos);
+
+        bool shouldFire =
+            (right && AnyComboPushed(RightKeyCombos)) ||
+            (left && AnyComboPushed(LeftKeyCombos)) ||
+            (down && AnyComboPushed(DownKeyCombos)) ||
+            (up && AnyComboPushed(UpKeyCombos));
+
+        return new DigitalDirectionState(right, left, down, up, shouldFire);
+    }
+
+    private static bool AnyComboDown(List<KeyCombo> combos)
+    {
+        foreach (KeyCombo combo in combos)
+        {
+            if (combo.IsComboDown())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool AnyComboPushed(List<KeyCombo> combos)
+    {
+        foreach (KeyCombo combo in combos)
+        {
+            if (combo.IsComboPushed())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Keyboard counterpart to <see cref="HandleGamepadNavigation(GamePadForNavigation)"/> (issue
+    /// #4272): resolves the same <see cref="GamepadNavigationMode"/> and dispatches to
+    /// <see cref="Gum.Forms.SpatialNavigationService"/> scoring (honoring
+    /// <see cref="SpatialNavigationUp"/>-style overrides) or index-based <see cref="HandleTab"/>,
+    /// driven by <see cref="UpKeyCombos"/>/<see cref="DownKeyCombos"/>/<see cref="LeftKeyCombos"/>/
+    /// <see cref="RightKeyCombos"/> instead of a gamepad's D-pad/stick. Called once per frame from
+    /// <see cref="HandleKeyboardFocusUpdate"/>, for whichever element currently has focus.
+    /// </summary>
+    private void HandleKeyboardDirectionalNavigation()
+    {
+        (GamepadNavigationMode mode, GraphicalUiElement? spatialRoot) = ResolveGamepadNavigationMode();
+
+        if (mode == Controls.GamepadNavigationMode.Spatial && spatialRoot != null)
+        {
+            DigitalDirectionState state = GetDigitalDirectionStateFromKeyCombos();
+
+            FrameworkElement? explicitOverride = GetExplicitDirectionOverride(state);
+            if (explicitOverride != null)
+            {
+                explicitOverride.IsFocused = true;
+                this.IsFocused = false;
+                return;
+            }
+
+            float? angle = GetRequestedDirectionAngle(state);
+            if (angle == null)
+            {
+                return;
+            }
+
+            var candidates = Gum.Forms.FrameworkElementTreeExtensions.ProjectToFrameworkElements(spatialRoot.Descendants())
+                .Where(CanElementBeFocused);
+
+            FrameworkElement? best = Gum.Forms.SpatialNavigationService.FindBestCandidate(this, angle.Value, candidates);
+            if (best != null)
+            {
+                best.IsFocused = true;
+                this.IsFocused = false;
+            }
+            return;
+        }
+
+        if (AnyComboPushed(DownKeyCombos) ||
+            (IsUsingLeftAndRightGamepadDirectionsForNavigation && AnyComboPushed(RightKeyCombos)))
+        {
+            this.HandleTab(TabDirection.Down, this, loop: true);
+        }
+        else if (AnyComboPushed(UpKeyCombos) ||
+            (IsUsingLeftAndRightGamepadDirectionsForNavigation && AnyComboPushed(LeftKeyCombos)))
+        {
+            this.HandleTab(TabDirection.Up, this, loop: true);
+        }
     }
 #endif
 


### PR DESCRIPTION
Closes #4272

## Problem
Keyboard focus navigation was Tab/Shift+Tab only (linear index order) — arrow keys did nothing, and there was no way to reach the direction-agnostic ("spatial") navigation gamepad D-pad/stick already have (`GamepadNavigationMode.Spatial`, `SpatialNavigationUp/Down/Left/Right` overrides, issue #4129/#4274).

## Fix
- New static combo lists on `FrameworkElement`: `UpKeyCombos`/`DownKeyCombos`/`LeftKeyCombos`/`RightKeyCombos`, empty by default. Arrow keys are opt-in, not a default — Slider/ListBox/TextBox already claim them for value/selection/caret behavior, so defaulting to bound keys would silently change existing projects' behavior.
- Extracted the gamepad D-pad/stick override + angle logic (`GetDigitalDirectionState`, `TryGetExplicitDirectionOverride`, `TryGetRequestedDirectionAngle`) so the scoring/override core now operates on the shared `DigitalDirectionState` struct directly, with thin gamepad and new keyboard-combo builders feeding it. Gamepad behavior is unchanged (pinned by the existing `GamepadNavigationModeTests`/`ControllerSpatialNavigationTests` suites, still green).
- New `HandleKeyboardDirectionalNavigation`, wired into `HandleKeyboardFocusUpdate`, resolves the same `GamepadNavigationMode` (TabOrder or Spatial) a container already declares and dispatches to `HandleTab` or `SpatialNavigationService.FindBestCandidate` accordingly.
- Left/Right reuse the existing `IsUsingLeftAndRightGamepadDirectionsForNavigation` flag (the same one `Slider` already sets `false`) rather than adding a parallel flag, so a control that opts D-pad Left/Right out of navigation gets the same protection from keyboard Left/Right for free.

## Testing
- New `KeyboardDirectionalNavigationTests` (6 tests): empty-default no-op, TabOrder Up/Down, Spatial-mode movement, explicit `SpatialNavigationRight` override, and the Slider opt-out (confirmed non-vacuous by temporarily removing the flag guard and watching that specific test go red, then reverting).
- Full `MonoGameGum.Tests` suite green (2098/2098). `RaylibGum.Tests` spatial-nav suite green (shares the same source via a linked file).
- `KniGum` builds clean.

FRB canary: not needed — every new member sits inside the file's pre-existing `#if !FRB` region (the same one `GamepadNavigationMode`/spatial nav already uses), so FRB doesn't compile any of this code at all.

Manual test: needed — opened a MonoGame scratch project with a `Spatial`-mode panel (Up/Down/Left/Right buttons around a center button) plus a `Slider`, arrow-key combos configured. Ready for a keyboard check that arrows move focus by screen position and the Slider's Left/Right change its value without stealing focus.
