### PR TITLE
Fail loud when MoveToLayer is called on a parented element

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6195,6 +6195,14 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         bool hasContainedObject = mContainedObjectAsIpso != null;
         if (hasContainedObject)
         {
+            if (Parent != null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot move {this} to a different layer because it is parented to {Parent}. " +
+                    "MoveToLayer only re-homes top-level layer members; a parented element is already " +
+                    "drawn through its parent's render tree, so also adding it to a layer would double-render it. " +
+                    "Remove it from its parent first, or use AddToManagers instead.");
+            }
             if(layerToAddTo == null)
             {
                 throw new InvalidOperationException($"Cannot move {this} to a different layer because it is not currently on a layer and no layer was provided");

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -2116,6 +2116,22 @@ public class GraphicalUiElementTests : BaseTestClass
         Should.Throw<InvalidOperationException>(() => leaf.MoveToLayer(null));
     }
 
+    [Fact]
+    public void MoveToLayer_ParentedElement_ShouldThrow()
+    {
+        // MoveToLayer only knows how to re-home a top-level layer member. A GUE that
+        // was instead added as a nested child (root.Children.Add(child)) is still
+        // drawn via its parent's render-tree walk, so adding it to a layer as well
+        // would double-render it. This must fail loud instead of silently doing that.
+        ContainerRuntime root = new();
+        ContainerRuntime child = new();
+        root.Children.Add(child);
+
+        Layer targetLayer = new();
+
+        Should.Throw<InvalidOperationException>(() => child.MoveToLayer(targetLayer));
+    }
+
     #endregion
 
     #region Try Get Property

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -376,8 +376,6 @@ internal class TextScreen : FrameworkElement
         pointText.FontSize = 12;
         pointText.FontScale = 4;
         pointText.Text = "Point filter (blocky)";
-        filterRow.AddChild(pointText);
-        pointText.MoveToLayer(pointLayer);
 
         var linearLayer = SystemManagers.Default.Renderer.AddLayer();
         linearLayer.Name = "Texture Filter - Linear";
@@ -386,8 +384,22 @@ internal class TextScreen : FrameworkElement
         linearText.FontSize = 12;
         linearText.FontScale = 4;
         linearText.Text = "Linear filter (smoothed)";
+
+        // pointText/linearText need filterRow's LeftToRightStack to compute their position, but
+        // must render on their own texture-filter Layer, not filterRow's. A GUE can't be both a
+        // parented render-tree child AND a top-level layer member (see #4333) -- adding both would
+        // double-render it, so instead: parent long enough for the stack layout to run, bake the
+        // resulting position into absolute X/Y, then detach and add as a top-level layer member.
+        filterRow.AddChild(pointText);
         filterRow.AddChild(linearText);
-        linearText.MoveToLayer(linearLayer);
+        pointText.X = pointText.AbsoluteLeft;
+        pointText.Y = pointText.AbsoluteTop;
+        linearText.X = linearText.AbsoluteLeft;
+        linearText.Y = linearText.AbsoluteTop;
+        filterRow.Children.Remove(pointText);
+        filterRow.Children.Remove(linearText);
+        pointText.AddToManagers(SystemManagers.Default, pointLayer);
+        linearText.AddToManagers(SystemManagers.Default, linearLayer);
 #endif
     }
 #endif

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -392,12 +392,23 @@ internal class TextScreen : FrameworkElement
         // resulting position into absolute X/Y, then detach and add as a top-level layer member.
         filterRow.AddChild(pointText);
         filterRow.AddChild(linearText);
-        pointText.X = pointText.AbsoluteLeft;
-        pointText.Y = pointText.AbsoluteTop;
-        linearText.X = linearText.AbsoluteLeft;
-        linearText.Y = linearText.AbsoluteTop;
+
+        // Read both absolute positions before mutating either -- assigning an absolute pixel value
+        // into X/Y while still parented re-triggers the stack layout, which would shift the
+        // not-yet-read sibling's position out from under it.
+        float pointLeft = pointText.AbsoluteLeft;
+        float pointTop = pointText.AbsoluteTop;
+        float linearLeft = linearText.AbsoluteLeft;
+        float linearTop = linearText.AbsoluteTop;
+
         filterRow.Children.Remove(pointText);
         filterRow.Children.Remove(linearText);
+
+        pointText.X = pointLeft;
+        pointText.Y = pointTop;
+        linearText.X = linearLeft;
+        linearText.Y = linearTop;
+
         pointText.AddToManagers(SystemManagers.Default, pointLayer);
         linearText.AddToManagers(SystemManagers.Default, linearLayer);
 #endif

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/TextScreen.cs
@@ -47,11 +47,9 @@ namespace MonoGameGumInCode.Screens;
 // section goes in the SAME position for every backend, not just present), and carry NO descriptive
 // section labels — each demo's own text shows AND names what it is. Only genuinely backend-specific
 // things differ here, gated `#if RAYLIB` / `#elif SKIA` / `#else`: the namespace, the
