### PR TITLE
Skip CI on docs-only changes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,8 +3,10 @@ name: Build and Test Runtimes, Unit Tests, Generated Code Projects
 on:
   push:
     branches: [main]
+    paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   pull_request:
     branches: [master, main]
+    paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-samples.yaml
+++ b/.github/workflows/build-samples.yaml
@@ -6,8 +6,10 @@ name: "Build Samples"
 on:
   push:
     branches: [main]
+    paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   pull_request:
     branches: [master, main]
+    paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`build-and-test` and `build-samples` ran their full ~10min suite on every push/PR regardless of what changed, so a docs-only edit (e.g. #4293) paid full CI cost for zero build-relevant diff.

Adds `paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']` to both workflows' `push`/`pull_request` triggers. A push/PR touching only those paths now skips both workflows entirely.

`main` has no branch protection / required status checks, so there's no stuck-PR risk from a skipped run never reporting back.

Manual test: this PR itself touches `.github/workflows/*.yaml`, not the ignored paths, so CI still runs here — that validates the trigger syntax and that non-docs changes are unaffected. The docs-only skip itself will only be observable on the next docs-only PR after this merges.
