### PR TITLE
Add manually-triggered oversampled font regeneration for crisp text at zoom

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -144,6 +144,43 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
             "Because a content-derived Height must not be used to truncate the very lines it was derived from");
     }
 
+    // Issue #4302 follow-up: TextRuntime.RegenerateOversampledFont swaps BitmapFont to a font
+    // rasterized at oversampleRatio * FontSize, then sets FontScale = 1/oversampleRatio to compensate
+    // so the on-screen size is unchanged. Both setters call UpdateWrappedText() independently -- the
+    // BitmapFont setter fires FIRST, with the OLD (pre-swap) FontScale still in effect, so it wraps
+    // using the new (much wider) glyph metrics against a wrap width that hasn't been inflated yet.
+    // That intermediate wrap is wrong, but should be harmless IF the FontScale setter's later call
+    // fully recomputes WrappedText afterward. This test asserts the actual (post both-setters) result
+    // still matches the pre-swap wrap, exactly what a user should see (crisp text, same layout).
+    [Fact]
+    public void UpdateLines_WhenBitmapFontAndFontScaleBothChangeInOversampleOrder_ShouldWrapTheSameAsBeforeTheSwap()
+    {
+        const int baseAdvance = 10;
+        const float oversampleRatio = 2.5f;
+        const int oversampledAdvance = (int)(baseAdvance * oversampleRatio); // 25
+
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, AbcFontData(baseAdvance, lineHeight: 20));
+        baseFont.SetFontPattern(256, 256);
+        BitmapFont oversampledFont = new BitmapFont((Texture2D)null!, AbcFontData(oversampledAdvance, lineHeight: 50));
+        oversampledFont.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = baseFont;
+        text.Width = 5 * baseAdvance; // exactly fits "AB AB" (5 chars * baseAdvance)
+        text.RawText = "AB AB";
+
+        text.WrappedText.Count.ShouldBe(1, "because AB AB exactly fits the base font/width before any oversampling");
+
+        // Mirrors TextRuntime.RegenerateOversampledFont's exact call order: BitmapFont first, then FontScale.
+        text.BitmapFont = oversampledFont;
+        text.FontScale = 1f / oversampleRatio;
+
+        text.WrappedText.Count.ShouldBe(1,
+            "because the oversampled font's glyphs are exactly oversampleRatio times wider and FontScale " +
+            "compensates by the same ratio -- the on-screen size, and therefore the wrap, must not change");
+        text.WrappedText[0].ShouldBe("AB AB");
+    }
+
     // Two-char ("ab") BMFont with every glyph at a caller-chosen xadvance, so a test can build a
     // "base" font and a deliberately-wider "swapped" font and assert measurement honors each run's font.
     private static string TwoCharFontData(int xadvance, int lineHeight) =>

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -155,6 +155,84 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // The real bug (not the rounding-noise theory above): RelativeToChildren sizes the box to fit its
+    // OWN content, so it must never wrap, full stop -- regardless of which font is loaded or how
+    // imperfectly that font's glyph metrics scale. RegenerateOversampledFont swaps BitmapFont/FontScale
+    // directly on the renderable without calling back into GraphicalUiElement.UpdateLayout(), so a
+    // RelativeToChildren box's Width is never re-derived from the new font -- it stays frozen at the
+    // natural width measured against the OLD font. That staleness happens to cancel out mathematically
+    // when the new font scales perfectly linearly (see the Proportional test above), but any real
+    // rasterizer's hinting/rounding makes the oversampled font's glyphs not an exact multiple of the
+    // base font's, which the frozen Width has no way to absorb -- unlike a fresh RelativeToChildren
+    // measurement, which would just re-size to fit. NearlyProportionalFontCreator simulates that
+    // realistic 1px-per-glyph rounding noise at the oversampled size.
+    [Fact]
+    public void RegenerateOversampledFont_WithRelativeToChildrenWidth_ShouldNeverWrap()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            text.WrappedText.Count.ShouldBe(1, "because RelativeToChildren sizes the box to exactly fit this text before any oversampling");
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            text.WrappedText.Count.ShouldBe(1,
+                "because RelativeToChildren must re-size to fit whatever font is currently loaded -- it can never " +
+                "wrap its own content, even when the oversampled font's real-world glyph metrics aren't a perfect multiple of the base font's");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Every glyph's xadvance is 1px wider than a perfect (FontSize/baseFontSize)x scale of the base font
+    // whenever the requested size isn't baseFontSize itself -- simulates the rounding/hinting noise a
+    // real TrueType rasterizer introduces between two different point sizes of the same font.
+    private sealed class NearlyProportionalFontCreator : IInMemoryFontCreator
+    {
+        private readonly int _baseFontSize;
+
+        public NearlyProportionalFontCreator(int baseFontSize)
+        {
+            _baseFontSize = baseFontSize;
+        }
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            int xadvance = bmfcSave.FontSize;
+            if (bmfcSave.FontSize != _baseFontSize)
+            {
+                xadvance += 1;
+            }
+
+            string fontData =
+$@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=3
+char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+    }
+
     // Every glyph's xadvance equals the requested FontSize exactly, so a font generated at size N is
     // a perfect (N/baseSize)x scale of one generated at baseSize -- isolates whether Gum's own
     // wrap-width math introduces error, independent of any real rasterizer's rounding/hinting noise.

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -1,0 +1,147 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Issue #4302: TextRuntime.RegenerateOversampledFont rasterizes a font at a multiple of FontSize (for
+// crisper text under camera zoom) and compensates with Text.FontScale so the on-screen size is
+// unchanged. Gated behind the global TextRuntime.UseFontOversampling toggle (off by default, so
+// pixel-art projects see no behavior change) and requires an IInMemoryFontCreator (KernSmith) --
+// a disk-based font cache only holds a fixed set of pre-baked sizes, so arbitrary-ratio regeneration
+// only makes sense with dynamic generation.
+public class TextRuntimeFontOversamplingTests : BaseTestClass
+{
+    [Fact]
+    public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndCompensatesFontScale()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            creator.CapturedFontSize.ShouldBe(50);
+            var text = (Text)textRuntime.RenderableComponent;
+            text.BitmapFont.ShouldBeSameAs(stubFont);
+            text.FontScale.ShouldBe(20f / 50f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenOversamplingDisabled_DoesNotRegenerateFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var creator = new CapturingInMemoryFontCreator(new BitmapFont((Texture2D)null!, StubFontData));
+
+            TextRuntime.UseFontOversampling = false;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            var text = (Text)textRuntime.RenderableComponent;
+            var originalFont = text.BitmapFont;
+            var originalFontScale = text.FontScale;
+            // Assigning FontSize above already resolves this Text's normal (non-oversampled) font
+            // through the same global InMemoryFontCreator, so reset the call tracking here to isolate
+            // whether RegenerateOversampledFont itself invokes the creator.
+            creator.ResetCallTracking();
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeFalse();
+            creator.WasCalled.ShouldBeFalse();
+            text.BitmapFont.ShouldBeSameAs(originalFont);
+            text.FontScale.ShouldBe(originalFontScale);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenNoInMemoryFontCreatorRegistered_DoesNotRegenerateFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = null;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            var text = (Text)textRuntime.RenderableComponent;
+            var originalFont = text.BitmapFont;
+            var originalFontScale = text.FontScale;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeFalse();
+            text.BitmapFont.ShouldBeSameAs(originalFont);
+            text.FontScale.ShouldBe(originalFontScale);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    private const string StubFontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=1
+char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=15
+";
+
+    // Captures the FontSize the caller asked for and always returns the stub font supplied at
+    // construction, so tests can assert both "what raster size was requested" and "was it wired up".
+    private sealed class CapturingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        private readonly BitmapFont _fontToReturn;
+
+        public CapturingInMemoryFontCreator(BitmapFont fontToReturn)
+        {
+            _fontToReturn = fontToReturn;
+        }
+
+        public bool WasCalled { get; private set; }
+        public int CapturedFontSize { get; private set; }
+
+        public void ResetCallTracking() => WasCalled = false;
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            WasCalled = true;
+            CapturedFontSize = bmfcSave.FontSize;
+            return _fontToReturn;
+        }
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework.Graphics;
@@ -110,6 +111,70 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         {
             TextRuntime.UseFontOversampling = savedUseFontOversampling;
             CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Reproduction attempt for the wrap-earlier report on #4302: goes through the real TextRuntime
+    // property cascade (not a bare Text) with a fixed Width, using a fake creator whose glyph metrics
+    // scale perfectly with the requested FontSize -- i.e. the oversampled font is an exact multiple of
+    // the base font, same as the "AB AB" bare-Text regression test in TextTests.cs. If this passes,
+    // the TextRuntime/GraphicalUiElement plumbing isn't adding its own discrepancy on top of the core
+    // BitmapFont/FontScale swap (already proven sound by that other test) -- meaning a real-world
+    // wrap shift comes from the actual rasterizer's glyph metrics not scaling perfectly linearly,
+    // not from a logic bug in Gum's wrap-width math.
+    [Fact]
+    public void RegenerateOversampledFont_WithProportionalFont_DoesNotChangeWrappedLineCount()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new ProportionalFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.Absolute;
+            textRuntime.FontSize = 20;
+            textRuntime.Width = 5 * 20; // exactly fits "AB AB" (5 chars * FontSize-as-xadvance)
+            textRuntime.Text = "AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            text.WrappedText.Count.ShouldBe(1, "because AB AB exactly fits the base font/width before any oversampling");
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            text.WrappedText.Count.ShouldBe(1,
+                "because the fake creator's glyph metrics scale exactly with FontSize, so FontScale " +
+                "compensates perfectly -- the on-screen size, and therefore the wrap, must not change");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Every glyph's xadvance equals the requested FontSize exactly, so a font generated at size N is
+    // a perfect (N/baseSize)x scale of one generated at baseSize -- isolates whether Gum's own
+    // wrap-width math introduces error, independent of any real rasterizer's rounding/hinting noise.
+    private sealed class ProportionalFontCreator : IInMemoryFontCreator
+    {
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            int xadvance = bmfcSave.FontSize;
+            string fontData =
+$@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=3
+char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
+            font.SetFontPattern(256, 256);
+            return font;
         }
     }
 

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -660,6 +660,49 @@ public class TextRuntime : InteractiveGue
             dropshadowBlue,
             dropshadowAlpha);
     }
