### PR TITLE
Automatic zoom-driven font oversampling for XNALIKE, decoupled from FontScale

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2435,11 +2435,35 @@ public partial class CustomSetPropertyOnRenderable
 #else
         var textRuntime = graphicalUiElement as Gum.GueDeriving.TextRuntime;
 
+        // A font property being re-resolved (through either this string path or the direct
+        // TextRuntime property setters, which funnel back into this same method via the
+        // UpdateFontFromProperties delegate -- see the gum-property-assignment skill) means
+        // whatever automatic font oversampling (issue #4317) was in effect is stale: it compensated
+        // for the OLD FontSize's raster, not the new font this method is about to assign. Reset here,
+        // the single point both paths converge on, so a Font/FontSize change never leaves an old
+        // compensation ratio applied to a newly-resolved font -- which would otherwise render at the
+        // wrong size until the next zoom change happened to trigger a fresh regeneration. Guarded by
+        // textRuntime != null below (a bare Text renderable with no owning TextRuntime never has
+        // oversampling applied to begin with).
 #endif
         if (text == null || textRuntime == null)
         {
             return;
         }
+
+#if XNALIKE && !FRB
+        // This file also compiles (unchanged) for SilkNetGum (SKIA) and, via a namespace swap, for
+        // RaylibGum -- neither has ResetAutomaticOversamplingState (oversampling is XNALIKE-only for
+        // now; Raylib parity is issue #4317's own follow-up), so this must stay XNALIKE-gated even
+        // though it's already inside the non-FRB branch above. FRB is excluded too: an FRB build that
+        // also defines XNALIKE would otherwise see textRuntime typed as the plain GraphicalUiElement
+        // from the #if FRB branch above (no TextRuntime type available there yet), not TextRuntime.
+        if (asText.OversampleCompensationScale != 1f)
+        {
+            asText.OversampleCompensationScale = 1f;
+        }
+        textRuntime.ResetAutomaticOversamplingState();
+#endif
 
         BitmapFont font = null;
 

--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -144,16 +144,17 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
             "Because a content-derived Height must not be used to truncate the very lines it was derived from");
     }
 
-    // Issue #4302 follow-up: TextRuntime.RegenerateOversampledFont swaps BitmapFont to a font
-    // rasterized at oversampleRatio * FontSize, then sets FontScale = 1/oversampleRatio to compensate
-    // so the on-screen size is unchanged. Both setters call UpdateWrappedText() independently -- the
-    // BitmapFont setter fires FIRST, with the OLD (pre-swap) FontScale still in effect, so it wraps
+    // Issue #4302/#4317: TextRuntime.RegenerateOversampledFont swaps BitmapFont to a font rasterized
+    // at oversampleRatio * FontSize, then sets the internal-only OversampleCompensationScale to
+    // 1/oversampleRatio to compensate so the on-screen size is unchanged (composing with, rather than
+    // overwriting, the public FontScale). Both setters call UpdateWrappedText() independently -- the
+    // BitmapFont setter fires FIRST, with the OLD (pre-swap) compensation still in effect, so it wraps
     // using the new (much wider) glyph metrics against a wrap width that hasn't been inflated yet.
-    // That intermediate wrap is wrong, but should be harmless IF the FontScale setter's later call
+    // That intermediate wrap is wrong, but should be harmless IF the compensation setter's later call
     // fully recomputes WrappedText afterward. This test asserts the actual (post both-setters) result
     // still matches the pre-swap wrap, exactly what a user should see (crisp text, same layout).
     [Fact]
-    public void UpdateLines_WhenBitmapFontAndFontScaleBothChangeInOversampleOrder_ShouldWrapTheSameAsBeforeTheSwap()
+    public void UpdateLines_WhenBitmapFontAndOversampleCompensationBothChangeInOversampleOrder_ShouldWrapTheSameAsBeforeTheSwap()
     {
         const int baseAdvance = 10;
         const float oversampleRatio = 2.5f;
@@ -171,14 +172,55 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
 
         text.WrappedText.Count.ShouldBe(1, "because AB AB exactly fits the base font/width before any oversampling");
 
-        // Mirrors TextRuntime.RegenerateOversampledFont's exact call order: BitmapFont first, then FontScale.
+        // Mirrors TextRuntime.RegenerateOversampledFont's exact call order: BitmapFont first, then compensation.
         text.BitmapFont = oversampledFont;
-        text.FontScale = 1f / oversampleRatio;
+        text.OversampleCompensationScale = 1f / oversampleRatio;
 
         text.WrappedText.Count.ShouldBe(1,
-            "because the oversampled font's glyphs are exactly oversampleRatio times wider and FontScale " +
-            "compensates by the same ratio -- the on-screen size, and therefore the wrap, must not change");
+            "because the oversampled font's glyphs are exactly oversampleRatio times wider and the " +
+            "compensation scale offsets by the same ratio -- the on-screen size, and therefore the wrap, must not change");
         text.WrappedText[0].ShouldBe("AB AB");
