### PR TITLE
Fix the broken tool build: gate ReflectionManager's trim attribute behind NET5_0_OR_GREATER

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -75,6 +75,12 @@ Gating pattern:
 
 Don't `#if` away entire types or methods unless you've confirmed no caller references them across targets — that's a much harder refactor.
 
+## `ToolsUtilities/` also compiles into a .NET Framework 4.7.2 project
+
+`ToolsUtilities.csproj` is a legacy non-SDK project targeting `v4.7.2` that compiles the same `ToolsUtilities/*.cs` files `GumCommon` does, so net8.0 is not the floor for that folder. A .NET 5+ API compiles in `GumCommon` and breaks CI's `Build-Tool` job while every runtime csproj stays green — build `GumFull.sln` to catch it.
+
+Trim and AOT attributes (`RequiresUnreferencedCode`, `DynamicallyAccessedMembers`, `UnconditionalSuppressMessage`) are the common case, since none exist on .NET Framework. Gate the attribute and its `using System.Diagnostics.CodeAnalysis;` with `#if NET5_0_OR_GREATER`.
+
 ## Guard symmetry — a member behind `#if !FRB` cannot be called from shared un-guarded code
 
 The mirror of the rule above, and the single most common way a Gum change silently breaks FRB1: you add a method/property behind `#if !FRB` (e.g. on `TextRuntime`, which does not exist under FRB — FRB uses `GraphicalUiElement` directly), then call it from **shared** code that compiles under both FRB and non-FRB. The non-FRB build is green, so the break is invisible until the FRB canary runs — which is exactly what CI does not gate on. This broke FRB in #3413 (`GetFontCacheFileName`/`CopyFontGenerationFieldsTo`).

--- a/ToolsUtilities/ReflectionManager.cs
+++ b/ToolsUtilities/ReflectionManager.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Reflection;
 
 namespace ToolsUtilities
 {
     public static class ReflectionManager
     {
+        // Gated because this file also compiles into ToolsUtilities.csproj, which targets .NET
+        // Framework 4.7.2 and has no trim attributes.
+#if NET5_0_OR_GREATER
         [RequiresUnreferencedCode(
             "Enumerates every property and field on the container's own type, any of which may be " +
             "removed under PublishTrimmed if nothing else in the app references it.")]
+#endif
         public static List<T> GetMembersOfType<T>(object container)
         {
             Type typeOfT = typeof(T);


### PR DESCRIPTION
`main` does not build. #4327 merged with `Build-Tool` red.

`ToolsUtilities.csproj` is a legacy non-SDK project targeting .NET Framework 4.7.2, and it compiles the same `ToolsUtilities/*.cs` files `GumCommon` does. `RequiresUnreferencedCodeAttribute` does not exist there, so the annotation #4327 added to `ReflectionManager.GetMembersOfType` is a hard `CS0246` in that project and takes `GumFull.sln` down with it. Every runtime csproj stayed green, which is why it slipped through.

Gated the attribute and its `using` behind `#if NET5_0_OR_GREATER`. It still applies in `GumCommon`, where it does the work.

`coder.md` gains the trap, since only building the runtime csprojs will never surface it.

Verified with a clean `dotnet build GumFull.sln` off this branch: 0 errors.
