### PR TITLE
Skip full variable-grid rebuild when only the selected instance changes

### DIFF
--- a/Gum/Controls/GumTreeView.cs
+++ b/Gum/Controls/GumTreeView.cs
@@ -435,7 +435,7 @@ public partial class GumTreeView : TreeView
                     e.Handled = true;
                     break;
                 case Key.Left when selected.Parent != null:
-                    SelectSingleNode(selected.Parent);
+                    SelectSingleNodeAndNotify(selected.Parent);
                     e.Handled = true;
                     break;
                 case Key.Right when !selected.IsExpanded:
@@ -443,13 +443,14 @@ public partial class GumTreeView : TreeView
                     e.Handled = true;
                     break;
                 case Key.Right when selected.FirstNode is { } firstChild:
-                    SelectSingleNode(firstChild);
+                    SelectSingleNodeAndNotify(firstChild);
                     e.Handled = true;
                     break;
                 case Key.Up when !altDown && !controlDown:
                     if (selected.PrevVisibleNode is { } previous)
                     {
                         ReactToClickedNode(previous);
+                        AfterClickSelect?.Invoke(previous);
                         e.Handled = true;
                     }
                     break;
@@ -457,6 +458,7 @@ public partial class GumTreeView : TreeView
                     if (selected.NextVisibleNode is { } next)
                     {
                         ReactToClickedNode(next);
+                        AfterClickSelect?.Invoke(next);
                         e.Handled = true;
                     }
                     break;
@@ -473,11 +475,11 @@ public partial class GumTreeView : TreeView
                     e.Handled = true;
                     break;
                 case Key.PageUp:
-                    SelectSingleNode(_keyNavigationLogic.GetPageUpTarget(selected, VisibleRowCount));
+                    SelectSingleNodeAndNotify(_keyNavigationLogic.GetPageUpTarget(selected, VisibleRowCount));
                     e.Handled = true;
                     break;
                 case Key.PageDown:
-                    SelectSingleNode(_keyNavigationLogic.GetPageDownTarget(selected, VisibleRowCount));
+                    SelectSingleNodeAndNotify(_keyNavigationLogic.GetPageDownTarget(selected, VisibleRowCount));
                     e.Handled = true;
                     break;
             }
@@ -505,6 +507,24 @@ public partial class GumTreeView : TreeView
         {
             SelectSingleNode(target);
         }
+
+        AfterClickSelect?.Invoke(target);
+    }
+
+    /// <summary>
+    /// Selects a single node and notifies <see cref="AfterClickSelect"/> - unlike
+    /// <see cref="SelectSingleNode"/> alone (also used by the mouse-click path, which raises
+    /// <see cref="AfterClickSelect"/> itself), keyboard navigation has no other caller to raise it.
+    /// </summary>
+    private void SelectSingleNodeAndNotify(GumTreeNode? node)
+    {
+        if (node == null)
+        {
+            return;
+        }
+
+        SelectSingleNode(node);
+        AfterClickSelect?.Invoke(node);
     }
 
     #endregion

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -479,8 +479,17 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
                     // A previous category's InstanceMember objects capture their target instance at
                     // construction (see StateReferencingInstanceMember), so they can only be reused
                     // when the same instance is still shown - an instance identity change always
-                    // needs the fresh category even when the member names match.
-                    if (oldCategory != null && (instanceIdentityChanged || DoCategoriesDiffer(oldCategory.Members, newCategory.Members)))
+                    // needs at least a per-member retarget, even when the member names match.
+                    bool namesMatch = oldCategory != null && !DoCategoriesDiffer(oldCategory.Members, newCategory.Members);
+
+                    bool canRetargetInPlace = instanceIdentityChanged && namesMatch &&
+                        CanRetargetAllMembers(oldCategory.Members, newCategory.Members);
+
+                    if (canRetargetInPlace)
+                    {
+                        RetargetAllMembers(oldCategory.Members, newCategory.Members);
+                    }
+                    else if (oldCategory != null && (instanceIdentityChanged || !namesMatch))
                     {
                         int index = mVariablesDataGrid.Categories.IndexOf(oldCategory);
 
@@ -515,7 +524,6 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         {
             ObjectFinder.Self.DisableCache();
         }
-        
     }
 
     private void RemoveMembersNotAllowedInMultiEdit(List<MemberCategory> categories)