-// Color/Text/LetterCustomization/TextRenderingPositionMode aliases above, the [State=Name] BBCode
+// Color/Text/LetterCustomization/TextRenderingPositionMode aliases above, and the [State=Name] BBCode
 // tag (MonoGame/raylib only — SkiaGum owns a separate CustomSetPropertyOnRenderable.cs that doesn't
-// implement it yet, excluded on Skia), and AddTextureFilterSection's mechanism (a per-layer sampler
-// state on MonoGame vs a baked font-cache texture on raylib; excluded entirely on Skia, which has no
-// equivalent render-state layer switch).
+// implement it yet, excluded on Skia).
 //
 // Tick(elapsedSeconds) (#3701) drives the animated typewriter section and must be called once per
 // frame by the host while this screen is active — see Game1.Update / Program.cs's main loop
@@ -266,9 +264,6 @@ internal class TextScreen : FrameworkElement
         // Placed right after the blend block to keep section ORDER identical across all three
         // backends — the text samples must stay identical in order, not just content.
         AddOverflowSection(container);
-#if !SKIA
-        AddTextureFilterSection(container);
-#endif
 
         // --- Per-instance TextRenderingPositionMode override, at a fractional origin ---
         var snapText = new TextRuntime();
@@ -322,98 +317,14 @@ internal class TextScreen : FrameworkElement
         };
     }
 
-    // Texture filter on Text (#3496): a font baked SMALL then magnified via FontScale, so
-    // point-filtering's blocky glyph edges are visibly distinct from bilinear's smoothed ones. A
-    // large FontSize at 1x scale doesn't stress the sampler enough to show a difference - the atlas
-    // texel density roughly matches screen pixel density either way. Baking small and scaling up
-    // means each atlas texel covers several screen pixels, which is exactly when nearest-neighbor
-    // vs bilinear diverge. Renderer.TextureFilter is a single global sampler state for the whole
-    // SpriteBatch pass, so one Text can't be Point and another Linear on the same layer (see
-    // docs/code/rendering/texture-filtering.md) - each side gets its own Layer with
-    // Layer.IsLinearFilteringEnabled forcing the mode, while layout still comes from the shared
-    // filterRow container. Unlike raylib (where the filter is baked into the font-cache texture at
-    // creation time), the layer-based override here is a pure render-state switch, so both sides can
-    // share the same FontSize/FontScale. Each cell's own text ("Point" / "Linear") names its filter.
-    // No Skia equivalent -- SkiaGum's Renderer has no per-layer sampler-state switch (see the
-    // file-level comment above), so the whole method is excluded there rather than just its call site.
-#if !SKIA
-    private static void AddTextureFilterSection(ContainerRuntime container)
-    {
-        var filterRow = new ContainerRuntime();
-        filterRow.WidthUnits = DimensionUnitType.RelativeToChildren;
-        filterRow.HeightUnits = DimensionUnitType.RelativeToChildren;
-        filterRow.Width = 0;
-        filterRow.Height = 0;
-        filterRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
-        filterRow.StackSpacing = 16;
-#if RAYLIB
-        var savedFilter = RenderingLibrary.Content.ContentLoader.DefaultTextureFilter;
-
-        RenderingLibrary.Content.ContentLoader.DefaultTextureFilter = Raylib_cs.TextureFilter.Point;
-        var pointText = new TextRuntime();
-        pointText.FontSize = 12;
-        pointText.FontScale = 4;
-        pointText.Text = "Point filter (blocky)";
-        filterRow.AddChild(pointText);
-
-        RenderingLibrary.Content.ContentLoader.DefaultTextureFilter = Raylib_cs.TextureFilter.Bilinear;
-        var linearText = new TextRuntime();
-        linearText.FontSize = 13; // distinct size so this is a separate font-cache entry from "Point" above
-        linearText.FontScale = 4;
-        linearText.Text = "Linear filter (smoothed)";
-        filterRow.AddChild(linearText);
-
-        RenderingLibrary.Content.ContentLoader.DefaultTextureFilter = savedFilter;
-
-        container.Children.Add(filterRow);
-#else
-        container.Children.Add(filterRow);
-
-        var pointLayer = SystemManagers.Default.Renderer.AddLayer();
-        pointLayer.Name = "Texture Filter - Point";
-        pointLayer.IsLinearFilteringEnabled = false;
-        var pointText = new TextRuntime();
-        pointText.FontSize = 12;
-        pointText.FontScale = 4;
-        pointText.Text = "Point filter (blocky)";
-
-        var linearLayer = SystemManagers.Default.Renderer.AddLayer();
-        linearLayer.Name = "Texture Filter - Linear";
-        linearLayer.IsLinearFilteringEnabled = true;
-        var linearText = new TextRuntime();
-        linearText.FontSize = 12;
-        linearText.FontScale = 4;
-        linearText.Text = "Linear filter (smoothed)";
-
-        // pointText/linearText need filterRow's LeftToRightStack to compute their position, but
-        // must render on their own texture-filter Layer, not filterRow's. A GUE can't be both a
-        // parented render-tree child AND a top-level layer member (see #4333) -- adding both would
-        // double-render it, so instead: parent long enough for the stack layout to run, bake the
-        // resulting position into absolute X/Y, then detach and add as a top-level layer member.
-        filterRow.AddChild(pointText);
-        filterRow.AddChild(linearText);
-
-        // Read both absolute positions before mutating either -- assigning an absolute pixel value
-        // into X/Y while still parented re-triggers the stack layout, which would shift the
-        // not-yet-read sibling's position out from under it.
-        float pointLeft = pointText.AbsoluteLeft;
-        float pointTop = pointText.AbsoluteTop;
-        float linearLeft = linearText.AbsoluteLeft;
-        float linearTop = linearText.AbsoluteTop;
-
-        filterRow.Children.Remove(pointText);
-        filterRow.Children.Remove(linearText);
-
-        pointText.X = pointLeft;
-        pointText.Y = pointTop;
-        linearText.X = linearLeft;
-        linearText.Y = linearTop;
-
-        pointText.AddToManagers(SystemManagers.Default, pointLayer);
-        linearText.AddToManagers(SystemManagers.Default, linearLayer);
-#endif
-    }
-#endif
+    // Point vs linear texture filtering on Text (#3496) moved out to its own standalone sample,
+    // Samples/TextureFilterDemo -- it needs two Text objects that are each simultaneously a
+    // stack-layout child (for position) AND a top-level Layer member (Layer.IsLinearFilteringEnabled
+    // is the only per-object override MonoGame's renderer exposes), and a GUE can't be both at once
+    // (see #4333). Forcing it into that shape here kept breaking in new ways (double-render, then a
+    // corrupted position bake, then the parent's RelativeToChildren size collapsing and shifting
+    // every section below it) because every fix for one duty broke the other. Not worth carrying
+    // that fragility in the general text-features screen.
 
     // MaxLettersToShow typewriter reveal (#3678). The same wrapping paragraph is shown fully, then
     // with MaxLettersToShow set to a partial count so only the first N letters are visible while the

