### PR TITLE
Annotate remaining XmlSerializer/TypeManager trim warnings

### DIFF
--- a/Gum/DataTypes/PluginSettingsSave.cs
+++ b/Gum/DataTypes/PluginSettingsSave.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using ToolsUtilities;
 
 namespace Gum.DataTypes
@@ -19,11 +20,15 @@ namespace Gum.DataTypes
             DisabledPlugins = new List<string>();
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Deserializes PluginSettingsSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
         public static PluginSettingsSave Load(string fileName)
         {
             return FileManager.XmlDeserialize<PluginSettingsSave>(fileName);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Serializes this PluginSettingsSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
         public void Save(string fileName)
         {
             FileManager.XmlSerialize(this, fileName);

--- a/Gum/DataTypes/StateSaveExtensionMethods.cs
+++ b/Gum/DataTypes/StateSaveExtensionMethods.cs
@@ -3,6 +3,9 @@ using System;
 using System.CodeDom;
 using System.Collections;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq;
 using System.Reflection.Emit;
 using System.Security.Cryptography.X509Certificates;
@@ -962,6 +965,12 @@ public static class StateSaveExtensionMethods
 
     }
 
+    // Gated because this file also compiles into GumRuntime.csproj (net472) and is shared
+    // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "T is always StateSave (no subclasses exist), which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
     public static T Clone<T>(this StateSave whatToClone) where T : StateSave
     {
         T toReturn = FileManager.CloneSaveObjectCast<StateSave, T>(whatToClone);

--- a/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Xml.Serialization;
 using ToolsUtilities;
 
@@ -66,6 +69,12 @@ namespace Gum.Content.AnimationChain
 
         #endregion
 
+        // Gated because this file also compiles into GumRuntime.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Deserializes AnimationChainListSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\") under Gum.Content.AnimationChain.*.")]
+#endif
         public static AnimationChainListSave FromFile(string fileName)
         {
             AnimationChainListSave? toReturn = null;

--- a/Gum/Reflection/ITypeManager.cs
+++ b/Gum/Reflection/ITypeManager.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Gum.Reflection;
 
 public interface ITypeManager
 {
     void AddType(Type type);
+
+    [RequiresDynamicCode("Resolving a nullable-enum type name calls Type.MakeGenericType, which requires generating new code at runtime.")]
     Type GetTypeFromString(string typeAsString);
+
+    [RequiresUnreferencedCode("Scans all types in the executing, RenderingLibrary, and GumCommon-linked assemblies via Assembly.GetTypes(), which can be incomplete or throw after trimming.")]
     void Initialize();
 }

--- a/Gum/Reflection/TypeManager.cs
+++ b/Gum/Reflection/TypeManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using RenderingLibrary.Graphics;
 using Gum.DataTypes;
@@ -15,6 +16,7 @@ public class TypeManager : ITypeManager
         mTypes.Add(type);
     }
 
+    [RequiresUnreferencedCode("Scans all types in the executing, RenderingLibrary, and GumCommon-linked assemblies via Assembly.GetTypes(), which can be incomplete or throw after trimming.")]
     public void Initialize()
     {
         List<Type> allTypes = new List<Type>();
@@ -29,6 +31,7 @@ public class TypeManager : ITypeManager
     }
 
 
+    [RequiresDynamicCode("Resolving a nullable-enum type name calls Type.MakeGenericType, which requires generating new code at runtime.")]
     public Type GetTypeFromString(string typeAsString)
     {
         if (mTypes == null)

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0</TargetFrameworks>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>

--- a/GumCommon/ILLink.Descriptors.xml
+++ b/GumCommon/ILLink.Descriptors.xml
@@ -4,5 +4,9 @@
     <type fullname="Gum.StateAnimation.SaveClasses.*" preserve="all" />
     <type fullname="Gum.Forms.Controls.*" preserve="all" />
     <type fullname="Gum.Wireframe.GraphicalUiElement" preserve="all" />
+    <!-- AnimationChainListSave/AnimationChainSave/AnimationFrameSave: loaded from .achx files by
+         AnimationChainListSave.FromFile, reachable at runtime via
+         CustomSetPropertyOnRenderable's AnimationChains property setter. -->
+    <type fullname="Gum.Content.AnimationChain.*" preserve="all" />
   </assembly>
 </linker>

--- a/GumDataTypes/Behaviors/BehaviorReference.cs
+++ b/GumDataTypes/Behaviors/BehaviorReference.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using Gum.DataTypes.Serialization.Json;
 using ToolsUtilities;
@@ -74,6 +77,12 @@ namespace Gum.DataTypes.Behaviors
             }
         }
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Deserializes BehaviorSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public static BehaviorSave DeserializeBehavior(string filePath, int projectVersion)
         {
             // No content-sniffing between XML and JSON - the file's own extension determines the format.

--- a/GumDataTypes/Behaviors/BehaviorSave.cs
+++ b/GumDataTypes/Behaviors/BehaviorSave.cs
@@ -2,6 +2,9 @@
 using Gum.DataTypes.Variables;
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Linq;
 using System.Xml.Serialization;
 using ToolsUtilities;
@@ -76,6 +79,12 @@ namespace Gum.DataTypes.Behaviors
         }
 
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "this.GetType() is always BehaviorSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public void Save(string fileName, bool useCompactFormat = false)
         {
             // No content-sniffing between XML and JSON - the target file's own extension decides

--- a/GumDataTypes/ComponentSave.cs
+++ b/GumDataTypes/ComponentSave.cs
@@ -1,5 +1,8 @@
 ﻿using Gum.DataTypes.Behaviors;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using ToolsUtilities;
 
 namespace Gum.DataTypes;
@@ -20,6 +23,12 @@ public class ComponentSave : ElementSave
         get { return ElementReference.ComponentSubfolder; }
     }
 
+    // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+    // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Clones this ComponentSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
     public ComponentSave Clone()
     {
         var cloned = FileManager.CloneSaveObject(this);

--- a/GumDataTypes/ElementReference.cs
+++ b/GumDataTypes/ElementReference.cs
@@ -1,5 +1,8 @@
 ﻿using Gum.DataTypes.Serialization.Json;
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using ToolsUtilities;
 
@@ -175,6 +178,12 @@ namespace Gum.DataTypes
             GumProjectSave.StandardJsonExtension
         };
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "T is always an ElementSave subtype, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public static T DeserializeElement<T>(string filePath, int projectVersion) where T : ElementSave, new()
         {
             // No content-sniffing between XML and JSON - the file's own extension determines the format.

--- a/GumDataTypes/ElementSave.cs
+++ b/GumDataTypes/ElementSave.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using Gum.DataTypes.Variables;
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Xml.Serialization;
 using ToolsUtilities;
 using Gum.DataTypes.Behaviors;
@@ -193,6 +196,12 @@ namespace Gum.DataTypes
             return null;
         }
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "this.GetType() is always an ElementSave subtype, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public void Save(string fileName, bool useCompactFormat = false)
         {
             // No content-sniffing between XML and JSON - the target file's own extension decides

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -2,6 +2,9 @@
 using Gum.DataTypes.Serialization.Json;
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -495,6 +498,12 @@ public class GumProjectSave
         return Load(fileName, LinkLoadingPreference.PreferLinked, out result);
     }
 
+    // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+    // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Deserializes GumProjectSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
     public static GumProjectSave? Load(string fileName, LinkLoadingPreference linkLoadingPreference, out GumLoadResult result)
     {
         result = new GumLoadResult();
@@ -843,6 +852,10 @@ public class GumProjectSave
     public static bool IsJsonFormat(string fileName) =>
         string.Equals(FileManager.GetExtension(fileName), ProjectJsonExtension, StringComparison.OrdinalIgnoreCase);
 
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Serializes this GumProjectSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
     public void Save(string fileName, bool saveElements)
     {
         // No content-sniffing between XML and JSON - the target file's own extension decides the

--- a/GumDataTypes/InstanceSave.cs
+++ b/GumDataTypes/InstanceSave.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml.Serialization;
+﻿#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Xml.Serialization;
 using ToolsUtilities;
 
 namespace Gum.DataTypes
@@ -41,6 +44,12 @@ namespace Gum.DataTypes
 
         // Modify Clone if adding any XmlIgnored properties
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Clones this InstanceSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public InstanceSave Clone()
         {
             InstanceSave cloned = FileManager.CloneSaveObject(this);

--- a/GumDataTypes/ScreenSave.cs
+++ b/GumDataTypes/ScreenSave.cs
@@ -1,4 +1,7 @@
-﻿using ToolsUtilities;
+﻿#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using ToolsUtilities;
 
 namespace Gum.DataTypes
 {
@@ -14,6 +17,12 @@ namespace Gum.DataTypes
             get { return ElementReference.ScreenSubfolder; }
         }
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Clones this ScreenSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]
+#endif
         public ScreenSave Clone()
         {
             var cloned = FileManager.CloneSaveObject(this);

--- a/GumDataTypes/Serialization/GumFileSerializer.cs
+++ b/GumDataTypes/Serialization/GumFileSerializer.cs
@@ -2,6 +2,9 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Text;
 using System.Xml.Serialization;
@@ -11,6 +14,14 @@ namespace Gum.DataTypes;
 
 public static class GumFileSerializer
 {
+    // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+    // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+    private const string TrimSuppressionJustification =
+        "rootType/T is always a Gum.DataTypes.* save class (ElementSave/BehaviorSave/GumProjectSave/StateSave and friends), " +
+        "which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").";
+#endif
+
     private static readonly Dictionary<Type, XmlSerializer> _compactSerializers = new();
     private static readonly Dictionary<Type, XmlSerializer> _legacyInstancesCompactSerializers = new();
     private static XmlSerializer? _gumProjectCompactSerializer;
@@ -65,6 +76,9 @@ public static class GumFileSerializer
     /// Full compact serializer: VariableSave and InstanceSave members as XML attributes.
     /// Use for v2 files where both variables and instances are in attribute format.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimSuppressionJustification)]
+#endif
     public static XmlSerializer GetCompactSerializer(Type rootType)
     {
         lock (_compactSerializers)
@@ -92,6 +106,9 @@ public static class GumFileSerializer
     /// Mixed serializer: VariableSave members as XML attributes, InstanceSave as child elements.
     /// Use for transitional files saved before instance compaction was introduced.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimSuppressionJustification)]
+#endif
     public static XmlSerializer GetLegacyInstancesCompactSerializer(Type rootType)
     {
         lock (_legacyInstancesCompactSerializers)
@@ -108,6 +125,9 @@ public static class GumFileSerializer
         }
     }
 
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimSuppressionJustification)]
+#endif
     public static XmlSerializer GetGumProjectCompactSerializer()
     {
         lock (_compactSerializers)
@@ -179,6 +199,9 @@ public static class GumFileSerializer
     /// Deserializes an <see cref="ElementSave"/> subtype from already-loaded XML text,
     /// selecting compact or legacy XML deserialization based on the content and project version.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimSuppressionJustification)]
+#endif
     public static T? DeserializeElementSave<T>(string content, int projectVersion) where T : ElementSave, new()
     {
         if (projectVersion >= (int)GumProjectSave.GumxVersions.AttributeVersion)
@@ -202,6 +225,9 @@ public static class GumFileSerializer
     /// Deserializes a <see cref="BehaviorSave"/> from already-loaded XML text,
     /// selecting compact or legacy XML deserialization based on the content and project version.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimSuppressionJustification)]
+#endif
     public static BehaviorSave? DeserializeBehaviorSave(string content, int projectVersion)
     {
         if (projectVersion >= (int)GumProjectSave.GumxVersions.AttributeVersion)

--- a/GumDataTypes/Variables/VariableListSave.cs
+++ b/GumDataTypes/Variables/VariableListSave.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 using System.Collections;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using ToolsUtilities;
 using Vector2 = System.Numerics.Vector2;
 using Matrix = System.Numerics.Matrix4x4;
@@ -129,6 +132,12 @@ namespace Gum.DataTypes.Variables
             set;
         } = new List<T>();
 
+        // Gated because this file also compiles into GumDataTypes.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026",
+            Justification = "Clones this VariableListSave<T> instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\") under Gum.DataTypes.Variables.*.")]
+#endif
         public new VariableListSave<T> Clone()
         {
             return FileManager.CloneSaveObject<VariableListSave<T>>(this);

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -11,6 +11,7 @@ using RenderingLibrary.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -819,6 +820,8 @@ public partial class GumService : IGumService
     /// <see cref="GumProjectSave.ElementAnimations"/>. The element name is derived from the file's path,
     /// not from the (stale) value serialized inside the file. Returns the number of animation files loaded.
     /// </summary>
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Deserializes ElementAnimationsSave, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\") under Gum.StateAnimation.SaveClasses.*.")]
     internal static int LoadAnimationsFromProvider(GumProjectSave project, IGumFileProvider provider)
     {
         // Filename-only pattern (no '/'): GlobMatcher matches it against the file name regardless of

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -19,6 +19,7 @@
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(IncludeIOS)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(IncludeAndroid)' == 'true' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">$(TargetFrameworks);net9.0-android</TargetFrameworks>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text;
 using System.Reflection;
 using System.IO;
@@ -14,6 +17,13 @@ namespace ToolsUtilities
     /// </summary>
     public static partial class FileManager
     {
+        // Gated because this file also compiles into ToolsUtilities.csproj (net472) and is shared
+        // with FlatRedBall via GumCoreShared.projitems, neither of which has trim attributes.
+#if NET5_0_OR_GREATER
+        private const string XmlSerializerTrimMessage =
+            "Uses System.Xml.Serialization.XmlSerializer with a type known only at runtime; members of that type may be trimmed if not referenced directly elsewhere.";
+#endif
+
         public const char DefaultSlash = '\\';
         #region Fields
 
@@ -101,6 +111,9 @@ namespace ToolsUtilities
         }
 
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static bool AreSaveObjectsEqual<T>(T first, T second)
         {
             string firstAsString;
@@ -112,6 +125,9 @@ namespace ToolsUtilities
             return firstAsString == secondAsString;
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T CloneSaveObject<T>(T objectToClone)
         {
             string container;
@@ -123,6 +139,9 @@ namespace ToolsUtilities
             return (T)serializer.Deserialize(new StringReader(container));
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T CloneSaveObjectCast<U, T>(U objectToClone)
         {
             string container;
@@ -782,6 +801,9 @@ namespace ToolsUtilities
         }
 
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T XmlDeserialize<T>(string fileName)
         {
             T objectToReturn = default(T);
@@ -889,6 +911,9 @@ namespace ToolsUtilities
             }
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T XmlDeserializeFromStream<T>(Stream stream)
         {
             Type type = typeof(T);
@@ -902,6 +927,9 @@ namespace ToolsUtilities
 
 
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static XmlSerializer GetXmlSerializer(Type type)
         {
             lock (mXmlSerializers)
@@ -937,6 +965,9 @@ namespace ToolsUtilities
         }
 
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static void XmlSerialize<T>(T objectToSerialize, out string stringToSerializeTo)
         {
             MemoryStream memoryStream = new MemoryStream();
@@ -1434,11 +1465,17 @@ namespace ToolsUtilities
             }
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static void XmlSerialize(Type type, object objectToSerialize, string fileName)
         {
             XmlSerialize(objectToSerialize, fileName, GetXmlSerializer(type));
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static void XmlSerialize(object objectToSerialize, string fileName, XmlSerializer serializer)
         {
             // Make sure that the directory for the file exists
@@ -1470,11 +1507,17 @@ namespace ToolsUtilities
             }
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static void XmlSerialize<T>(T objectToSerialize, string fileName)
         {
             XmlSerialize(typeof(T), objectToSerialize, fileName);
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T XmlDeserialize<T>(string fileName, XmlSerializer serializer)
         {
             if (IsMobile)
@@ -1496,12 +1539,18 @@ namespace ToolsUtilities
             }
         }
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T XmlDeserializeFromStream<T>(Stream stream, XmlSerializer serializer)
         {
             return (T)serializer.Deserialize(stream);
         }
 
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode(XmlSerializerTrimMessage)]
+#endif
         public static T XmlDeserializeEmbeddedResource<T>(Assembly assembly, string location)
         {
             T objectToReturn = default(T);


### PR DESCRIPTION
Closes #4326.

## What changed

Two remaining IL2026/IL3050 clusters from a from-file, rooted (`TrimmerRootAssembly` on `GumCommon`+`MonoGameGum`) trimmed publish:

1. **`XmlSerializer` in Gum's own save classes** — `GumFileSerializer`, `GumProjectSave`, `ElementReference`, `ElementSave`, `BehaviorSave`, `ComponentSave`, `ScreenSave`, `InstanceSave`, `VariableListSave<T>`, `BehaviorReference`, `PluginSettingsSave`, `AnimationChainListSave`, `GumService.LoadAnimationsFromProvider` — every one of these only ever hands `XmlSerializer` a concrete Gum save type (`ElementSave`/`BehaviorSave`/`GumProjectSave`/`StateSave`/`ElementAnimationsSave`/`AnimationChainListSave`/... — all under namespaces GumCommon's `ILLink.Descriptors.xml` preserves `preserve="all"`). Suppressed with `[UnconditionalSuppressMessage]` citing that descriptor.
   - Found one real gap while verifying "confirm the descriptor genuinely covers everything": `AnimationChainListSave`/`AnimationChainSave`/`AnimationFrameSave` (`.achx` legacy animation loading, reachable at runtime via `CustomSetPropertyOnRenderable`'s `AnimationChains` setter) live in `Gum.Content.AnimationChain`, which wasn't in the preserved-namespace list. Added it.
2. **`FileManager`'s generic `Xml*` helpers** — these are honestly generic over any `T`, so suppressing would be a lie. Marked `[RequiresUnreferencedCode]` instead, and propagated through the full internal call chain (13 methods) so the warning doesn't just resurface one level up.
3. **`TypeManager`** — `Initialize()` (`Assembly.GetTypes()`) gets `[RequiresUnreferencedCode]`, `GetTypeFromString()` (`Type.MakeGenericType`) gets `[RequiresDynamicCode]` (this is the IL3050/AOT-only one). It's tool-only in practice (only `Program.cs`/DI wiring call it), so this correctly makes the warning disappear for real from-file games without lying about the risk if the tool's own trim-unsafe path were ever exercised.

`ParsedFontFile.cs` (also listed in the issue) was already fixed by #4325, landed the same day the issue was filed — confirmed via `git log` and re-verified it has no `XmlSerializer` left.

**Net472/netstandard2.0 gating:** most of the touched files also compile into `GumDataTypes.csproj`/`ToolsUtilities.csproj` (net472) and are shared with FlatRedBall via `GumCoreShared.projitems`, none of which has the .NET5+ trim attributes. Every new attribute/using is gated behind `#if NET5_0_OR_GREATER`, matching the existing `ToolsUtilities/ReflectionManager.cs` precedent.

**Follow-on (partial):** enabled `<EnableTrimAnalyzer>true</EnableTrimAnalyzer>` on `GumCommon`/`MonoGameGum` per the issue's "keep it at zero" section — the free option, verified clean. Did not add the heavier CI-stub-publish job; that's a bigger, separate piece of work and is called out as a candidate follow-up in the issue's own comment thread if wanted.

## Verification

- Built a scratch stub app replicating the issue's own repro (`TrimmerRootAssembly` on `GumCommon`+`MonoGameGum`, `PublishTrimmed`): zero Gum-originated `IL2026` remain (only pre-existing third-party `IL2104` from `BrotliSharpLib`/`CsvHelper`, out of scope). A separate `PublishAot` pass confirms `IL3050` is also gone.
- `GumDataTypesNet6.csproj` (netstandard2.0 + net6.0), `GumCommon.csproj`, `MonoGameGum.csproj`, `GumFull.sln`, and `MonoGameGum.Tests` (2120 tests) all build/pass clean.
- FRB canary (`GumCore.DesktopGlNet6.csproj` against `FlatRedBall@NetStandard`): pass.

Manual test: not needed — this is attribute/descriptor-only, zero runtime behavior change, covered by the trim-repro verification above plus the full unit test suite staying green.
