### PR TITLE
Widen FontSize from int to float end-to-end

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -1431,7 +1431,7 @@ public partial class CustomSetPropertyOnRenderable
     // The eight font-resolution stacks (mirroring the MonoGame path). Inline [FontSize]/[IsBold]/etc. tags
     // push their value on open and pop on close, so a run resolves to the font implied by every tag currently
     // open over it - the whole reason nested markup needs a stack rather than a flat lookup.
-    static Stack<int> fontSizeStack = new Stack<int>();
+    static Stack<float> fontSizeStack = new Stack<float>();
     static Stack<string> fontNameStack = new Stack<string>();
     static Stack<int> outlineThicknessStack = new Stack<int>();
     static Stack<bool> useFontSmoothingStack = new Stack<bool>();
@@ -1476,7 +1476,7 @@ public partial class CustomSetPropertyOnRenderable
     /// the caller.
     /// </summary>
     static BmfcSave BuildInlineRunBmfcSave(
-        int fontSize, int outlineThickness, bool useFontSmoothing, bool isItalic, bool isBold,
+        float fontSize, int outlineThickness, bool useFontSmoothing, bool isItalic, bool isBold,
         string? fontFilePath, string fontName)
     {
         BmfcSave bmfcSave = new BmfcSave();
@@ -1888,7 +1888,7 @@ public partial class CustomSetPropertyOnRenderable
                     castedValue = GetAndCreateFontIfNecessary();
                     break;
                 case "FontSize":
-                    if (int.TryParse(tag.Argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedSize))
+                    if (float.TryParse(tag.Argument, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsedSize))
                     {
                         fontSizeStack.Push(parsedSize);
                         castedValue = GetAndCreateFontIfNecessary();
@@ -1897,7 +1897,7 @@ public partial class CustomSetPropertyOnRenderable
                         // rasterized at the requested size, so store the raw pixel size as a float and let the
                         // renderer scale the base atlas to it (a blurry-but-correct approximation). The XNA
                         // path never needs this - it can new BitmapFont(...) at any size.
-                        castedValue ??= (float)parsedSize;
+                        castedValue ??= parsedSize;
 #endif
                     }
                     else

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFractionalFontSizeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFractionalFontSizeTests.cs
@@ -1,0 +1,66 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.Tests.Runtimes;
+
+// Issue #4304: the shared inline-BBCode font-size stack (Gum/Wireframe/CustomSetPropertyOnRenderable.cs,
+// fontSizeStack) parsed [FontSize=N] with int.TryParse, so a fractional argument like "18.5" failed to
+// parse and was silently treated as a closing tag (Pop) instead of pushing the requested size. Widening
+// the stack to float alongside TextRuntime.FontSize fixes this: a fractional inline run now resolves via
+// float.TryParse and reaches the per-run BmfcSave unrounded.
+public class TextRuntimeBbCodeFractionalFontSizeTests : BaseTestClass
+{
+    [Fact]
+    public void Text_WithFractionalInlineFontSizeRun_PassesUnroundedSizeToInMemoryFontCreator()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var recordingCreator = new RecordingInMemoryFontCreator();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = recordingCreator;
+
+            TextRuntime textRuntime = new();
+            // A font/size NOT in the test harness's stubbed embedded resources (which only cover
+            // Arial-18), so resolution actually reaches the in-memory creator.
+            textRuntime.Font = "Garet";
+            textRuntime.FontSize = 12;
+
+            textRuntime.Text = "normal [FontSize=18.5]enlarged[/FontSize] normal";
+
+            var fractionalRequest = recordingCreator.Requests.Single(r => r.FontSize == 18.5f);
+            fractionalRequest.FontSize.ShouldBe(18.5f);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    private sealed class RecordingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public List<BmfcSave> Requests { get; } = new();
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            Requests.Add(bmfcSave);
+            BitmapFont font = new BitmapFont((Texture2D)null!, FontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        private const string FontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=1
+char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=15
+";
+    }
+}

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -212,7 +212,7 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
 
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
-            int xadvance = bmfcSave.FontSize;
+            int xadvance = (int)bmfcSave.FontSize;
             if (bmfcSave.FontSize != _baseFontSize)
             {
                 xadvance += 1;
@@ -240,7 +240,7 @@ char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
     {
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
-            int xadvance = bmfcSave.FontSize;
+            int xadvance = (int)bmfcSave.FontSize;
             string fontData =
 $@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
 common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
@@ -283,7 +283,7 @@ char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
             WasCalled = true;
-            CapturedFontSize = bmfcSave.FontSize;
+            CapturedFontSize = (int)bmfcSave.FontSize;
             return _fontToReturn;
         }
     }

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -275,8 +275,8 @@ char id=67 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
     {
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
-            int advance = bmfcSave.FontSize / 2;
-            BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: bmfcSave.FontSize));
+            int advance = (int)bmfcSave.FontSize / 2;
+            BitmapFont font = new BitmapFont((Texture2D)null!, AbcFontData(advance, lineHeight: (int)bmfcSave.FontSize));
             font.SetFontPattern(256, 256);
             return font;
         }

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -352,8 +352,8 @@ public class TextRuntime : InteractiveGue
         set { font = value; UpdateToFontValues(); }
     }
 
-    int fontSize;
-    public int FontSize
+    float fontSize;
+    public float FontSize
     {
         get { return fontSize; }
         set { fontSize = value; UpdateToFontValues(); }
@@ -698,7 +698,7 @@ public class TextRuntime : InteractiveGue
         }
 
         ContainedText.BitmapFont = font;
