### PR TITLE
Fix variable grid leaving stale/missing categories after instance-type selection change

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -474,32 +474,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             else
             {
                 // todo: handle multiselect
-                foreach (var newCategory in listOfCategories[0])
-                {
-                    // let's see if any variables have changed
-                    var oldCategory = mVariablesDataGrid.Categories.FirstOrDefault(item => item.Name == newCategory.Name);
-
-                    // A previous category's InstanceMember objects capture their target instance at
-                    // construction (see StateReferencingInstanceMember), so they can only be reused
-                    // when the same instance is still shown - an instance identity change always
-                    // needs at least a per-member retarget, even when the member names match.
-                    bool namesMatch = oldCategory != null && !DoCategoriesDiffer(oldCategory.Members, newCategory.Members);
-
-                    bool canRetargetInPlace = instanceIdentityChanged && namesMatch &&
-                        CanRetargetAllMembers(oldCategory.Members, newCategory.Members);
-
-                    if (canRetargetInPlace)
-                    {
-                        RetargetAllMembers(oldCategory.Members, newCategory.Members);
-                    }
-                    else if (oldCategory != null && (instanceIdentityChanged || !namesMatch))
-                    {
-                        int index = mVariablesDataGrid.Categories.IndexOf(oldCategory);
-
-                        mVariablesDataGrid.Categories.RemoveAt(index);
-                        mVariablesDataGrid.Categories.Insert(index, newCategory);
-                    }
-                }
+                ReconcileCategories(mVariablesDataGrid.Categories, listOfCategories[0], instanceIdentityChanged);
             }
 
             RefreshErrors(element);
@@ -691,6 +666,63 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
 
 
             this.VariableViewModel.ErrorInformation = message;
+        }
+    }
+
+    /// <summary>
+    /// Reconciles <paramref name="gridCategories"/> (the categories currently shown in the grid) against
+    /// <paramref name="newCategories"/> (the categories for the newly selected instance), retargeting
+    /// members in place where possible instead of rebuilding containers.
+    /// </summary>
+    public static void ReconcileCategories(
+        IList<MemberCategory> gridCategories,
+        IReadOnlyList<MemberCategory> newCategories,
+        bool instanceIdentityChanged)
+    {
+        foreach (var newCategory in newCategories)
+        {
+            // let's see if any variables have changed
+            var oldCategory = gridCategories.FirstOrDefault(item => item.Name == newCategory.Name);
+
+            // A previous category's InstanceMember objects capture their target instance at
+            // construction (see StateReferencingInstanceMember), so they can only be reused
+            // when the same instance is still shown - an instance identity change always
+            // needs at least a per-member retarget, even when the member names match.
+            bool namesMatch = oldCategory != null && !DoCategoriesDiffer(oldCategory.Members, newCategory.Members);
+
+            bool canRetargetInPlace = instanceIdentityChanged && namesMatch &&
+                CanRetargetAllMembers(oldCategory.Members, newCategory.Members);
+
+            if (canRetargetInPlace)
+            {
+                RetargetAllMembers(oldCategory.Members, newCategory.Members);
+            }
+            else if (oldCategory != null && (instanceIdentityChanged || !namesMatch))
+            {
+                int index = gridCategories.IndexOf(oldCategory);
+
+                gridCategories.RemoveAt(index);
+                gridCategories.Insert(index, newCategory);
+            }
+            else if (oldCategory == null)
+            {
+                // The new instance has a category the previously-shown instance didn't (e.g. "Text"
+                // when the previous instance had no Text category) - it has no counterpart to
+                // retarget or replace, so it must be added.
+                gridCategories.Add(newCategory);
+            }
+        }
+
+        // Categories left over from the previously-shown instance with no counterpart in
+        // newCategories (e.g. "Text" from a previously-selected Text instance, when the newly-selected
+        // instance isn't text) must be removed - otherwise they stay stuck in the grid.
+        for (int i = gridCategories.Count - 1; i >= 0; i--)
+        {
+            var existingCategory = gridCategories[i];
+            if (!newCategories.Any(newCategory => newCategory.Name == existingCategory.Name))
+            {
+                gridCategories.RemoveAt(i);
+            }
         }
     }
 

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerReconcileCategoriesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerReconcileCategoriesTests.cs
@@ -42,8 +42,104 @@ public class PropertyGridManagerReconcileCategoriesTests : BaseTestClass
         gridCategories.Select(c => c.Name).ShouldNotContain("Text");
     }
 