+
+#if XNALIKE
+    /// <summary>
+    /// Regenerates this text's font at <paramref name="oversampleRatio"/> times <see cref="FontSize"/>
+    /// via <see cref="CustomSetPropertyOnRenderableType.InMemoryFontCreator"/>, then compensates with
+    /// the contained Text's FontScale so the on-screen size is unchanged --
+    /// the glyphs are just rasterized at a higher pixel density (issue #4302).
+    /// </summary>
+    /// <param name="oversampleRatio">How many times larger than <see cref="FontSize"/> to rasterize
+    /// the font, e.g. the current camera zoom. Rounded to the nearest whole pixel size.</param>
+    /// <returns>
+    /// True if the font was regenerated. False if <see cref="UseFontOversampling"/> is off, no
+    /// in-memory font creator is registered, or <paramref name="oversampleRatio"/> is not positive --
+    /// oversampling only makes sense with dynamic font generation, since a disk-based font cache
+    /// holds a fixed set of pre-baked sizes.
+    /// </returns>
+    public bool RegenerateOversampledFont(float oversampleRatio)
+    {
+        if (!UseFontOversampling || CustomSetPropertyOnRenderableType.InMemoryFontCreator == null || oversampleRatio <= 0)
+        {
+            return false;
+        }
+
+        var rasterFontSize = Math.Max(1, (int)Math.Round(FontSize * oversampleRatio));
+
+        var fontFilePath = BmfcSave.ResolveTtfSourcePath(UseCustomFont, CustomFontFile, Font);
+
+        var bmfcSave = new BmfcSave();
+        CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
+        bmfcSave.FontSize = rasterFontSize;
+
+        var font = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryCreateFont(bmfcSave);
+        if (font == null)
+        {
+            return false;
+        }
+
+        ContainedText.BitmapFont = font;
+        ContainedText.FontScale = (float)FontSize / rasterFontSize;
+
+        return true;
+    }
+#endif
 #endif
 
     public TextOverflowHorizontalMode TextOverflowHorizontalMode