-        ContainedText.FontScale = (float)FontSize / rasterFontSize;
+        ContainedText.FontScale = FontSize / rasterFontSize;
 
         // BitmapFont/FontScale are renderable-level properties -- assigning them directly (bypassing
         // the normal property-setter cascade a call like FontSize= goes through) never notifies this

--- a/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
+++ b/RenderingLibrary/Graphics/Fonts/BmfcSave.cs
@@ -22,9 +22,11 @@ public class BmfcSave
     public string FontName = "Arial";
 
     /// <summary>
-    /// The font size in points.
+    /// The font size in points. Fractional values are rasterized natively by KernSmith; the legacy
+    /// bmfont.exe backend rounds to the nearest whole pixel size (<see cref="GetGdiRoundedFontSize"/>)
+    /// since it writes into a Windows GDI LOGFONT, which only accepts whole pixel heights.
     /// </summary>
-    public int FontSize = 20;
+    public float FontSize = 20;
 
     /// <summary>
     /// The thickness of the font outline in pixels. Zero means no outline.
@@ -274,7 +276,7 @@ public class BmfcSave
         template = template.Replace("FontNameVariable", FontName);
 
         template = template.Replace("FontFileVariable", FontFile ?? "");
-        template = template.Replace("FontSizeVariable", FontSize.ToString());
+        template = template.Replace("FontSizeVariable", GetGdiRoundedFontSize(FontSize).ToString());
         template = template.Replace("OutlineThicknessVariable", OutlineThickness.ToString());
         template = template.Replace("{UseSmoothing}", UseSmoothing ? "1" : "0");
         template = template.Replace("{IsItalic}", IsItalic ? "1" : "0");
@@ -324,6 +326,15 @@ public class BmfcSave
         template = template.Replace("chars=32-126,160-255", charsReplacement);
 
         FileManager.SaveText(template, fileName);
+    }
+
+    /// <summary>
+    /// Rounds a fractional font size to the nearest whole pixel size for the GDI-backed bmfont.exe
+    /// backend, which cannot rasterize fractional point sizes.
+    /// </summary>
+    public static int GetGdiRoundedFontSize(float fontSize)
+    {
+        return (int)System.Math.Round(fontSize, MidpointRounding.AwayFromZero);
     }
 
     /// <summary>
@@ -645,7 +656,9 @@ public class BmfcSave
     /// The file name encodes all properties that affect rendering so that
     /// different font configurations produce different cache files.
     /// </summary>
-    /// <param name="fontSize">The font size in points.</param>
+    /// <param name="fontSize">The font size in points. A whole-number value produces the same file
+    /// name as the equivalent int did before fractional sizes were supported (#4304); a fractional
+    /// value produces a distinct name from either neighboring whole number.</param>
     /// <param name="fontName">The font family name.</param>
     /// <param name="outline">The outline thickness.</param>
     /// <param name="useFontSmoothing">Whether font smoothing is enabled.</param>
@@ -654,7 +667,7 @@ public class BmfcSave
     /// <param name="fontFilePath">Optional .ttf file path. When set, the file name (without extension) is used
     /// as the font name and a "_ttf" suffix is appended to prevent collision with same-named system fonts.</param>
     /// <returns>A relative file path under "FontCache/" suitable for caching this font.</returns>
