### PR TITLE
Fail the build when a consumer's AssemblyName collides with a Gum runtime assembly

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -407,6 +407,9 @@ jobs:
       #   - Gum.ProjectServices.SkiaGum.Tests (SkiaGum SVG export — renders into
       #                                     SKSvgCanvas, CPU-only like SkiaGum.Tests)
       #   - Gum.Analyzers.Tests            (Roslyn analyzers; pure compilation)
+      #   - Gum.AssemblyNameGuard.Tests    (MSBuild buildTransitive collision guard;
+      #                                     shells out to `dotnet build` against temp
+      #                                     projects, no window/GPU. #4311)
       #   - Gum.Cli.Tests                  (CLI subcommand smoke tests; fonts, the
       #                                     raylib-backend screenshot test, and the
       #                                     diff-screenshots test (which renders via
@@ -514,6 +517,10 @@ jobs:
       - name: Gum.Presentation.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
         run: dotnet test "Tests/Gum.Presentation.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
+
+      - name: Gum.AssemblyNameGuard.Tests
+        if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'
+        run: dotnet test "Tests/Gum.AssemblyNameGuard.Tests" --configuration Release --no-build --logger "trx" --results-directory "TestResults"
 
       - name: Gum.Analyzers.Tests
         if: github.event_name != 'push' || steps.cache-workloads.outputs.cache-hit != 'true'

