### PR TITLE
Fix docs-only CI guard: paths-filter needs predicate-quantifier: every

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -289,6 +289,11 @@ jobs:
         id: docs-only
         uses: dorny/paths-filter@v3
         with:
+          # predicate-quantifier: every is required for the '!'-prefixed excludes below to
+          # actually exclude. The default ('some'/OR) matches a file against '**' alone and
+          # short-circuits true, so every PR — docs-only or not — reported non-docs=true and
+          # this guard never actually skipped the expensive steps it gates.
+          predicate-quantifier: every
           filters: |
             non-docs:
               - '**'


### PR DESCRIPTION
The step-level docs-only guard added in #4315 never worked: `dorny/paths-filter@v3` defaults to `predicate-quantifier: some` (OR), so a file matches the bare `**` pattern and short-circuits true before the `!docs/**` etc. excludes are considered. Every PR reported `non-docs=true`, so the "expensive step" guards never skipped anything.

Confirmed via #4339's macOS job log: all 6 changed files were under `docs/`, but `paths-filter` still reported `non-docs=true` and the Mac lane installed the full workload set (~5 min) for a pure doc change.

Fix: add `predicate-quantifier: every` so the excludes actually apply (gitignore-style AND-of-include-and-excludes).

Manual test: not needed for this PR itself, since it's a non-docs change and correctly triggers the full guarded steps. The fix's actual effect (skipping expensive steps) should be visible on the next docs-only PR after this merges.