### PR TITLE
Warm up hot Variables-tab WPF displayer controls at startup (#4283)

### DIFF
--- a/Gum/Diagnostics/StartupPerfLog.cs
+++ b/Gum/Diagnostics/StartupPerfLog.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Gum.Diagnostics;
+
+/// <summary>
+/// TEMPORARY instrumentation for issue #4283 (evaluating a WPF displayer control warm-up pass).
+/// Writes wall-clock-since-start timestamps to a fixed log file so before/after startup timing
+/// can be compared without asking anyone to relay console output. Remove once #4283 is resolved.
+/// </summary>
+internal static class StartupPerfLog
+{
+    private static readonly string LogFilePath = Path.Combine(Path.GetTempPath(), "gum_startup_timing.log");
+    private static readonly Stopwatch Stopwatch = new();
+
+    /// <summary>
+    /// Starts the stopwatch and truncates the log file. Must be called once, as early as possible
+    /// in <c>Main</c>, before anything else runs.
+    /// </summary>
+    public static void Start()
+    {
+        Stopwatch.Restart();
+        File.WriteAllText(LogFilePath, string.Empty);
+    }
+
+    /// <summary>
+    /// Appends a timestamped line (milliseconds since <see cref="Start"/>) to the log file.
+    /// Never throws - a diagnostic write must not be able to affect real app behavior.
+    /// </summary>
+    public static void Log(string message)
+    {
+        try
+        {
+            File.AppendAllText(LogFilePath, $"{Stopwatch.ElapsedMilliseconds,6}ms | {message}{Environment.NewLine}");
+        }
+        catch
+        {
+            // Best-effort diagnostic logging only.
+        }
+    }
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -277,12 +277,23 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     /// <param name="state">The state to display.</param>
     /// <param name="instance">The instance to display. May be null.</param>
     /// <param name="force">Whether to refresh even if the element, state, and instance have not changed.</param>
-    private void RefreshDataGrid(ElementSave? element, 
-        StateSave? state, 
-        StateSaveCategory? stateCategory, 
-        List<InstanceSave> newInstances, 
+    // TEMPORARY instrumentation for #4283 - remove once the warm-up evaluation is done.
+    private static bool _hasLoggedFirstRefreshDataGrid;
+
+    private void RefreshDataGrid(ElementSave? element,
+        StateSave? state,
+        StateSaveCategory? stateCategory,
+        List<InstanceSave> newInstances,
         BehaviorSave? behaviorSave, bool force = false)
     {
+        if (!_hasLoggedFirstRefreshDataGrid)
+        {
+            _hasLoggedFirstRefreshDataGrid = true;
+            Gum.Diagnostics.StartupPerfLog.Log(
+                $"PropertyGridManager.RefreshDataGrid first call (displayer warm-up: " +
+                $"{VariableGridDisplayerWarmup.WarmedCount}/{VariableGridDisplayerWarmup.TotalCount} types warmed)");
+        }
+
         ObjectFinder.Self.EnableCache();
         try
         {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableGridDisplayerWarmup.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableGridDisplayerWarmup.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Gum.Controls.DataUi;
+using Gum.Diagnostics;
+using Gum.Plugins.VariableGrid;
+using WpfDataUi.Controls;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Proactively instantiates the WPF displayer controls used by the Variables tab so that each
+/// control type's one-time style/template resolution and BAML parse cost lands during startup
+/// idle time instead of on the user's first click into the grid (#4283).
+/// </summary>
+/// <remarks>
+/// Instances are constructed but never added to a visual tree or shown - construction alone is
+/// enough to force WPF to resolve the type's style/template. Each construction is queued as its
+/// own low-priority dispatcher callback so real UI work (window paint, user input) is always free
+/// to run first rather than waiting behind one large block of warm-up work.
+/// </remarks>
+internal static class VariableGridDisplayerWarmup
+{
+    private static readonly Func<UserControl>[] Factories =
+    {
+        () => new TextBoxDisplay(),
+        () => new SliderDisplay(),
+        () => new ComboBoxDisplay(),
+        () => new CheckBoxDisplay(),
+        () => new NullableBoolDisplay(),
+        () => new AngleSelectorDisplay(),
+        () => new FileSelectionDisplay(),
+        () => new MultiLineTextBoxDisplay(),
+        () => new StringListTextBoxDisplay(),
+        () => new ListBoxDisplay(),
+        () => new ToggleButtonOptionDisplay(Array.Empty<ToggleButtonOptionDisplay.Option>()),
+        () => new ColorDisplay(),
+        () => new VariableRemoveButton(),
+    };
+
+    // Keeps constructed instances reachable for the lifetime of the app. Not required for
+    // correctness (nothing here is reused later), but avoids relying on GC timing mid-warm-up.
+    private static readonly List<UserControl> WarmedControls = new();
+
+    /// <summary>Number of displayer types warmed so far. For diagnostics only.</summary>
+    public static int WarmedCount => WarmedControls.Count;
+
+    /// <summary>Total number of displayer types this pass will warm.</summary>
+    public static int TotalCount => Factories.Length;
+
+    /// <summary>
+    /// Queues one <see cref="DispatcherPriority.Background"/> callback per displayer type on the
+    /// given dispatcher. Safe to call multiple times - only the first call schedules work.
+    /// </summary>
+    public static void ScheduleWarmUp(Dispatcher dispatcher)
+    {
+        if (WarmedControls.Count > 0 || Factories.Length == 0)
+        {
+            return;
+        }
+
+        StartupPerfLog.Log("VariableGridDisplayerWarmup.ScheduleWarmUp queued");
+        ScheduleNext(dispatcher, index: 0);
+    }
+
+    private static void ScheduleNext(Dispatcher dispatcher, int index)
+    {
+        if (index >= Factories.Length)
+        {
+            StartupPerfLog.Log($"VariableGridDisplayerWarmup complete ({WarmedControls.Count}/{Factories.Length})");
+            return;
+        }
+
+        dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+        {
+            var factory = Factories[index];
+            try
+            {
+                WarmedControls.Add(factory());
+            }
+            catch (Exception exception)
+            {
+                // Warm-up is a best-effort perf optimization - a failure here must never surface
+                // to the user or block the rest of the grid from working normally.
+                StartupPerfLog.Log($"VariableGridDisplayerWarmup[{index}] failed: {exception.Message}");
+            }
+
+            ScheduleNext(dispatcher, index + 1);
+        }));
+    }
+}

--- a/Gum/Program.cs
+++ b/Gum/Program.cs
@@ -34,6 +34,9 @@ namespace Gum
         [STAThread]
         static int Main(string[] args)
         {
+            // TEMPORARY instrumentation for #4283 - remove once the warm-up evaluation is done.
+            Gum.Diagnostics.StartupPerfLog.Start();
+
             System.Windows.Media.RenderOptions.ProcessRenderMode = System.Windows.Interop.RenderMode.SoftwareOnly;
             System.Windows.Forms.Application.EnableVisualStyles();
             System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
@@ -82,7 +85,10 @@ namespace Gum
             };
 
             app.MainWindow = host.Services.GetRequiredService<MainWindow>();
+            // TEMPORARY instrumentation for #4283 - remove once the warm-up evaluation is done.
+            app.MainWindow.ContentRendered += (_, _) => Gum.Diagnostics.StartupPerfLog.Log("MainWindow.ContentRendered (first paint)");
             app.MainWindow.Visibility = Visibility.Visible;
+            Gum.Diagnostics.StartupPerfLog.Log("MainWindow.Visibility = Visible");
 
             await InitializeGum(host.Services).ConfigureAwait(true);
 

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -904,6 +904,11 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         IEffectiveThemeSettings themeSettings = _themingService.EffectiveSettings;
         ApplyThemeSettings(themeSettings);
 
+        // Queued at Background dispatcher priority, so it only runs once the main window has
+        // finished its own higher-priority paint/input work - see VariableGridDisplayerWarmup
+        // remarks. #4283.
+        VariableGridDisplayerWarmup.ScheduleWarmUp(System.Windows.Application.Current.Dispatcher);
+
         // Must be the last statement in this method - XnaUpdate (wired up in
         // HandleWireframeInitialized, which runs earlier during startup) can fire before this
         // event handler runs, since WPF's CompositionTarget.Rendering isn't gated on it. Only


### PR DESCRIPTION
## Summary
Evaluates the fix proposed in #4283: proactively construct one instance of each hot Variables-tab WPF displayer control type on a background-priority dispatcher callback after the main window is shown, so the one-time style/template resolution + BAML parse cost for each type lands during startup idle time instead of on the user's first click into the Variables grid.

Hot set (confirmed via `PreferredDisplayer` assignments in `StandardElementsManager.GumTool.cs`/`PropertyGridManager.cs` and `SingleDataUiContainer`'s type-fallback table): `TextBoxDisplay`, `SliderDisplay`, `ComboBoxDisplay`, `CheckBoxDisplay`, `NullableBoolDisplay`, `AngleSelectorDisplay`, `FileSelectionDisplay`, `MultiLineTextBoxDisplay`, `StringListTextBoxDisplay`, `ListBoxDisplay`, `ToggleButtonOptionDisplay`, `ColorDisplay`, `VariableRemoveButton`.

Excluded as not confirmed hot for the Variables tab specifically: `MultiFileDisplay` (Project Properties dialog only), `PlusMinusTextBox`/`EditableComboBoxDisplay` (no call sites found anywhere in the tool).

Each warm-up construction is queued as its own `Dispatcher.BeginInvoke(DispatcherPriority.Background, ...)` call (chained one-at-a-time) rather than one big batch, so real UI work (paint, input) always gets priority over the remaining warm-up work.

Also adds **temporary** timing instrumentation (`Gum.Diagnostics.StartupPerfLog`, per the `self-serve-logging` skill) writing to `%TEMP%\gum_startup_timing.log`: time to `MainWindow.Visibility = Visible`, time to `MainWindow.ContentRendered` (first paint), warm-up schedule/completion, and the first `PropertyGridManager.RefreshDataGrid` call with how many of the 13 types were already warmed at that point. Remove after evaluation.

Companion to #4282 (ReadyToRun publish) - intentionally separate, does not touch publish/csproj settings.

Closes #4283

## Test plan
- [x] `dotnet build GumFull.sln` - succeeds, no new warnings
- [ ] Manual: run built `Gum.exe`, use the Variables tab, confirm no regression; read `%TEMP%\gum_startup_timing.log` for before/after timing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