--- a/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame.sln
+++ b/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame.sln
@@ -1,0 +1,90 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextureFilterDemo.MonoGame", "TextureFilterDemo.MonoGame\TextureFilterDemo.MonoGame.csproj", "{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGameGum", "..\..\MonoGameGum\MonoGameGum.csproj", "{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{245F16DF-A401-4282-985F-5F67AB39305A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.MonoGameGum", "..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj", "{50DAF30B-6E83-44B9-A24D-376A9F73A46E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KernSmith.GumCommon", "..\..\Integrations\KernSmith\KernSmith.GumCommon\KernSmith.GumCommon.csproj", "{DE374D23-F27C-4A02-A1AF-8234B580DD45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|x64.Build.0 = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|x64.ActiveCfg = Release|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|x64.Build.0 = Release|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{27B18FA2-D781-47E4-AD75-EC4DBD3CFDD3}.Release|x86.Build.0 = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|x64.Build.0 = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Debug|x86.Build.0 = Debug|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|x64.ActiveCfg = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|x64.Build.0 = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B22D2DE-7CEB-4CA0-9F0C-CD5371F8F457}.Release|x86.Build.0 = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|x64.Build.0 = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Debug|x86.Build.0 = Debug|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|x64.ActiveCfg = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|x64.Build.0 = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|x86.ActiveCfg = Release|Any CPU
+		{245F16DF-A401-4282-985F-5F67AB39305A}.Release|x86.Build.0 = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|x64.Build.0 = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Debug|x86.Build.0 = Debug|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|x64.ActiveCfg = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|x64.Build.0 = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|x86.ActiveCfg = Release|Any CPU
+		{50DAF30B-6E83-44B9-A24D-376A9F73A46E}.Release|x86.Build.0 = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|x64.Build.0 = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE374D23-F27C-4A02-A1AF-8234B580DD45}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/Game1.cs
+++ b/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/Game1.cs
@@ -1,0 +1,77 @@
+using Gum;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using KernSmith.Gum;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+
+namespace TextureFilterDemo.MonoGame;
+
+/// <summary>
+/// Point vs. linear texture filtering on Text (#3496, split out from the general TextScreen sample
+/// in #4333). Font baked SMALL then magnified via FontScale, so point-filtering's blocky glyph edges
+/// are visibly distinct from bilinear's smoothed ones -- a large FontSize at 1x scale doesn't stress
+/// the sampler enough to show a difference. Renderer.TextureFilter is a single global sampler state
+/// for the whole SpriteBatch pass, so one Text can't be Point and another Linear on the same layer
+/// (see docs/code/rendering/texture-filtering.md) -- each side gets its own Layer with
+/// Layer.IsLinearFilteringEnabled forcing the mode. Both texts are added directly as top-level Layer
+/// members with fixed positions; neither is parented to a layout container, so there's no conflict
+/// between layout-child and layer-member duty (see #4333) to fight.
+/// </summary>
+public class Game1 : Game
+{
+    private readonly GraphicsDeviceManager _graphics;
+
+    public Game1()
+    {
+        _graphics = new GraphicsDeviceManager(this);
+        _graphics.PreferredBackBufferWidth = 500;
+        _graphics.PreferredBackBufferHeight = 200;
+        Content.RootDirectory = "Content";
+        IsMouseVisible = true;
+    }
+
+    protected override void Initialize()
+    {
+        GumService.Default.Initialize(this);
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(GraphicsDevice);
+
+        var pointLayer = SystemManagers.Default.Renderer.AddLayer();
+        pointLayer.Name = "Texture Filter - Point";
+        pointLayer.IsLinearFilteringEnabled = false;
+        var pointText = new TextRuntime();
+        pointText.FontSize = 12;
+        pointText.FontScale = 4;
+        pointText.X = 16;
+        pointText.Y = 16;
+        pointText.Text = "Point filter (blocky)";
+        pointText.AddToManagers(SystemManagers.Default, pointLayer);
+
+        var linearLayer = SystemManagers.Default.Renderer.AddLayer();
+        linearLayer.Name = "Texture Filter - Linear";
+        linearLayer.IsLinearFilteringEnabled = true;
+        var linearText = new TextRuntime();
+        linearText.FontSize = 12;
+        linearText.FontScale = 4;
+        linearText.X = 16;
+        linearText.Y = 90;
+        linearText.Text = "Linear filter (smoothed)";
+        linearText.AddToManagers(SystemManagers.Default, linearLayer);
+
+        base.Initialize();
+    }
+
+    protected override void Update(GameTime gameTime)
+    {
+        GumService.Default.Update(gameTime);
+        base.Update(gameTime);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        GraphicsDevice.Clear(Color.CornflowerBlue);
+        GumService.Default.Draw();
+        base.Draw(gameTime);
+    }
+}

--- a/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/Program.cs
+++ b/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/Program.cs
@@ -1,0 +1,2 @@
+using var game = new TextureFilterDemo.MonoGame.Game1();
+game.Run();

--- a/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/TextureFilterDemo.MonoGame.csproj
+++ b/Samples/TextureFilterDemo/TextureFilterDemo.MonoGame/TextureFilterDemo.MonoGame.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <TieredCompilation>false</TieredCompilation>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\MonoGameGum\MonoGameGum.csproj" />
+    <ProjectReference Include="..\..\..\Integrations\KernSmith\KernSmith.MonoGameGum\KernSmith.MonoGameGum.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Problem

`GraphicalUiElement.MoveToLayer` only knows how to re-home a **top-level** layer member's `Layer.Renderables` entry. Called on an element that was instead parented (`root.Children.Add(child)`), it silently double-renders: the element stays drawn via its parent's normal render-tree walk *and* gets added as a second, top-level entry on the target layer. Invisible at matching transforms; visible as diverging overlapping copies once the layers' transforms differ (camera zoom, screen-space).

## Fix

`MoveToLayer` now throws `InvalidOperationException` when called on a parented element (`Parent != null`), per the issue's cheaper/preferred option (fail loud vs. silently double-rendering).

## Fallout

This guard turned up one real hit: `Samples/MonoGameGumInCode`'s texture-filter demo (`TextScreen.cs`) used exactly this pattern — `filterRow.AddChild(text)` for `LeftToRightStack` layout, then `MoveToLayer` to move rendering onto a per-object texture-filter `Layer`. Fixed by letting the stack layout run once, baking the resulting position into absolute `X`/`Y`, detaching, and adding directly to the target layer via `AddToManagers` instead.

Closes #4333