+    }
+
+    // Issue #4317: OversampleCompensationScale must compose multiplicatively with the public FontScale
+    // rather than overwrite it -- the defect the old RegenerateOversampledFont (which assigned straight
+    // into FontScale) had.
+    [Fact]
+    public void EffectiveFontScale_ComposesFontScaleWithOversampleCompensationScale()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.FontScale = 2f;
+        text.RawText = "AB";
+        float widthAtUserScaleOnly = text.WrappedTextWidth;
+
+        text.OversampleCompensationScale = 0.4f;
+
+        text.FontScale.ShouldBe(2f, "because setting OversampleCompensationScale must not touch the public FontScale");
+        text.WrappedTextWidth.ShouldBe(widthAtUserScaleOnly * 0.4f, tolerance: 0.001f,
+            customMessage: "because the effective on-screen width is FontScale composed with OversampleCompensationScale, not just one or the other");
+    }
+
+    // Issue #4317: the render-time hook TextRuntime wires automatic oversampling through.
+    [Fact]
+    public void PreRender_InvokesOnPreRenderHook()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = font;
+        text.RawText = "AB";
+
+        bool wasInvoked = false;
+        text.OnPreRender = () => wasInvoked = true;
+
+        ((IRenderable)text).PreRender();
+
+        wasInvoked.ShouldBeTrue();
     }
 
     // Two-char ("ab") BMFont with every glyph at a caller-chosen xadvance, so a test can build a

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -2,6 +2,7 @@ using Gum.DataTypes;
 using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
@@ -10,15 +11,20 @@ using Xunit;
 namespace MonoGameGum.Tests.Runtimes;
 
 // Issue #4302: TextRuntime.RegenerateOversampledFont rasterizes a font at a multiple of FontSize (for
