### PR TITLE
Bump GumSyntaxVersion to 4 for FilledStrokedRectangle, stamp FRB's GumCore.* assemblies

### DIFF
--- a/GumCommon/AssemblyAttributes.cs
+++ b/GumCommon/AssemblyAttributes.cs
@@ -11,4 +11,4 @@ using Gum.DataTypes;
 //
 // The version history is maintained in one place — see:
 // https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
-[assembly: GumSyntaxVersion(Version = 3)]
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/GumCore/GumCoreXnaPc/AssemblyAttributes.cs
+++ b/GumCore/GumCoreXnaPc/AssemblyAttributes.cs
@@ -1,0 +1,16 @@
+using Gum.DataTypes;
+
+// Gum runtime syntax version — an assembly-level integer the Gum tool's code generator (and, for
+// these FRB-facing GumCore.* assemblies specifically, FlatRedBall's own Glue codegen) reads to
+// decide which runtime conventions/namespaces/types to emit code against. This is NOT the .gumx
+// project file format version.
+//
+// Shared across every GumCore.* project under GumCoreXnaPc (DesktopGlNet6, FNA, Kni.DesktopGL,
+// Kni.Web, Android, iOS) via an individual <Compile Include> in each .csproj - these projects pull
+// their source from GumCoreShared.projitems/GumCoreShared.FlatRedBall.projitems rather than a
+// single shared project file, so this one file is included the same way rather than introducing a
+// new shared-project mechanism just for one attribute.
+//
+// Keep this value in lock-step with GumCommon/MonoGameGum/RaylibGum/SkiaGum/SilkNetGum's own
+// AssemblyAttributes.cs - see GumDataTypes/GumSyntaxVersionAttribute.cs for the version history.
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.DesktopGlNet6/GumCore.DesktopGlNet6.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -42,6 +42,9 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\..\FlatRedBall\Engines\FlatRedBallXNA\FlatRedBallDesktopGLNet6\FlatRedBallDesktopGLNet6.csproj" />
 		<ProjectReference Include="..\..\..\..\FlatRedBall\Engines\Forms\FlatRedBall.Forms\StateInterpolation\StateInterpolation.DesktopGlNet6\StateInterpolation.DesktopNet6.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\AssemblyAttributes.cs" />
 	</ItemGroup>
 	<Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
 	<Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />

--- a/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.FNA/GumCore.FNA.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -34,6 +34,9 @@
         <PackageReference Include="SharpCompress" Version="0.48.0" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Compile Include="..\AssemblyAttributes.cs" />
+    </ItemGroup>
     <Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
     <Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />
 </Project>

--- a/GumCore/GumCoreXnaPc/GumCore.Kni.DesktopGL/GumCore.Kni.DesktopGL.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.Kni.DesktopGL/GumCore.Kni.DesktopGL.csproj
@@ -9,6 +9,9 @@
 
 	</PropertyGroup>
 
+    <ItemGroup>
+        <Compile Include="..\AssemblyAttributes.cs" />
+    </ItemGroup>
     <Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
     <Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />
     <ItemGroup>

--- a/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
+++ b/GumCore/GumCoreXnaPc/GumCore.Kni.Web/GumCore.Kni.Web.csproj
@@ -20,6 +20,9 @@
 
 	</PropertyGroup>
 
+	<ItemGroup>
+		<Compile Include="..\AssemblyAttributes.cs" />
+	</ItemGroup>
 	<Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
 	<Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />
 	<ItemGroup>

--- a/GumCore/GumCoreXnaPc/GumCoreAndroid/GumCoreAndroid.csproj
+++ b/GumCore/GumCoreXnaPc/GumCoreAndroid/GumCoreAndroid.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0-android</TargetFramework>
@@ -17,6 +17,9 @@
 		<DefineConstants>$(DefineConstants);MONOGAME;FRB</DefineConstants>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<Compile Include="..\AssemblyAttributes.cs" />
+	</ItemGroup>
 	<Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
 
 	<Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />

--- a/GumCore/GumCoreXnaPc/GumCoreiOS/GumCoreiOS.csproj
+++ b/GumCore/GumCoreXnaPc/GumCoreiOS/GumCoreiOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0-ios</TargetFramework>
@@ -27,6 +27,9 @@
 		<PackageReference Include="SharpCompress" Version="0.48.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Compile Include="..\AssemblyAttributes.cs" />