-    public static string GetFontCacheFileNameFor(int fontSize, string fontName, int outline, bool useFontSmoothing,
+    public static string GetFontCacheFileNameFor(float fontSize, string fontName, int outline, bool useFontSmoothing,
         bool isItalic = false, bool isBold = false, string? fontFilePath = null,
         bool hasDropshadow = false, float dropshadowOffsetX = 0f, float dropshadowOffsetY = 0f,
         float dropshadowBlur = 0f, byte dropshadowRed = 0, byte dropshadowGreen = 0, byte dropshadowBlue = 0,
@@ -677,7 +690,7 @@ public class BmfcSave
         // don't allow some characters in the file name:
         effectiveFontName = effectiveFontName.Replace(' ', '_');
 
-        fileName = "Font" + fontSize + effectiveFontName;
+        fileName = "Font" + FormatCacheKeyFloat(fontSize) + effectiveFontName;
 
         if(isFromFile)
         {

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -483,7 +483,7 @@ public class Text : IVisible, IRenderableIpso,
             ? global::Gum.RenderingLibrary.BlendExtensions.ToBlendState(Blend.Value)
             : global::Gum.BlendState.NonPremultiplied;
 
-    public int FontSize
+    public float FontSize
     {
         get => _fontSize;
         set
@@ -543,7 +543,7 @@ public class Text : IVisible, IRenderableIpso,
     }
 
     int? maxNumberOfLines;
-    private int _fontSize = 12;
+    private float _fontSize = 12;
 
     /// <summary>
     /// The maximum number of lines to display. This can be used to 

--- a/Runtimes/SkiaGum/Renderables/Text.cs
+++ b/Runtimes/SkiaGum/Renderables/Text.cs
@@ -190,9 +190,9 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
 
         }
     }
-    public int FontSize
+    public float FontSize
     {
-        get => _fontSize; 
+        get => _fontSize;
         set
         {
             _fontSize = value;
@@ -455,7 +455,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
             textBlock.AddText("My", GetRawMeasurementStyle());
             return textBlock.Lines.Count > 0
                 ? (int)MathF.Ceiling(textBlock.Lines[0].Height)
-                : FontSize;
+                : (int)MathF.Ceiling(FontSize);
         }
     }
 
@@ -995,7 +995,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     private bool _isTruncatingWithEllipsisOnLastLine;
     private TextOverflowVerticalMode _textOverflowVerticalMode;
     private string _fontName = "Arial";
-    private int _fontSize = 18;
+    private float _fontSize = 18;
     private SKTypeface? _typeface;
     private float _fontScale;
     private float _boldWeight = 1;
@@ -1354,7 +1354,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     {
         var color = this.Color;
         string? fontFamily = EffectiveFontFamily;
-        int fontSizePixels = FontSize;
+        float fontSizePixels = FontSize;
         float fontScale = FontScale;
         bool italic = this.IsItalic;
         int weight = (int)(400 * BoldWeight);
@@ -1388,7 +1388,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
                         color = new SKColor(color.Red, color.Green, (byte)variable.Value, color.Alpha);
                         break;
                     case "FontSize":
-                        fontSizePixels = (int)variable.Value;
+                        fontSizePixels = (float)variable.Value;
                         break;
                     case "FontScale":
                         fontScale = (float)variable.Value;
@@ -1517,7 +1517,7 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
     /// their character range in the stripped <see cref="_layoutText"/>. Each supported tag maps to a
     /// value the shared <see cref="StyledSubstringSplitter"/> and <see cref="BuildRunStyle"/> understand:
     /// Font -> resolved family-name string (via <see cref="Content.Fonts.GumFontMapper.ResolveFontFamily"/>),
-    /// Color -> System.Drawing.Color, Red/Green/Blue -> byte, FontSize -> int, FontScale -> float,
+    /// Color -> System.Drawing.Color, Red/Green/Blue -> byte, FontSize -> float, FontScale -> float,
     /// IsBold/IsItalic -> bool, OutlineThickness -> int. Tags whose argument fails to parse are skipped
     /// (rendered with base style).
     /// </summary>
@@ -1555,9 +1555,9 @@ public class Text : IRenderableIpso, IVisible, IFormsText, ICloneable
                     break;
                 case "fontsize":
                     variableName = "FontSize";
-                    value = int.TryParse(argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out var size)
+                    value = float.TryParse(argument, NumberStyles.Float, CultureInfo.InvariantCulture, out var size)
                         ? size
-                        : (int?)null;
+                        : (float?)null;
                     break;
                 case "fontscale":
                     variableName = "FontScale";

--- a/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
+++ b/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
@@ -164,8 +164,8 @@ public class TextRuntime : InteractiveGue
         set { font = value; UpdateToFontValues(); }
     }
 
-    int fontSize;
-    public int FontSize
+    float fontSize;
+    public float FontSize
     {
         get => fontSize;
         set { fontSize = value; UpdateToFontValues(); }

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -59,8 +59,8 @@ public class Game1 : Game
 
         FontPlaygroundScreen.Build(GumService.Default.Root);
 
-        BuildZoomOversamplingDemo();
         BuildFractionalFontSizeDemo();
+        BuildZoomOversamplingDemo();
 
         base.Initialize();
     }
@@ -70,7 +70,7 @@ public class Game1 : Game
         _fractionalFontSizeText = new TextRuntime();
         _fractionalFontSizeText.Font = "Arial";
         _fractionalFontSizeText.X = 16;
-        _fractionalFontSizeText.Y = 660;
+        _fractionalFontSizeText.Y = 560;
         _fractionalFontSizeText.Red = 255;
         _fractionalFontSizeText.Green = 255;
         _fractionalFontSizeText.Blue = 255;
@@ -96,7 +96,7 @@ public class Game1 : Game
         _plainZoomPreviewText.Text = "Scroll to zoom (always blurry)";
         _plainZoomPreviewText.FontSize = 24;
         _plainZoomPreviewText.X = 16;
-        _plainZoomPreviewText.Y = 560;
+        _plainZoomPreviewText.Y = 600;
         _plainZoomPreviewText.Red = 255;
         _plainZoomPreviewText.Green = 255;
         _plainZoomPreviewText.Blue = 255;
@@ -107,7 +107,7 @@ public class Game1 : Game
         _oversampledZoomPreviewText.Text = "Scroll to zoom, then press R (crisp)";
         _oversampledZoomPreviewText.FontSize = 24;
         _oversampledZoomPreviewText.X = 16;
-        _oversampledZoomPreviewText.Y = 600;
+        _oversampledZoomPreviewText.Y = 640;
         _oversampledZoomPreviewText.Red = 255;
         _oversampledZoomPreviewText.Green = 255;
         _oversampledZoomPreviewText.Blue = 255;

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -35,6 +35,11 @@ public class Game1 : Game
     // camera transform above). Confirms KernSmith rebakes crisply at each new fractional size as it
     // changes continuously, and the label shows the live requested FontSize (with decimals) so the
     // number is readable while zooming.
+    //
+    // This deliberately does NOT demonstrate crisp text under CAMERA zoom (that's a different feature
+    // -- automatic, FontScale-free oversampling -- tracked separately in #4317, since it needs a
+    // render-time compensation mechanism that doesn't exist yet; see that issue for why hijacking
+    // FontScale, the way RegenerateOversampledFont below does, isn't the right shape for it).
     private TextRuntime _fractionalFontSizeText = null!;
     private const float FractionalFontSizeMin = 8f;
     // Capped well below the full 8-96 slider range in FontPlaygroundScreen so this text -- reserved

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -36,14 +36,20 @@ public class Game1 : Game
     // number is readable while zooming.
     private TextRuntime _fractionalFontSizeText = null!;
     private const float FractionalFontSizeMin = 8f;
-    private const float FractionalFontSizeMax = 96f;
+    // Capped well below the full 8-96 slider range in FontPlaygroundScreen so this text -- reserved
+    // the top band of the page (see FontPlaygroundScreen.BuildInternal's controlsPanel.Visual.Y
+    // comment) -- can never grow tall/wide enough to run into the controls panel below it.
+    private const float FractionalFontSizeMax = 48f;
     private float _fractionalFontSize = 24f;
 
     public Game1()
     {
         _graphics = new GraphicsDeviceManager(this);
         _graphics.PreferredBackBufferWidth = 1024;
-        _graphics.PreferredBackBufferHeight = 768;
+        // Taller than the 768 the rest of the page's content originally fit in, to give the
+        // fractional-FontSize demo's reserved top band (see FontPlaygroundScreen's controlsPanel
+        // comment) room without cramming the zoom-demo pair against the bottom edge.
+        _graphics.PreferredBackBufferHeight = 820;
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
     }
@@ -70,7 +76,7 @@ public class Game1 : Game
         _fractionalFontSizeText = new TextRuntime();
         _fractionalFontSizeText.Font = "Arial";
         _fractionalFontSizeText.X = 16;
-        _fractionalFontSizeText.Y = 560;
+        _fractionalFontSizeText.Y = 4;
         _fractionalFontSizeText.Red = 255;
         _fractionalFontSizeText.Green = 255;
         _fractionalFontSizeText.Blue = 255;
@@ -96,7 +102,7 @@ public class Game1 : Game
         _plainZoomPreviewText.Text = "Scroll to zoom (always blurry)";
         _plainZoomPreviewText.FontSize = 24;
         _plainZoomPreviewText.X = 16;
-        _plainZoomPreviewText.Y = 600;
+        _plainZoomPreviewText.Y = 650;
         _plainZoomPreviewText.Red = 255;
         _plainZoomPreviewText.Green = 255;
         _plainZoomPreviewText.Blue = 255;
@@ -107,7 +113,7 @@ public class Game1 : Game
         _oversampledZoomPreviewText.Text = "Scroll to zoom, then press R (crisp)";
         _oversampledZoomPreviewText.FontSize = 24;
         _oversampledZoomPreviewText.X = 16;
-        _oversampledZoomPreviewText.Y = 640;
+        _oversampledZoomPreviewText.Y = 690;
         _oversampledZoomPreviewText.Red = 255;
         _oversampledZoomPreviewText.Green = 255;
         _oversampledZoomPreviewText.Blue = 255;

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -5,6 +5,7 @@ using KernSmith.Gum;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using RenderingLibrary;
+using RenderingLibrary.Graphics;
 
 namespace FontPlayground.MonoGame;
 
@@ -83,6 +84,17 @@ public class Game1 : Game
         _fractionalFontSizeText.Alpha = 255;
         GumService.Default.Root.Children.Add(_fractionalFontSizeText);
 
+        // Everything else in this sample renders through the main camera, which the mouse wheel
+        // also zooms (see UpdateZoomOversamplingDemo) -- if this text stayed on that same layer, its
+        // own FontSize growth would compound with the camera's zoom on top of it (pixelation, drift
+        // from the zoom pivot, size growing faster than the displayed number). A screen-space layer
+        // (IsInScreenSpace) is ignored by the main camera entirely, so this text's on-screen size and
+        // position are driven ONLY by its own FontSize/X/Y -- exactly what the demo needs to show.
+        Layer screenSpaceLayer = SystemManagers.Default.Renderer.AddLayer();
+        screenSpaceLayer.Name = "Fractional FontSize (screen space)";
+        screenSpaceLayer.LayerCameraSettings = new LayerCameraSettings { IsInScreenSpace = true };
+        _fractionalFontSizeText.MoveToLayer(screenSpaceLayer);
+
         ApplyFractionalFontSize();
     }
 