-// crisper text under camera zoom) and compensates with Text.FontScale so the on-screen size is
-// unchanged. Gated behind the global TextRuntime.UseFontOversampling toggle (off by default, so
-// pixel-art projects see no behavior change) and requires an IInMemoryFontCreator (KernSmith) --
-// a disk-based font cache only holds a fixed set of pre-baked sizes, so arbitrary-ratio regeneration
-// only makes sense with dynamic generation.
+// crisper text under camera zoom). Gated behind the global TextRuntime.UseFontOversampling toggle
+// (off by default, so pixel-art projects see no behavior change) and requires an IInMemoryFontCreator
+// (KernSmith) -- a disk-based font cache only holds a fixed set of pre-baked sizes, so arbitrary-ratio
+// regeneration only makes sense with dynamic generation.
+//
+// Issue #4317 follow-up: the original mechanism compensated by overwriting the public Text.FontScale,
+// which silently stomped a caller's own FontScale/[FontScale] BBCode usage. It now compensates via the
+// internal-only Text.OversampleCompensationScale, which composes multiplicatively with FontScale
+// instead -- see the "ComposesWith" tests below. This file also covers the automatic, render-time
+// trigger (UpdateAutomaticFontOversampling) that replaces the old manual "press R" call.
 public class TextRuntimeFontOversamplingTests : BaseTestClass
 {
     [Fact]
-    public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndCompensatesFontScale()
+    public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndLeavesFontScaleUntouched()
     {
         bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
         IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
@@ -37,10 +43,109 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             bool result = textRuntime.RegenerateOversampledFont(2.5f);
 
             result.ShouldBeTrue();
-            creator.CapturedFontSize.ShouldBe(50);
+            creator.CapturedFontSize.ShouldBe(50f);
             var text = (Text)textRuntime.RenderableComponent;
             text.BitmapFont.ShouldBeSameAs(stubFont);
-            text.FontScale.ShouldBe(20f / 50f);
+            text.OversampleCompensationScale.ShouldBe(20f / 50f);
+            text.FontScale.ShouldBe(1f, "because oversampling must compensate through the internal-only " +
+                "OversampleCompensationScale, not by overwriting the public FontScale (issue #4317)");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_RequestsExactFractionalRasterSize_WithoutRounding()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+
+            textRuntime.RegenerateOversampledFont(2.37f);
+
+            // 20 * 2.37 = 47.4 -- must reach the rasterizer exactly, not rounded to 47 (issue #4317
+            // asks for the exact fractional target now that #4304 made BmfcSave.FontSize a float).
+            creator.CapturedFontSize.ShouldBe(47.4f, tolerance: 0.0001f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenUserFontScaleIsSet_ComposesWithCompensationInsteadOfOverwritingIt()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.FontScale = 2f; // the caller's own explicit scale -- must survive oversampling.
+
+            textRuntime.RegenerateOversampledFont(2.5f);
+
+            var text = (Text)textRuntime.RenderableComponent;
+            text.FontScale.ShouldBe(2f, "because the caller's own FontScale must not be stomped by oversampling");
+            ((IText)text).FontScale.ShouldBe(2f * (20f / 50f),
+                "because the effective on-screen scale is the caller's FontScale composed with the " +
+                "internal compensation, not just the compensation alone");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void FontSize_WhenChangedAfterOversampling_ResetsCompensationBackToNeutral()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.RegenerateOversampledFont(2.5f);
+            var text = (Text)textRuntime.RenderableComponent;
+            text.OversampleCompensationScale.ShouldBe(20f / 50f);
+
+            // A plain FontSize change (not going through RegenerateOversampledFont) re-resolves the
+            // font at its normal, un-oversampled size -- the OLD compensation ratio must not linger
+            // and shrink/grow the new font incorrectly (issue #4317).
+            textRuntime.FontSize = 30;
+
+            text.OversampleCompensationScale.ShouldBe(1f);
         }
         finally
         {
@@ -112,6 +217,177 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             TextRuntime.UseFontOversampling = savedUseFontOversampling;
             CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
         }
+    }
+
+    // Issue #4317: UpdateAutomaticFontOversampling(float) is the testable decision core behind the
+    // Text.OnPreRender-wired automatic trigger -- given an effective zoom, decide whether to
+    // re-rasterize. The parameterless overload (camera/layer lookup) isn't unit-tested here since it
+    // needs a real SystemManagers/Renderer/Camera graph; that's covered by the FontPlayground manual
+    // test instead.
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenZoomedIn_RegeneratesAtEffectiveZoom()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            creator.ResetCallTracking();
+
+            bool result = textRuntime.UpdateAutomaticFontOversampling(2.5f);
+
+            result.ShouldBeTrue();
+            creator.CapturedFontSize.ShouldBe(50f);
+            var text = (Text)textRuntime.RenderableComponent;
+            text.OversampleCompensationScale.ShouldBe(20f / 50f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenZoomBelowOne_ClampsToNativeResolution_NeverUndersamples()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px, establishes a baseline to zoom back out from
+            creator.ResetCallTracking();
+
+            // Zoomed OUT (0.5x) -- oversampling only ever increases raster resolution, it must not
+            // also rasterize below native size when zoomed out.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(0.5f);
+
+            result.ShouldBeTrue();
+            creator.CapturedFontSize.ShouldBe(20f, "because a zoom below 1 must clamp to native resolution (raster = FontSize), not undersample below it");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenRasterPixelDeltaBelowOne_DoesNotRegenerateAgain()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+            creator.ResetCallTracking();
+
+            // 20 * 2.52 = 50.4 -- less than 1px away from the 50px already rasterized.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(2.52f);
+
+            result.ShouldBeFalse();
+            creator.WasCalled.ShouldBeFalse("because continuous zooming must not re-rasterize every frame for imperceptible deltas");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenRasterPixelDeltaAtLeastOne_RegeneratesAgain()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
+            stubFont.SetFontPattern(256, 256);
+            var creator = new CapturingInMemoryFontCreator(stubFont);
+
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+            creator.ResetCallTracking();
+
+            // 20 * 3.0 = 60 -- 10px past the 50px already rasterized.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(3.0f);
+
+            result.ShouldBeTrue();
+            creator.WasCalled.ShouldBeTrue();
+            creator.CapturedFontSize.ShouldBe(60f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void GetEffectiveZoom_WhenLayerIsNull_ReturnsCameraZoom()
+    {
+        var camera = new Camera { Zoom = 3f };
+
+        TextRuntime.GetEffectiveZoom(null, camera).ShouldBe(3f);
+    }
+
+    [Fact]
+    public void GetEffectiveZoom_WhenLayerHasNoZoomOverride_FallsBackToCameraZoom()
+    {
+        var camera = new Camera { Zoom = 3f };
+        var layer = new Layer { LayerCameraSettings = new LayerCameraSettings() };
+
+        TextRuntime.GetEffectiveZoom(layer, camera).ShouldBe(3f);
+    }
+
+    [Fact]
+    public void GetEffectiveZoom_WhenLayerOverridesZoom_UsesLayerZoomInsteadOfCamera()
+    {
+        var camera = new Camera { Zoom = 3f };
+        var layer = new Layer { LayerCameraSettings = new LayerCameraSettings { Zoom = 5f } };
+
+        TextRuntime.GetEffectiveZoom(layer, camera).ShouldBe(5f);
+    }
+
+    [Fact]
+    public void GetEffectiveZoom_WhenLayerIsScreenSpaceWithNoZoomOverride_IgnoresCameraAndReturnsOne()
+    {
+        var camera = new Camera { Zoom = 3f };
+        var layer = new Layer { LayerCameraSettings = new LayerCameraSettings { IsInScreenSpace = true } };
+
+        TextRuntime.GetEffectiveZoom(layer, camera).ShouldBe(1f,
+            "because a screen-space layer with no explicit Zoom override must stay 1:1 regardless of camera zoom");
     }
 
     // Reproduction attempt for the wrap-earlier report on #4302: goes through the real TextRuntime
@@ -276,14 +552,14 @@ char id=32 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=
         }
 
         public bool WasCalled { get; private set; }
-        public int CapturedFontSize { get; private set; }
+        public float CapturedFontSize { get; private set; }
 
         public void ResetCallTracking() => WasCalled = false;
 
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
             WasCalled = true;
-            CapturedFontSize = (int)bmfcSave.FontSize;
+            CapturedFontSize = bmfcSave.FontSize;
             return _fontToReturn;
         }
     }

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -53,6 +53,9 @@ public class TextRuntime : InteractiveGue
             if (_containedText == null)
             {
                 _containedText = (Text)this.RenderableComponent;
+#if XNALIKE
+                _containedText.OnPreRender = UpdateAutomaticFontOversampling;
+#endif
             }
             return _containedText;
         }
