### PR TITLE
Skip font collection for state/instance pairs the state does not touch

### DIFF
--- a/GumCommon/Bundle/FontReferenceCollector.cs
+++ b/GumCommon/Bundle/FontReferenceCollector.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -81,13 +81,28 @@ public class FontReferenceCollector
                 // paths the references may not have been applied yet.
                 element.ApplyVariableReferences(state);
 
-                foreach (BmfcSave bmfcSave in CollectAllBmfcSavesFor(instance: null, state, fontRanges, spacingHorizontal, spacingVertical))
+                // A non-default state that sets nothing for a given owner resolves that owner's
+                // font properties identically to the default state, which is always collected -
+                // so it can only produce an already-deduplicated entry. Skipping those pairs is
+                // what keeps collection from costing (states x instances) recursive lookups on a
+                // project whose category states mostly touch one instance each.
+                bool isDefaultState = state == element.DefaultState;
+
+                if (isDefaultState || StateSetsAnythingFor(state, ownerName: null))
                 {
-                    bitmapFonts[bmfcSave.FontCacheFileName] = bmfcSave;
+                    foreach (BmfcSave bmfcSave in CollectAllBmfcSavesFor(instance: null, state, fontRanges, spacingHorizontal, spacingVertical))
+                    {
+                        bitmapFonts[bmfcSave.FontCacheFileName] = bmfcSave;
+                    }
                 }
 
                 foreach (InstanceSave instance in element.Instances)
                 {
+                    if (!isDefaultState && !StateSetsAnythingFor(state, instance.Name))
+                    {
+                        continue;
+                    }
+
                     foreach (BmfcSave bmfcSaveInner in CollectAllBmfcSavesFor(instance, state, fontRanges, spacingHorizontal, spacingVertical))
                     {
                         bitmapFonts[bmfcSaveInner.FontCacheFileName] = bmfcSaveInner;
@@ -104,6 +119,25 @@ public class FontReferenceCollector
         }
 
         return bitmapFonts;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="stateSave"/> sets any variable belonging to <paramref name="ownerName"/>
+    /// - an instance name, or null for the element itself. Deliberately checks membership rather than
+    /// font-specific names: a font property can reach an owner under an arbitrary name through an
+    /// exposed variable, so only "sets nothing at all for this owner" is safe to skip.
+    /// </summary>
+    private static bool StateSetsAnythingFor(StateSave stateSave, string? ownerName)
+    {
+        if (ownerName == null)
+        {
+            return stateSave.Variables.Any(v => !v.Name.Contains('.'))
+                || stateSave.VariableLists.Any(vl => string.IsNullOrEmpty(vl.SourceObject));
+        }
+
+        string prefix = ownerName + ".";
+        return stateSave.Variables.Any(v => v.Name.StartsWith(prefix, StringComparison.Ordinal))
+            || stateSave.VariableLists.Any(vl => vl.SourceObject == ownerName);
     }
 
     private static BmfcSave? TryGetBmfcSaveFor(InstanceSave? instance, StateSave stateSave,

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -1126,6 +1126,46 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
         }
     }
 
+    [Fact]
+    public async Task CreateAllMissingFontFiles_ShouldGenerateOnlyTheFontMissingFromDisk()
+    {
+        // The counterpart to the "already up to date" guard above, and the reason font collection
+        // must not drop entries: a font whose .fnt is absent has to be regenerated on load, and the
+        // one already cached must not be regenerated.
+        string projectDirectory = Path.Combine(Path.GetTempPath(), "GumFontGenTest_" + Guid.NewGuid()) + Path.DirectorySeparatorChar;
+        Directory.CreateDirectory(projectDirectory);
+        try
+        {
+            ScreenSave screen = new ScreenSave { Name = "Screen" };
+            StateSave state = AddState(screen);
+            SetVar(state, "Font", "Arial");
+            SetVar(state, "FontSize", 14);
+            Project.Screens.Add(screen);
+
+            // Arial@18 comes from the Text standard element (see this class's constructor). Cache
+            // that one only, leaving Arial@14 missing.
+            BmfcSave cachedFont = new BmfcSave { FontName = "Arial", FontSize = 18 };
+            BmfcSave missingFont = new BmfcSave { FontName = "Arial", FontSize = 14 };
+
+            string cachedFntPath = Path.Combine(projectDirectory, cachedFont.FontCacheFileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(cachedFntPath)!);
+            File.WriteAllText(cachedFntPath, "cached");
+
+            ControllableFontFileGenerator generator = new();
+            HeadlessFontGenerationService service = new(generator);
+
+            await service.CreateAllMissingFontFiles(Project, projectDirectory, forceRecreate: false);
+
+            generator.GenerateFontCallCount.ShouldBe(1);
+            generator.GeneratedFntPaths.ShouldHaveSingleItem()
+                .ShouldEndWith(Path.GetFileName(missingFont.FontCacheFileName));
+        }
+        finally
+        {
+            Directory.Delete(projectDirectory, recursive: true);
+        }
+    }
+
     #endregion
 
     // -------------------------------------------------------------------------