@@ -878,6 +921,18 @@ public class TextRuntime : InteractiveGue
     // todo - add more here
     public static string DefaultFont = "Arial";
     public static int DefaultFontSize = 18;
+
+    /// <summary>
+    /// Whether <see cref="RegenerateOversampledFont"/> is allowed to regenerate fonts at a higher
+    /// raster size than <see cref="FontSize"/> for crisper text under camera zoom. Off by default:
+    /// pixel-art games deliberately want blocky/nearest-neighbor text, and whether a project wants
+    /// oversampling at all is a project-wide decision, so a single global toggle (not a per-instance
+    /// one) is sufficient for now. A per-instance override (letting individual TextRuntimes opt out of
+    /// or into oversampling independently of this project-wide default) is a plausible future
+    /// extension if a real need for mixed pixel-art/crisp text within one project shows up, but is not
+    /// built here.
+    /// </summary>
+    public static bool UseFontOversampling = false;
 
     /// <summary>
     /// Indicates whether the font should be assigned during object construction.

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -700,6 +700,12 @@ public class TextRuntime : InteractiveGue
         ContainedText.BitmapFont = font;
         ContainedText.FontScale = (float)FontSize / rasterFontSize;
 
+        // BitmapFont/FontScale are renderable-level properties -- assigning them directly (bypassing
+        // the normal property-setter cascade a call like FontSize= goes through) never notifies this
+        // element's own layout. Without this, a RelativeToChildren box keeps whatever Width it measured
+        // against the OLD font and wraps the NEW font's (differently-measuring) glyphs against it.
+        UpdateLayout();
+
         return true;
     }
 #endif

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -1,8 +1,10 @@
 using Gum;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using KernSmith.Gum;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using RenderingLibrary;
 
 namespace FontPlayground.MonoGame;
 