+	</ItemGroup>
 	<Import Project="..\..\..\GumCoreShared.projitems" Label="Shared" />
 
 	<Import Project="..\..\..\..\FlatRedBall\FRBDK\Glue\GumPlugin\GumPlugin\GumCoreShared.FlatRedBall.projitems" Label="Shared" />

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\FontGeneratorType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\GuideRectangle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\GumProjectSave.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\GumSyntaxVersionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\IInstanceContainer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\InstanceSave.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GumDataTypes\IStateContainer.cs" />

--- a/GumDataTypes/GumSyntaxVersionAttribute.cs
+++ b/GumDataTypes/GumSyntaxVersionAttribute.cs
@@ -29,6 +29,11 @@ public class GumSyntaxVersionAttribute : Attribute
     /// Version 2 collapses <c>ColoredCircleRuntime</c>/<c>ColoredRectangleRuntime</c>/<c>RoundedRectangleRuntime</c>
     /// into <c>CircleRuntime</c>/<c>RectangleRuntime</c> and exposes <c>FillColor</c>,
     /// <c>StrokeColor</c>, and <c>StrokeWidth</c> on them. See PR #2769 / issue #2768.
+    /// Version 3 unifies the <c>GumService</c> namespace (<c>GumService</c>/<c>WindowZoomMode</c> move
+    /// under <c>Gum</c>, <c>AddToRoot</c> becomes an instance method). See PR #3122 / issue #3119.
+    /// Version 4 adds <c>RenderingLibrary.Math.Geometry.FilledStrokedRectangle</c>, the flat fill+stroke
+    /// renderable FlatRedBall's Glue codegen backs a v3 (gumx <c>ShapeVariableExpansion</c>) Rectangle
+    /// with. See PR #4342 / issue #4341.
     /// </summary>
     public int Version;
 }

--- a/MonoGameGum/AssemblyAttributes.cs
+++ b/MonoGameGum/AssemblyAttributes.cs
@@ -11,4 +11,4 @@ using Gum.DataTypes;
 //
 // The version history is maintained in one place — see:
 // https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
-[assembly: GumSyntaxVersion(Version = 3)]
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/Runtimes/RaylibGum/AssemblyAttributes.cs
+++ b/Runtimes/RaylibGum/AssemblyAttributes.cs
@@ -16,4 +16,4 @@ using System.Runtime.CompilerServices;
 //
 // The version history is maintained in one place — see:
 // https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
-[assembly: GumSyntaxVersion(Version = 3)]
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/Runtimes/SilkNetGum/AssemblyAttributes.cs
+++ b/Runtimes/SilkNetGum/AssemblyAttributes.cs
@@ -7,4 +7,4 @@ using System.Runtime.CompilerServices;
 // decide which runtime conventions/namespaces to emit code against. Kept in lock step with the
 // other runtime assemblies (GumCommon, MonoGameGum, RaylibGum, SkiaGum, SokolGum). See:
 // https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
-[assembly: GumSyntaxVersion(Version = 3)]
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/Runtimes/SkiaGum/AssemblyAttributes.cs
+++ b/Runtimes/SkiaGum/AssemblyAttributes.cs
@@ -11,4 +11,4 @@ using Gum.DataTypes;
 //
 // The version history is maintained in one place — see:
 // https://docs.flatredball.com/gum/gum-tool/upgrading/syntax-versions
-[assembly: GumSyntaxVersion(Version = 3)]
+[assembly: GumSyntaxVersion(Version = 4)]

--- a/Tests/Gum.ProjectServices.Tests/SyntaxVersionDetectionServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/SyntaxVersionDetectionServiceTests.cs
@@ -561,7 +561,7 @@ public class SyntaxVersionDetectionServiceTests : IDisposable
         SyntaxVersionResult result = sut.Detect(settings, gameDir);
 
         result.Source.ShouldBe(SyntaxVersionSource.NuGetPackage);
-        result.Version.ShouldBe(3);
+        result.Version.ShouldBe(4);
     }
 
     [Fact]


### PR DESCRIPTION
Bumps `GumSyntaxVersion` to 4 for `FilledStrokedRectangle` support, and stamps it on FRB's `GumCore.*` assemblies (they never carried the attribute before).

Lets FlatRedBall's Glue detect a referenced `GumCore.*.dll` that's too old for a v3 Rectangle project and error at Glue-time instead of NREing at runtime (`ContainedRectangle` null in `SetInitialState`, when the referenced assembly predates `FilledStrokedRectangle`).

Related: vchelaru/FlatRedBall#1967, vchelaru/FlatRedBall#1968
