### PR TITLE
Move the load-time missing-font scan off the project-load path

### DIFF
--- a/Gum/Plugins/Fonts/MainFontPlugin.cs
+++ b/Gum/Plugins/Fonts/MainFontPlugin.cs
@@ -1,4 +1,4 @@
-using Gum.Commands;
+﻿using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Gum.Services.Dialogs;
 using System.Diagnostics;
+using Gum.Services;
 using Gum.Services.Fonts;
 
 namespace Gum.Plugins.Fonts;
@@ -26,11 +27,12 @@ public class MainFontPlugin : PriorityPlugin
         IGuiCommands guiCommands,
         IFontManager fontManager,
         IDialogService dialogService,
-        IProjectState projectState)
+        IProjectState projectState,
+        IDispatcher dispatcher)
     {
         _fontManager = fontManager;
         _dialogService = dialogService;
-        _fontCacheLogic = new FontCacheLogic(fontManager, dialogService, projectState);
+        _fontCacheLogic = new FontCacheLogic(fontManager, dialogService, projectState, dispatcher);
     }
 
     public override void StartUp()
@@ -63,8 +65,8 @@ public class MainFontPlugin : PriorityPlugin
 
     }
 
-    private async void HandleProjectLoaded(GumProjectSave save) =>
-        await _fontCacheLogic.CreateMissingFontFilesForLoadedProject();
+    private void HandleProjectLoaded(GumProjectSave save) =>
+        _fontCacheLogic.ScheduleMissingFontCreationForLoadedProject();
 
     private void HandleClearFontCache(object? sender, System.Windows.RoutedEventArgs e)
     {

--- a/Tests/Gum.Presentation.Tests/FontCacheLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/FontCacheLogicTests.cs
@@ -1,3 +1,6 @@
+﻿using Gum.Services;
+using System.Collections.Generic;
+using System;
 using Gum.DataTypes;
 using Gum.Plugins.Fonts;
 using Gum.Services.Dialogs;
@@ -18,11 +21,13 @@ public class FontCacheLogicTests
     private readonly Mock<IFontManager> _fontManager = new();
     private readonly Mock<IDialogService> _dialogService = new();
     private readonly Mock<IProjectState> _projectState = new();
+    private readonly RecordingDispatcher _dispatcher = new();
     private readonly FontCacheLogic _logic;
 
     public FontCacheLogicTests()
     {
-        _logic = new FontCacheLogic(_fontManager.Object, _dialogService.Object, _projectState.Object);
+        _logic = new FontCacheLogic(_fontManager.Object, _dialogService.Object, _projectState.Object,
+            _dispatcher);
     }
 
     [Fact]
@@ -71,5 +76,37 @@ public class FontCacheLogicTests
         _fontManager.Verify(x => x.CreateAllMissingFontFiles(project, true), Times.Once);
         _dialogService.Verify(
             x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
+    }
+
+    [Fact]
+    public void ScheduleMissingFontCreationForLoadedProject_DoesNotScanUntilThePostedWorkRuns()
+    {
+        // The scan is pre-generation, not a prerequisite - keeping it off the project-load path is
+        // the whole point, so posting must not run it inline.
+        _logic.ScheduleMissingFontCreationForLoadedProject();
+
+        _dispatcher.PostedActions.Count.ShouldBe(1);
+        _fontManager.Verify(m => m.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<bool>()), Times.Never);
+
+        _dispatcher.RunPosted();
+
+        _fontManager.Verify(m => m.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<bool>()), Times.Once);
+    }
+
+    private sealed class RecordingDispatcher : IDispatcher
+    {
+        public List<Action> PostedActions { get; } = new();
+
+        public void Invoke(Action action) => action();
+
+        public void Post(Action action) => PostedActions.Add(action);
+
+        public void RunPosted()
+        {
+            foreach (Action action in PostedActions)
+            {
+                action();
+            }
+        }
     }
 }

--- a/Tools/Gum.Presentation/Plugins/Fonts/FontCacheLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/Fonts/FontCacheLogic.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.DataTypes;
+using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.Services.Fonts;
 using Gum.ToolStates;
@@ -20,16 +21,34 @@ public class FontCacheLogic
     private readonly IFontManager _fontManager;
     private readonly IDialogService _dialogService;
     private readonly IProjectState _projectState;
+    private readonly IDispatcher _dispatcher;
 
-    public FontCacheLogic(IFontManager fontManager, IDialogService dialogService, IProjectState projectState)
+    public FontCacheLogic(IFontManager fontManager, IDialogService dialogService, IProjectState projectState,
+        IDispatcher dispatcher)
     {
         _fontManager = fontManager;
         _dialogService = dialogService;
         _projectState = projectState;
+        _dispatcher = dispatcher;
     }
 
     /// <summary>
-    /// Creates any missing font files for the just-loaded project.
+    /// Queues creation of any missing font files for the loaded project to run after the caller
+    /// returns, rather than on the project-load path. Scanning the project for required fonts costs
+    /// hundreds of milliseconds and, in the normal case, finds every font already cached - so it is
+    /// pre-generation, not a prerequisite: a font that really is missing is still created on demand
+    /// when text using it renders (see <c>CustomSetPropertyOnRenderable.UpdateToFontValues</c>).
+    /// The scan reads the current project when it runs, so a project loaded in the meantime is the
+    /// one scanned.
+    /// </summary>
+    public void ScheduleMissingFontCreationForLoadedProject()
+    {
+        _dispatcher.Post(async () => await CreateMissingFontFilesForLoadedProject());
+    }
+
+    /// <summary>
+    /// Creates any missing font files for the loaded project. Prefer
+    /// <see cref="ScheduleMissingFontCreationForLoadedProject"/> on the project-load path.
     /// </summary>
     public async Task CreateMissingFontFilesForLoadedProject()
     {


### PR DESCRIPTION
The residual left by #4297. `MainFontPlugin`'s `ProjectLoad` handler ran the full required-font scan inline — 553–1416 ms on a 51-screen project — and in the normal case concluded every font was already cached.

**It is pre-generation, not a prerequisite.** A font that really is missing is still created on demand when text using it renders: both `CustomSetPropertyOnRenderable.UpdateToFontValues` (base path) and the BBCode inline-run path call `FontService.CreateFontIfNecessary`. I verified both call sites before writing this rather than trusting the skill's description of them.

So `FontCacheLogic` now posts the scan via `IDispatcher` instead of awaiting it inline. It reads the current project when it runs, so a project loaded in the meantime is the one scanned.

## Numbers

Same build, only `Post` vs inline toggled, 3 runs each:

| | inline | deferred |
|---|---|---|
| `MainFontPlugin` ProjectLoad | 1416 / 712 / 553 ms | **absent from the load path** |

This is a structural removal, not a speedup — the saving is whatever the scan costs on a given machine and project, and it scales with project size. The timing log confirms the scan now completes *after* `MainWindow first paint` in every run (4503 ms vs 3879 ms first paint; 3847 vs 3197; 11285 vs 9922).

Cold-start totals moved 6672/4156/3733 → 3937/3241/(10108, machine-load outlier). Too noisy to quote a single figure; the handler row is the honest one.

## Tests

`ScheduleMissingFontCreationForLoadedProject_DoesNotScanUntilThePostedWorkRuns` asserts nothing runs inline and the scan does run once the posted work executes, via a recording `IDispatcher`. Folded into the existing `FontCacheLogicTests` rather than a parallel class.

Part of #4289
