### PR TITLE
Narrow GameUiSamples content glob and drop its stray leading space (#4321)

### DIFF
--- a/Samples/GameUiSamples/GameUiSamples.csproj
+++ b/Samples/GameUiSamples/GameUiSamples.csproj
@@ -32,9 +32,9 @@
     <Folder Include="Components\HyTaleComponents\Pieces\" />
     <Folder Include="Content\GumProject\Components\FrbClickerComponents\" />
     <Folder Include="DefsData\" />
-	  <None Update=" Content\**\*.*">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
+    <None Update="Content\GumProject\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />


### PR DESCRIPTION
Closes #4321

## The issue's premise was wrong

MSBuild trims whitespace from item specs, so `Update=" Content\**\*.*"` **did** match and `PreserveNewest` **was** applied. Confirmed with `dotnet msbuild -getItem:None`: the `Content\GumProject\GameUiSamplesGumProject.gumx` item carries `CopyToOutputDirectory: PreserveNewest`, and a clean build copies all 237 `GumProject` files today. Whatever broke the scratch copy in #4318, it wasn't this.

## What still needed fixing

The space was misleading, and `Content\**` was broader than intended — it also swept in `Content.mgcb` and would pick up anything MGCB writes into the `Content/bin` and `Content/obj` directories it creates.

Narrowed to `Content\GumProject\**\*.*`, matching `Samples/MVVM`. Clean-rebuild output is identical except `Content.mgcb` is no longer copied; `Game1` only loads `GumProject/GameUiSamplesgumProject.gumx`.
