### PR TITLE
Make self-reference block spatial navigation direction instead of unfocusing

### DIFF
--- a/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/ControllerSpatialNavigationTests.cs
@@ -212,6 +212,30 @@ public class ControllerSpatialNavigationTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleGamepadSpatialNavigation_SelfReferencingExplicitOverride_BlocksDirectionWithoutLosingFocus()
+    {
+        // Issue #4298: assigning a control to its own SpatialNavigationRight is the documented way to
+        // block rightward navigation entirely. It must consume the press without moving focus anywhere,
+        // including off of itself.
+        ContainerRuntime root = new ContainerRuntime();
+
+        SpatialNavHarness origin = CreateHarness(root, 0, 0);
+        SpatialNavHarness nearestByScore = CreateHarness(root, 150, 0);
+        origin.SpatialNavigationRight = origin;
+
+        origin.IsFocused = true;
+
+        GamePad gamepad = new GamePad();
+        gamepad.SetButtonState(GamepadButton.DPadRight, true);
+        gamepad.Activity(1);
+
+        origin.InvokeHandleGamepadSpatialNavigation(gamepad, root);
+
+        origin.IsFocused.ShouldBeTrue();
+        nearestByScore.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleGamepadSpatialNavigation_SkillTreeLayoutDPadDown_MovesFocusToNearestDownwardCandidate()
     {
         // Reproduces the manual-test demo's scattered 6-button layout reported in issue #4129:

--- a/MonoGameGum.Tests/Forms/KeyboardDirectionalNavigationTests.cs
+++ b/MonoGameGum.Tests/Forms/KeyboardDirectionalNavigationTests.cs
@@ -146,6 +146,38 @@ public class KeyboardDirectionalNavigationTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleKeyboardFocusUpdate_SelfReferencingSpatialNavigationRightOverride_BlocksDirectionWithoutLosingFocus()
+    {
+        // Issue #4298: assigning a control to its own SpatialNavigationRight is the documented way to
+        // block rightward navigation entirely. It must consume the key press without moving focus
+        // anywhere, including off of itself.
+        Panel panel = new Panel();
+        panel.AddToRoot();
+        panel.GamepadNavigationMode = GamepadNavigationMode.Spatial;
+
+        Button origin = new Button();
+        panel.AddChild(origin);
+        origin.X = 0;
+        origin.Y = 0;
+
+        Button nearestByScore = new Button();
+        panel.AddChild(nearestByScore);
+        nearestByScore.X = 150;
+        nearestByScore.Y = 0;
+
+        origin.SpatialNavigationRight = origin;
+        origin.IsFocused = true;
+
+        FrameworkElement.RightKeyCombos.Add(new KeyCombo { PushedKey = Keys.Right });
+        FrameworkElement.KeyboardsForUiControl.Add(CreateKeyboardMock(Keys.Right).Object);
+
+        origin.OnFocusUpdate();
+
+        origin.IsFocused.ShouldBeTrue();
+        nearestByScore.IsFocused.ShouldBeFalse();
+    }
+
+    [Fact]
     public void HandleKeyboardFocusUpdate_SliderRightKeyComboConfigured_SpatialMode_AdjustsValueAndDoesNotNavigate()
     {
         // Slider disables Left/Right-as-navigation in its own constructor

--- a/MonoGameGum/Forms/Controls/FrameworkElement.cs
+++ b/MonoGameGum/Forms/Controls/FrameworkElement.cs
@@ -1193,7 +1193,9 @@ public class FrameworkElement : INotifyPropertyChanged
     /// single-direction D-pad press — or a left-stick push snapped to its nearest cardinal — in that
     /// direction moves focus straight to the assigned element, skipping
     /// <see cref="Gum.Forms.SpatialNavigationService"/> scoring entirely. Not consulted for diagonal
-    /// D-pad presses (two held), which have no single well-defined cardinal to key off.
+    /// D-pad presses (two held), which have no single well-defined cardinal to key off. Assigning a
+    /// control to itself blocks that direction entirely: the press is consumed and focus stays put,
+    /// rather than falling back to automatic scoring the way an unset (null) override does.
     /// Only meaningful while resolved <see cref="GamepadNavigationMode"/> is
     /// <see cref="Controls.GamepadNavigationMode.Spatial"/>.
     /// </summary>
@@ -1649,8 +1651,11 @@ public class FrameworkElement : INotifyPropertyChanged
         FrameworkElement? explicitOverride = TryGetExplicitDirectionOverride(gamepad);
         if (explicitOverride != null)
         {
-            explicitOverride.IsFocused = true;
-            this.IsFocused = false;
+            if (explicitOverride != this)
+            {
+                explicitOverride.IsFocused = true;
+                this.IsFocused = false;
+            }
             return;
         }
 
@@ -1900,8 +1905,11 @@ public class FrameworkElement : INotifyPropertyChanged
             FrameworkElement? explicitOverride = GetExplicitDirectionOverride(state);
             if (explicitOverride != null)
             {
-                explicitOverride.IsFocused = true;
-                this.IsFocused = false;
+                if (explicitOverride != this)
+                {
+                    explicitOverride.IsFocused = true;
+                    this.IsFocused = false;
+                }
                 return;
             }
 

--- a/docs/code/events-and-interactivity/tabbing-moving-focus.md
+++ b/docs/code/events-and-interactivity/tabbing-moving-focus.md
@@ -153,6 +153,17 @@ myButton.SpatialNavigationRight = otherButton;
 
 An explicit override only applies to a single-direction DPad press. It is not consulted for a diagonal press or for left stick input, since neither has one well-defined cardinal direction to match against.
 
+#### Blocking a Direction Entirely
+
+Assigning a control to itself blocks that direction: the press is consumed and focus stays put, instead of falling back to automatic scoring. This is useful when a neighboring control should only be reachable by an explicit action (for example, pressing a confirm button) rather than by drifting into it with spatial navigation.
+
+```csharp
+// Initialize
+myButton.SpatialNavigationRight = myButton;
+```
+
+Leaving the property unset is not the same as blocking the direction. With no override assigned, that direction still falls back to automatic distance/angle scoring and can still move focus to a nearby control.
+
 ## Modal Tab Trapping
 
 When you show an element modally by adding it to `GumService.Default.ModalRoot`, tab focus is confined to the controls inside that modal element. Tabbing forward past the last focusable control wraps back to the first, and Shift+Tabbing before the first control wraps to the last. Focus never escapes to the controls behind the modal under the regular `Root`.


### PR DESCRIPTION
## Summary

Assigning a control to its own `SpatialNavigationUp/Down/Left/Right` was meant to be a way to block that direction, but it silently unfocused the control instead: `explicitOverride.IsFocused = true` was a no-op (already true), but the unconditional `this.IsFocused = false` right after it still ran. Guard both call sites (gamepad D-pad/stick path and keyboard arrow-key path) so a self-reference consumes the input and returns without touching `IsFocused`.

## Changes

- `MonoGameGum/Forms/Controls/FrameworkElement.cs` — guard in `HandleGamepadSpatialNavigation` and `HandleKeyboardDirectionalNavigation`; updated the `SpatialNavigationUp` XML doc.
- Unit tests in `ControllerSpatialNavigationTests.cs` and `KeyboardDirectionalNavigationTests.cs` reproducing the bug (self-reference losing focus) before the fix.
- `docs/code/events-and-interactivity/tabbing-moving-focus.md` — documents the self-reference blocking convention under "Explicit Direction Overrides".

Closes #4298

## Test plan
- [x] New tests fail before the fix, pass after
- [x] Full `MonoGameGum.Tests` suite green (2108 passed)

Manual test: not needed — pure input-routing/focus-state logic (no rendering/layout), directly exercised by unit tests calling the real per-frame entry points (`HandleGamepadSpatialNavigation`, `OnFocusUpdate`) with a real `GamePad`/mocked keyboard; `IsFocused` is the exact observable data asserted, not something a manual pass would only approximate.

FRB canary: not needed — every touched line sits inside `#if !FRB` (`FrameworkElement.cs:1627-1945` and the property block at `1177-1229`), so none of it compiles into the FRB1 build.