@@ -147,10 +159,18 @@ public class Game1 : Game
         Camera camera = SystemManagers.Default.Renderer.Camera;
         if (scrollWheelDelta != 0)
         {
-            camera.Zoom = System.Math.Clamp(camera.Zoom * (1 + scrollWheelDelta * 0.001f), 0.25f, 8f);
+            // Multiplying by (1 + delta*k) for a scroll up and by (1 - delta*k) for the same-sized
+            // scroll down is NOT an inverse pair -- (1+k)*(1-k) = 1-k^2 < 1, so scrolling up then down
+            // the same amount nets a small loss every time. An exponential step (Pow(base, delta)) IS
+            // its own exact inverse (Pow(b,d) * Pow(b,-d) = 1 always), so equal-and-opposite scrolling
+            // returns to precisely the original value.
+            const float zoomStepBase = 1.001f;
+            float zoomMultiplier = System.MathF.Pow(zoomStepBase, scrollWheelDelta);
+
+            camera.Zoom = System.Math.Clamp(camera.Zoom * zoomMultiplier, 0.25f, 8f);
 
             _fractionalFontSize = System.Math.Clamp(
-                _fractionalFontSize * (1 + scrollWheelDelta * 0.001f), FractionalFontSizeMin, FractionalFontSizeMax);
+                _fractionalFontSize * zoomMultiplier, FractionalFontSizeMin, FractionalFontSizeMax);
             ApplyFractionalFontSize();
         }
 

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -28,6 +28,17 @@ public class Game1 : Game
     private int _previousScrollWheelValue;
     private bool _wasRKeyDown;
 