@@ -16,6 +18,15 @@ namespace FontPlayground.MonoGame;
 public class Game1 : Game
 {
     private readonly GraphicsDeviceManager _graphics;
+
+    // Issue #4302 manual-test rig: mouse wheel zooms the camera, blurring both preview texts below
+    // the playground the same way any zoomed Gum UI blurs today. Pressing R regenerates only
+    // _oversampledZoomPreviewText's font at the current zoom (manually-triggered, per this issue's
+    // scope), so it turns crisp again while _plainZoomPreviewText stays blurry for comparison.
+    private TextRuntime _plainZoomPreviewText = null!;
+    private TextRuntime _oversampledZoomPreviewText = null!;
+    private int _previousScrollWheelValue;
+    private bool _wasRKeyDown;
 
     public Game1()
     {
@@ -37,7 +48,40 @@ public class Game1 : Game
 
         FontPlaygroundScreen.Build(GumService.Default.Root);
 
+        BuildZoomOversamplingDemo();
+
         base.Initialize();
+    }
+
+    private void BuildZoomOversamplingDemo()
+    {
+        // Off by default project-wide (see TextRuntime.UseFontOversampling); this sample opts in
+        // to demonstrate the feature.
+        TextRuntime.UseFontOversampling = true;
+
+        _plainZoomPreviewText = new TextRuntime();
+        _plainZoomPreviewText.Text = "Scroll to zoom (always blurry)";
+        _plainZoomPreviewText.FontSize = 24;
+        _plainZoomPreviewText.X = 16;
+        _plainZoomPreviewText.Y = 560;
+        _plainZoomPreviewText.Red = 255;
+        _plainZoomPreviewText.Green = 255;
+        _plainZoomPreviewText.Blue = 255;
+        _plainZoomPreviewText.Alpha = 255;
+        GumService.Default.Root.Children.Add(_plainZoomPreviewText);
+
+        _oversampledZoomPreviewText = new TextRuntime();
+        _oversampledZoomPreviewText.Text = "Scroll to zoom, then press R (crisp)";
+        _oversampledZoomPreviewText.FontSize = 24;
+        _oversampledZoomPreviewText.X = 16;
+        _oversampledZoomPreviewText.Y = 600;
+        _oversampledZoomPreviewText.Red = 255;
+        _oversampledZoomPreviewText.Green = 255;
+        _oversampledZoomPreviewText.Blue = 255;
+        _oversampledZoomPreviewText.Alpha = 255;
+        GumService.Default.Root.Children.Add(_oversampledZoomPreviewText);
+
+        _previousScrollWheelValue = Mouse.GetState().ScrollWheelValue;
     }
 
     protected override void Update(GameTime gameTime)
@@ -48,9 +92,31 @@ public class Game1 : Game
             Exit();
         }
 
