### PR TITLE
Make MonoGameGum mobile TFMs opt-in, matching KniGum

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -51,13 +51,12 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      # Restore NuGet packages once. ExcludeIOS / ExcludeAndroid let the tool build
-      # on CI runners that do not have the mobile workloads installed. Mobile-TFM
-      # assemblies are skipped; consumers who need them build locally with the
-      # workloads installed.
+      # Restore NuGet packages once. MonoGameGum/KniGum default to desktop-only
+      # (mobile TFMs are opt-in via IncludeIOS/IncludeAndroid), so this runner
+      # never needs the mobile workloads installed.
       # Uses GumFull.sln so the CLI is built and copied into the Gum tool output
       - name: Restore
-        run: dotnet restore GumFull.sln -p:ExcludeIOS=true -p:ExcludeAndroid=true
+        run: dotnet restore GumFull.sln
 
       # Update AssemblyInfo.cs version dynamically to current date. The build version lives
       # in an AssemblyMetadata("BuildVersion", ...) attribute rather than
@@ -81,7 +80,7 @@ jobs:
       # Build GUM TOOL (GumFull.sln includes Gum.Cli, which gets copied into the tool output;
       # plugins use $(SolutionDir) in their post-build events so they must be built via the solution)
       - name: Build Gum Tool
-        run: dotnet build GumFull.sln -c Release --no-restore -p:ExcludeIOS=true -p:ExcludeAndroid=true
+        run: dotnet build GumFull.sln -c Release --no-restore
 
       # Publish Gum as a framework-dependent single-file bundle.
       # All managed assemblies are bundled into Gum.exe; the .NET runtime is still required.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -62,8 +62,8 @@ jobs:
   # before System32).
   #
   # Needs neither FNA/Sokol submodules nor mobile workloads - the harness only references
-  # MonoGameGum/GumCommon - so ExcludeAndroid/ExcludeIOS keep restore on just net8.0, same escape
-  # hatches Build-Generated-Code below uses for the same reason.
+  # MonoGameGum/GumCommon, and mobile TFMs are opt-in (IncludeIOS/IncludeAndroid), so restore
+  # stays on just net8.0 with no flags needed.
   Native-AOT-Smoke:
     if: github.event_name != 'push'
     runs-on: windows-latest
@@ -84,7 +84,7 @@ jobs:
         run: echo "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Publish harness as Native AOT
-        run: dotnet publish "Tests/NativeAotSmoke.Harness/NativeAotSmoke.Harness.csproj" --configuration Release -r win-x64 --self-contained -p:ExcludeAndroid=true -p:ExcludeIOS=true
+        run: dotnet publish "Tests/NativeAotSmoke.Harness/NativeAotSmoke.Harness.csproj" --configuration Release -r win-x64 --self-contained
 
       # Same download/extract as "Install Mesa llvmpipe" below, pointed at this job's own AOT
       # publish output instead of RaylibGum.Tests' bin dir.

--- a/.github/workflows/dotnet-nuget.yaml
+++ b/.github/workflows/dotnet-nuget.yaml
@@ -129,11 +129,12 @@ jobs:
         dotnet workload install wasm-tools
         dotnet workload install maui
     
-    # IncludeAndroid=true forces KniGum's net9.0-android TFM to be restored, built, and
-    # packed. KniGum uses opt-in for Android (see KniGum.csproj); without this flag the
-    # published Gum.KNI nupkg would silently drop its Android TFM.
+    # IncludeAndroid/IncludeIOS force KniGum's net9.0-android TFM and MonoGameGum's
+    # net9.0-ios/net9.0-android TFMs to be restored, built, and packed. Both csprojs use
+    # opt-in for mobile (see their comments); without these flags the published Gum.KNI /
+    # Gum.MonoGame nupkgs would silently drop their mobile TFMs.
     - name: Restore dependencies
-      run: dotnet restore ${{ env.SOLUTION_FILE }} -p:IncludeAndroid=true
+      run: dotnet restore ${{ env.SOLUTION_FILE }} -p:IncludeAndroid=true -p:IncludeIOS=true
 
     - name: Compute version override
       id: ver
@@ -147,7 +148,7 @@ jobs:
         }
 
     - name: Build solution
-      run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore -p:IncludeAnalyzers=true -p:IncludeAndroid=true ${{ steps.ver.outputs.flag }}
+      run: dotnet build ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-restore -p:IncludeAnalyzers=true -p:IncludeAndroid=true -p:IncludeIOS=true ${{ steps.ver.outputs.flag }}
 
     # Vic says - why run tests? This seems redundant since we already run tests before merging into main
     # - name: Run tests
@@ -155,7 +156,7 @@ jobs:
 
     # Pack NuGet packages (Debug build) - includes both .nupkg and .snupkg
     - name: Pack NuGet packages
-      run: dotnet pack ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-build --output ./nupkgs --include-symbols --include-source -p:IncludeAnalyzers=true -p:IncludeAndroid=true ${{ steps.ver.outputs.flag }}
+      run: dotnet pack ${{ env.SOLUTION_FILE }} --configuration ${{ env.CONFIGURATION }} --no-build --output ./nupkgs --include-symbols --include-source -p:IncludeAnalyzers=true -p:IncludeAndroid=true -p:IncludeIOS=true ${{ steps.ver.outputs.flag }}
 
     # Build and pack GumCli as a dotnet tool (not in AllLibraries.sln)
     - name: Build GumCli

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -5,16 +5,15 @@
 			KNI does not currently ship an iOS build, but the Android build enables native
 			on-screen keyboard support in the shared Forms TextBox code.
 