+    // Issue #4304 manual-test rig: a single Text whose FontSize tracks the mouse wheel directly (NOT
+    // camera.Zoom -- this text is drawn in normal, unzoomed screen space so the raster size KernSmith
+    // bakes always matches this text's own on-screen footprint 1:1, with no compounding from the
+    // camera transform above). Confirms KernSmith rebakes crisply at each new fractional size as it
+    // changes continuously, and the label shows the live requested FontSize (with decimals) so the
+    // number is readable while zooming.
+    private TextRuntime _fractionalFontSizeText = null!;
+    private const float FractionalFontSizeMin = 8f;
+    private const float FractionalFontSizeMax = 96f;
+    private float _fractionalFontSize = 24f;
+
     public Game1()
     {
         _graphics = new GraphicsDeviceManager(this);
@@ -49,8 +60,30 @@ public class Game1 : Game
         FontPlaygroundScreen.Build(GumService.Default.Root);
 
         BuildZoomOversamplingDemo();
+        BuildFractionalFontSizeDemo();
 
         base.Initialize();
+    }
+
+    private void BuildFractionalFontSizeDemo()
+    {
+        _fractionalFontSizeText = new TextRuntime();
+        _fractionalFontSizeText.Font = "Arial";
+        _fractionalFontSizeText.X = 16;
+        _fractionalFontSizeText.Y = 660;
+        _fractionalFontSizeText.Red = 255;
+        _fractionalFontSizeText.Green = 255;
+        _fractionalFontSizeText.Blue = 255;
+        _fractionalFontSizeText.Alpha = 255;
+        GumService.Default.Root.Children.Add(_fractionalFontSizeText);
+
+        ApplyFractionalFontSize();
+    }
+
+    private void ApplyFractionalFontSize()
+    {
+        _fractionalFontSizeText.FontSize = _fractionalFontSize;
+        _fractionalFontSizeText.Text = $"Font size: {_fractionalFontSize:0.00}";
     }
 
     private void BuildZoomOversamplingDemo()
@@ -109,6 +142,10 @@ public class Game1 : Game
         if (scrollWheelDelta != 0)
         {
             camera.Zoom = System.Math.Clamp(camera.Zoom * (1 + scrollWheelDelta * 0.001f), 0.25f, 8f);
+
+            _fractionalFontSize = System.Math.Clamp(
+                _fractionalFontSize * (1 + scrollWheelDelta * 0.001f), FractionalFontSizeMin, FractionalFontSizeMax);
+            ApplyFractionalFontSize();
         }
 
         bool isRKeyDown = Keyboard.GetState().IsKeyDown(Keys.R);

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -48,6 +48,17 @@ public class FontPlaygroundScreen
     private TextRuntime _bbCodeDropshadowPreviewText = null!;
 
     /// <summary>
+    /// How many rows the fractional-FontSize column (issue #4304 manual test) builds, each 0.25
+    /// larger than the last starting at <see cref="FractionalFontSizeColumnStart"/>.
+    /// </summary>
+    private const int FractionalFontSizeColumnCount = 20;
+
+    /// <summary>
+    /// The smallest FontSize in the fractional-FontSize column (issue #4304 manual test).
+    /// </summary>
+    private const float FractionalFontSizeColumnStart = 10f;
+
+    /// <summary>
     /// Builds the font-playground controls and preview text into the given root and wires up
     /// live updates. Returns the created screen so the host can keep it alive if desired; the
     /// host can also safely ignore the return value because the wired event handlers keep the
@@ -213,7 +224,38 @@ public class FontPlaygroundScreen
         _bbCodeDropshadowPreviewText.HasDropshadow = true;
         root.Children.Add(_bbCodeDropshadowPreviewText);
 
+        BuildFractionalFontSizeColumn(root);
+
         ApplyFontSettings();
+    }
+
+    /// <summary>
+    /// Issue #4304 manual test: a column of Text instances, each 0.25 larger than the one above it
+    /// starting at <see cref="FractionalFontSizeColumnStart"/>, so fractional FontSize can be
+    /// compared visually. Each label includes its own FontSize so a row is identifiable at a glance.
+    /// KernSmith rasterizes each size natively (no rounding), unlike the legacy bmfont.exe backend.
+    /// </summary>
+    private static void BuildFractionalFontSizeColumn(InteractiveGue root)
+    {
+        float y = 250;
+        for (int i = 0; i < FractionalFontSizeColumnCount; i++)
+        {
+            float fontSize = FractionalFontSizeColumnStart + i * 0.25f;
+
+            TextRuntime text = new TextRuntime();
+            text.Font = "Arial";
+            text.FontSize = fontSize;
+            text.Text = $"{fontSize:0.00} The quick brown fox";
+            text.X = 290;
+            text.Y = y;
+            text.Red = 255;
+            text.Green = 255;
+            text.Blue = 255;
+            text.Alpha = 255;
+            root.Children.Add(text);
+
+            y += fontSize + 4;
+        }
     }
 
     /// <summary>

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -67,7 +67,9 @@ public class FontPlaygroundScreen
         controlsPanel.Orientation = Orientation.Vertical;
         controlsPanel.Spacing = 6;
         controlsPanel.Visual.X = 16;
-        controlsPanel.Visual.Y = 16;
+        // Y=100 (rather than a page-edge 16) leaves a reserved top band clear for the host's own
+        // page-level content (e.g. FontPlayground.MonoGame's fractional-FontSize demo text).
+        controlsPanel.Visual.Y = 100;
         root.AddChild(controlsPanel);
 
         // Font family