@@ -665,11 +668,15 @@ public class TextRuntime : InteractiveGue
     /// <summary>
     /// Regenerates this text's font at <paramref name="oversampleRatio"/> times <see cref="FontSize"/>
     /// via <see cref="CustomSetPropertyOnRenderableType.InMemoryFontCreator"/>, then compensates with
-    /// the contained Text's FontScale so the on-screen size is unchanged --
-    /// the glyphs are just rasterized at a higher pixel density (issue #4302).
+    /// the contained Text's internal-only <see cref="Text.OversampleCompensationScale"/> so the
+    /// on-screen size is unchanged -- the glyphs are just rasterized at a higher pixel density
+    /// (issue #4302). Unlike the compensation this replaced, it composes with the public
+    /// <see cref="FontScale"/> instead of overwriting it (issue #4317), so a caller's own FontScale
+    /// (including inline [FontScale] BBCode runs) keeps working while oversampling is active.
     /// </summary>
     /// <param name="oversampleRatio">How many times larger than <see cref="FontSize"/> to rasterize
-    /// the font, e.g. the current camera zoom. Rounded to the nearest whole pixel size.</param>
+    /// the font, e.g. the current effective camera/layer zoom. Requested as an exact fraction --
+    /// KernSmith's rasterizer has fractional precision (see issue #4304), so this is not rounded.</param>
     /// <returns>
     /// True if the font was regenerated. False if <see cref="UseFontOversampling"/> is off, no
     /// in-memory font creator is registered, or <paramref name="oversampleRatio"/> is not positive --
@@ -683,7 +690,7 @@ public class TextRuntime : InteractiveGue
             return false;
         }
 
-        var rasterFontSize = Math.Max(1, (int)Math.Round(FontSize * oversampleRatio));
+        var rasterFontSize = System.MathF.Max(1f, FontSize * oversampleRatio);
 
         var fontFilePath = BmfcSave.ResolveTtfSourcePath(UseCustomFont, CustomFontFile, Font);
 
@@ -698,16 +705,96 @@ public class TextRuntime : InteractiveGue
         }
 
         ContainedText.BitmapFont = font;
-        ContainedText.FontScale = FontSize / rasterFontSize;
+        ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
 
-        // BitmapFont/FontScale are renderable-level properties -- assigning them directly (bypassing
-        // the normal property-setter cascade a call like FontSize= goes through) never notifies this
-        // element's own layout. Without this, a RelativeToChildren box keeps whatever Width it measured
-        // against the OLD font and wraps the NEW font's (differently-measuring) glyphs against it.
+        // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
+        // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)
+        // never notifies this element's own layout. Without this, a RelativeToChildren box keeps
+        // whatever Width it measured against the OLD font and wraps the NEW font's (differently-
+        // measuring) glyphs against it.
         UpdateLayout();
 
         return true;
     }