-			NOTE: This csproj uses opt-IN for Android (IncludeAndroid=true), which is the
-			opposite of MonoGameGum.csproj's opt-OUT convention (ExcludeAndroid=true). The
-			inversion is intentional: the Gum tool (GumFull.sln) references this csproj as
-			a ProjectReference, and IDEs (Visual Studio / Rider) evaluate csprojs with
-			default property values when opening a solution. With opt-out, every tool user
-			was forced to install the Android workload just to load the tool — even though
-			the tool itself never targets Android. Opt-in keeps the default build desktop-
-			only; release pipelines that pack Gum.KNI pass -p:IncludeAndroid=true so the
-			published NuGet still ships the net9.0-android TFM. Do not "fix" this to match
-			MonoGameGum without first solving the IDE-load problem above.
+			NOTE: This csproj uses opt-IN for Android (IncludeAndroid=true) — MonoGameGum.csproj
+			now uses the same opt-in convention (IncludeIOS/IncludeAndroid) for the same reason:
+			the Gum tool (GumFull.sln) references this csproj as a ProjectReference, and IDEs
+			(Visual Studio / Rider) evaluate csprojs with default property values when opening a
+			solution. Opt-out forced every tool user to install the Android workload just to load
+			the tool, even though the tool itself never targets Android. Opt-in keeps the default
+			build desktop-only; release pipelines that pack Gum.KNI/Gum.MonoGame pass
+			-p:IncludeAndroid=true -p:IncludeIOS=true so the published NuGets still ship their
+			mobile TFMs.
 		-->
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(IncludeAndroid)' == 'true'">$(TargetFrameworks);net9.0-android</TargetFrameworks>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -2,22 +2,23 @@
 
 	<PropertyGroup>
 		<!--
-			Target frameworks are composed based on which mobile workloads the developer has
-			installed. ExcludeIOS=true skips the iOS target (no iOS workload needed);
-			ExcludeAndroid=true skips the Android target (no Android workload needed). CI uses
-			both escape hatches because the release runner only has the base .NET SDK installed.
+			This csproj uses opt-IN for mobile (IncludeIOS=true / IncludeAndroid=true), matching
+			KniGum.csproj's convention (see its comment). Opt-out was tried first and kept every
+			source-linker's IDE/build on the hook for the iOS/Android workloads by default, since
+			ProjectReference AdditionalProperties do not flow into a referenced project's own
+			TargetFrameworks evaluation — only real global properties do (CLI -p:, env vars, or a
+			Directory.Build.props actually in scope for this csproj). Opt-in keeps the default
+			build desktop-only for everyone; release pipelines that pack Gum.MonoGame pass
+			-p:IncludeIOS=true -p:IncludeAndroid=true so the published NuGet still ships both
+			mobile TFMs. Do not flip this back to opt-out.
 
 			The mobile targets are net9.0-* and are additionally gated on the active SDK being
-			.NET 9+. A .NET 8 SDK cannot evaluate a net9.0-* TFM at all (NETSDK1139), and that
-			evaluation happens during NuGet restore — where ProjectReference AdditionalProperties
-			like ExcludeIOS do NOT flow — so source-linkers pinned to the .NET 8 SDK would
-			otherwise break on restore before the build-time escape hatches ever apply. The
-			SDK gate keeps net8.0-SDK restores clean while net9+ SDK builds still get the mobile
-			TFMs.
+			.NET 9+, so opting in on a .NET 8 SDK doesn't hit NETSDK1139 (a .NET 8 SDK cannot
+			evaluate a net9.0-* TFM at all).
 		-->
 		<TargetFrameworks>net8.0</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeIOS)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="'$(ExcludeAndroid)' != 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="'$(IncludeIOS)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="'$(IncludeAndroid)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-android</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Source-linking `MonoGameGum.csproj` on a .NET 9+ SDK forced `net9.0-ios`/`net9.0-android` into every restore/build, since the old `ExcludeIOS`/`ExcludeAndroid` flags are opt-**out** and don't propagate through a `ProjectReference` from the consumer's own project — only real global properties (CLI `-p:`, env vars) do. Every desktop-only source-linker on SDK 9+ hit mobile-workload errors with no project-level fix available.

`KniGum.csproj` already solved this for Android with opt-**in** (`IncludeAndroid`). This PR applies the same convention to `MonoGameGum.csproj` (`IncludeIOS`/`IncludeAndroid`, both default off) and cleans up every workflow that referenced the old flags:

- `build-and-release.yml` / `build-and-test.yaml`: drop the now-inert `-p:ExcludeIOS=true -p:ExcludeAndroid=true` — desktop-only is already the default.
- `dotnet-nuget.yaml`: add `-p:IncludeIOS=true` alongside the existing `-p:IncludeAndroid=true` on restore/build/pack, so the published `Gum.MonoGame` nupkg keeps shipping both mobile TFMs.
- `KniGum.csproj`: updated its comment, which described `MonoGameGum` as the opt-out counter-example.

Verified: `dotnet msbuild MonoGameGum/MonoGameGum.csproj -getProperty:TargetFrameworks` → `net8.0` by default, `net8.0;net9.0-ios;net9.0-android` with both flags passed. `MonoGameGum.Tests` and `KniGum` build clean (0 errors) at the new default; `MonoGameGum.csproj` builds clean with both flags opted in.

Manual test: not needed beyond the above — this is a TFM-selection/CI-flag change with no runtime behavior difference for existing desktop consumers.
