### PR TITLE
Fix spatial navigation excluding narrow candidates below/above a wide origin

### DIFF
--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -67,9 +67,11 @@ public class ControllerSpatialNavigationTests : BaseTestClass
     {
         ContainerRuntime root = new ContainerRuntime();
 
+        // Deltas keep the default-sized harness rectangles from overlapping each other; distance is
+        // measured rect-to-rect, so an overlap would flatten the angle between them to axis-aligned.
         SpatialNavHarness origin = CreateHarness(root, 0, 0);
-        SpatialNavHarness right = CreateHarness(root, 150, 0);
-        SpatialNavHarness downRight = CreateHarness(root, 100, 100);
+        SpatialNavHarness right = CreateHarness(root, 400, 0);
+        SpatialNavHarness downRight = CreateHarness(root, 200, 200);
 
         origin.IsFocused = true;
 
@@ -98,8 +100,8 @@ public class ControllerSpatialNavigationTests : BaseTestClass
         ContainerRuntime root = new ContainerRuntime();
 
         SpatialNavHarness origin = CreateHarness(root, 0, 0);
-        SpatialNavHarness pureRight = CreateHarness(root, 150, 0);
-        SpatialNavHarness diagonal = CreateHarness(root, 100, -100);
+        SpatialNavHarness pureRight = CreateHarness(root, 400, 0);
+        SpatialNavHarness diagonal = CreateHarness(root, 200, -200);
 
         origin.IsFocused = true;
 
@@ -124,8 +126,8 @@ public class ControllerSpatialNavigationTests : BaseTestClass
         ContainerRuntime root = new ContainerRuntime();
 
         SpatialNavHarness origin = CreateHarness(root, 0, 0);
-        SpatialNavHarness right = CreateHarness(root, 150, 0);
-        SpatialNavHarness above = CreateHarness(root, 0, -150);
+        SpatialNavHarness right = CreateHarness(root, 400, 0);
+        SpatialNavHarness above = CreateHarness(root, 0, -400);
 
         origin.IsFocused = true;
 
@@ -269,8 +271,8 @@ public class ControllerSpatialNavigationTests : BaseTestClass
         ContainerRuntime root = new ContainerRuntime();
 
         SpatialNavHarness origin = CreateHarness(root, 0, 0);
-        SpatialNavHarness downRight = CreateHarness(root, 100, 100);
-        SpatialNavHarness right = CreateHarness(root, 150, 0);
+        SpatialNavHarness downRight = CreateHarness(root, 200, 200);
+        SpatialNavHarness right = CreateHarness(root, 400, 0);
 
         origin.IsFocused = true;
 

--- a/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
+++ b/MonoGameGum.Tests/Forms/SpatialNavigationServiceTests.cs
@@ -22,9 +22,12 @@ public class SpatialNavigationServiceTests : BaseTestClass
     [Fact]
     public void FindBestCandidate_DiagonalRequest_PicksDiagonallyPlacedCandidate()
     {
+        // Deltas are large enough that none of these default-sized (128x31) buttons' rectangles
+        // overlap each other -- distance is now measured rect-to-rect, so overlapping rectangles
+        // would otherwise flatten the angle between them to purely axis-aligned.
         Button origin = CreatePositionedButton(0, 0);
-        Button rightOnAxis = CreatePositionedButton(150, 0);
-        Button downRightDiagonal = CreatePositionedButton(100, 100);
+        Button rightOnAxis = CreatePositionedButton(400, 0);
+        Button downRightDiagonal = CreatePositionedButton(200, 200);
 
         List<FrameworkElement> candidates = new() { rightOnAxis, downRightDiagonal };
 
@@ -165,8 +168,9 @@ public class SpatialNavigationServiceTests : BaseTestClass
     [Fact]
     public void FindBestCandidate_NeverReturnsOrigin_EvenIfPresentInCandidates()
     {
+        // 200-unit delta so the default-sized (128x31) buttons' rectangles don't overlap.
         Button origin = CreatePositionedButton(0, 0);
-        Button only = CreatePositionedButton(100, 0);
+        Button only = CreatePositionedButton(200, 0);
 
         List<FrameworkElement> candidates = new() { origin, only };
 
@@ -178,9 +182,10 @@ public class SpatialNavigationServiceTests : BaseTestClass
     [Fact]
     public void FindBestCandidate_PicksNearerOnAxisCandidate_OverFartherOne()
     {
+        // Deltas keep the default-sized (128x31) buttons' rectangles from overlapping each other.
         Button origin = CreatePositionedButton(0, 0);
-        Button near = CreatePositionedButton(100, 0);
-        Button far = CreatePositionedButton(300, 0);
+        Button near = CreatePositionedButton(200, 0);
+        Button far = CreatePositionedButton(500, 0);
 
         List<FrameworkElement> candidates = new() { near, far };
 
@@ -259,6 +264,40 @@ public class SpatialNavigationServiceTests : BaseTestClass
         FrameworkElement? result = SpatialNavigationService.FindBestCandidate(origin, straightDown, candidates);
 
         result.ShouldBe(wideBelow);
+    }
+
+    [Fact]
+    public void FindBestCandidate_FromWideOrigin_PicksNarrowCandidateOffsetFromOriginCenter()
+    {
+        // Reproduces issue #4287: mirror image of the "wide candidate" fix above. Here the ORIGIN is
+        // wide (e.g. a full-width Slider sitting between a top-left and bottom-left button), and the
+        // candidate is narrow. Measuring from the origin's raw center puts the reference point far
+        // to the side of the candidate, so the candidate's true closest point (directly below the
+        // origin's left edge) falls outside the direction cone and is wrongly excluded.
+        Button wideOrigin = new();
+        wideOrigin.AddToRoot();
+        wideOrigin.WidthUnits = DimensionUnitType.Absolute;
+        wideOrigin.HeightUnits = DimensionUnitType.Absolute;
+        wideOrigin.X = 0;
+        wideOrigin.Y = 275;
+        wideOrigin.Width = 800;
+        wideOrigin.Height = 50;
+
+        Button narrowBelow = new();
+        narrowBelow.AddToRoot();
+        narrowBelow.WidthUnits = DimensionUnitType.Absolute;
+        narrowBelow.HeightUnits = DimensionUnitType.Absolute;
+        narrowBelow.X = 0;
+        narrowBelow.Y = 550;
+        narrowBelow.Width = 50;
+        narrowBelow.Height = 50;
+
+        List<FrameworkElement> candidates = new() { narrowBelow };
+
+        float straightDown = MathF.PI / 2f;
+        FrameworkElement? result = SpatialNavigationService.FindBestCandidate(wideOrigin, straightDown, candidates);
+
+        result.ShouldBe(narrowBelow);
     }
 
     [Fact]

--- a/MonoGameGum/Forms/SpatialNavigationService.cs
+++ b/MonoGameGum/Forms/SpatialNavigationService.cs
@@ -16,14 +16,15 @@ public static class SpatialNavigationService
 {
     /// <summary>
     /// Returns whichever <paramref name="candidates"/> element best matches
-    /// <paramref name="directionAngleRadians"/> from <paramref name="origin"/>'s center, or null if
-    /// none qualify. Distance and angle to each candidate are measured to the closest point on that
-    /// candidate's own rectangle to <paramref name="origin"/>'s center, not the candidate's raw
-    /// center — a wide candidate (e.g. a full-width Slider) can otherwise have its center sit far
-    /// enough to the side that the angle falls outside the direction cone, even though the
-    /// candidate's rectangle spans directly across from the origin. Candidates outside the
-    /// direction cone (<paramref name="maxAngleRadians"/> either side of the requested angle) are
-    /// excluded so navigation never moves backwards; among the rest, the lowest
+    /// <paramref name="directionAngleRadians"/> from <paramref name="origin"/>, or null if none
+    /// qualify. Distance and angle are measured between the closest points of the origin's and each
+    /// candidate's rectangles (the AABB gap along each axis, zero on an axis where the two rectangles'
+    /// ranges overlap), not raw center-to-center — either rectangle can be wide (e.g. a full-width
+    /// Slider as the origin or as a candidate) and have its center sit far enough to the side that a
+    /// center-based angle falls outside the direction cone, even though the rectangles are directly
+    /// across from each other. Candidates outside the direction cone
+    /// (<paramref name="maxAngleRadians"/> either side of the requested angle) are excluded so
+    /// navigation never moves backwards; among the rest, the lowest
     /// <c>distance * (1 + angleWeight * angleDiff / maxAngleRadians)</c> score wins.
     /// </summary>
     /// <param name="origin">The currently-focused element navigation is relative to.</param>
@@ -52,8 +53,6 @@ public static class SpatialNavigationService
     {
         List<FrameworkElement> candidateList = candidates as List<FrameworkElement> ?? new List<FrameworkElement>(candidates);
 
-        (float originX, float originY) = GetCenter(origin);
-
         FrameworkElement? best = null;
         float bestScore = float.MaxValue;
 
@@ -67,9 +66,7 @@ public static class SpatialNavigationService
                 continue;
             }
 
-            (float candidateX, float candidateY) = GetClosestPoint(candidate, originX, originY);
-            float dx = candidateX - originX;
-            float dy = candidateY - originY;
+            (float dx, float dy) = GetClosestGap(origin, candidate);
             float distance = MathF.Sqrt(dx * dx + dy * dy);
 
             if (distance == 0f)
@@ -113,26 +110,52 @@ public static class SpatialNavigationService
         return false;
     }
 
-    private static (float x, float y) GetCenter(FrameworkElement element)
+    // The (dx, dy) gap from origin's rectangle to candidate's rectangle: zero on any axis where the
+    // two rectangles' ranges overlap on that axis, and the true edge-to-edge gap (signed, positive
+    // toward candidate) on any axis where they don't. This is symmetric in rectangle size -- unlike
+    // measuring from one side's raw center, a wide rectangle on EITHER side (origin or candidate)
+    // can't push the angle off-axis on an axis where the two actually line up.
+    private static (float dx, float dy) GetClosestGap(FrameworkElement origin, FrameworkElement candidate)
     {
-        float x = (element.Visual.AbsoluteLeft + element.Visual.AbsoluteRight) / 2f;
-        float y = (element.Visual.AbsoluteTop + element.Visual.AbsoluteBottom) / 2f;
-        return (x, y);
-    }
+        float originLeft = origin.Visual.AbsoluteLeft;
+        float originRight = origin.Visual.AbsoluteRight;
+        float originTop = origin.Visual.AbsoluteTop;
+        float originBottom = origin.Visual.AbsoluteBottom;
 
-    // The point on element's rectangle nearest to (fromX, fromY) -- equal to element's own center
-    // when (fromX, fromY) falls outside its bounds on both axes, but clamped onto the rectangle's
-    // edge on any axis where (fromX, fromY) already overlaps it.
-    private static (float x, float y) GetClosestPoint(FrameworkElement element, float fromX, float fromY)
-    {
-        float left = element.Visual.AbsoluteLeft;
-        float right = element.Visual.AbsoluteRight;
-        float top = element.Visual.AbsoluteTop;
-        float bottom = element.Visual.AbsoluteBottom;
+        float candidateLeft = candidate.Visual.AbsoluteLeft;
+        float candidateRight = candidate.Visual.AbsoluteRight;
+        float candidateTop = candidate.Visual.AbsoluteTop;
+        float candidateBottom = candidate.Visual.AbsoluteBottom;
 
-        float x = Math.Clamp(fromX, left, right);
-        float y = Math.Clamp(fromY, top, bottom);
-        return (x, y);
+        float dx;
+        if (candidateRight < originLeft)
+        {
+            dx = candidateRight - originLeft;
+        }
+        else if (candidateLeft > originRight)
+        {
+            dx = candidateLeft - originRight;
+        }
+        else
+        {
+            dx = 0f;
+        }
+
+        float dy;
+        if (candidateBottom < originTop)
+        {
+            dy = candidateBottom - originTop;
+        }
+        else if (candidateTop > originBottom)
+        {
+            dy = candidateTop - originBottom;
+        }
+        else
+        {
+            dy = 0f;
+        }
+
+        return (dx, dy);
     }
 
     // Wraps to (-π, π] so the angular difference between two directions is always the shorter way around.


### PR DESCRIPTION
Closes #4287

`SpatialNavigationService.FindBestCandidate` measured distance/angle from a candidate's closest point to the *origin's raw center*. When origin is wide (e.g. a full-width Slider), its center can sit far to the side of a narrow candidate directly below/above it, excluding it from the direction cone.

Fix: measure via true rect-to-rect (AABB) gap distance instead — zero on any axis where the two rectangles' ranges overlap, symmetric regardless of which side is wide.

Fixing this exposed 4 pre-existing tests whose default-sized (128x31) buttons/harnesses accidentally overlapped at their small position deltas — harmless under the old center-based math, but true rect distance correctly treats overlapping rects as zero-gap. Increased those deltas so the rects stay separated; behavior/intent unchanged.
