### PR TITLE
Unblock docs-only PRs; update August 2026 migration doc for the August 3 release

### DIFF
--- a/.claude/skills/gum-release/SKILL.md
+++ b/.claude/skills/gum-release/SKILL.md
@@ -19,7 +19,7 @@ The release process lives in **[`docs/contributing/building-and-releasing-gum.md
 1. **Read the doc** above and confirm the current step list with the user.
 2. **Track progress** — create one task per step (`TaskCreate`) so nothing is dropped across the long-running release, and mark each `completed` as the user confirms it.
 3. **Walk the steps in order**, one at a time. For each, state what the user needs to do (the doc has the detail) and wait for confirmation before advancing.
-4. **Hand off the automatable step.** When you reach release-notes generation, invoke the **`gum-monthly-release`** skill — it drafts the notes and is the only step with real automation. Everything else (NuGet workflow trigger, Build-and-Release workflow, screenshots, migration doc, announcements, FRB FTP upload) is the user's manual action; you confirm and check it off.
+4. **Hand off the automatable step.** Release-notes generation is the only step with real automation, and it lives in **`gum-monthly-release`**. That skill is `disable-model-invocation: true`, so the `Skill` tool refuses it — read `.claude/skills/gum-monthly-release/SKILL.md` and follow it yourself instead. Everything else (NuGet workflow trigger, Build-and-Release workflow, screenshots, migration doc, announcements, FRB FTP upload) is the user's manual action; you confirm and check it off.
 
 ## Gotchas
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,12 +1,20 @@
 name: Build and Test Runtimes, Unit Tests, Generated Code Projects
 
+# Do NOT add paths-ignore to the pull_request trigger. This workflow produces
+# `Build-and-Test (macos-15)` and `Build-and-Test (windows-latest)`, both of
+# which main's ruleset lists as required status checks. A path-filtered trigger
+# does not skip the check, it prevents the check from ever being reported, so
+# any PR matching the filter (a docs-only PR) is stuck at BLOCKED permanently
+# with no way to re-run it into a passing state. If the CI cost of docs-only
+# PRs needs cutting again, guard the expensive *steps* inside the job so the
+# job still runs and reports; the required contexts must always report.
+# push is safe to filter: pushes to main are not gated on required checks.
 on:
   push:
     branches: [main]
     paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   pull_request:
     branches: [master, main]
-    paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']
   workflow_dispatch:
 
 jobs:

--- a/docs/gum-tool/upgrading/migrating-to-2026-august.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-august.md
@@ -6,7 +6,10 @@ This page discusses breaking changes and other considerations when migrating fro
 
 ## What Changed at a Glance
 
-This release renames `GraphicalUiElement`'s `GetAbsoluteWidth()` and `GetAbsoluteHeight()` methods to the `AbsoluteWidth` and `AbsoluteHeight` properties, matching the existing `AbsoluteLeft`/`AbsoluteTop`/`AbsoluteRight`/`AbsoluteBottom` properties. This is a **soft break**: the old methods still compile and work, but now emit a `CS0618` obsolete warning.
+Two changes need your attention:
+
+* `GraphicalUiElement`'s `GetAbsoluteWidth()` and `GetAbsoluteHeight()` methods are renamed to the `AbsoluteWidth` and `AbsoluteHeight` properties, matching the existing `AbsoluteLeft`/`AbsoluteTop`/`AbsoluteRight`/`AbsoluteBottom` properties. This is a **soft break**: the old methods still compile and work, but now emit a `CS0618` obsolete warning.
+* `MonoGameGum.csproj`'s iOS and Android target frameworks changed from opt-out to opt-in. This affects you only if you reference the MonoGameGum **source project** directly. If you use the `Gum.MonoGame` NuGet package, nothing changes.
 
 ## Upgrading the Gum Tool
 
@@ -14,7 +17,7 @@ This release renames `GraphicalUiElement`'s `GetAbsoluteWidth()` and `GetAbsolut
 {% tab title="Windows" %}
 To upgrade the Gum tool:
 
-1. Download Gum.zip from the [August 2, 2026 release on GitHub](https://github.com/vchelaru/Gum/releases/tag/Release_August_02_2026)
+1. Download Gum.zip from the [August 3, 2026 release on GitHub](https://github.com/vchelaru/Gum/releases/tag/Release_August_03_2026)
 2. Delete the old tool from your machine
 3. Unzip the gum tool to the same location as to not break any file associations
 {% endtab %}
@@ -26,7 +29,7 @@ Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
 
 ## Upgrading the Runtime
 
-This release's runtime ships as NuGet version **`2026.8.2.1`**. Upgrade your Gum NuGet packages to this version. For more information, see the NuGet packages for your particular platform:
+This release's runtime ships as NuGet version **`2026.8.3.1`**. Upgrade your Gum NuGet packages to this version. For more information, see the NuGet packages for your particular platform:
 
 * MonoGame - [https://www.nuget.org/packages/Gum.MonoGame/](https://www.nuget.org/packages/Gum.MonoGame/)
 * KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
@@ -64,3 +67,24 @@ var height = graphicalUiElement.GetAbsoluteHeight();
 var width = graphicalUiElement.AbsoluteWidth;
 var height = graphicalUiElement.AbsoluteHeight;
 ```
+
+### MonoGameGum's iOS and Android Target Frameworks Are Now Opt-In
+
+This section applies only if you reference `MonoGameGum.csproj` directly (source linking). If you use the `Gum.MonoGame` NuGet package, you can skip it: the published package still ships both mobile target frameworks and nothing changes for you.
+
+`MonoGameGum.csproj` used to build its iOS and Android target frameworks by default, with `ExcludeIOS` and `ExcludeAndroid` properties available to turn them off. Those properties did not propagate through a `ProjectReference` from your own project, so on a .NET 9 or newer SDK every desktop-only source-linked build pulled in `net9.0-ios` and `net9.0-android` and failed with mobile workload errors that had no project-level fix.
+
+The flags are now opt-in, matching `KniGum.csproj`:
+
+| Old (opt-out)     | New (opt-in)     |
+| ----------------- | ---------------- |
+| `ExcludeIOS`      | `IncludeIOS`     |
+| `ExcludeAndroid`  | `IncludeAndroid` |
+
+Desktop-only builds now work with no flags at all. If you were deliberately building the mobile target frameworks from source, pass the new properties on the command line or as environment variables:
+
+```
+dotnet build MonoGameGum/MonoGameGum.csproj -p:IncludeIOS=true -p:IncludeAndroid=true
+```
+
+Setting them inside your own `.csproj` does not work. Only real global properties propagate through a `ProjectReference`.


### PR DESCRIPTION
Three changes from driving the August 3, 2026 release.

**Unblock docs-only PRs (`build-and-test.yaml`)**

`main`'s ruleset requires `Build-and-Test (macos-15)` and `Build-and-Test (windows-latest)`, both produced by this workflow. #4295 added `paths-ignore: ['docs/**', '**/*.md', '.gitbook/**']` to its `pull_request` trigger. A path-filtered trigger does not skip a required check, it stops the check being reported at all, so every docs-only PR sits at `BLOCKED` with no way to re-run it green. This PR hit it.

Dropped the filter from `pull_request`; `push` keeps it, since pushes to `main` are not gated on required checks. `build-samples.yaml` is untouched, `Build-Samples` is not required. Restoring the CI savings properly (guard the expensive steps, not the trigger) is #4310.

**`migrating-to-2026-august.md`**

- Tool download link now points at `Release_August_03_2026`.
- Runtime NuGet version bumped to `2026.8.3.1`.
- New breaking-change section for #4296: `MonoGameGum.csproj`'s iOS/Android target frameworks flipped from opt-out (`ExcludeIOS`/`ExcludeAndroid`) to opt-in (`IncludeIOS`/`IncludeAndroid`). Source-linkers who deliberately built the mobile TFMs now need to pass the new flags as global properties; `Gum.MonoGame` NuGet consumers are unaffected.

**`gum-release` skill**

Step 4 told the orchestrator to invoke `gum-monthly-release` via the `Skill` tool, but that skill is `disable-model-invocation: true`, so the call is refused and the checklist stalls at the notes step. It now says to read and follow that `SKILL.md` directly.

Manual test: not needed — docs, guidance files, and a CI trigger. No product code touched; the workflow change verifies itself by this PR's own checks now running.