--- a/AllLibraries.sln
+++ b/AllLibraries.sln
@@ -185,6 +185,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ImageDiff", "Tools\Gum.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.ImageDiff.Tests", "Tests\Gum.ImageDiff.Tests\Gum.ImageDiff.Tests.csproj", "{2561CC66-26AC-4050-8990-3684A920EBDF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gum.AssemblyNameGuard.Tests", "Tests\Gum.AssemblyNameGuard.Tests\Gum.AssemblyNameGuard.Tests.csproj", "{06C3F783-8188-4F6D-B871-B11AA71CF9D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1692,6 +1694,24 @@ Global
 		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x64.Build.0 = Release|Any CPU
 		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x86.ActiveCfg = Release|Any CPU
 		{2561CC66-26AC-4050-8990-3684A920EBDF}.Release|x86.Build.0 = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|Any CPU.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|Any CPU.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|x64.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|x64.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|x86.ActiveCfg = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release_No_Diagnostics|x86.Build.0 = Debug|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|x64.Build.0 = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1780,6 +1800,7 @@ Global
 		{262E0C3E-E199-4A7D-B5A4-3A171D1421B2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{0035DE6B-986D-4B75-ADF0-8D286C170807} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{2561CC66-26AC-4050-8990-3684A920EBDF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{06C3F783-8188-4F6D-B871-B11AA71CF9D4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01002AE6-0158-417E-9B83-D4234361EC1B}

--- a/AssemblyNameCollisionGuard.targets
+++ b/AssemblyNameCollisionGuard.targets
@@ -1,0 +1,20 @@
+<Project>
+
+	<!--
+		Shared by every Gum runtime NuGet package's buildTransitive\<PackageId>.targets wrapper
+		(see e.g. Runtimes/SilkNetGum/build/Gum.SilkNet.targets). A consumer whose own AssemblyName
+		matches the runtime's produces a same-named output DLL that overwrites the runtime's copy
+		in the shared output folder on every build, since both land in the same bin directory with
+		no build-time signal - only a TypeLoadException the first time a Gum type is touched at
+		runtime. See #4311.
+
+		The wrapper sets GumRuntimeAssemblyName/GumRuntimePackageId before importing this file, so
+		this logic is written once and packed unchanged into every runtime package.
+	-->
+	<Target Name="GumAssemblyNameCollisionGuard" BeforeTargets="CoreCompile">
+		<Error
+			Condition="'$(AssemblyName)' == '$(GumRuntimeAssemblyName)'"
+			Text="Your project's assembly name '$(AssemblyName)' collides with the assembly shipped by $(GumRuntimePackageId). Your project's output DLL will overwrite Gum's in the output folder, causing a TypeLoadException at runtime. Set &lt;AssemblyName&gt; in your .csproj to something else." />
+	</Target>
+
+</Project>

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -325,4 +325,15 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
+	<!--
+		Guards against a consumer whose own AssemblyName collides with this package's assembly
+		name (MonoGameGum), which silently overwrites the runtime DLL in the shared output folder.
+		NuGet auto-imports buildTransitive\Gum.MonoGame.targets into every consumer; it imports
+		the shared check packed alongside it. See #4311.
+	-->
+	<ItemGroup>
+		<None Include="..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+		<None Include="build\Gum.MonoGame.targets" Pack="true" PackagePath="buildTransitive\Gum.MonoGame.targets" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/MonoGameGum/build/Gum.MonoGame.targets
+++ b/MonoGameGum/build/Gum.MonoGame.targets
@@ -1,0 +1,13 @@
+<Project>
+
+	<!-- NuGet auto-imports buildTransitive\<PackageId>.targets into every direct AND transitive
+	     consumer of this package. Sets this package's identity, then delegates the actual check
+	     to AssemblyNameCollisionGuard.targets, packed alongside this file. See #4311. -->
+	<PropertyGroup>
+		<GumRuntimeAssemblyName>MonoGameGum</GumRuntimeAssemblyName>
+		<GumRuntimePackageId>Gum.MonoGame</GumRuntimePackageId>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)AssemblyNameCollisionGuard.targets" />
+
+</Project>

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -293,4 +293,15 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
+	<!--
+		Guards against a consumer whose own AssemblyName collides with this package's assembly
+		name (RaylibGum), which silently overwrites the runtime DLL in the shared output folder.
+		NuGet auto-imports buildTransitive\Gum.raylib.targets into every consumer; it imports the
+		shared check packed alongside it. See #4311.
+	-->
+	<ItemGroup>
+		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+		<None Include="build\Gum.raylib.targets" Pack="true" PackagePath="buildTransitive\Gum.raylib.targets" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/RaylibGum/build/Gum.raylib.targets
+++ b/Runtimes/RaylibGum/build/Gum.raylib.targets
@@ -1,0 +1,13 @@
+<Project>
+
+	<!-- NuGet auto-imports buildTransitive\<PackageId>.targets into every direct AND transitive
+	     consumer of this package. Sets this package's identity, then delegates the actual check
+	     to AssemblyNameCollisionGuard.targets, packed alongside this file. See #4311. -->
+	<PropertyGroup>
+		<GumRuntimeAssemblyName>RaylibGum</GumRuntimeAssemblyName>
+		<GumRuntimePackageId>Gum.raylib</GumRuntimePackageId>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)AssemblyNameCollisionGuard.targets" />
+
+</Project>

--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -203,4 +203,17 @@
 			  Visible="false" />
 	</ItemGroup>
 
+	<!--
+		Guards against a consumer whose own AssemblyName collides with this package's assembly
+		name (SilkNetGum), which silently overwrites the runtime DLL in the shared output folder
+		(the exact failure this project's own sample worked around - see
+		Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj). NuGet auto-imports
+		buildTransitive\Gum.SilkNet.targets into every consumer; it imports the shared check
+		packed alongside it. See #4311.
+	-->
+	<ItemGroup>
+		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+		<None Include="build\Gum.SilkNet.targets" Pack="true" PackagePath="buildTransitive\Gum.SilkNet.targets" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/SilkNetGum/build/Gum.SilkNet.targets
+++ b/Runtimes/SilkNetGum/build/Gum.SilkNet.targets
@@ -1,0 +1,13 @@
+<Project>
+
+	<!-- NuGet auto-imports buildTransitive\<PackageId>.targets into every direct AND transitive
+	     consumer of this package. Sets this package's identity, then delegates the actual check
+	     to AssemblyNameCollisionGuard.targets, packed alongside this file. See #4311. -->
+	<PropertyGroup>
+		<GumRuntimeAssemblyName>SilkNetGum</GumRuntimeAssemblyName>
+		<GumRuntimePackageId>Gum.SilkNet</GumRuntimePackageId>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)AssemblyNameCollisionGuard.targets" />
+
+</Project>

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -205,4 +205,15 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
+	<!--
+		Guards against a consumer whose own AssemblyName collides with this package's assembly
+		name (SkiaGum), which silently overwrites the runtime DLL in the shared output folder.
+		NuGet auto-imports buildTransitive\Gum.SkiaSharp.targets into every consumer; it imports
+		the shared check packed alongside it. See #4311.
+	-->
+	<ItemGroup>
+		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+		<None Include="build\Gum.SkiaSharp.targets" Pack="true" PackagePath="buildTransitive\Gum.SkiaSharp.targets" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/SkiaGum/build/Gum.SkiaSharp.targets
+++ b/Runtimes/SkiaGum/build/Gum.SkiaSharp.targets
@@ -1,0 +1,13 @@
+<Project>
+
+	<!-- NuGet auto-imports buildTransitive\<PackageId>.targets into every direct AND transitive
+	     consumer of this package. Sets this package's identity, then delegates the actual check
+	     to AssemblyNameCollisionGuard.targets, packed alongside this file. See #4311. -->
+	<PropertyGroup>
+		<GumRuntimeAssemblyName>SkiaGum</GumRuntimeAssemblyName>
+		<GumRuntimePackageId>Gum.SkiaSharp</GumRuntimePackageId>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)AssemblyNameCollisionGuard.targets" />
+
+</Project>

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -206,4 +206,15 @@
 		<PackageReference Include="TextCopy" Version="6.2.1" Condition="!$(TargetFramework.Contains('ios'))" />
 	</ItemGroup>
 