@@ -188,7 +190,7 @@ public class FontPlaygroundScreen
         _previewText = new TextRuntime();
         _previewText.Text = "The quick brown fox 0123";
         _previewText.X = 290;
-        _previewText.Y = 24;
+        _previewText.Y = 108;
         // White text. Red/Green/Blue/Alpha are platform-neutral int properties (unlike the
         // backend-specific Color property), so setting them here keeps this file portable.
         _previewText.Red = 255;
@@ -204,7 +206,7 @@ public class FontPlaygroundScreen
         _bbCodeDropshadowPreviewText.Text =
             "Shadow on [HasDropshadow=false]shadow off[/HasDropshadow] shadow on again";
         _bbCodeDropshadowPreviewText.X = 290;
-        _bbCodeDropshadowPreviewText.Y = 90;
+        _bbCodeDropshadowPreviewText.Y = 174;
         _bbCodeDropshadowPreviewText.Width = 500;
         _bbCodeDropshadowPreviewText.Red = 255;
         _bbCodeDropshadowPreviewText.Green = 255;

--- a/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
+++ b/Samples/FontPlayground/Shared/FontPlaygroundScreen.cs
@@ -48,17 +48,6 @@ public class FontPlaygroundScreen
     private TextRuntime _bbCodeDropshadowPreviewText = null!;
 
     /// <summary>
-    /// How many rows the fractional-FontSize column (issue #4304 manual test) builds, each 0.25
-    /// larger than the last starting at <see cref="FractionalFontSizeColumnStart"/>.
-    /// </summary>
-    private const int FractionalFontSizeColumnCount = 20;
-
-    /// <summary>
-    /// The smallest FontSize in the fractional-FontSize column (issue #4304 manual test).
-    /// </summary>
-    private const float FractionalFontSizeColumnStart = 10f;
-
-    /// <summary>
     /// Builds the font-playground controls and preview text into the given root and wires up
     /// live updates. Returns the created screen so the host can keep it alive if desired; the
     /// host can also safely ignore the return value because the wired event handlers keep the
@@ -224,38 +213,7 @@ public class FontPlaygroundScreen
         _bbCodeDropshadowPreviewText.HasDropshadow = true;
         root.Children.Add(_bbCodeDropshadowPreviewText);
 
-        BuildFractionalFontSizeColumn(root);
-
         ApplyFontSettings();
-    }
-
-    /// <summary>
-    /// Issue #4304 manual test: a column of Text instances, each 0.25 larger than the one above it
-    /// starting at <see cref="FractionalFontSizeColumnStart"/>, so fractional FontSize can be
-    /// compared visually. Each label includes its own FontSize so a row is identifiable at a glance.
-    /// KernSmith rasterizes each size natively (no rounding), unlike the legacy bmfont.exe backend.
-    /// </summary>
-    private static void BuildFractionalFontSizeColumn(InteractiveGue root)
-    {
-        float y = 250;
-        for (int i = 0; i < FractionalFontSizeColumnCount; i++)
-        {
-            float fontSize = FractionalFontSizeColumnStart + i * 0.25f;
-
-            TextRuntime text = new TextRuntime();
-            text.Font = "Arial";
-            text.FontSize = fontSize;
-            text.Text = $"{fontSize:0.00} The quick brown fox";
-            text.X = 290;
-            text.Y = y;
-            text.Red = 255;
-            text.Green = 255;
-            text.Blue = 255;
-            text.Alpha = 255;
-            root.Children.Add(text);
-
-            y += fontSize + 4;
-        }
     }
 
     /// <summary>

--- a/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/KernSmithFileGeneratorSizeTests.cs
@@ -59,4 +59,22 @@ public class KernSmithFileGeneratorSizeTests
 
         result.Pages.Count.ShouldBe(1);
     }
+
+    // Issue #4304: KernSmith's own FontGeneratorOptions.Size is float and rasterizes fractional
+    // point sizes natively (unlike the legacy bmfont.exe/GDI backend), so BuildOptions must pass a
+    // fractional BmfcSave.FontSize through unrounded.
+    [Fact]
+    public void BuildOptions_ShouldPassFractionalFontSizeThroughUnrounded()
+    {
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 18.5f,
+            Ranges = "32-126",
+        };
+
+        FontGeneratorOptions options = KernSmithFileGenerator.BuildOptions(bmfcSave);
+
+        options.Size.ShouldBe(18.5f);
+    }
 }

--- a/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveFontCacheKeyTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveFontCacheKeyTests.cs
@@ -42,4 +42,29 @@ public class BmfcSaveFontCacheKeyTests
 
         blur2.ShouldNotBe(blur5);
     }
+
+    // Issue #4304: fractional FontSize needs its own distinct cache file so the KernSmith backend
+    // (which rasterizes fractional point sizes natively) doesn't collide with either neighboring
+    // integer size.
+    [Fact]
+    public void CacheName_WithFractionalFontSize_DistinguishesFromNeighboringIntegers()
+    {
+        string eighteen = BmfcSave.GetFontCacheFileNameFor(18, "Arial", 0, true);
+        string eighteenHalf = BmfcSave.GetFontCacheFileNameFor(18.5f, "Arial", 0, true);
+        string nineteen = BmfcSave.GetFontCacheFileNameFor(19, "Arial", 0, true);
+
+        eighteenHalf.ShouldNotBe(eighteen);
+        eighteenHalf.ShouldNotBe(nineteen);
+    }
+
+    // Existing cache files on disk are named from whole-number sizes (e.g. "Font18Arial.fnt"); a
+    // whole-number float must produce the identical name so those caches keep hitting.
+    [Fact]
+    public void CacheName_WithWholeNumberFontSize_MatchesLegacyIntegerFormat()
+    {
+        string fromInt = BmfcSave.GetFontCacheFileNameFor(18, "Arial", 0, true);
+        string fromFloat = BmfcSave.GetFontCacheFileNameFor(18f, "Arial", 0, true);
+
+        fromFloat.ShouldBe(fromInt);
+    }
 }