+        UpdateZoomOversamplingDemo();
+
         GumService.Default.Update(gameTime);
 
         base.Update(gameTime);
+    }
+
+    private void UpdateZoomOversamplingDemo()
+    {
+        MouseState mouseState = Mouse.GetState();
+        int scrollWheelDelta = mouseState.ScrollWheelValue - _previousScrollWheelValue;
+        _previousScrollWheelValue = mouseState.ScrollWheelValue;
+
+        Camera camera = SystemManagers.Default.Renderer.Camera;
+        if (scrollWheelDelta != 0)
+        {
+            camera.Zoom = System.Math.Clamp(camera.Zoom * (1 + scrollWheelDelta * 0.001f), 0.25f, 8f);
+        }
+
+        bool isRKeyDown = Keyboard.GetState().IsKeyDown(Keys.R);
+        if (isRKeyDown && !_wasRKeyDown)
+        {
+            _oversampledZoomPreviewText.RegenerateOversampledFont(camera.Zoom);
+        }
+        _wasRKeyDown = isRKeyDown;
     }
 
     protected override void Draw(GameTime gameTime)


### PR DESCRIPTION
## Summary
- Adds `TextRuntime.RegenerateOversampledFont(float oversampleRatio)`: rasterizes this text's font at `oversampleRatio * FontSize` via the registered `IInMemoryFontCreator` (KernSmith), then sets `Text.FontScale` so the on-screen size is unchanged -- only the glyph texel density goes up. Manually-triggered only; no auto-detection yet (that's #4303).
- Gated behind `TextRuntime.UseFontOversampling` (static, off by default) -- pixel-art projects see zero behavior change unless they opt in.
- Scoped to XNALIKE (MonoGame/KNI/FNA) + KernSmith for this first increment. Raylib/Skia and the disk-based font cache are out of scope: arbitrary-ratio regeneration only makes sense with dynamic font generation, and threading it through the full FRB-shared `GetOrCreateBakedFont` cascade would be much larger and riskier than this first step warrants.
- Wires a manual-test rig into the `FontPlayground.MonoGame` sample: scroll wheel zooms the camera (blurring both preview texts, as today), pressing `R` regenerates only one via the new API so it turns crisp again while the other stays blurry.

Closes #4302

## Test plan
- New unit tests in `MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs`: happy path (regenerates at the rounded oversampled size, compensates FontScale), disabled-toggle no-op, no-creator no-op. All verified red-before-green against the actual guard logic.
- Full `MonoGameGum.Tests` suite green (2112/2112), `RaylibGum.Tests` green (575/575), `SkiaGum`/`KniGum` build clean -- confirms the `#if XNALIKE` gating doesn't affect other backends.
- FRB canary: not needed -- the new method is nested inside the existing `#if !FRB` region (never compiled for FRB) and nothing else calls it, so there's no guard-symmetry risk.
- Manual test: needed. Visual Studio is open on `Samples\FontPlayground\FontPlayground.MonoGame.sln`. Steps:
  1. Run the `FontPlayground.MonoGame` project (F5).
  2. Scroll the mouse wheel to zoom in on the window -- both preview texts near the bottom should go blurry, same as any zoomed Gum text today.
  3. Press `R` -- the second text ("...press R (crisp)") should snap sharp while the first stays blurry, at the same zoom level.
