### PR TITLE
Fix --rebuildfonts hanging on projects that need font generation

### DIFF
--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -8,14 +8,14 @@ using Gum.Commands;
 using ToolsUtilities;
 using Gum.Messages;
 using Gum.Extensions;
-using Gum.Services.Fonts;
+using Gum.ProjectServices.FontGeneration;
 
 namespace Gum.CommandLine
 {
     /// <inheritdoc cref="ICommandLineManager"/>
     public class CommandLineManager : ICommandLineManager
     {
-        private readonly IFontManager _fontManager;
+        private readonly IHeadlessFontGenerationService _fontGenerationService;
         private readonly IGuiCommands _guiCommands;
         private readonly IFileCommands _fileCommands;
         private readonly IMessenger _messenger;
@@ -46,13 +46,13 @@ namespace Gum.CommandLine
         #endregion
 
         public CommandLineManager(
-            IFontManager fontManager,
+            IHeadlessFontGenerationService fontGenerationService,
             IGuiCommands guiCommands,
             IFileCommands fileCommands,
             IMessenger messenger,
             IProjectManager projectManager)
         {
-            _fontManager = fontManager;
+            _fontGenerationService = fontGenerationService;
             _guiCommands = guiCommands;
             _fileCommands = fileCommands;
             _messenger = messenger;
@@ -142,7 +142,10 @@ namespace Gum.CommandLine
             _fileCommands.LoadProject(gumxFile);
 
             // 3.
-            await _fontManager.CreateAllMissingFontFiles(_projectManager.GumProjectSave);
+            // Use the headless service with no callbacks - the CLI runs before app.Run(), so the
+            // WPF dispatcher never pumps and any Dispatcher.Invoke would block forever.
+            await _fontGenerationService.CreateAllMissingFontFiles(
+                _projectManager.GumProjectSave, _fileCommands.ProjectDirectory.FullPath);
 
             // 4.
             _messenger.Send<CloseMainWindowMessage>();

--- a/Tool/Tests/GumToolUnitTests/CommandLine/CommandLineManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/CommandLine/CommandLineManagerTests.cs
@@ -7,16 +7,17 @@ using Gum.CommandLine;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
-using Gum.Services.Fonts;
+using Gum.ProjectServices.FontGeneration;
 using Moq;
 using Shouldly;
+using ToolsUtilities;
 using Xunit;
 
 namespace GumToolUnitTests.CommandLine;
 
 public class CommandLineManagerTests
 {
-    private readonly Mock<IFontManager> _fontManager;
+    private readonly Mock<IHeadlessFontGenerationService> _fontGenerationService;
     private readonly Mock<IGuiCommands> _guiCommands;
     private readonly Mock<IFileCommands> _fileCommands;
     private readonly Mock<IMessenger> _messenger;
@@ -25,14 +26,14 @@ public class CommandLineManagerTests
 
     public CommandLineManagerTests()
     {
-        _fontManager = new Mock<IFontManager>();
+        _fontGenerationService = new Mock<IHeadlessFontGenerationService>();
         _guiCommands = new Mock<IGuiCommands>();
         _fileCommands = new Mock<IFileCommands>();
         _messenger = new Mock<IMessenger>();
         _projectManager = new Mock<IProjectManager>();
 
         _commandLineManager = new CommandLineManager(
-            _fontManager.Object,
+            _fontGenerationService.Object,
             _guiCommands.Object,
             _fileCommands.Object,
             _messenger.Object,
@@ -62,15 +63,20 @@ public class CommandLineManagerTests
     [Fact]
     public async Task ReadCommandLine_SetsExitAndRebuildsFonts_WhenRebuildFontsArg()
     {
-        _fontManager
-            .Setup(f => f.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<bool>()))
+        // The --rebuildfonts path must go through the headless font service (no UI callbacks), so
+        // it works before app.Run() without touching the WPF dispatcher.
+        _fileCommands.Setup(f => f.ProjectDirectory).Returns(new FilePath("MyProject.gumx"));
+        _fontGenerationService
+            .Setup(f => f.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<string>(), It.IsAny<bool>()))
             .Returns(Task.CompletedTask);
 
         await _commandLineManager.ReadCommandLine(new[] { "Gum.exe", "--rebuildfonts", "MyProject.gumx" });
 
         _commandLineManager.ShouldExitImmediately.ShouldBeTrue();
         _fileCommands.Verify(f => f.LoadProject("MyProject.gumx"), Times.Once);
-        _fontManager.Verify(f => f.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<bool>()), Times.Once);
+        _fontGenerationService.Verify(
+            f => f.CreateAllMissingFontFiles(It.IsAny<GumProjectSave>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the `--rebuildfonts` command-line switch hanging (never exiting) whenever a project actually needs font files generated.

## Root cause

The CLI path runs before `app.Run()` — `Program.MainAsync` only reaches `app.Run()` when `ShouldExitImmediately` is false — so the WPF dispatcher never pumps while the STA thread is blocked in `GetAwaiter().GetResult()`.

Font generation is genuinely asynchronous (`Task.WhenAll` in `HeadlessFontGenerationService.GenerateMissingFontsFor`), so the continuation resumes on a background thread. The tool's `ToolFontGenerationCallbacks` then routes output through `GuiCommands.PrintOutput` → `Dispatcher.Invoke`, which blocks forever against a dispatcher that will never run. `ShouldExitImmediately` is never observed, so the process hangs instead of exiting.

## Fix

Route `--rebuildfonts` through `IHeadlessFontGenerationService` directly, with no callbacks (`HeadlessFontGenerationService` defaults a null callbacks argument to `NoOpFontGenerationCallbacks`) — the same path the standalone `GumProjectFontGenerator` console app uses. This removes all WPF/dispatcher interaction from the command-line path.

Also drops the now-unused `IFontManager` dependency from `CommandLineManager`.

No behavior change for normal GUI use; only the `--rebuildfonts` command line is affected.

## Testing

- `CommandLineManagerTests` updated: `--rebuildfonts` is now verified to invoke `IHeadlessFontGenerationService.CreateAllMissingFontFiles` with the loaded project.
- `GumToolUnitTests`: 1218 passed, 0 failed.
- `GumFull.sln` builds with 0 errors.