--- a/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveGdiFontSizeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/Fonts/BmfcSaveGdiFontSizeTests.cs
@@ -1,0 +1,37 @@
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.V2.Fonts;
+
+/// <summary>
+/// Issue #4304 — the legacy bmfont.exe backend writes FontSize into a Windows GDI LOGFONT, which
+/// only accepts whole pixel heights, so a fractional <see cref="BmfcSave.FontSize"/> must round
+/// before it reaches the .bmfc template.
+/// </summary>
+public class BmfcSaveGdiFontSizeTests
+{
+    [Fact]
+    public void GetGdiRoundedFontSize_RoundsDownForFractionBelowHalf()
+    {
+        BmfcSave.GetGdiRoundedFontSize(18.3f).ShouldBe(18);
+    }
+
+    [Fact]
+    public void GetGdiRoundedFontSize_RoundsUpForFractionAboveHalf()
+    {
+        BmfcSave.GetGdiRoundedFontSize(18.7f).ShouldBe(19);
+    }
+
+    [Fact]
+    public void GetGdiRoundedFontSize_RoundsHalfAwayFromZero()
+    {
+        BmfcSave.GetGdiRoundedFontSize(18.5f).ShouldBe(19);
+    }
+
+    [Fact]
+    public void GetGdiRoundedFontSize_LeavesWholeNumberUnchanged()
+    {
+        BmfcSave.GetGdiRoundedFontSize(18f).ShouldBe(18);
+    }
+}

--- a/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeFractionalFontSizeTests.cs
+++ b/Tests/MonoGameGum.Tests.V2/GueDeriving/TextRuntimeFractionalFontSizeTests.cs
@@ -1,0 +1,71 @@
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.V2.GueDeriving;
+
+/// <summary>
+/// Issue #4304: TextRuntime.FontSize is float, so a fractional size round-trips and flows through to
+/// BmfcSave/the font cache key unrounded — the KernSmith backend rasterizes it natively.
+/// </summary>
+public class TextRuntimeFractionalFontSizeTests
+{
+    [Fact]
+    public void SettingFontSize_RoundTripsFractionalValue()
+    {
+        TextRuntime text = new TextRuntime();
+        text.FontSize = 18.5f;
+
+        text.FontSize.ShouldBe(18.5f);
+    }
+
+    [Fact]
+    public void SettingFractionalFontSize_PassesUnroundedValueToInMemoryFontCreator()
+    {
+        CapturingInMemoryFontCreator creator = new CapturingInMemoryFontCreator();
+        IInMemoryFontCreator? previous = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+        try
+        {
+            TextRuntime text = new TextRuntime();
+            text.Font = "Arial";
+            text.FontSize = 18.5f;
+
+            creator.LastBmfcSave.ShouldNotBeNull();
+            creator.LastBmfcSave!.FontSize.ShouldBe(18.5f);
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = previous;
+        }
+    }
+
+    [Fact]
+    public void GetFontCacheFileName_WithFractionalFontSize_DiffersFromNeighboringIntegers()
+    {
+        TextRuntime eighteen = new TextRuntime { Font = "Arial", FontSize = 18 };
+        TextRuntime eighteenHalf = new TextRuntime { Font = "Arial", FontSize = 18.5f };
+        TextRuntime nineteen = new TextRuntime { Font = "Arial", FontSize = 19 };
+
+        string eighteenKey = eighteen.GetFontCacheFileName(fontFilePath: null);
+        string eighteenHalfKey = eighteenHalf.GetFontCacheFileName(fontFilePath: null);
+        string nineteenKey = nineteen.GetFontCacheFileName(fontFilePath: null);
+
+        eighteenHalfKey.ShouldNotBe(eighteenKey);
+        eighteenHalfKey.ShouldNotBe(nineteenKey);
+    }
+
+    private sealed class CapturingInMemoryFontCreator : IInMemoryFontCreator
+    {
+        public BmfcSave? LastBmfcSave { get; private set; }
+
+        public RenderingLibrary.Graphics.BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            LastBmfcSave = bmfcSave;
+            return null;
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -510,6 +510,18 @@ public class TextRuntimeTests : BaseTestClass
         sut.FontSize.ShouldBe(24);
     }
 
+    // Issue #4304: FontSize is float end-to-end, and must forward unrounded onto the renderable
+    // (asText.FontSize in CustomSetPropertyOnRenderable) rather than truncating to an int.
+    [Fact]
+    public void FontSize_WithFractionalValue_ForwardsUnroundedToRenderable()
+    {
+        TextRuntime sut = new();
+        sut.FontSize = 18.5f;
+
+        Gum.Renderables.Text internalText = (Gum.Renderables.Text)sut.RenderableComponent;
+        internalText.FontSize.ShouldBe(18.5f);
+    }
+
     #endregion
 
     #region GetCharacterIndexAtPosition

--- a/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/TextRuntimeTests.cs
@@ -243,6 +243,18 @@ public class TextRuntimeTests
         sut.FontSize.ShouldBe(24);
     }
 
