### PR TITLE
Require FRB canary worktrees to be a sibling of Gum, not nested

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -87,7 +87,7 @@ The mirror of the rule above, and the single most common way a Gum change silent
 
 So whenever you add or move a member behind **any** platform `#if` (`!FRB`, `!RAYLIB`, `XNALIKE`, etc.):
 1. `grep` for every call site of that member. If any lives in un-guarded shared source, the call site must be guarded too **or** you must provide a same-named shim for the excluded platform (an FRB-only extension method on `GraphicalUiElement` is the established pattern — see `CustomSetPropertyOnRenderable.cs`).
-2. Run the FRB canary build (`frb-build-verification` skill) from the **primary checkout** before finishing — it is the only build that exercises the `#if FRB` path, and worktrees cannot run it.
+2. Run the FRB canary build (`frb-build-verification` skill) from your worktree before finishing — it is the only build that exercises the `#if FRB` path. The worktree must be a sibling of the Gum repo, not nested under `.claude/worktrees/`, for the build's relative-path imports to resolve.
 
 # Test-Driven Development (Required)
 

--- a/.claude/skills/frb-build-verification/SKILL.md
+++ b/.claude/skills/frb-build-verification/SKILL.md
@@ -15,9 +15,11 @@ This is only doable when a **FlatRedBall checkout exists as a sibling of the Gum
 
 Check the sibling's checked-out branch before trusting the canary — `git status`/`git branch --show-current` there. A stale or already-merged local branch doesn't error, it just silently compiles against old FRB-side source, so a clean canary result proves nothing. The sibling's default branch is `origin/NetStandard`, not `main`/`master`.
 
-## Must run from the PRIMARY checkout, never a worktree
+## Worktree must be a sibling of Gum, not nested under `.claude/worktrees/`
 
-The sibling-relative imports are computed from the csproj location, and the FlatRedBall-side csprojs pull Gum source by relative path into the **primary** Gum checkout (`…\Gum\MonoGameGum\…`). A worktree under `.claude/worktrees/<branch>/` is both nested too deep (so `..\..\..\..\FlatRedBall` resolves to nothing — `MSB4019`) and not the path FRB compiles from. To FRB-verify a branch, **check that branch out in the primary Gum checkout** and build there. Worktrees cannot FRB-verify.
+The sibling-relative imports (`..\..\..\..\FlatRedBall\…`) are computed from the csproj's location. A git worktree is a full checkout, so its internal directory structure mirrors the primary checkout at the same depth — the import resolves correctly as long as the worktree root itself sits at the same level as `Gum\` and `FlatRedBall\` (i.e. directly under the parent `GitHub\` folder). A worktree nested under `.claude/worktrees/<branch>/` is one level too deep, so the import resolves to nowhere (`MSB4019`).
+
+Create issue worktrees as a sibling of the Gum repo (e.g. `<gum-repo>/../gum-wt-<branch>/`), not under `.claude/worktrees/`.
 
 ## Canaries
 


### PR DESCRIPTION
## Summary
- FRB canary worktrees nested under `.claude/worktrees/<branch>/` sit one directory level too deep for the `..\..\..\..\FlatRedBall` relative import to resolve (MSB4019), which forced the canary to run from the primary checkout — serializing agents that needed it.
- Placing the worktree as a direct sibling of `Gum\` (e.g. `<gum-repo>/../gum-wt-<branch>/`) mirrors the primary checkout's relative depth, so the canary now runs from any worktree independently. Verified by building `GumCore.DesktopGlNet6.csproj` clean from such a worktree, no path errors.
- Updates `frb-build-verification` skill and `coder.md` accordingly.

## Test plan
- [x] Built `GumCore.DesktopGlNet6.csproj` from a sibling-placed test worktree — 0 errors.
- Docs-only change otherwise; no runtime behavior affected.