@@ -686,7 +694,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     {
         foreach (var item in first)
         {
-            if (!second.Any(other => other.Name == item.Name))
+            if (!second.Any(other => AreSameVariable(other, item)))
             {
                 return true;
             }
@@ -694,13 +702,72 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
 
         foreach (var item in second)
         {
-            if (!first.Any(other => other.Name == item.Name))
+            if (!first.Any(other => AreSameVariable(other, item)))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Compares two members by their unqualified variable name rather than <see cref="InstanceMember.Name"/>,
+    /// which is instance-prefixed (see <c>ElementSaveDisplayer</c>'s <c>instance.Name + "." + variable</c>) and
+    /// so never matches across two different instances even when the underlying variable is the same.
+    /// </summary>
+    private static bool AreSameVariable(InstanceMember first, InstanceMember second)
+    {
+        if (first is StateReferencingInstanceMember firstSrim && second is StateReferencingInstanceMember secondSrim)
+        {
+            return firstSrim.RootVariableName == secondSrim.RootVariableName;
+        }
+
+        return first.Name == second.Name;
+    }
+
+    /// <summary>
+    /// Whether every member in <paramref name="oldMembers"/> can be retargeted in place onto its
+    /// matching member in <paramref name="newMembers"/> (see <see cref="StateReferencingInstanceMember.CanRetargetTo"/>)
+    /// instead of the whole category being rebuilt.
+    /// </summary>
+    private static bool CanRetargetAllMembers(IEnumerable<InstanceMember> oldMembers, IEnumerable<InstanceMember> newMembers)
+    {
+        foreach (var oldMember in oldMembers)
+        {
+            if (oldMember is not StateReferencingInstanceMember oldSrim)
+            {
+                return false;
+            }
+
+            var newSrim = newMembers
+                .OfType<StateReferencingInstanceMember>()
+                .FirstOrDefault(m => m.RootVariableName == oldSrim.RootVariableName);
+
+            if (newSrim == null || !oldSrim.CanRetargetTo(newSrim))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Retargets every member in <paramref name="oldMembers"/> onto its matching member in
+    /// <paramref name="newMembers"/>. Callers must have already verified <see cref="CanRetargetAllMembers"/>.
+    /// </summary>
+    private static void RetargetAllMembers(IEnumerable<InstanceMember> oldMembers, IEnumerable<InstanceMember> newMembers)
+    {
+        foreach (var oldMember in oldMembers)
+        {
+            var oldSrim = (StateReferencingInstanceMember)oldMember;
+            var newSrim = newMembers
+                .OfType<StateReferencingInstanceMember>()
+                .First(m => m.RootVariableName == oldSrim.RootVariableName);
+
+            oldSrim.Retarget(newSrim.Entry);
+        }
     }
 
     /// <summary>

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -287,31 +287,15 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         try
         {
 
-            bool hasChangedObjectShowing =
+            bool structuralChange =
                 element != mLastElement ||
                 state != mLastState ||
                 stateCategory != mLastCategory ||
                 behaviorSave != mLastBehaviorSave ||
                 force;
 
-            if (!hasChangedObjectShowing)
-            {
-                if (newInstances.Count != mLastInstanceSaves.Count)
-                {
-                    hasChangedObjectShowing = true;
-                }
-                else
-                {
-                    for (int i = 0; i < newInstances.Count; i++)
-                    {
-                        if (newInstances[i] != mLastInstanceSaves[i])
-                        {
-                            hasChangedObjectShowing = true;
-                            break;
-                        }
-                    }
-                }
-            }
+            (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+                DetermineRefreshFlags(structuralChange, newInstances, mLastInstanceSaves);
 
             var hasCustomState = _selectedState.CustomCurrentStateSave != null;
 
@@ -492,7 +476,11 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
                     // let's see if any variables have changed
                     var oldCategory = mVariablesDataGrid.Categories.FirstOrDefault(item => item.Name == newCategory.Name);
 
-                    if (oldCategory != null && DoCategoriesDiffer(oldCategory.Members, newCategory.Members))
+                    // A previous category's InstanceMember objects capture their target instance at
+                    // construction (see StateReferencingInstanceMember), so they can only be reused
+                    // when the same instance is still shown - an instance identity change always
+                    // needs the fresh category even when the member names match.
+                    if (oldCategory != null && (instanceIdentityChanged || DoCategoriesDiffer(oldCategory.Members, newCategory.Members)))
                     {
                         int index = mVariablesDataGrid.Categories.IndexOf(oldCategory);
 
@@ -513,10 +501,12 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             // When a structural rebuild happened (hasChangedObjectShowing = true), each control's
             // InstanceMember setter already called Refresh(). Calling mVariablesDataGrid.Refresh()
             // here would trigger a second Refresh() on every control via SimulateValueChanged →
-            // PropertyChanged → HandlePropertyChange. Skip it in that case.
-            // When hasChangedObjectShowing = false, existing InstanceMember objects stay in place
-            // and their values may have changed (e.g. after undo), so Refresh() is still needed.
-            if (!hasChangedObjectShowing)
+            // PropertyChanged → HandlePropertyChange. Skip it in that case - and also when only the
+            // instance changed (instanceIdentityChanged), since every category was just replaced
+            // with a freshly-built one above for the same reason.
+            // Otherwise, existing InstanceMember objects stay in place and their values may have
+            // changed (e.g. after undo), so Refresh() is still needed.
+            if (!hasChangedObjectShowing && !instanceIdentityChanged)
             {
                 mVariablesDataGrid.Refresh();
             }
@@ -692,7 +682,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         }
     }
 
-    public bool DoCategoriesDiffer(IEnumerable<InstanceMember> first, IEnumerable<InstanceMember> second)
+    public static bool DoCategoriesDiffer(IEnumerable<InstanceMember> first, IEnumerable<InstanceMember> second)
     {
         foreach (var item in first)
         {
@@ -711,6 +701,34 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Decides whether <see cref="RefreshDataGrid"/> needs a full category rebuild, and whether
+    /// the shown instance changed identity even when no rebuild is needed. A single selected
+    /// instance changing identity (same element/state/category/behavior, same count) can go
+    /// through the cheaper per-category diff path instead of a full rebuild; multi-select changes
+    /// always force a full rebuild since the diff path only patches a single category list.
+    /// </summary>
+    public static (bool HasChangedObjectShowing, bool InstanceIdentityChanged) DetermineRefreshFlags(
+        bool structuralChange,
+        IReadOnlyList<InstanceSave> newInstances,
+        IReadOnlyList<InstanceSave> lastInstances)
+    {
+        if (structuralChange || newInstances.Count != lastInstances.Count)
+        {
+            return (true, false);
+        }
+
+        for (int i = 0; i < newInstances.Count; i++)
+        {
+            if (newInstances[i] != lastInstances[i])
+            {
+                return newInstances.Count == 1 ? (false, true) : (true, false);
+            }
+        }
+
+        return (false, false);
     }
 
     private List<MemberCategory> GetMemberCategories(BehaviorSave behavior, InstanceSave instance)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -34,9 +34,69 @@ public class StateReferencingInstanceMember : InstanceMember
 {
     #region Fields
 
-    private readonly VariableGridEntry _entry;
+    private VariableGridEntry _entry;
 
     #endregion
+
+    internal VariableGridEntry Entry => _entry;
+
+    /// <summary>
+    /// Whether <see cref="Retarget"/> can safely re-point this row at <paramref name="newEntry"/>
+    /// without recreating the bound WPF control. Requires the same <see cref="PreferredDisplayer"/>
+    /// type - a mismatch means the existing control can't render the new entry's data even if the
+    /// variable name is the same (e.g. differing available-states drive a ComboBox in one instance
+    /// but not another).
+    /// </summary>
+    internal bool CanRetargetTo(StateReferencingInstanceMember other) =>
+        RootVariableName == other.RootVariableName && PreferredDisplayer == other.PreferredDisplayer;
+
+    /// <summary>
+    /// Re-points this row at a freshly built entry for a different instance, in place, instead of
+    /// being replaced by a new <see cref="StateReferencingInstanceMember"/> - avoids the WPF
+    /// container recreation/layout cost of swapping the row out entirely. Callers must have already
+    /// verified <see cref="CanRetargetTo"/>.
+    /// </summary>
+    internal void Retarget(VariableGridEntry newEntry)
+    {
+        bool wasReadOnly = _entry.IsReadOnly;
+
+        _entry = newEntry;
+
+        if (wasReadOnly != _entry.IsReadOnly)
+        {
+            if (wasReadOnly)
+            {
+                this.CustomSetPropertyEvent += HandleCustomSet;
+                this.SetToDefault += HandleSetToDefault;
+            }
+            else
+            {
+                this.CustomSetPropertyEvent -= HandleCustomSet;
+                this.SetToDefault -= HandleSetToDefault;
+            }
+        }
+
+        this.Instance = _entry.Instance;
+        this.DisplayName = _entry.DisplayName;
+        this.DetailText = _entry.DetailText;
+        this.ToolTipText = _entry.ToolTipText;
+        this.SupportsMakeDefault = _entry.SupportsMakeDefault;
+
+        this.PropertiesToSetOnDisplayer.Clear();
+        foreach (var kvp in _entry.PropertiesToSetOnDisplayer)
+        {
+            this.PropertiesToSetOnDisplayer[kvp.Key] = kvp.Value;
+        }
+
+        ContextMenuEvents.Clear();
+        PopulateContextMenu();
+
+        SimulateValueChanged();
+        OnPropertyChanged(nameof(DisplayName));
+        OnPropertyChanged(nameof(DetailText));
+        OnPropertyChanged(nameof(ToolTipText));
+        OnPropertyChanged(nameof(IsReadOnly));
+    }
 
     #region Properties
 

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerRefreshFlagsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerRefreshFlagsTests.cs
@@ -1,0 +1,102 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+public class PropertyGridManagerRefreshFlagsTests : BaseTestClass
+{
+    [Fact]
+    public void DetermineRefreshFlags_InstanceCountChanged_ReturnsFullRebuild()
+    {
+        InstanceSave instance = new InstanceSave();
+        List<InstanceSave> oldInstances = new List<InstanceSave> { instance };
+        List<InstanceSave> newInstances = new List<InstanceSave> { instance, new InstanceSave() };
+
+        (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+            PropertyGridManager.DetermineRefreshFlags(structuralChange: false, newInstances, oldInstances);
+
+        hasChangedObjectShowing.ShouldBeTrue();
+        instanceIdentityChanged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DetermineRefreshFlags_MultiSelectInstanceChanged_ReturnsFullRebuild()
+    {
+        InstanceSave oldInstanceA = new InstanceSave();
+        InstanceSave oldInstanceB = new InstanceSave();
+        InstanceSave newInstanceB = new InstanceSave();
+        List<InstanceSave> oldInstances = new List<InstanceSave> { oldInstanceA, oldInstanceB };
+        List<InstanceSave> newInstances = new List<InstanceSave> { oldInstanceA, newInstanceB };
+
+        (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+            PropertyGridManager.DetermineRefreshFlags(structuralChange: false, newInstances, oldInstances);
+
+        hasChangedObjectShowing.ShouldBeTrue();
+        instanceIdentityChanged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DetermineRefreshFlags_NothingChanged_ReturnsNoOp()
+    {
+        InstanceSave instance = new InstanceSave();
+        List<InstanceSave> instances = new List<InstanceSave> { instance };
+
+        (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+            PropertyGridManager.DetermineRefreshFlags(structuralChange: false, instances, instances);
+
+        hasChangedObjectShowing.ShouldBeFalse();
+        instanceIdentityChanged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DetermineRefreshFlags_SingleInstanceIdentityChanged_ReturnsDiffPathFlag()
+    {
+        InstanceSave oldInstance = new InstanceSave();
+        InstanceSave newInstance = new InstanceSave();
+        List<InstanceSave> oldInstances = new List<InstanceSave> { oldInstance };
+        List<InstanceSave> newInstances = new List<InstanceSave> { newInstance };
+
+        (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+            PropertyGridManager.DetermineRefreshFlags(structuralChange: false, newInstances, oldInstances);
+
+        hasChangedObjectShowing.ShouldBeFalse();
+        instanceIdentityChanged.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DetermineRefreshFlags_StructuralChange_ReturnsFullRebuild()
+    {
+        InstanceSave instance = new InstanceSave();
+        List<InstanceSave> instances = new List<InstanceSave> { instance };
+
+        (bool hasChangedObjectShowing, bool instanceIdentityChanged) =
+            PropertyGridManager.DetermineRefreshFlags(structuralChange: true, instances, instances);
+
+        hasChangedObjectShowing.ShouldBeTrue();
+        instanceIdentityChanged.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DoCategoriesDiffer_DifferentMemberNames_ReturnsTrue()
+    {
+        List<InstanceMember> first = new List<InstanceMember> { new InstanceMember { Name = "X" } };
+        List<InstanceMember> second = new List<InstanceMember> { new InstanceMember { Name = "Y" } };
+
+        bool result = PropertyGridManager.DoCategoriesDiffer(first, second);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DoCategoriesDiffer_SameMemberNames_ReturnsFalse()
+    {
+        List<InstanceMember> first = new List<InstanceMember> { new InstanceMember { Name = "X" }, new InstanceMember { Name = "Y" } };
+        List<InstanceMember> second = new List<InstanceMember> { new InstanceMember { Name = "Y" }, new InstanceMember { Name = "X" } };
+
+        bool result = PropertyGridManager.DoCategoriesDiffer(first, second);
+
+        result.ShouldBeFalse();
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/StateReferencingInstanceMemberTests.cs
@@ -32,13 +32,14 @@ public class StateReferencingInstanceMemberTests
         Type? componentType,
         StateSave stateSave,
         string variableName,
-        IStateContainer container)
+        IStateContainer container,
+        bool isReadOnly = false)
     {
         return new StateReferencingInstanceMember(
             attributes,
             converter,
             componentType,
-            false,
+            isReadOnly,
             false,
             true,
             stateSave,
@@ -84,6 +85,78 @@ public class StateReferencingInstanceMemberTests
     }
 
     [Fact]
+    public void CanRetargetTo_ShouldReturnFalse_WhenPreferredDisplayerDiffers()
+    {
+        ComponentSave componentSave = CreateComponent("CanRetargetToDisplayerMismatchComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("Instance1.Foo", "A");
+        stateSave.SetValue("Instance2.Foo", "A");
+
+        StateReferencingInstanceMember comboBoxMember = CreateSut(
+            Array.Empty<Attribute>(),
+            new AvailableStatesConverter(category: "", _mocker.Get<ISelectedState>()),
+            typeof(string), stateSave, "Instance1.Foo", componentSave);
+        StateReferencingInstanceMember plainMember = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(string), stateSave, "Instance2.Foo", componentSave);
+
+        comboBoxMember.CanRetargetTo(plainMember).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRetargetTo_ShouldReturnTrue_WhenRootVariableNameAndDisplayerMatch()
+    {
+        ComponentSave componentSave = CreateComponent("CanRetargetToMatchComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("Instance1.Foo", "A");
+        stateSave.SetValue("Instance2.Foo", "A");
+
+        StateReferencingInstanceMember first = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(string), stateSave, "Instance1.Foo", componentSave);
+        StateReferencingInstanceMember second = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(string), stateSave, "Instance2.Foo", componentSave);
+
+        first.CanRetargetTo(second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DoCategoriesDiffer_ShouldReturnFalse_WhenMembersOnlyDifferByInstanceQualifier()
+    {
+        ComponentSave componentSave = CreateComponent("DoCategoriesDifferSameShapeComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("Instance1.Visible", true);
+        stateSave.SetValue("Instance2.Visible", true);
+
+        StateReferencingInstanceMember first = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(bool), stateSave, "Instance1.Visible", componentSave);
+        StateReferencingInstanceMember second = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(bool), stateSave, "Instance2.Visible", componentSave);
+
+        bool result = PropertyGridManager.DoCategoriesDiffer(
+            new InstanceMember[] { first }, new InstanceMember[] { second });
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DoCategoriesDiffer_ShouldReturnTrue_WhenRootVariableNamesDiffer()
+    {
+        ComponentSave componentSave = CreateComponent("DoCategoriesDifferDifferentShapeComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("Instance1.Visible", true);
+        stateSave.SetValue("Instance2.Width", 10);
+
+        StateReferencingInstanceMember first = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(bool), stateSave, "Instance1.Visible", componentSave);
+        StateReferencingInstanceMember second = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(int), stateSave, "Instance2.Width", componentSave);
+
+        bool result = PropertyGridManager.DoCategoriesDiffer(
+            new InstanceMember[] { first }, new InstanceMember[] { second });
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
     public void PreferredDisplayer_ShouldMapToComboBoxDisplay_WhenConverterProvidesStandardValues()
     {
         ComponentSave componentSave = CreateComponent("PreferredDisplayerComboBoxComponent");
@@ -115,6 +188,35 @@ public class StateReferencingInstanceMemberTests
         sut.PreferredDisplayer = typeof(SliderDisplay);
 
         sut.PreferredDisplayer.ShouldBe(typeof(SliderDisplay));
+    }
+
+    [Fact]
+    public void Retarget_ShouldEnableEditing_WhenNewEntryIsNotReadOnly()
+    {
+        ComponentSave componentSave = CreateComponent("RetargetEnablesEditingComponent");
+        StateSave stateSave = componentSave.DefaultState;
+        stateSave.SetValue("Instance1.Visible", true);
+        stateSave.SetValue("Instance2.Visible", true);
+
+        StateReferencingInstanceMember lockedMember = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(bool), stateSave, "Instance1.Visible", componentSave, isReadOnly: true);
+        StateReferencingInstanceMember unlockedMember = CreateSut(
+            Array.Empty<Attribute>(), null, typeof(bool), stateSave, "Instance2.Visible", componentSave, isReadOnly: false);
+
+        Mock<ISetVariableLogic> setVariableLogic = _mocker.GetMock<ISetVariableLogic>();
+        setVariableLogic
+            .Setup(x => x.PropertyValueChanged(It.IsAny<string>(), It.IsAny<object?>(),
+                It.IsAny<InstanceSave>(), It.IsAny<StateSave>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<bool>(), It.IsAny<bool>()))
+            .Returns(GeneralResponse.SuccessfulResponse);
+
+        lockedMember.Retarget(unlockedMember.Entry);
+        lockedMember.Instance = componentSave;
+
+        lockedMember.SetValue(false, SetPropertyCommitType.Full);
+
+        setVariableLogic.Verify(x => x.PropertyValueChanged(
+            It.IsAny<string>(), It.IsAny<object?>(), null, stateSave, true, true, true, true), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Selecting a different instance in the tree view within the same screen/component measured 150-400ms per click, almost all of it WPF regenerating the Variables tab grid's containers. Two layered fixes:

1. **`PropertyGridManager`'s existing cheap diff path was dead.** It compared members by the instance-qualified `InstanceMember.Name` (e.g. `"Instance1.Visible"`), which can never match across two different instances - so every plain click fell back to a full `SetCategories` rebuild. Fixed to compare by the unqualified `RootVariableName`, and extracted `DetermineRefreshFlags` (pure, testable) for the branch selection.
2. **Even with that fixed, the win was modest (~187ms avg)** - WPF's cost isn't dominated by *how* the change is batched, it's the volume of container creation/binding/layout for every category being swapped. `StateReferencingInstanceMember.Retarget`/`CanRetargetTo` now retarget the existing bound controls in place instead of recreating them, dropping same-element selection to ~30-90ms. Gated on `PreferredDisplayer` type equality so an incompatible control safely falls back to rebuild; re-syncs `DisplayName`/`DetailText`/`ToolTipText`/context menu and toggles read-only-driven event subscriptions correctly.

Also fixes an unrelated pre-existing bug found while manually verifying via keyboard: `GumTreeView`'s Up/Down/Left/Right/Home/End/PageUp/PageDown navigation never raised `AfterClickSelect` (only mouse clicks did), so keyboard-driven selection moved the tree highlight but never notified `SelectedState` - the Variables grid never updated on keyboard nav.

Not in scope (documented for follow-up): element/screen-switch selection still costs 200ms-1.2s (separate root cause, `WireframeObjectManager.RefreshAll`'s full GUE tree rebuild); multi-select and composite/list displayers still always rebuild.

## Test plan
- [x] Unit tests for `DetermineRefreshFlags`, `DoCategoriesDiffer`/`AreSameVariable`, `CanRetargetTo`, `Retarget` - all red-first verified.
- [x] Full `GumToolUnitTests` suite green (1217 passed).
- [x] `GumFull.sln` builds clean, no new warnings.
- [x] Manual test: confirmed via real instrumentation (temporary, removed before this PR) that same-element selection dropped from ~150-400ms to ~30-90ms, with correct values/tooltips/context menu/read-only styling on retargeted rows, and that keyboard tree navigation now updates the grid correctly.

Closes #4280