+    // Issue #4304: FontSize is float end-to-end, and must forward unrounded onto the renderable
+    // (asText.FontSize in SystemManagers.UpdateFonts) rather than truncating to an int.
+    [Fact]
+    public void FontSize_WithFractionalValue_ForwardsUnroundedToRenderable()
+    {
+        TextRuntime sut = new();
+        sut.FontSize = 18.5f;
+
+        Text containedText = (Text)sut.RenderableComponent;
+        containedText.FontSize.ShouldBe(18.5f);
+    }
+
     #endregion
 
     #region FontScale

--- a/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
+++ b/Tests/SkiaGum.Tests/Renderables/TextBbCodeTests.cs
@@ -77,6 +77,20 @@ public class TextBbCodeTests
         runs.Single(r => r.Text == "big").Style.FontSize.ShouldBe(baseFontSize * 2);
     }
 
+    // Issue #4304: FontSize is float end-to-end, and Skia draws vector text directly (no baked
+    // atlas), so a fractional [FontSize=N] run resolves to the exact requested pixel size with no
+    // rounding.
+    [Fact]
+    public void GetStyledRuns_FractionalFontSizeTag_ResolvesToExactPixelSize()
+    {
+        Text text = MakeText();
+        text.RawText = "plain [FontSize=18.5]enlarged[/FontSize] plain";
+
+        List<Text.StyledTextRun> runs = text.GetStyledRuns();
+
+        runs.Single(r => r.Text == "enlarged").Style.FontSize.ShouldBe(18.5f);
+    }
+
     [Fact]
     public void GetStyledRuns_FontTag_ChangesRunFontFamily()
     {

--- a/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
+++ b/Tools/Gum.ProjectServices/FontGeneration/HeadlessFontGenerationService.cs
@@ -565,7 +565,10 @@ public class HeadlessFontGenerationService : IHeadlessFontGenerationService
         {
             int spacingHorizontal = bmfcSave.SpacingHorizontal;
             int spacingVertical = bmfcSave.SpacingVertical;
-            int fontSize = bmfcSave.FontSize;
+            // This heuristic only runs for the bmfont.exe backend (RequiresSizeEstimation), which
+            // itself rounds FontSize to the nearest whole pixel size (GetGdiRoundedFontSize) before
+            // rasterizing, so estimate against that same rounded value.
+            int fontSize = BmfcSave.GetGdiRoundedFontSize(bmfcSave.FontSize);
             bool isBold = bmfcSave.IsBold;
 
             int numberWide, numberTall;


### PR DESCRIPTION
## Summary
`FontSize` widens from `int` to `float` end-to-end: `TextRuntime.FontSize`, `BmfcSave.FontSize`/`GetFontCacheFileNameFor` (cache-key), `SkiaGum`/`RaylibGum`'s `Text.FontSize`, and the shared inline-BBCode `[FontSize=N]` stack. A fractional size like `18.5` now renders distinctly from `18`/`19`.

Scope was widened from the issue's original TextRuntime+BmfcSave ask after confirming the renderable classes below TextRuntime (`SkiaGum.Text`, `RaylibGum.Text`) are also `int` today and would otherwise quantize even after the layers above them went float — see issue comments for the discussion.

## Backend behavior
- **KernSmith** (recommended backend): rasterizes fractional sizes natively — `FontGeneratorOptions.Size` is `float` on the FreeType backend Gum registers. No logic change needed, just the wider type flowing through.
- **bmfont.exe/GDI** (legacy backend): can't rasterize fractional point sizes (GDI `LOGFONT.lfHeight` is a whole pixel height). `BmfcSave.Save()` and `HeadlessFontGenerationService`'s size-estimation heuristic both round via the new `BmfcSave.GetGdiRoundedFontSize`.
- **Skia**: draws vector text directly (no baked atlas), so a fractional `FontSize` reaches `SKFont`/RichTextKit `Style.FontSize` with zero quantization.
- **SokolGum**: mirrored `TextRuntime.FontSize` to `int`→`float` for source parity (its own `Renderables.Text.FontSize` was already `float`), but **not build-verified** — the `Sokol.NET` submodule isn't initialized in this environment and Sokol is experimental/uncovered by CI.

Tool property grid is untouched — this ships as a runtime-only API, driven by code.

## Test plan
- [x] `BmfcSave`/`GetFontCacheFileNameFor`/`GetGdiRoundedFontSize` unit tests (`Tests/MonoGameGum.Tests.V2/Fonts/`)
- [x] `TextRuntime.FontSize` round-trip + cache-key + KernSmith passthrough tests
- [x] Shared BBCode `[FontSize=18.5]` tag test (`MonoGameGum.Tests`)
- [x] `SkiaGum.Text` fractional pixel-size test via `GetStyledRuns`
- [x] `RaylibGum.Text` fractional forwarding test
- [x] `KernSmithFileGenerator.BuildOptions` passthrough test
- [x] Full suites green: `MonoGameGum.Tests` (2116), `MonoGameGum.Tests.V2` (154), `MonoGameGum.Tests.V3` (61), `SkiaGum.Tests` (421), `RaylibGum.Tests` (576), `Gum.ProjectServices.Tests` (473), `Gum.Bundle.Tests` (69), `Gum.Themes.Tests` (30), `GumToolUnitTests` (1218)
- [x] `GumFull.sln` and `KniGum.csproj` build clean

Manual test: not needed — purely a type-widening + rasterization-backend change with no tool-UI surface; covered by the unit tests above plus the solution/project builds.
