### PR TITLE
Publish the FRB-flavoured GumCore projects as NuGet packages

### DIFF
--- a/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
@@ -5,6 +5,16 @@
 		<LangVersion>12.0</LangVersion>
 		<NoWarn>1591</NoWarn>
 		<Nullable>enable</Nullable>
+		<!-- Published to nuget.org by FlatRedBall's Engine.yml, not by Gum's own release. The
+		     assembly is Gum source compiled with FRB's defines and referencing FRB, so the
+		     package id is FlatRedBall-scoped to say who ships it. Assembly name is unchanged. -->
+		<PackageId>FlatRedBall.GumCore.DesktopGlNet6</PackageId>
+		<Title>GumCore for FlatRedBall (.NET Desktop GL)</Title>
+		<Authors>FlatRedBall</Authors>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>Gum layout and rendering runtime, built for FlatRedBall</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>1.0.0</Version>
 
 	</PropertyGroup>
 

--- a/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
@@ -7,11 +7,24 @@
         <DefineConstants>$(DefineConstants)TRACE;FNA;XNA4;FRB</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1591</NoWarn>
+		<!-- Published to nuget.org by FlatRedBall's Engine.yml, not by Gum's own release. The
+		     assembly is Gum source compiled with FRB's defines and referencing FRB, so the
+		     package id is FlatRedBall-scoped to say who ships it. Assembly name is unchanged. -->
+		<PackageId>FlatRedBall.GumCore.FNA</PackageId>
+		<Title>GumCore for FlatRedBall (FNA)</Title>
+		<Authors>FlatRedBall</Authors>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>Gum layout and rendering runtime, built for FlatRedBall</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>1.0.0</Version>
 
 	</PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\FlatRedBall\Engines\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" />
+      <!-- FNA is not published on nuget.org, so this must not become a package dependency.
+           FNA.dll reaches consumers embedded in the FlatRedBall.FNA package, which this project
+           picks up transitively through StateInterpolation.FNA. -->
+      <ProjectReference Include="..\..\..\..\FlatRedBall\Engines\FlatRedBallXNA\3rd Party Libraries\FNA\FNA.Core.csproj" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.FNA\StateInterpolation.FNA.csproj" />

--- a/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
@@ -7,6 +7,16 @@
 		<DefineConstants>$(DefineConstants)TRACE;FNA;XNA4;WEB;BLAZORGL;KNI;FRB</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1591</NoWarn>
+		<!-- Published to nuget.org by FlatRedBall's Engine.yml, not by Gum's own release. The
+		     assembly is Gum source compiled with FRB's defines and referencing FRB, so the
+		     package id is FlatRedBall-scoped to say who ships it. Assembly name is unchanged. -->
+		<PackageId>FlatRedBall.GumCore.Kni.Web</PackageId>
+		<Title>GumCore for FlatRedBall (Web)</Title>
+		<Authors>FlatRedBall</Authors>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Description>Gum layout and rendering runtime, built for FlatRedBall</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>1.0.0</Version>
 
 	</PropertyGroup>
 


### PR DESCRIPTION
Makes `GumCore.DesktopGlNet6`, `GumCore.FNA` and `GumCore.Kni.Web` produce NuGet packages.

These three are Gum source compiled with FlatRedBall's defines and referencing FlatRedBall — they are built and published by FlatRedBall's `Engine.yml`, not by Gum's own release. Until now they reached users as loose DLLs inside FlatRedBall's template zips, versioned independently of the engine NuGet package. A project whose bundled GumCore predated a `.gumx` format change failed to load its own UI at runtime.

Package ids are `FlatRedBall.`-scoped (`FlatRedBall.GumCore.DesktopGlNet6`, etc.) so the id says who publishes the package. Assembly names are unchanged.

`GumCore.FNA`'s reference to `FNA.Core.csproj` is marked `PrivateAssets="all"` — FNA is not on nuget.org, and `FNA.dll` reaches consumers embedded in the `FlatRedBall.FNA` package.

Nothing in Gum's own build or release consumes these projects, so this is additive here.

Part of vchelaru/FlatRedBall#1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