+
+    float _lastAutoOversampleRatio = 1f;
+
+    /// <summary>
+    /// Wired to <see cref="Text.OnPreRender"/> so it runs once per frame for every visible Text on
+    /// the layered draw path -- resolves the current effective camera/layer zoom and delegates the
+    /// actual regenerate-or-not decision to <see cref="UpdateAutomaticFontOversampling(float)"/>.
+    /// Replaces the #4302 manual "press R" trigger with the render-time mechanism issue #4317 asks for.
+    /// </summary>
+    void UpdateAutomaticFontOversampling()
+    {
+        var camera = EffectiveManagers?.Renderer?.Camera;
+        if (camera != null)
+        {
+            UpdateAutomaticFontOversampling(GetEffectiveZoom(this.Layer, camera));
+        }
+    }
+
+    /// <summary>
+    /// Given the current effective screen scale (see <see cref="GetEffectiveZoom"/>), re-rasterizes
+    /// this Text's font only when the requested raster pixel size would move by at least a full pixel
+    /// from what it was last rasterized at -- so continuously zooming doesn't regenerate every frame
+    /// for imperceptible deltas. Split out from the parameterless <see cref="UpdateAutomaticFontOversampling()"/>
+    /// so the decision logic is testable without a real Camera/Layer/SystemManagers graph.
+    /// </summary>
+    /// <returns>True if the font was regenerated.</returns>
+    internal bool UpdateAutomaticFontOversampling(float effectiveZoom)
+    {
+        if (!UseFontOversampling || CustomSetPropertyOnRenderableType.InMemoryFontCreator == null)
+        {
+            return false;
+        }
+
+        // Regenerating below native resolution isn't this feature's job -- only oversample, never
+        // undersample.
+        var oversampleRatio = System.Math.Max(1f, effectiveZoom);
+
+        var rasterDelta = System.MathF.Abs(FontSize * oversampleRatio - FontSize * _lastAutoOversampleRatio);
+        if (rasterDelta >= 1f && RegenerateOversampledFont(oversampleRatio))
+        {
+            _lastAutoOversampleRatio = oversampleRatio;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The effective screen scale a Text on <paramref name="layer"/> renders at -- composes the main
+    /// <paramref name="camera"/>'s zoom with the layer's own <see cref="LayerCameraSettings.Zoom"/>
+    /// override. Mirrors <c>SpriteRenderer.GetZoomAndMatrix</c>'s zoom resolution; kept as a small,
+    /// independent copy here (rather than a shared call into that method) since it sits in
+    /// matrix-routing code documented as historically regression-prone -- see the
+    /// gum-monogame-rendering skill's "Matrix Routing" section.
+    /// </summary>
+    internal static float GetEffectiveZoom(Layer? layer, Camera camera)
+    {
+        var layerCameraSettings = layer?.LayerCameraSettings;
+        if (layerCameraSettings == null)
+        {
+            return camera.Zoom;
+        }
+
+        return layerCameraSettings.IsInScreenSpace
+            ? layerCameraSettings.Zoom ?? 1f
+            : layerCameraSettings.Zoom ?? camera.Zoom;
+    }
+
+    /// <summary>
+    /// Called by <see cref="CustomSetPropertyOnRenderable.UpdateToFontValues"/> (the single choke
+    /// point both the direct-property-setter and string/state-based <c>SetProperty</c> paths
+    /// converge on -- see the gum-property-assignment skill) whenever a font property (Font,
+    /// FontSize, IsBold, etc.) is re-resolved. Resets the automatic-oversampling hysteresis cache so
+    /// the next PreRender re-evaluates against the NEW FontSize instead of comparing it to a ratio
+    /// computed for the OLD one, which could otherwise read as "no change" and leave oversampling
+    /// stale (issue #4317). <see cref="Text.OversampleCompensationScale"/> itself is reset by the
+    /// caller directly, since it lives on the renderable that caller already has a reference to.
+    /// </summary>
+    internal void ResetAutomaticOversamplingState() => _lastAutoOversampleRatio = 1f;
 #endif
 #endif
 

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -180,7 +180,42 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
     float mFontScale = 1;
 
-    private float EffectiveFontScale => mFontScale * SystemManagers.GlobalFontScale;
+    float mOversampleCompensationScale = 1;
+
+    /// <summary>
+    /// Internal-only multiplicative compensation for automatic font oversampling (issue #4317).
+    /// Composes with the public <see cref="FontScale"/> instead of overwriting it -- the raster
+    /// swaps to a higher-resolution <see cref="BitmapFont"/> under zoom, and this scale shrinks it
+    /// back down to the requested on-screen size, so a caller's own FontScale (including inline
+    /// [FontScale] BBCode runs) keeps working unmodified. Defaults to 1 (no compensation).
+    /// </summary>
+    internal float OversampleCompensationScale
+    {
+        get => mOversampleCompensationScale;
+        set
+        {
+            if (value != mOversampleCompensationScale)
+            {
+                mOversampleCompensationScale = value;
+                UpdateWrappedText();
+                mNeedsBitmapFontRefresh = true;
+                UpdatePreRenderDimensions();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs once per frame during this Text's <see cref="IRenderable.PreRender"/>, before texture
+    /// regeneration. Used by <c>TextRuntime</c> (XNALIKE) to automatically re-rasterize at the
+    /// current camera/layer zoom (issue #4317) -- kept here rather than on the runtime because
+    /// PreRender is the render-time hook the layered draw path already calls per visible renderable.
+    /// </summary>
+    internal Action? OnPreRender;
+
+    private float ComposeFontScale(float baseFontScale) =>
+        baseFontScale * SystemManagers.GlobalFontScale * mOversampleCompensationScale;
+
+    private float EffectiveFontScale => ComposeFontScale(mFontScale);
 
     float IText.FontScale => EffectiveFontScale;
 
@@ -902,6 +937,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
     void IRenderable.PreRender()
     {
+        OnPreRender?.Invoke();
         TryUpdateTextureToRender();
     }
 
@@ -1186,7 +1222,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                         }
                         else if (variable.VariableName == nameof(FontScale))
                         {
-                            fontScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                            fontScale = ComposeFontScale((float)variable.Value);
                         }
                         else if (variable.VariableName == nameof(BitmapFont))
                         {
@@ -1386,7 +1422,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                 var variable = substring.Variables[variableIndex];
                 if (variable.VariableName == nameof(FontScale))
                 {
-                    currentFontScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                    currentFontScale = ComposeFontScale((float)variable.Value);
                     lineHeight = System.Math.Max(lineHeight, currentFont.EffectiveLineHeight(currentFontScale, 1));
                     maxBaseline = System.Math.Max(maxBaseline, currentFontScale * currentFont.BaselineY);
                 }
@@ -1690,7 +1726,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                 var variable = substring.Variables[variableIndex];
                 if (variable.VariableName == nameof(FontScale))
                 {
-                    runScale = (float)variable.Value * SystemManagers.GlobalFontScale;
+                    runScale = ComposeFontScale((float)variable.Value);
                     runHeightScale = runScale;
                 }
                 else if (variable.VariableName == nameof(BitmapFont))

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -41,10 +41,12 @@ public class Game1 : Game
     // automatic-oversampling demo below (BuildZoomOversamplingDemo / issue #4317).
     private TextRuntime _fractionalFontSizeText = null!;
     private const float FractionalFontSizeMin = 8f;
-    // Capped well below the full 8-96 slider range in FontPlaygroundScreen so this text -- reserved
-    // the top band of the page (see FontPlaygroundScreen.BuildInternal's controlsPanel.Visual.Y
-    // comment) -- can never grow tall/wide enough to run into the controls panel below it.
-    private const float FractionalFontSizeMax = 48f;
+    // Matches the full 8-96 slider range in FontPlaygroundScreen. This text sits at Y=4 in the
+    // reserved top band (see FontPlaygroundScreen.BuildInternal's controlsPanel.Visual.Y=100
+    // comment), so there's ~96px of headroom before its box reaches the controls panel below --
+    // a taller font (bigger FontSize -> taller glyph box) can eat into that margin at the top of
+    // the range. If that becomes visually cramped, lower this or move controlsPanel.Visual.Y down.
+    private const float FractionalFontSizeMax = 96f;
     private float _fractionalFontSize = 24f;
 
     public Game1()

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -20,14 +20,15 @@ public class Game1 : Game
 {
     private readonly GraphicsDeviceManager _graphics;
 
-    // Issue #4302 manual-test rig: mouse wheel zooms the camera, blurring both preview texts below
-    // the playground the same way any zoomed Gum UI blurs today. Pressing R regenerates only
-    // _oversampledZoomPreviewText's font at the current zoom (manually-triggered, per this issue's
-    // scope), so it turns crisp again while _plainZoomPreviewText stays blurry for comparison.
+    // Issue #4317 manual-test rig: mouse wheel zooms the shared camera, magnifying both preview texts
+    // uniformly (same as any zoomed Gum UI). _oversampledZoomPreviewText re-rasterizes itself
+    // automatically at render time (TextRuntime.UpdateAutomaticFontOversampling, wired to Text.OnPreRender)
+    // and stays crisp at every zoom level with no input required, while _plainZoomPreviewText -- an
+    // ordinary Text with no oversampling -- visibly blurs/pixelates under the same zoom, for comparison.
+    // (#4302's original version of this rig required manually pressing R; that trigger no longer exists.)
     private TextRuntime _plainZoomPreviewText = null!;
     private TextRuntime _oversampledZoomPreviewText = null!;
     private int _previousScrollWheelValue;
-    private bool _wasRKeyDown;
 
     // Issue #4304 manual-test rig: a single Text whose FontSize tracks the mouse wheel directly (NOT
     // camera.Zoom -- this text is drawn in normal, unzoomed screen space so the raster size KernSmith
@@ -36,10 +37,8 @@ public class Game1 : Game
     // changes continuously, and the label shows the live requested FontSize (with decimals) so the
     // number is readable while zooming.
     //
-    // This deliberately does NOT demonstrate crisp text under CAMERA zoom (that's a different feature
-    // -- automatic, FontScale-free oversampling -- tracked separately in #4317, since it needs a
-    // render-time compensation mechanism that doesn't exist yet; see that issue for why hijacking
-    // FontScale, the way RegenerateOversampledFont below does, isn't the right shape for it).
+    // This deliberately does NOT demonstrate crisp text under CAMERA zoom -- that's the separate
+    // automatic-oversampling demo below (BuildZoomOversamplingDemo / issue #4317).
     private TextRuntime _fractionalFontSizeText = null!;
     private const float FractionalFontSizeMin = 8f;
     // Capped well below the full 8-96 slider range in FontPlaygroundScreen so this text -- reserved
@@ -127,7 +126,7 @@ public class Game1 : Game
         GumService.Default.Root.Children.Add(_plainZoomPreviewText);
 
         _oversampledZoomPreviewText = new TextRuntime();
-        _oversampledZoomPreviewText.Text = "Scroll to zoom, then press R (crisp)";
+        _oversampledZoomPreviewText.Text = "Scroll to zoom (auto-crisp)";
         _oversampledZoomPreviewText.FontSize = 24;
         _oversampledZoomPreviewText.X = 16;
         _oversampledZoomPreviewText.Y = 690;
@@ -179,12 +178,9 @@ public class Game1 : Game
             ApplyFractionalFontSize();
         }
 
-        bool isRKeyDown = Keyboard.GetState().IsKeyDown(Keys.R);
-        if (isRKeyDown && !_wasRKeyDown)
-        {
-            _oversampledZoomPreviewText.RegenerateOversampledFont(camera.Zoom);
-        }
-        _wasRKeyDown = isRKeyDown;
+        // No manual trigger needed here -- _oversampledZoomPreviewText re-rasterizes itself every
+        // frame via TextRuntime.UpdateAutomaticFontOversampling, wired to Text.OnPreRender, which
+        // reads this same camera's Zoom (issue #4317).
     }
 
     protected override void Draw(GameTime gameTime)

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -86,7 +86,6 @@ public class Game1 : Game
         _fractionalFontSizeText.Green = 255;
         _fractionalFontSizeText.Blue = 255;
         _fractionalFontSizeText.Alpha = 255;
-        GumService.Default.Root.Children.Add(_fractionalFontSizeText);
 
         // Everything else in this sample renders through the main camera, which the mouse wheel
         // also zooms (see UpdateZoomOversamplingDemo) -- if this text stayed on that same layer, its
@@ -94,10 +93,20 @@ public class Game1 : Game
         // from the zoom pivot, size growing faster than the displayed number). A screen-space layer
         // (IsInScreenSpace) is ignored by the main camera entirely, so this text's on-screen size and
         // position are driven ONLY by its own FontSize/X/Y -- exactly what the demo needs to show.
+        //
+        // Registered as a TOP-LEVEL layer member via AddToManagers rather than parented under Root
+        // (Root.Children.Add) + MoveToLayer -- MoveToLayer only re-homes a TOP-LEVEL renderable's
+        // layer membership, it does not detach a nested child from its parent's own render-tree walk.
+        // Parenting under Root and then calling MoveToLayer left this text rendered TWICE: once via
+        // Root's default-layer subtree walk (still scaled by the main camera zoom) AND once via its
+        // own top-level entry on the screen-space layer -- invisible at zoom 1 (both draws coincide)
+        // but increasingly visible as two diverging, overlapping copies at any other zoom. Surfaced
+        // manually testing #4317; tracked generally (MoveToLayer silently double-rendering a parented
+        // element) in #4333.
         Layer screenSpaceLayer = SystemManagers.Default.Renderer.AddLayer();
         screenSpaceLayer.Name = "Fractional FontSize (screen space)";
         screenSpaceLayer.LayerCameraSettings = new LayerCameraSettings { IsInScreenSpace = true };
-        _fractionalFontSizeText.MoveToLayer(screenSpaceLayer);
+        _fractionalFontSizeText.AddToManagers(SystemManagers.Default, screenSpaceLayer);
 
         ApplyFractionalFontSize();
     }

--- a/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
+++ b/Samples/FontPlayground/FontPlayground.MonoGame/Game1.cs
@@ -40,14 +40,12 @@ public class Game1 : Game
     // This deliberately does NOT demonstrate crisp text under CAMERA zoom -- that's the separate
     // automatic-oversampling demo below (BuildZoomOversamplingDemo / issue #4317).
     private TextRuntime _fractionalFontSizeText = null!;
-    private const float FractionalFontSizeMin = 8f;
-    // Matches the full 8-96 slider range in FontPlaygroundScreen. This text sits at Y=4 in the
-    // reserved top band (see FontPlaygroundScreen.BuildInternal's controlsPanel.Visual.Y=100
-    // comment), so there's ~96px of headroom before its box reaches the controls panel below --
-    // a taller font (bigger FontSize -> taller glyph box) can eat into that margin at the top of
-    // the range. If that becomes visually cramped, lower this or move controlsPanel.Visual.Y down.
-    private const float FractionalFontSizeMax = 96f;
-    private float _fractionalFontSize = 24f;
+    // The base FontSize at camera.Zoom == 1. _fractionalFontSize is derived directly from the SAME
+    // (already-clamped) camera.Zoom each scroll tick -- not tracked as its own independently-clamped
+    // running product -- so it can never drift out of sync with the camera's own 0.25-8x zoom range;
+    // it necessarily stops growing/shrinking exactly when the camera's clamp does.
+    private const float BaseFractionalFontSize = 24f;
+    private float _fractionalFontSize = BaseFractionalFontSize;
 
     public Game1()
     {
@@ -184,8 +182,7 @@ public class Game1 : Game
 
             camera.Zoom = System.Math.Clamp(camera.Zoom * zoomMultiplier, 0.25f, 8f);
 
-            _fractionalFontSize = System.Math.Clamp(
-                _fractionalFontSize * zoomMultiplier, FractionalFontSizeMin, FractionalFontSizeMax);
+            _fractionalFontSize = BaseFractionalFontSize * camera.Zoom;
             ApplyFractionalFontSize();
         }
 


### PR DESCRIPTION
## Summary

- Replaces #4302's manually-triggered `RegenerateOversampledFont` with an automatic, render-time mechanism: `TextRuntime.UpdateAutomaticFontOversampling`, wired to a new `Text.OnPreRender` hook, re-rasterizes at the current effective camera/layer zoom every frame (1px hysteresis threshold, no manual call needed).
- Compensation now goes through a new internal-only `Text.OversampleCompensationScale` that composes multiplicatively with the public `FontScale`, instead of overwriting it — fixes the design flaw #4317 identified (a user's own `FontScale`/inline `[FontScale]` BBCode run was silently stomped while oversampling was active).
- Requests the exact fractional raster size (`FontSize * ratio`, no rounding) per #4304, instead of the old `(int)Math.Round(...)`.
- Updated the FontPlayground MonoGame sample's manual-test rig to match the issue's spec: both preview texts live in normal world space under the shared camera, the oversampled one is now automatic (no "press R").
- Raylib has no oversampling mechanism at all (flawed or otherwise) — scoped out to #4330 rather than doubling this PR's size.

## Test plan

- [x] Unit tests: `EffectiveFontScale`/`OversampleCompensationScale` composition, exact-fractional raster size, automatic-trigger hysteresis (regenerate/skip thresholds, never-undersample clamp), `GetEffectiveZoom` branch coverage, font-property-change reset. Full `MonoGameGum.Tests` suite green (2133/2133), `GumToolUnitTests` green (1218/1220, 2 pre-existing skips).
- [x] Builds clean: `GumFull.sln`, `MonoGameGum.Tests`, `KniGum`, `RaylibGum`, `SkiaGum`, `SilkNetGum`.
- [x] FRB canary: pass (0 errors, matches baseline).
- [ ] Manual test (FontPlayground.MonoGame sample, opened in VS): scroll the mouse wheel to zoom the shared camera — "Scroll to zoom (auto-crisp)" should stay sharp at every zoom level, while "Scroll to zoom (always blurry)" visibly pixelates, demonstrating the fix side-by-side.

Closes #4317