-    private static MemberCategory MakeCategory(string name)
+    [Fact]
+    public void ReconcileCategories_MultipleNewCategories_AllInserted()
     {
-        return new MemberCategory { Name = name };
+        List<MemberCategory> gridCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position")
+        };
+        List<MemberCategory> newCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Text"),
+            MakeCategory("Appearance")
+        };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        gridCategories.Select(c => c.Name).ShouldBe(new[] { "Position", "Text", "Appearance" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ReconcileCategories_NewListEmpty_RemovesEveryExistingCategory()
+    {
+        List<MemberCategory> gridCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Text")
+        };
+        List<MemberCategory> newCategories = new List<MemberCategory>();
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        gridCategories.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// Reproduces the reported bug end to end: switching from a Text instance (which has a "Text"
+    /// category the Rectangle doesn't) to a Rectangle instance (which has an "Appearance" category
+    /// the Text instance didn't show) in one selection change.
+    /// </summary>
+    [Fact]
+    public void ReconcileCategories_SwitchingInstanceTypes_DropsOldCategoryAndAddsNewOne()
+    {
+        List<MemberCategory> gridCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Text")
+        };
+        List<MemberCategory> newCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Appearance")
+        };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        gridCategories.Select(c => c.Name).ShouldBe(new[] { "Position", "Appearance" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ReconcileCategories_MatchingCategoryWithNonRetargetableMembers_ReplacesCategoryObject()
+    {
+        MemberCategory oldCategory = MakeCategory("Position", new InstanceMember { Name = "X" });
+        List<MemberCategory> gridCategories = new List<MemberCategory> { oldCategory };
+        MemberCategory newCategory = MakeCategory("Position", new InstanceMember { Name = "X" });
+        List<MemberCategory> newCategories = new List<MemberCategory> { newCategory };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        // Plain InstanceMember rows aren't StateReferencingInstanceMember, so they can't be
+        // retargeted in place - the category must be swapped for the new instance's category object.
+        gridCategories.ShouldHaveSingleItem();
+        gridCategories[0].ShouldBeSameAs(newCategory);
+        gridCategories[0].ShouldNotBeSameAs(oldCategory);
+    }
+
+    [Fact]
+    public void ReconcileCategories_UnchangedCategoryNoIdentityChange_LeavesCategoryObjectAlone()
+    {
+        MemberCategory oldCategory = MakeCategory("Position", new InstanceMember { Name = "X" });
+        List<MemberCategory> gridCategories = new List<MemberCategory> { oldCategory };
+        List<MemberCategory> newCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position", new InstanceMember { Name = "X" })
+        };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: false);
+
+        gridCategories.ShouldHaveSingleItem();
+        gridCategories[0].ShouldBeSameAs(oldCategory);
+    }
+
+    private static MemberCategory MakeCategory(string name, params InstanceMember[] members)
+    {
+        MemberCategory category = new MemberCategory { Name = name };
+        foreach (InstanceMember member in members)
+        {
+            category.Members.Add(member);
+        }
+        return category;
     }
 }

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerReconcileCategoriesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerReconcileCategoriesTests.cs
@@ -1,0 +1,49 @@
+using Gum.Managers;
+using Shouldly;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+public class PropertyGridManagerReconcileCategoriesTests : BaseTestClass
+{
+    [Fact]
+    public void ReconcileCategories_NewCategoryNotPreviouslyShown_IsInserted()
+    {
+        List<MemberCategory> gridCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position")
+        };
+        List<MemberCategory> newCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Text")
+        };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        gridCategories.Select(c => c.Name).ShouldContain("Text");
+    }
+
+    [Fact]
+    public void ReconcileCategories_OldCategoryNotInNewList_IsRemoved()
+    {
+        List<MemberCategory> gridCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position"),
+            MakeCategory("Text")
+        };
+        List<MemberCategory> newCategories = new List<MemberCategory>
+        {
+            MakeCategory("Position")
+        };
+
+        PropertyGridManager.ReconcileCategories(gridCategories, newCategories, instanceIdentityChanged: true);
+
+        gridCategories.Select(c => c.Name).ShouldNotContain("Text");
+    }
+
+    private static MemberCategory MakeCategory(string name)
+    {
+        return new MemberCategory { Name = name };
+    }
+}


### PR DESCRIPTION
## Summary
- `PropertyGridManager.RefreshDataGrid`'s single-instance retarget-in-place path (#4281) only reconciled categories whose **name already existed in both** the old and new instance's category list. A brand-new category (e.g. "Text", not previously shown) was never inserted, and a stale category (e.g. "Text" left over after selecting a Rectangle) was never removed.
- Extracted the reconcile loop into a testable static `ReconcileCategories` and added the missing insert/remove passes.

## Test plan
- [x] `PropertyGridManagerReconcileCategoriesTests` (new): reproduces both symptoms, red before the fix, green after.
- [x] Full `GumToolUnitTests` suite green (1220 passed, 2 pre-existing unrelated skips).
- [x] `GumFull.sln` builds with 0 errors, no new warnings.

Closes #4335
