### PR TITLE
Parse XML-format .fnt files without XmlSerializer (#4319)

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -110,6 +110,8 @@ annotations raise CS8632 there). Put `#nullable enable` at the top of the shared
 annotations stay valid and warning-free in every consumer regardless of their setting. (Issue
 #3218, relocating the render-only `GumService` into WPF/MAUI/Silk hosts with differing settings.)
 
+**Gotcha — never add an extension method to a shared file that a project both links and references.** `RaylibGum.csproj` `<Compile Include>`s files under `RenderingLibrary/` *and* references `GumCommon`, which compiles the same sources, so every type in them exists twice in that build. Duplicate *types* are only a warning (CS0436 — the compiler prefers the source copy); duplicate *extension methods* are a hard CS0121 ambiguity at every call site, and it surfaces in the linking project only, so a green build of the file's home project proves nothing. Use an instance member or an explicitly-qualified static call instead.
+
 ## Mechanical Steps
 
 1. Read all three per-platform source files end to end. Write down every difference.

--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -33,6 +33,7 @@ Keep it scannable for a future implementer:
 - **Problem** — what's wrong / the user's report, verbatim intent preserved.
 - **Suggested improvement** (when applicable) — concrete target behavior or message.
 - **Source** — file:line pointer(s) found by a quick Grep, plus a one-line note on what the fix touches. A precise pointer turns a vague report into actionable work; spend a moment to find it.
+- **Reach** — how a user lands on the broken code path, and whether that path is the recommended route or a legacy corner the tool never produces on its own. A defect reachable only through hand-authored input is near-zero impact; say so instead of letting it read like an ordinary bug.
 
 ## Title
 Specific and self-describing — names the feature area and the gap (e.g. `Animation keyframe "Could not find state or animation" error should name the missing reference`), not a generic summary.

--- a/.claude/skills/gum-runtime-fonts/SKILL.md
+++ b/.claude/skills/gum-runtime-fonts/SKILL.md
@@ -5,7 +5,11 @@ description: Gum runtime font loading (MonoGame/KNI) — three loading paths (cu
 
 # Runtime Font Loading
 
-Gum renders text using **BitmapFont** — a `.fnt` descriptor file plus one or more `.png` texture atlases. There are three ways to get a BitmapFont onto a TextRuntime, each with different tradeoffs.
+Gum renders text using **BitmapFont** — a `.fnt` descriptor file plus one or more `.png` texture atlases. There are three ways to get a BitmapFont onto a TextRuntime, each with different tradeoffs. Path 3 (in-memory generation, typically KernSmith) is the recommended route for new projects; pre-generated `.fnt` files on disk are the older path.
+
+## `.fnt` encodings
+
+BMFont defines three encodings for the same data, and `ParsedFontFile` picks a branch off the first character. Gum's tool and KernSmith both emit **text**, so that is the only branch normal users reach. XML requires hand-authoring a file from BMFont's XML export and deserializes via `XmlSerializer` (so it is not Native AOT safe); binary throws outright. Treat gaps confined to the XML or binary branch as near-zero user impact.
 
 ## Three Font Loading Paths
 

--- a/MonoGameGum.Tests/RenderingLibraries/ParsedFontFileTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/ParsedFontFileTests.cs
@@ -1,0 +1,78 @@
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+public class ParsedFontFileTests
+{
+    const string xmlFontWithEverySection = @"<?xml version=""1.0""?>
+<font>
+  <info face=""Arial"" size=""-18"" bold=""0"" italic=""0"" charset="""" unicode=""1"" stretchH=""100"" smooth=""1"" aa=""1"" padding=""0,0,0,0"" spacing=""1,1"" outline=""2""/>
+  <common lineHeight=""21"" base=""17"" scaleW=""256"" scaleH=""256"" pages=""2"" packed=""0"" alphaChnl=""0"" redChnl=""4"" greenChnl=""4"" blueChnl=""4""/>
+  <pages>
+    <page id=""0"" file=""Font18Arial_0.png""/>
+    <page id=""1"" file=""Font18Arial_1.png""/>
+  </pages>
+  <chars count=""1"">
+    <char id=""65"" x=""206"" y=""102"" width=""3"" height=""1"" xoffset=""-1"" yoffset=""20"" xadvance=""5"" page=""1"" chnl=""15""/>
+  </chars>
+  <kernings count=""1"">
+    <kerning first=""65"" second=""86"" amount=""-2""/>
+  </kernings>
+</font>";
+
+    const string xmlFontWithoutOutline = @"<?xml version=""1.0""?>
+<font>
+  <info face=""Arial"" size=""-18""/>
+  <common lineHeight=""21"" base=""17""/>
+  <pages>
+    <page id=""0"" file=""Font18Arial_0.png""/>
+  </pages>
+  <chars count=""1"">
+    <char id=""65"" x=""206"" y=""102"" width=""3"" height=""1"" xoffset=""-1"" yoffset=""20"" xadvance=""5"" page=""0"" chnl=""15""/>
+  </chars>
+</font>";
+
+    [Fact]
+    public void Constructor_ShouldDefaultOmittedAttributesAndSections_InXmlFormat()
+    {
+        ParsedFontFile parsedFontFile = new ParsedFontFile(xmlFontWithoutOutline);
+
+        parsedFontFile.Info.Outline.ShouldBe(0);
+        parsedFontFile.Kernings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_ShouldParseEverySectionOfXmlFormat()
+    {
+        ParsedFontFile parsedFontFile = new ParsedFontFile(xmlFontWithEverySection);
+
+        parsedFontFile.Info.Size.ShouldBe(18, "because a negative size in the file means the size was matched to character height");
+        parsedFontFile.Info.Outline.ShouldBe(2);
+
+        parsedFontFile.Common.LineHeight.ShouldBe(21);
+        parsedFontFile.Common.Base.ShouldBe(17);
+
+        parsedFontFile.Pages.Count.ShouldBe(2);
+        parsedFontFile.Pages[1].Id.ShouldBe(1);
+        parsedFontFile.Pages[1].File.ShouldBe("Font18Arial_1.png");
+        parsedFontFile.GetPagesAsArrayOfStrings.ShouldBe(new[] { "Font18Arial_0.png", "Font18Arial_1.png" });
+
+        FontFileCharLine charLine = parsedFontFile.Chars.ShouldHaveSingleItem();
+        charLine.Id.ShouldBe(65);
+        charLine.X.ShouldBe(206);
+        charLine.Y.ShouldBe(102);
+        charLine.Width.ShouldBe(3);
+        charLine.Height.ShouldBe(1);
+        charLine.XOffset.ShouldBe(-1);
+        charLine.YOffset.ShouldBe(20);
+        charLine.XAdvance.ShouldBe(5);
+        charLine.Page.ShouldBe(1);
+
+        FontFileKerningLine kerningLine = parsedFontFile.Kernings.ShouldHaveSingleItem();
+        kerningLine.First.ShouldBe(65);
+        kerningLine.Second.ShouldBe(86);
+        kerningLine.Amount.ShouldBe(-2);
+    }
+}

--- a/RenderingLibrary/Graphics/Fonts/ParsedFontFile.cs
+++ b/RenderingLibrary/Graphics/Fonts/ParsedFontFile.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
+using System.Xml.Linq;
 using ToolsUtilities;
 
 namespace RenderingLibrary.Graphics;
@@ -65,38 +64,38 @@ public class ParsedFontFile
 
     private void ParseXmlText(string contents)
     {
-        XmlSerializer serializer = FileManager.GetXmlSerializer(typeof(XMLFont));
-        using var reader = new StringReader(contents);
-        var xmlFont = (XMLFont?)serializer.Deserialize(reader);
+        XElement? root = XDocument.Parse(contents).Root;
 
-        if (xmlFont == null)
+        if (root == null)
         {
-            throw new InvalidOperationException("Unable to load XML Font file, deserialization failed!");
+            throw new InvalidOperationException("Unable to load XML Font file, it has no root element!");
         }
 
-        if (xmlFont.Info != null)
+        XElement? infoElement = root.Element("info");
+        if (infoElement != null)
         {
-            Info = new FontFileInfoLine(xmlFont);
+            Info = new FontFileInfoLine(infoElement);
         }
 
-        if (xmlFont.Common != null)
+        XElement? commonElement = root.Element("common");
+        if (commonElement != null)
         {
-            Common = new FontFileCommonLine(xmlFont);
+            Common = new FontFileCommonLine(commonElement);
         }
 
-        foreach (XMLFont.XMLChar charLine in xmlFont.Chars)
+        foreach (XElement charElement in root.Elements("chars").Elements("char"))
         {
-            Chars.Add(new FontFileCharLine(charLine));
+            Chars.Add(new FontFileCharLine(charElement));
         }
 
-        foreach (XMLFont.XMLKerning kerningLine in xmlFont.Kernings)
+        foreach (XElement kerningElement in root.Elements("kernings").Elements("kerning"))
         {
-            Kernings.Add(new FontFileKerningLine(kerningLine));
+            Kernings.Add(new FontFileKerningLine(kerningElement));
         }
 
-        foreach (XMLFont.XMLPage page in xmlFont.Pages)
+        foreach (XElement pageElement in root.Elements("pages").Elements("page"))
         {
-            Pages.Add(new FontFilePage(page));
+            Pages.Add(new FontFilePage(pageElement));
         }
 
         if (Info == null || Common == null)
@@ -187,10 +186,10 @@ public class FontFilePage
         File = file;
     }
 
-    public FontFilePage(XMLFont.XMLPage page)
+    public FontFilePage(XElement pageElement)
     {
-        Id = page.Id;
-        File = page.File;
+        Id = (int?)pageElement.Attribute("id") ?? 0;
+        File = (string?)pageElement.Attribute("file") ?? "";
     }
 }
 
@@ -211,13 +210,10 @@ public class FontFileInfoLine
         }
     }
 
-    public FontFileInfoLine(XMLFont xmlFont)
+    public FontFileInfoLine(XElement infoElement)
     {
-        if (xmlFont.Info != null)
-        {
-            Outline = xmlFont.Info.Outline;
-            Size = xmlFont.Info.Size;
-        }
+        Outline = (int?)infoElement.Attribute("outline") ?? 0;
+        Size = System.Math.Abs((int?)infoElement.Attribute("size") ?? 0);
     }
 }
 
@@ -232,13 +228,10 @@ public class FontFileCommonLine
         Base = line.NumericAttributes["base"];
     }
 
-    public FontFileCommonLine(XMLFont xmlFont)
+    public FontFileCommonLine(XElement commonElement)
     {
-        if (xmlFont.Common != null)
-        {
-            LineHeight = xmlFont.Common.LineHeight;
-            Base = xmlFont.Common.Base;
-        }
+        LineHeight = (int?)commonElement.Attribute("lineHeight") ?? 0;
+        Base = (int?)commonElement.Attribute("base") ?? 0;
     }
 }
 
@@ -272,17 +265,17 @@ public class FontFileCharLine
         }
     }
 
-    public FontFileCharLine(XMLFont.XMLChar charLine)
+    public FontFileCharLine(XElement charElement)
     {
-        Id = charLine.Id;
-        X = charLine.X;
-        Y = charLine.Y;
-        Width = charLine.Width;
-        Height = charLine.Height;
-        XOffset = charLine.XOffset;
-        YOffset = charLine.YOffset;
-        XAdvance = charLine.XAdvance;
-        Page = charLine.Page;
+        Id = (int?)charElement.Attribute("id") ?? 0;
+        X = (int?)charElement.Attribute("x") ?? 0;
+        Y = (int?)charElement.Attribute("y") ?? 0;
+        Width = (int?)charElement.Attribute("width") ?? 0;
+        Height = (int?)charElement.Attribute("height") ?? 0;
+        XOffset = (int?)charElement.Attribute("xoffset") ?? 0;
+        YOffset = (int?)charElement.Attribute("yoffset") ?? 0;
+        XAdvance = (int?)charElement.Attribute("xadvance") ?? 0;
+        Page = (int?)charElement.Attribute("page") ?? 0;
     }
 
     public override string ToString()
@@ -304,101 +297,13 @@ public class FontFileKerningLine
         Amount = line.NumericAttributes["amount"];
     }
 
-    public FontFileKerningLine(XMLFont.XMLKerning kerningLine)
+    public FontFileKerningLine(XElement kerningElement)
     {
-        First = kerningLine.First;
-        Second = kerningLine.Second;
-        Amount = kerningLine.Amount;
+        First = (int?)kerningElement.Attribute("first") ?? 0;
+        Second = (int?)kerningElement.Attribute("second") ?? 0;
+        Amount = (int?)kerningElement.Attribute("amount") ?? 0;
     }
 }
-
-
-// The below classes are entirely to import the BMFont XML format
-// https://www.angelcode.com/products/bmfont/doc/file_format.html
-[XmlRoot("font")]
-public class XMLFont
-{
-    [XmlElement("info")]
-    public XMLInfo Info { get; set; }
-
-    [XmlElement("common")]
-    public XMLCommon Common { get; set; }
-
-    [XmlArray("pages")]
-    [XmlArrayItem("page")]
-    public List<XMLPage> Pages { get; set; }
-
-    [XmlArray("chars")]
-    [XmlArrayItem("char")]
-    public List<XMLChar> Chars { get; set; }
-
-    [XmlArray("kernings")]
-    [XmlArrayItem("kerning")]
-    public List<XMLKerning> Kernings { get; set; }
-
-    [XmlType("info")]
-    public class XMLInfo
-    {
-        [XmlAttribute("face")] public string Face { get; set; }
-        [XmlAttribute("size")] public int Size { get; set; }
-        [XmlAttribute("bold")] public int Bold { get; set; }
-        [XmlAttribute("italic")] public int Italic { get; set; }
-        [XmlAttribute("charset")] public string Charset { get; set; }
-        [XmlAttribute("unicode")] public int Unicode { get; set; }
-        [XmlAttribute("stretchH")] public int StretchH { get; set; }
-        [XmlAttribute("smooth")] public int Smooth { get; set; }
-        [XmlAttribute("aa")] public int Aa { get; set; }
-        [XmlAttribute("padding")] public string Padding { get; set; }
-        [XmlAttribute("spacing")] public string Spacing { get; set; }
-        [XmlAttribute("outline")] public int Outline { get; set; }
-    }
-
-    [XmlType("common")]
-    public class XMLCommon
-    {
-        [XmlAttribute("lineHeight")] public int LineHeight { get; set; }
-        [XmlAttribute("base")] public int Base { get; set; }
-        [XmlAttribute("scaleW")] public int ScaleW { get; set; }
-        [XmlAttribute("scaleH")] public int ScaleH { get; set; }
-        [XmlAttribute("pages")] public int Pages { get; set; }
-        [XmlAttribute("packed")] public int Packed { get; set; }
-        [XmlAttribute("alphaChnl")] public int AlphaChnl { get; set; }
-        [XmlAttribute("redChnl")] public int RedChnl { get; set; }
-        [XmlAttribute("greenChnl")] public int GreenChnl { get; set; }
-        [XmlAttribute("blueChnl")] public int BlueChnl { get; set; }
-    }
-
-    [XmlType("page")]
-    public class XMLPage
-    {
-        [XmlAttribute("id")] public int Id { get; set; }
-        [XmlAttribute("file")] public string File { get; set; }
-    }
-
-    [XmlType("char")]
-    public class XMLChar
-    {
-        [XmlAttribute("id")] public int Id { get; set; }
-        [XmlAttribute("x")] public int X { get; set; }
-        [XmlAttribute("y")] public int Y { get; set; }
-        [XmlAttribute("width")] public int Width { get; set; }
-        [XmlAttribute("height")] public int Height { get; set; }
-        [XmlAttribute("xoffset")] public int XOffset { get; set; }
-        [XmlAttribute("yoffset")] public int YOffset { get; set; }
-        [XmlAttribute("xadvance")] public int XAdvance { get; set; }
-        [XmlAttribute("page")] public int Page { get; set; }
-        [XmlAttribute("chnl")] public int Chnl { get; set; }
-    }
-
-    [XmlType("kerning")]
-    public class XMLKerning
-    {
-        [XmlAttribute("first")] public int First { get; set; }
-        [XmlAttribute("second")] public int Second { get; set; }
-        [XmlAttribute("amount")] public int Amount { get; set; }
-    }
-}
-
 
 public class ParsedFontLine
 {


### PR DESCRIPTION
`ParsedFontFile` routed BMFont's XML encoding through `XmlSerializer`, which is not Native AOT compatible (same root cause as #4170/#4171, ADR 0013). Replaced with a direct `XDocument` read and deleted the `XMLFont` DTO tree — no format change, no user migration, net -95 lines.

Reach is small: the Gum tool and KernSmith both emit the text encoding, so only a hand-authored `.fnt` from BMFont's XML export hits this branch.

Also fixes an inconsistency the new tests caught: BMFont writes a negative `size` to mean "matched to character height", and the text path already normalized it with `Math.Abs` while the XML path passed the sign through. RaylibGum's `ContentLoader` takes `Info.Size` straight into `Font.BaseSize`, so an XML `.fnt` gave it a negative base size.

Tests: `ParsedFontFileTests` pins the XML path's info/common/pages/chars/kernings mapping and its omitted-attribute defaults. Kernings and pages had no coverage in either encoding before.

Also adds three skill notes: `.fnt` encodings and their relative reach (`gum-runtime-fonts`), a "Reach" bullet requiring issues to state how a user lands on the broken path (`gum-issue-creation`), and a landmine — an extension method in a source file that a project both `<Compile Include>`s and gets via an assembly reference is a hard CS0121 ambiguity, which is what the first draft of this parser hit in RaylibGum (`gum-cross-platform-unification`).

Closes #4319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