+	<!--
+		Guards against a consumer whose own AssemblyName collides with this package's assembly
+		name (SokolGum), which silently overwrites the runtime DLL in the shared output folder.
+		NuGet auto-imports buildTransitive\Gum.sokol.targets into every consumer; it imports the
+		shared check packed alongside it. See #4311.
+	-->
+	<ItemGroup>
+		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+		<None Include="build\Gum.sokol.targets" Pack="true" PackagePath="buildTransitive\Gum.sokol.targets" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/Runtimes/SokolGum/build/Gum.sokol.targets
+++ b/Runtimes/SokolGum/build/Gum.sokol.targets
@@ -1,0 +1,13 @@
+<Project>
+
+	<!-- NuGet auto-imports buildTransitive\<PackageId>.targets into every direct AND transitive
+	     consumer of this package. Sets this package's identity, then delegates the actual check
+	     to AssemblyNameCollisionGuard.targets, packed alongside this file. See #4311. -->
+	<PropertyGroup>
+		<GumRuntimeAssemblyName>SokolGum</GumRuntimeAssemblyName>
+		<GumRuntimePackageId>Gum.sokol</GumRuntimePackageId>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)AssemblyNameCollisionGuard.targets" />
+
+</Project>

--- a/Tests/Gum.AssemblyNameGuard.Tests/AssemblyNameCollisionGuardTests.cs
+++ b/Tests/Gum.AssemblyNameGuard.Tests/AssemblyNameCollisionGuardTests.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics;
+using Shouldly;
+
+namespace Gum.AssemblyNameGuard.Tests;
+
+/// <summary>
+/// Proves the shared MSBuild guard (<c>AssemblyNameCollisionGuard.targets</c>, packed as
+/// buildTransitive into every Gum runtime NuGet package) actually fails a real `dotnet build`
+/// when the consuming project's AssemblyName collides with a Gum runtime assembly, and stays
+/// out of the way otherwise. See issue #4311.
+/// </summary>
+public class AssemblyNameCollisionGuardTests
+{
+    [Fact]
+    public void Build_WithCollidingAssemblyName_FailsWithGuardError()
+    {
+        BuildResult result = BuildTempProjectImportingGuard(
+            assemblyName: "SilkNetGum",
+            guardAssemblyName: "SilkNetGum",
+            guardPackageId: "Gum.SilkNet");
+
+        result.ExitCode.ShouldNotBe(0);
+        result.Output.ShouldContain(
+            "Your project's assembly name 'SilkNetGum' collides with the assembly shipped by Gum.SilkNet");
+    }
+
+    [Fact]
+    public void Build_WithNonCollidingAssemblyName_SucceedsWithoutGuardError()
+    {
+        BuildResult result = BuildTempProjectImportingGuard(
+            assemblyName: "MyGameSilkNetGum",
+            guardAssemblyName: "SilkNetGum",
+            guardPackageId: "Gum.SilkNet");
+
+        result.ExitCode.ShouldBe(0);
+        result.Output.ShouldNotContain("collides with the assembly shipped by");
+    }
+
+    private static BuildResult BuildTempProjectImportingGuard(
+        string assemblyName, string guardAssemblyName, string guardPackageId)
+    {
+        string guardTargetsPath = Path.Combine(RepoPaths.RepoRoot, "AssemblyNameCollisionGuard.targets")
+            .Replace('\\', '/');
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumAssemblyNameGuardTests_" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string csprojContents = $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <OutputType>Library</OutputType>
+                    <AssemblyName>{assemblyName}</AssemblyName>
+                    <GumRuntimeAssemblyName>{guardAssemblyName}</GumRuntimeAssemblyName>
+                    <GumRuntimePackageId>{guardPackageId}</GumRuntimePackageId>
+                  </PropertyGroup>
+                  <Import Project="{guardTargetsPath}" />
+                </Project>
+                """;
+            string csprojPath = Path.Combine(tempDir, "TestConsumer.csproj");
+            File.WriteAllText(csprojPath, csprojContents);
+
+            ProcessStartInfo startInfo = new("dotnet", $"build \"{csprojPath}\" --nologo")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using Process process = Process.Start(startInfo)!;
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            return new BuildResult(process.ExitCode, stdout + stderr);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private readonly record struct BuildResult(int ExitCode, string Output);
+}

--- a/Tests/Gum.AssemblyNameGuard.Tests/Gum.AssemblyNameGuard.Tests.csproj
+++ b/Tests/Gum.AssemblyNameGuard.Tests/Gum.AssemblyNameGuard.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Shouldly" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/Tests/Gum.AssemblyNameGuard.Tests/RepoPaths.cs
+++ b/Tests/Gum.AssemblyNameGuard.Tests/RepoPaths.cs
@@ -1,0 +1,22 @@
+namespace Gum.AssemblyNameGuard.Tests;
+
+internal static class RepoPaths
+{
+    public static string RepoRoot { get; } = FindRepoRoot();
+
+    private static string FindRepoRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        for (int i = 0; i < 10; i++)
+        {
+            if (File.Exists(Path.Combine(current, "GumFull.sln")))
+            {
+                return current;
+            }
+            string? parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent) || parent == current) break;
+            current = parent;
+        }
+        throw new InvalidOperationException("could not locate repo root from " + AppContext.BaseDirectory);
+    }
+}

--- a/Tests/Gum.AssemblyNameGuard.Tests/RuntimeTargetsWrapperTests.cs
+++ b/Tests/Gum.AssemblyNameGuard.Tests/RuntimeTargetsWrapperTests.cs
@@ -1,0 +1,45 @@
+using System.Xml.Linq;
+using Shouldly;
+
+namespace Gum.AssemblyNameGuard.Tests;
+
+/// <summary>
+/// Each Gum runtime packs its own buildTransitive\<c>PackageId</c>.targets wrapper (the file
+/// name NuGet requires for auto-import) that sets this package's identity and imports the
+/// shared <see cref="AssemblyNameCollisionGuardTests"/>-covered guard logic. This asserts each
+/// wrapper is wired to the right assembly name / package id, without paying for a real
+/// `dotnet build` per runtime. See #4311.
+/// </summary>
+public class RuntimeTargetsWrapperTests
+{
+    public static IEnumerable<object[]> Wrappers()
+    {
+        yield return new object[] { "MonoGameGum/build/Gum.MonoGame.targets", "MonoGameGum", "Gum.MonoGame" };
+        yield return new object[] { "Runtimes/SkiaGum/build/Gum.SkiaSharp.targets", "SkiaGum", "Gum.SkiaSharp" };
+        yield return new object[] { "Runtimes/RaylibGum/build/Gum.raylib.targets", "RaylibGum", "Gum.raylib" };
+        yield return new object[] { "Runtimes/SilkNetGum/build/Gum.SilkNet.targets", "SilkNetGum", "Gum.SilkNet" };
+        yield return new object[] { "Runtimes/SokolGum/build/Gum.sokol.targets", "SokolGum", "Gum.sokol" };
+    }
+
+    [Theory]
+    [MemberData(nameof(Wrappers))]
+    public void Wrapper_SetsExpectedRuntimeIdentityAndImportsSharedGuard(
+        string relativePath, string expectedAssemblyName, string expectedPackageId)
+    {
+        string fullPath = Path.Combine(RepoPaths.RepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(fullPath).ShouldBeTrue($"{relativePath} should exist");
+
+        XDocument document = XDocument.Load(fullPath);
+        XNamespace ns = document.Root!.Name.Namespace;
+
+        string? assemblyName = document.Descendants(ns + "GumRuntimeAssemblyName").FirstOrDefault()?.Value;
+        string? packageId = document.Descendants(ns + "GumRuntimePackageId").FirstOrDefault()?.Value;
+        bool importsSharedGuard = document.Descendants(ns + "Import")
+            .Any(import => (string?)import.Attribute("Project") is string project
+                && project.EndsWith("AssemblyNameCollisionGuard.targets", StringComparison.Ordinal));
+
+        assemblyName.ShouldBe(expectedAssemblyName);
+        packageId.ShouldBe(expectedPackageId);
+        importsSharedGuard.ShouldBeTrue($"{relativePath} should import the shared AssemblyNameCollisionGuard.targets");
+    }
+}

--- a/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
@@ -78,6 +78,10 @@ There's no shape support or KernSmith package for FNA yet — skip those lines i
 {% endtab %}
 {% endtabs %}
 
+{% hint style="warning" %}
+Don't name your project `MonoGameGum` (or `KniGum` / `FnaGum` for the KNI/FNA tabs), that's the assembly name inside the matching runtime package. A same-named project produces a same-named output DLL that silently overwrites the runtime's copy in your `bin` folder, causing a `TypeLoadException` at runtime with no build warning. Gum's build now catches this for you: if your `AssemblyName` collides, the build fails with an error telling you to change it.
+{% endhint %}
+
 ## Adding Source (Optional)
 
 You can directly link your project to source instead of a NuGet package for improved debuggability, access to fixes and features before NuGet packages are published, or if you are interested in contributing.

--- a/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/raylib-raylib-cs.md
@@ -24,6 +24,10 @@ Or add through command line:
 dotnet add package Gum.raylib
 ```
 
+{% hint style="warning" %}
+Don't name your project `RaylibGum`, that's the assembly name inside the `Gum.raylib` package. A same-named project produces a same-named output DLL that silently overwrites the runtime's copy in your `bin` folder, causing a `TypeLoadException` at runtime with no build warning. Gum's build now catches this for you: if your `AssemblyName` collides, the build fails with an error telling you to change it.
+{% endhint %}
+
 ## Adding Source (Optional)
 
 You can directly link your project to source instead of a NuGet package for improved debuggability, access to fixes and features before NuGet packages are published, or if you are interested in contributing.

--- a/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/silk.net.md
@@ -24,6 +24,10 @@ dotnet add package Gum.SilkNet
 
 `Gum.SilkNet` renders through SkiaSharp and adds real Forms input (mouse, keyboard, focus) via `Silk.NET.Input`. Your project still owns window creation and the render loop; Gum takes an `SKCanvas` and an `IInputContext` you hand it.
 
+{% hint style="warning" %}
+Don't name your project `SilkNetGum`, that's the assembly name inside the `Gum.SilkNet` package. A same-named project produces a same-named output DLL that silently overwrites the runtime's copy in your `bin` folder, causing a `TypeLoadException` at runtime with no build warning. Gum's build now catches this for you: if your `AssemblyName` collides, the build fails with an error telling you to change it.
+{% endhint %}
+
 ## Adding Source (Optional)
 
 You can directly link your project to source instead of a NuGet package for improved debuggability, access to fixes and features before NuGet packages are published, or if you are interested in contributing.


### PR DESCRIPTION
Closes #4311.

## Summary
- Packs a shared `buildTransitive/AssemblyNameCollisionGuard.targets` MSBuild guard into every Gum runtime NuGet package (`Gum.MonoGame`, `Gum.SkiaSharp`, `Gum.raylib`, `Gum.SilkNet`, `Gum.sokol`). NuGet auto-imports it into direct *and transitive* consumers; if the consumer's `AssemblyName` matches the runtime's, the build now fails with a clear error telling them to change `<AssemblyName>`.
- Each package's `buildTransitive/<PackageId>.targets` wrapper just sets the runtime's identity and imports the one shared guard file, so the actual check logic lives in a single place.
- Verified end-to-end against a real packed `.nupkg` (not just a direct `Import`): a consumer csproj named `SilkNetGum.csproj` referencing `Gum.SilkNet` via `PackageReference` now fails to build with the exact `TypeLoadException`-avoiding error; a non-colliding name builds clean.
- Added warnings to the MonoGame/KNI/FNA, raylib, and Silk.NET "Adding Gum" doc pages.

## Tests
New `Tests/Gum.AssemblyNameGuard.Tests` project (added to `AllLibraries.sln` and wired into CI's Bucket A):
- `AssemblyNameCollisionGuardTests` — shells out to a real `dotnet build` against a temp project importing the shared guard, asserting the colliding case fails with the expected message and the non-colliding case builds clean.
- `RuntimeTargetsWrapperTests` — fast XML assertions that each of the 5 per-package wrapper files sets the right assembly name/package id and imports the shared guard (no `dotnet build` per runtime).

Manual test: not needed, the automated build-time checks (including the real-NuGet-package end-to-end check performed during development) are the direct proof of the fix; there is no separate visual/runtime behavior to check by hand.

FRB canary: not needed, no FRB1-shared source touched.
