### PR TITLE
Add FilledStrokedRectangle: flat fill+stroke renderable for FRB's Rectangle codegen

### DIFF
--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -159,6 +159,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\IPositionedSizedObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\ISystemManagers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Math\FloatRectangle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Math\Geometry\FilledStrokedRectangle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Math\Geometry\Line.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Math\Geometry\LineCircle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Math\Geometry\LineGrid.cs" />

--- a/MonoGameGum.Tests/RenderingLibraries/Math/Geometry/FilledStrokedRectangleTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/Math/Geometry/FilledStrokedRectangleTests.cs
@@ -1,0 +1,118 @@
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Math.Geometry;
+using Shouldly;
+using System.Drawing;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries.Math.Geometry;
+
+public class FilledStrokedRectangleTests : BaseTestClass
+{
+    [Fact]
+    public void Alpha_ShouldReturnMoreOpaqueOfFillAndStrokeColor()
+    {
+        FilledStrokedRectangle sut = new();
+
+        sut.FillColor = Color.FromArgb(100, 255, 255, 255);
+        sut.StrokeColor = Color.FromArgb(200, 255, 255, 255);
+        sut.Alpha.ShouldBe(200);
+
+        sut.FillColor = Color.FromArgb(200, 255, 255, 255);
+        sut.StrokeColor = Color.FromArgb(100, 255, 255, 255);
+        sut.Alpha.ShouldBe(200);
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotThrow()
+    {
+        Should.NotThrow(() => new FilledStrokedRectangle());
+    }
+
+    [Fact]
+    public void FillColor_And_StrokeColor_ShouldBeIndependent()
+    {
+        FilledStrokedRectangle sut = new()
+        {
+            FillColor = Color.Red,
+            StrokeColor = Color.Blue
+        };
+
+        sut.FillColor.ShouldBe(Color.Red);
+        sut.StrokeColor.ShouldBe(Color.Blue);
+    }
+
+    [Fact]
+    public void IsFilled_ShouldDefaultToFalse()
+    {
+        FilledStrokedRectangle sut = new();
+        sut.IsFilled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFilled_And_StrokeWidth_ShouldGateIndependently()
+    {
+        // Fill only, no stroke:
+        FilledStrokedRectangle fillOnly = new()
+        {
+            IsFilled = true,
+            StrokeWidth = 0
+        };
+        fillOnly.IsFilled.ShouldBeTrue();
+        fillOnly.StrokeWidth.ShouldBe(0);
+
+        // Stroke only, no fill -- setting StrokeWidth must not implicitly turn on IsFilled,
+        // and setting IsFilled off above must not have reset StrokeWidth's own default elsewhere.
+        FilledStrokedRectangle strokeOnly = new()
+        {
+            IsFilled = false,
+            StrokeWidth = 5
+        };
+        strokeOnly.IsFilled.ShouldBeFalse();
+        strokeOnly.StrokeWidth.ShouldBe(5);
+    }
+
+    [Fact]
+    public void Parent_ShouldAddSelfToNewParentsChildren()
+    {
+        FilledStrokedRectangle sut = new();
+        LineRectangle parent = new();
+
+        sut.Parent = parent;
+
+        parent.Children.ShouldContain(sut);
+    }
+
+    [Fact]
+    public void Parent_ShouldRemoveSelfFromOldParentsChildren()
+    {
+        FilledStrokedRectangle sut = new();
+        LineRectangle oldParent = new();
+        LineRectangle newParent = new();
+
+        sut.Parent = oldParent;
+        sut.Parent = newParent;
+
+        oldParent.Children.ShouldNotContain(sut);
+        newParent.Children.ShouldContain(sut);
+    }
+
+    [Fact]
+    public void StrokeWidth_ShouldDefaultToOne()
+    {
+        FilledStrokedRectangle sut = new();
+        sut.StrokeWidth.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Width_And_Height_ShouldRoundTrip()
+    {
+        FilledStrokedRectangle sut = new()
+        {
+            Width = 100,
+            Height = 50
+        };
+
+        sut.Width.ShouldBe(100);
+        sut.Height.ShouldBe(50);
+    }
+}

--- a/MonoGameGum/FnaGum/FnaGum.csproj
+++ b/MonoGameGum/FnaGum/FnaGum.csproj
@@ -83,6 +83,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\TextManager.cs" Link="RenderingLibrary\TextManager.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\XNAExtensions.cs" Link="Utilities\XNAExtensions.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\FloatRectangle.cs" Link="Utilities\FloatRectangle.cs" />
+		<Compile Include="..\..\RenderingLibrary\Math\Geometry\FilledStrokedRectangle.cs" Link="Renderables\FilledStrokedRectangle.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\Line.cs" Link="Renderables\Line.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\LineCircle.cs" Link="Renderables\LineCircle.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\LineGrid.cs" Link="Renderables\LineGrid.cs" />

--- a/MonoGameGum/KniGum/KniGum.csproj
+++ b/MonoGameGum/KniGum/KniGum.csproj
@@ -108,6 +108,7 @@
 		<Compile Include="..\..\RenderingLibrary\Graphics\TextManager.cs" Link="RenderingLibrary\TextManager.cs" />
 		<Compile Include="..\..\RenderingLibrary\Graphics\XNAExtensions.cs" Link="Utilities\XNAExtensions.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\FloatRectangle.cs" Link="Utilities\FloatRectangle.cs" />
+		<Compile Include="..\..\RenderingLibrary\Math\Geometry\FilledStrokedRectangle.cs" Link="Renderables\FilledStrokedRectangle.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\Line.cs" Link="Renderables\Line.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\LineCircle.cs" Link="Renderables\LineCircle.cs" />
 		<Compile Include="..\..\RenderingLibrary\Math\Geometry\LineGrid.cs" Link="Renderables\LineGrid.cs" />

--- a/MonoGameGum/MonoGameGum.csproj
+++ b/MonoGameGum/MonoGameGum.csproj
@@ -238,6 +238,7 @@
 		<Compile Include="..\RenderingLibrary\Graphics\TextManager.cs" Link="RenderingLibrary\TextManager.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\XNAExtensions.cs" Link="Utilities\XNAExtensions.cs" />
 		<Compile Include="..\RenderingLibrary\Math\FloatRectangle.cs" Link="Utilities\FloatRectangle.cs" />
+		<Compile Include="..\RenderingLibrary\Math\Geometry\FilledStrokedRectangle.cs" Link="Renderables\FilledStrokedRectangle.cs" />
 		<Compile Include="..\RenderingLibrary\Math\Geometry\Line.cs" Link="Renderables\Line.cs" />
 		<Compile Include="..\RenderingLibrary\Math\Geometry\LineCircle.cs" Link="Renderables\LineCircle.cs" />
 		<Compile Include="..\RenderingLibrary\Math\Geometry\LineGrid.cs" Link="Renderables\LineGrid.cs" />

--- a/RenderingLibrary/Math/Geometry/FilledStrokedRectangle.cs
+++ b/RenderingLibrary/Math/Geometry/FilledStrokedRectangle.cs
@@ -1,0 +1,276 @@
+using RenderingLibrary.Graphics;
+using System.Collections.ObjectModel;
+using BlendState = Gum.BlendState;
+using Vector2 = System.Numerics.Vector2;
+using Color = System.Drawing.Color;
+
+namespace RenderingLibrary.Math.Geometry;
+
+/// <summary>
+/// Flat <see cref="IRenderableIpso"/> that draws a fill and a stroke in one <see cref="Render"/>
+/// call, gated independently (<see cref="IsFilled"/> for the fill, <see cref="StrokeWidth"/> &gt; 0
+/// for the stroke — neither hides the other). Added for FlatRedBall's Glue codegen (issue #4341),
+/// which emits one flat contained field per standard element and cannot adopt
+/// <c>RectangleRuntime</c>'s two-slot <c>GraphicalUiElement</c> composite. Reuses the fill and
+/// stroke draw techniques directly from <c>Sprite.Render</c> and
+/// <see cref="LineRectangle.RenderLinePrimitive"/>/<see cref="LineRectangle.UpdateLinePrimitive"/>
+/// (both already generic over any <see cref="IRenderableIpso"/>) rather than reimplementing either,
+/// so a fix to either draw path never needs hand-mirroring into a third place. Scope is plain
+/// square-corner fill + stroke only — no gradient, dropshadow, dashed stroke, corner radius, or
+/// antialiasing; those require the optional <c>Gum.Shapes</c>/<c>MonoGameGumShapes</c> package that
+/// <c>RectangleRuntime</c> itself gates behind, which FRB has no integration with.
+/// </summary>
+public class FilledStrokedRectangle : SpriteBatchRenderableBase, IVisible, IRenderableIpso
+{
+    #region Fields
+
+    Vector2 Position;
+
+    float mWidth = 32;
+    float mHeight = 32;
+    float mRotation;
+
+    IRenderableIpso? mParent;
+    ObservableCollectionNoReset<IRenderableIpso> mChildren;
+
+    SystemManagers? mManagers;
+
+    LinePrimitive mLinePrimitive;
+
+    Color _fillColor;
+    Color _strokeColor;
+    float _strokeWidth;
+
+    #endregion
+
+    #region Properties
+
+    ColorOperation IRenderableIpso.ColorOperation => ColorOperation.Modulate;
+
+    bool IRenderableIpso.ClipsChildren => false;
+
+    bool IRenderableIpso.IsRenderTarget => false;
+
+    /// <summary>
+    /// Unused unless this is ever placed in a render target's texture-blit path (see
+    /// <see cref="IRenderableIpso.Alpha"/>'s only reader, <c>Renderer.DrawRenderTargetToScreen</c>),
+    /// which requires <see cref="IRenderableIpso.IsRenderTarget"/> — always false here. Reports the
+    /// more opaque of the two colors so that reader still degrades sensibly if this type is ever
+    /// reused somewhere that path applies.
+    /// </summary>
+    public int Alpha => System.Math.Max(_fillColor.A, _strokeColor.A);
+
+    /// <summary>
+    /// When <c>true</c>, paints a solid fill using <see cref="FillColor"/>. Independent of the
+    /// stroke — both may render in the same <see cref="Render"/> call. Defaults to <c>false</c> so
+    /// a fresh rectangle is a stroke-only outline, matching <c>RectangleRuntime</c>'s default.
+    /// </summary>
+    public bool IsFilled { get; set; }
+
+    /// <summary>
+    /// Fill color, used when <see cref="IsFilled"/> is <c>true</c>.
+    /// </summary>
+    public Color FillColor
+    {
+        get => _fillColor;
+        set => _fillColor = value;
+    }
+
+    /// <summary>
+    /// Stroke color, used when <see cref="StrokeWidth"/> is &gt; 0.
+    /// </summary>
+    public Color StrokeColor
+    {
+        get => _strokeColor;
+        set
+        {
+            _strokeColor = value;
+            mLinePrimitive.Color = value;
+        }
+    }
+
+    /// <summary>
+    /// Stroke width in pixels. The stroke only renders when this is &gt; 0 — independent of
+    /// <see cref="IsFilled"/>. Defaults to 1 so a fresh rectangle keeps a visible outline.
+    /// </summary>
+    public float StrokeWidth
+    {
+        get => _strokeWidth;
+        set
+        {
+            _strokeWidth = value;
+            mLinePrimitive.LinePixelWidth = value;
+        }
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public float X
+    {
+        get => Position.X;
+        set => Position.X = value;
+    }
+
+    /// <inheritdoc/>
+    public float Y
+    {
+        get => Position.Y;
+        set => Position.Y = value;
+    }
+
+    /// <inheritdoc/>
+    public float Z { get; set; }
+
+    /// <inheritdoc/>
+    public float Rotation
+    {
+        get => mRotation;
+        set
+        {
+            mRotation = value;
+            UpdatePoints();
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool FlipHorizontal { get; set; }
+
+    /// <inheritdoc/>
+    public float Width
+    {
+        get => mWidth;
+        set
+        {
+            mWidth = value;
+            UpdatePoints();
+        }
+    }
+
+    /// <inheritdoc/>
+    public float Height
+    {
+        get => mHeight;
+        set
+        {
+            mHeight = value;
+            UpdatePoints();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IRenderableIpso? Parent
+    {
+        get => mParent;
+        set
+        {
+            if (mParent != value)
+            {
+                mParent?.Children.Remove(this);
+                mParent = value;
+                mParent?.Children.Add(this);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public ObservableCollection<IRenderableIpso> Children => mChildren;
+
+    /// <inheritdoc/>
+    public object? Tag { get; set; }
+
+    // Matches LineRectangle's Wrap: the fill pass's single-pixel UV stays within [0,1] regardless
+    // (wrap vs. clamp is irrelevant there), but the stroke pass's LinePrimitive can source a
+    // texture-repeat rectangle wider than the underlying texture (see LinePrimitive.Render), which
+    // needs wrap addressing to sample correctly.
+    /// <inheritdoc/>
+    public bool Wrap => true;
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Creates a new instance with no <see cref="SystemManagers"/>, resolving one from
+    /// <see cref="SystemManagers.Default"/> at construction time.
+    /// </summary>
+    public FilledStrokedRectangle() : this(null) { }
+
+    /// <summary>
+    /// Creates a new instance using the given <paramref name="managers"/>, or
+    /// <see cref="SystemManagers.Default"/> when <c>null</c>.
+    /// </summary>
+    public FilledStrokedRectangle(SystemManagers? managers)
+    {
+        mManagers = managers;
+        mChildren = new();
+        Visible = true;
+        _fillColor = Color.White;
+        _strokeColor = Color.White;
+        _strokeWidth = 1;
+
+        Renderer? renderer = mManagers != null
+            ? mManagers.Renderer
+            : SystemManagers.Default?.Renderer;
+
+        mLinePrimitive = new LinePrimitive(renderer?.TryGetSinglePixelTexture());
+        mLinePrimitive.Add(0, 0);
+        mLinePrimitive.Add(0, 0);
+        mLinePrimitive.Add(0, 0);
+        mLinePrimitive.Add(0, 0);
+        mLinePrimitive.Add(0, 0);
+        mLinePrimitive.Color = _strokeColor;
+        mLinePrimitive.LinePixelWidth = _strokeWidth;
+
+        UpdatePoints();
+    }
+
+    private void UpdatePoints() => LineRectangle.UpdateLinePrimitive(mLinePrimitive, this);
+
+    /// <inheritdoc/>
+    public override void Render(ISystemManagers managers)
+    {
+        var systemManagers = managers as SystemManagers;
+        Renderer renderer = systemManagers?.Renderer ?? Renderer.Self;
+
+        if (IsFilled && Width > 0 && Height > 0)
+        {
+            var texture = renderer.SinglePixelTexture;
+            var sourceRectangle = renderer.SinglePixelSourceRectangle;
+            var rotation = this.GetAbsoluteRotation(ignoreParentRotationIfRenderTarget: true);
+
+            // managers is always a real SystemManagers when Render is invoked by the actual
+            // renderer -- same assumption SolidRectangle/LineRectangle's own Render() methods make.
+            Sprite.Render(systemManagers!, renderer.SpriteRenderer, this, texture, FillColor,
+                sourceRectangle, flipVertical: false, rotationInDegrees: rotation);
+        }
+
+        if (StrokeWidth > 0)
+        {
+            LineRectangle.RenderLinePrimitive(mLinePrimitive, renderer.SpriteRenderer, this,
+                systemManagers!, isDotted: false);
+        }
+    }
+
+    void IRenderableIpso.SetParentDirect(IRenderableIpso? parent) => mParent = parent;
+
+    void IRenderable.PreRender() { }
+
+    #region IVisible Members
+
+    /// <inheritdoc/>
+    public bool Visible { get; set; }
+
+    /// <inheritdoc/>
+    public bool AbsoluteVisible => ((IVisible)this).GetAbsoluteVisible();
+
+    IVisible? IVisible.Parent => ((IRenderableIpso)this).Parent as IVisible;
+
+    #endregion
+
+    /// <inheritdoc/>
+    public override string ToString() => Name + " (FilledStrokedRectangle)";
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Adds `RenderingLibrary.Math.Geometry.FilledStrokedRectangle` — a flat `IRenderableIpso` that draws fill and stroke in one `Render()` call, gated independently (`IsFilled` for fill, `StrokeWidth > 0` for stroke, neither hides the other). Built for FlatRedBall's Glue codegen, which emits one flat contained field per standard element and can't adopt `RectangleRuntime`'s two-slot `GraphicalUiElement` composite.

Reuses the existing draw techniques directly — `Sprite.Render` for fill, `LineRectangle.RenderLinePrimitive`/`UpdateLinePrimitive` for stroke (both already static and generic over any `IRenderableIpso`) — instead of reimplementing either, so a fix to either draw path never needs hand-mirroring into a third place.

`RectangleRuntime`'s XNALIKE two-slot composite is unchanged — it's still needed so the optional `MonoGameGumShapes` package can swap in richer per-slot renderables (gradient/dropshadow/rounded corners). This new type is scoped to plain square-corner fill + stroke only, matching the issue.

Wiring FRB's `StandardsCodeGenerator` to actually use this type is tracked separately in the FlatRedBall repo (#1907/#1967).

## Test plan
- [x] New unit tests in `MonoGameGum.Tests/RenderingLibraries/Math/Geometry/FilledStrokedRectangleTests.cs` (defaults, independent fill/stroke gating, parent/children, alpha)
- [x] Full `MonoGameGum.Tests` suite green (2142/2142)
- [x] `KniGum` builds clean, no new warnings
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`, net6.0 + net8.0): 0 errors, matches baseline

Manual test: not needed — this is a new, standalone renderable type not wired into any existing runtime path (MonoGameGum's `RectangleRuntime` is untouched); correctness is covered by unit tests + the FRB canary compile.

Closes #4341