@@ -1180,10 +1220,12 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
         public bool RequiresSizeEstimation { get; init; } = false;
         public bool ShouldFail { get; init; }
         public int GenerateFontCallCount { get; private set; }
+        public List<string> GeneratedFntPaths { get; } = new();
 
         public Task<GeneralResponse> GenerateFont(BmfcSave bmfcSave, string outputFntPath, bool createTask)
         {
             GenerateFontCallCount++;
+            GeneratedFntPaths.Add(outputFntPath);
             GeneralResponse response = ShouldFail
                 ? GeneralResponse.UnsuccessfulWith("Simulated failure")
                 : GeneralResponse.SuccessfulResponse;

--- a/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessFontGenerationServiceTests.cs
@@ -1,4 +1,4 @@
-using Gum.DataTypes;
+﻿using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.ProjectServices.FontGeneration;
@@ -462,6 +462,35 @@ public class HeadlessFontGenerationServiceTests : BaseTestClass
         Dictionary<string, BmfcSave> result = _sut.CollectRequiredFonts(Project, new[] { component });
 
         result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CollectRequiredFonts_ShouldStillCollectFontOfInstanceUntouchedByACategoryState()
+    {
+        // A category state that overrides one instance says nothing about a sibling instance, so
+        // the sibling still resolves its font from the default state. Collection skips (state,
+        // instance) pairs the state sets nothing for, and must not lose the sibling's font.
+        ComponentSave component = new ComponentSave { Name = "Panel", BaseType = "Container" };
+        StateSave defaultState = AddState(component, "Default");
+        StateSave largeState = AddCategoryState(component, "SizeCategory", "Large");
+        AddTextInstance(component, "Title");
+        AddTextInstance(component, "Subtitle");
+
+        SetVar(defaultState, "Title.Font", "Arial");
+        SetVar(defaultState, "Title.FontSize", 18);
+        SetVar(defaultState, "Subtitle.Font", "Arial");
+        SetVar(defaultState, "Subtitle.FontSize", 12);
+
+        // Only Title is touched by the category state.
+        SetVar(largeState, "Title.Font", "Arial");
+        SetVar(largeState, "Title.FontSize", 32);
+
+        Dictionary<string, BmfcSave> result = _sut.CollectRequiredFonts(Project, new[] { component });
+
+        result.Count.ShouldBe(3);
+        result.Values.ShouldContain(f => f.FontSize == 18);
+        result.Values.ShouldContain(f => f.FontSize == 12);
+        result.Values.ShouldContain(f => f.FontSize == 32);
     }
 
     [Fact]


### PR DESCRIPTION
`FontReferenceCollector.Collect` resolved all six font properties for **every (state, instance) pair** — 3323 pairs / ~20k recursive variable lookups on a 51-screen project. A non-default state that sets nothing for a given owner resolves that owner's font properties identically to the default state, which is always collected, so those pairs could only ever produce an already-deduplicated entry.

Membership is checked, **not** font-specific variable names. A font property can reach an owner under an arbitrary name through an exposed variable (a component exposing its inner `Label.FontSize` as `HeaderSize`), so a name-based filter would silently drop fonts. Only "this state sets nothing at all for this owner" is safe. That's the difference between a 76% cut that's wrong and a 48% cut that's right.

## Numbers

Same build, only the filter toggled, 3 runs each:

| | before | after |
|---|---|---|
| `MainFontPlugin` ProjectLoad | 689 / 693 / 686 ms | 514 / 509 / 466 ms |

**~190 ms (28%)**, consistent across runs. Cold-start totals moved ~110 ms, which is inside run-to-run noise — take the handler number, not the total.

The remaining ~500 ms is inherent to the design: it's the *default* states resolving fonts through nested component instances via `RecursiveVariableFinder`, and default states are never skippable. Removing that needs the scan moved off the load path, not a cheaper scan — noted on the issue.

## Tests

`CollectRequiredFonts_ShouldStillCollectFontOfInstanceUntouchedByACategoryState` pins the skip path: a category state touching one instance must not lose a sibling's font. Green before and after; confirmed 3 tests go red if the skip is widened to all non-default states.

Closes #4289
