### PR TITLE
Resolve JSON-format extensions in pack, CopyLocally, and conflict-marker detection

### DIFF
--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -65,6 +65,11 @@ public class GumProjectDependencyWalker
         // scan of Screens/Components/StandardElements per call, so the walk's cost scales with
         // project size squared. EnableCache/DisableCache is reference-counted, so this composes
         // safely with an already-active cache from an outer caller.
+        // The single source of truth for "is this project JSON or XML formatted" (see
+        // GumProjectSave.IsJsonFormat) - element/behavior core files must resolve against the
+        // project's actual on-disk format, not always the XML extensions (#4345).
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(project.FullFileName ?? string.Empty);
+
         ObjectFinder.Self.EnableCache();
         try
         {
@@ -72,8 +77,8 @@ public class GumProjectDependencyWalker
             {
                 if (inclusion.HasFlag(GumBundleInclusion.Core))
                 {
-                    CollectCoreFiles(project, projectRootDirectory, core, missing);
-                    CollectInstanceTypeCoreFiles(project, core);
+                    CollectCoreFiles(project, projectRootDirectory, core, missing, isJsonFormat);
+                    CollectInstanceTypeCoreFiles(project, core, isJsonFormat);
                 }
 
                 if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
@@ -89,7 +94,7 @@ public class GumProjectDependencyWalker
             }
             else
             {
-                CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing);
+                CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing, isJsonFormat);
 
                 if (inclusion.HasFlag(GumBundleInclusion.FontCache))
                 {
@@ -119,7 +124,8 @@ public class GumProjectDependencyWalker
         GumProjectSave project,
         string projectRootDirectory,
         HashSet<string> core,
-        List<DependencyWarning> missing)
+        List<DependencyWarning> missing,
+        bool isJsonFormat)
     {
         // .gumx itself — derive from FullFileName when present, else from any single .gumx in the root.
         string? gumxRelative = TryGetGumxRelativePath(project, projectRootDirectory);
@@ -131,21 +137,21 @@ public class GumProjectDependencyWalker
         foreach (ElementReference reference in project.ScreenReferences ?? new List<ElementReference>())
         {
             reference.ElementType = ElementType.Screen;
-            AddElementReference(reference, projectRootDirectory, core, missing);
+            AddElementReference(reference, projectRootDirectory, core, missing, isJsonFormat);
         }
         foreach (ElementReference reference in project.ComponentReferences ?? new List<ElementReference>())
         {
             reference.ElementType = ElementType.Component;
-            AddElementReference(reference, projectRootDirectory, core, missing);
+            AddElementReference(reference, projectRootDirectory, core, missing, isJsonFormat);
         }
         foreach (ElementReference reference in project.StandardElementReferences ?? new List<ElementReference>())
         {
             reference.ElementType = ElementType.Standard;
-            AddElementReference(reference, projectRootDirectory, core, missing);
+            AddElementReference(reference, projectRootDirectory, core, missing, isJsonFormat);
         }
         foreach (BehaviorReference reference in project.BehaviorReferences ?? new List<BehaviorReference>())
         {
-            string relative = NormalizeRelative(BehaviorReference.Subfolder + "/" + reference.Name + "." + BehaviorReference.Extension);
+            string relative = NormalizeRelative(reference.GetRelativeFilePath(isJsonFormat));
             core.Add(relative);
             string fullPath = Path.Combine(projectRootDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
             if (!File.Exists(fullPath))
@@ -160,9 +166,10 @@ public class GumProjectDependencyWalker
         ElementReference reference,
         string projectRootDirectory,
         HashSet<string> core,
-        List<DependencyWarning> missing)
+        List<DependencyWarning> missing,
+        bool isJsonFormat)
     {
-        string relative = NormalizeRelative(reference.Subfolder + "/" + reference.Name + "." + reference.Extension);
+        string relative = NormalizeRelative(reference.Subfolder + "/" + reference.Name + "." + reference.GetExtension(isJsonFormat));
         core.Add(relative);
         string fullPath = Path.Combine(projectRootDirectory, relative.Replace('/', Path.DirectorySeparatorChar));
         if (!File.Exists(fullPath))
@@ -232,7 +239,7 @@ public class GumProjectDependencyWalker
         }
     }
 
-    private static void CollectInstanceTypeCoreFiles(GumProjectSave project, HashSet<string> core)
+    private static void CollectInstanceTypeCoreFiles(GumProjectSave project, HashSet<string> core, bool isJsonFormat)
     {
         // Mirror the historical ObjectFinder behavior: for every instance, add the .gucx/.gutx
         // file for its BaseType. Projects loaded normally have ComponentReferences/StandardElementReferences
@@ -265,10 +272,20 @@ public class GumProjectDependencyWalker
                     : null;
                 if (subfolder != null)
                 {
-                    core.Add(NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + instanceElement.FileExtension));
+                    core.Add(NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + GetElementExtension(instanceElement, isJsonFormat)));
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Returns <see cref="ElementSave.FileExtension"/> (XML) or its JSON counterpart, matching
+    /// the project's actual format. Same "x"-&gt;"j" convention as <see cref="ElementSave.Save"/>.
+    /// </summary>
+    private static string GetElementExtension(ElementSave element, bool isJsonFormat)
+    {
+        string extension = element.FileExtension;
+        return isJsonFormat ? extension.Substring(0, extension.Length - 1) + "j" : extension;
     }
 
     private static void CollectForSingleElement(
@@ -279,7 +296,8 @@ public class GumProjectDependencyWalker
         HashSet<string> core,
         HashSet<string> fontCache,
         HashSet<string> external,
-        List<DependencyWarning> missing)
+        List<DependencyWarning> missing,
+        bool isJsonFormat)
     {
         bool includeCore = inclusion.HasFlag(GumBundleInclusion.Core);
         bool includeFontCache = inclusion.HasFlag(GumBundleInclusion.FontCache);
@@ -317,7 +335,7 @@ public class GumProjectDependencyWalker
                             : null;
                         if (subfolder != null)
                         {
-                            string relative = NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + instanceElement.FileExtension);
+                            string relative = NormalizeRelative(subfolder + "/" + instanceElement.Name + "." + GetElementExtension(instanceElement, isJsonFormat));
                             core.Add(relative);
                         }
                     }

--- a/GumDataTypes/ElementReference.cs
+++ b/GumDataTypes/ElementReference.cs
@@ -52,6 +52,18 @@ namespace Gum.DataTypes
             }
         }
 
+        /// <summary>
+        /// Returns <see cref="Extension"/> (XML) or its JSON counterpart, matching the project's
+        /// actual format. Every JSON element extension is its XML counterpart with the trailing
+        /// "x" swapped for "j" (gusx-&gt;gusj, gucx-&gt;gucj, gutx-&gt;gutj), the same convention
+        /// used by <see cref="ElementSave.Save"/>.
+        /// </summary>
+        public string GetExtension(bool isJsonFormat)
+        {
+            string extension = Extension;
+            return isJsonFormat ? extension.Substring(0, extension.Length - 1) + "j" : extension;
+        }
+
         public string Subfolder
         {
             get

--- a/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerTests.cs
@@ -142,6 +142,69 @@ public class GumProjectDependencyWalkerTests : IDisposable
     }
 
     [Fact]
+    public void Walk_resolves_JSON_extensions_for_JSON_format_project()
+    {
+        // Regression guard for #4345: a project loaded from a .gumj file must resolve its
+        // element/behavior core files as .gusj/.gucj/.gutj/.behj, not the XML extensions.
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        ComponentSave component = TestProjectBuilder.BuildComponent("Button");
+        StandardElementSave standard = TestProjectBuilder.BuildStandard("Sprite");
+        BehaviorSave behavior = TestProjectBuilder.BuildBehavior("Toggle");
+        GumProjectSave project = TestProjectBuilder.BuildProject(
+            projectName: "JsonProject",
+            screens: new[] { screen },
+            components: new[] { component },
+            standards: new[] { standard },
+            behaviors: new[] { behavior });
+        project.FullFileName = "JsonProject." + GumProjectSave.ProjectJsonExtension;
+
+        string root = CreateProjectRoot(new[]
+        {
+            ("JsonProject.gumj", EmptyContent),
+            ("Screens/MainMenu.gusj", EmptyContent),
+            ("Components/Button.gucj", EmptyContent),
+            ("Standards/Sprite.gutj", EmptyContent),
+            ("Behaviors/Toggle.behj", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Screens/MainMenu.gusj");
+        result.CoreFiles.ShouldContain("Components/Button.gucj");
+        result.CoreFiles.ShouldContain("Standards/Sprite.gutj");
+        result.CoreFiles.ShouldContain("Behaviors/Toggle.behj");
+        result.MissingFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Walk_resolves_instance_BaseType_core_file_using_JSON_extension_for_JSON_format_project()
+    {
+        // Regression guard for #4345: CollectInstanceTypeCoreFiles adds the .gucx/.gutx file for
+        // every instance's BaseType - that lookup must also respect the project's JSON format.
+        ComponentSave button = TestProjectBuilder.BuildComponent("Button");
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        InstanceSave instance = new InstanceSave { Name = "MyButton", BaseType = "Button", ParentContainer = screen };
+        screen.Instances.Add(instance);
+        GumProjectSave project = TestProjectBuilder.BuildProject(
+            projectName: "JsonProject",
+            screens: new[] { screen },
+            components: new[] { button });
+        project.FullFileName = "JsonProject." + GumProjectSave.ProjectJsonExtension;
+
+        string root = CreateProjectRoot(new[]
+        {
+            ("JsonProject.gumj", EmptyContent),
+            ("Screens/MainMenu.gusj", EmptyContent),
+            ("Components/Button.gucj", EmptyContent),
+        });
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.Core);
+
+        result.CoreFiles.ShouldContain("Components/Button.gucj");
+        result.MissingFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Walk_normalizes_paths_to_forward_slashes()
     {
         ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");

--- a/Tests/Gum.Cli.Tests/PackCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/PackCommandTests.cs
@@ -199,6 +199,41 @@ public class PackCommandTests : IDisposable
     }
 
     [Fact]
+    public void Pack_resolves_JSON_extensions_for_JSON_format_project()
+    {
+        // Regression guard for #4345: gumcli new -> convert-to-json -> pack must not report every
+        // referenced screen/component/standard/behavior as missing because of a hardcoded XML extension.
+        // "empty" template (not the default "forms" one): forms pulls in SourcePath-linked
+        // behaviors that are only staged via `gumcli stage-forms-behaviors`, which is an
+        // unrelated, pre-existing gap - not part of this JSON-extension regression.
+        string projectDir = Path.Combine(_tempDirectory, "JsonProject");
+        string projectPath = Path.Combine(projectDir, "JsonProject.gumx");
+        CliTestHelper.Run("new", projectPath, "--template", "empty").ExitCode.ShouldBe(0);
+        CliTestHelper.Run("convert-to-json", projectPath).ExitCode.ShouldBe(0);
+        string gumjPath = Path.Combine(projectDir, "JsonProject.gumj");
+        string outputPath = Path.Combine(projectDir, "out.gumpkg");
+
+        // convert-to-json writes JSON siblings without touching the XML originals, so a converted
+        // project has both on disk. Delete the XML originals to reproduce a real JSON-only project
+        // (e.g. one where the user removed the XML after converting) - otherwise the old, broken
+        // extension resolution would silently succeed by finding the XML sibling instead.
+        string[] xmlExtensions = { "gumx", "gusx", "gucx", "gutx", "behx", "ganx" };
+        foreach (string xmlFile in Directory.EnumerateFiles(projectDir, "*.*", SearchOption.AllDirectories)
+                     .Where(f => xmlExtensions.Contains(Path.GetExtension(f).TrimStart('.'), StringComparer.OrdinalIgnoreCase)))
+        {
+            File.Delete(xmlFile);
+        }
+
+        CliTestHelper result = CliTestHelper.Run("pack", gumjPath, "-o", outputPath, "--include", "core");
+
+        result.StandardError.ShouldNotContain("missing:");
+        result.ExitCode.ShouldBe(0);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldContain("JsonProject.gumj");
+        entries.Keys.Any(k => k.EndsWith(".gutj")).ShouldBeTrue();
+    }
+
+    [Fact]
     public void Pack_writes_output_to_default_path_when_no_dash_o()
     {
         string projectPath = CreateCleanProject("DefaultOut");

--- a/Tests/Gum.Presentation.Tests/ProjectManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectManagerTests.cs
@@ -243,6 +243,45 @@ public class ProjectManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void CopyLinkedComponents_UsesJsonExtension_WhenProjectIsJsonFormat()
+    {
+        // Regression guard for #4345: CopyLocally destinations must resolve against the project's
+        // actual format, not always the XML extension (ElementReference.Extension is XML-only).
+        string tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "GumProjectManagerTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        Directory.CreateDirectory(Path.Combine(tempDirectory, "Components"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDirectory, "Source.gucj"), "json source contents");
+
+            GumProjectSave project = new GumProjectSave
+            {
+                FullFileName = Path.Combine(tempDirectory, "Project.gumj")
+            };
+            project.ComponentReferences.Add(new ElementReference
+            {
+                ElementType = ElementType.Component,
+                LinkType = LinkType.CopyLocally,
+                Name = "Copied",
+                Link = "Source.gucj"
+            });
+
+            _projectManager.CopyLinkedComponents(project);
+
+            string destination = Path.Combine(tempDirectory, "Components", "Copied.gucj");
+            File.Exists(destination).ShouldBeTrue();
+            File.ReadAllText(destination).ShouldBe("json source contents");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void CopyLinkedComponents_PrintsError_WhenSourceFileIsMissing()
     {
         string tempDirectory = Path.Combine(

--- a/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ProjectLoaderTests.cs
@@ -1,5 +1,8 @@
 using Gum.DataTypes;
+using Gum.Logic.FileWatch;
+using Gum.Managers;
 using Gum.ProjectServices;
+using Moq;
 using Shouldly;
 
 namespace Gum.ProjectServices.Tests;
@@ -563,6 +566,57 @@ public class ProjectLoaderTests
             result.LoadErrors.ShouldNotContain(e => e.ElementName == "GoodComponent");
 
             // The conflicted element gets a clear, dedicated conflict-marker error.
+            result.LoadErrors.ShouldContain(e =>
+                e.ElementName == "ConflictComponent" &&
+                e.Severity == ErrorSeverity.Error &&
+                e.Message.Contains("conflict marker"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_ShouldReportError_WhenJsonElementFileContainsGitConflictMarkers()
+    {
+        // Regression guard for #4345: conflict-marker detection must resolve against a JSON-format
+        // project's actual .gucj/.gusj/.gutj/.behj files, not just their XML counterparts.
+        string tempDir = Path.Combine(Path.GetTempPath(), "GumLoaderTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string gumxPath = Path.Combine(tempDir, "Test.gumx");
+        try
+        {
+            ProjectCreator creator = new ProjectCreator();
+            creator.Create(gumxPath);
+
+            string componentDir = Path.Combine(tempDir, "Components");
+            File.WriteAllText(Path.Combine(componentDir, "ConflictComponent.gucx"), """
+                <?xml version="1.0" encoding="utf-8"?>
+                <ComponentSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <Name>ConflictComponent</Name>
+                  <BaseType>Container</BaseType>
+                </ComponentSave>
+                """);
+
+            string gumxContent = File.ReadAllText(gumxPath);
+            gumxContent = gumxContent.Replace("</GumProjectSave>",
+                """  <ComponentReference Name="ConflictComponent" />""" + "\n</GumProjectSave>");
+            File.WriteAllText(gumxPath, gumxContent);
+
+            StandardElementsManager.Self.Initialize();
+            GumProjectSave project = GumProjectSave.Load(gumxPath, out _)!;
+            project.Initialize();
+            IConvertProjectToJsonService jsonService = new ConvertProjectToJsonService(new Mock<IFileWatchIgnoreList>().Object);
+            ConvertProjectToJsonResult convertResult = jsonService.ConvertToJson(project);
+
+            // Corrupt the JSON sibling with unresolved git conflict markers, mirroring the XML case.
+            string componentJsonPath = Path.Combine(componentDir, "ConflictComponent.gucj");
+            string jsonContent = File.ReadAllText(componentJsonPath);
+            File.WriteAllText(componentJsonPath, "<<<<<<< HEAD\n" + jsonContent + "\n=======\n>>>>>>> other-branch\n");
+
+            ProjectLoadResult result = _sut.Load(convertResult.ProjectFilePath);
+
             result.LoadErrors.ShouldContain(e =>
                 e.ElementName == "ConflictComponent" &&
                 e.Severity == ErrorSeverity.Error &&

--- a/Tools/Gum.Presentation/Managers/ProjectManager.cs
+++ b/Tools/Gum.Presentation/Managers/ProjectManager.cs
@@ -451,6 +451,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
     internal void CopyLinkedComponents(GumProjectSave gumProjectSave)
     {
         var gumDirectory = new FilePath(gumProjectSave.FullFileName).GetDirectoryContainingThis();
+        var isJsonFormat = GumProjectSave.IsJsonFormat(gumProjectSave.FullFileName);
 
         void CopyReference(ElementReference reference)
         {
@@ -458,7 +459,7 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
             {
                 // copy from the original location here
                 var source = gumDirectory.Original + reference.Link;
-                var destination = gumDirectory.Original + reference.Subfolder + "/" + reference.Name + "." + reference.Extension;
+                var destination = gumDirectory.Original + reference.Subfolder + "/" + reference.Name + "." + reference.GetExtension(isJsonFormat);
 
                 try
                 {

--- a/Tools/Gum.ProjectServices/ProjectLoader.cs
+++ b/Tools/Gum.ProjectServices/ProjectLoader.cs
@@ -54,7 +54,7 @@ public class ProjectLoader : IProjectLoader
                 project.Initialize();
 
                 var elementLoadErrors = ParseElementLoadErrors(gumLoadResult.ErrorMessage);
-                var conflictErrors = DetectConflictMarkers(project, projectDirectory);
+                var conflictErrors = DetectConflictMarkers(project, projectDirectory, GumProjectSave.IsJsonFormat(filePath));
 
                 // A conflicted element file is invalid XML, so it ALSO failed to deserialize and
                 // produced a cryptic "Malformed XML" entry via ParseElementLoadErrors. Drop those
@@ -259,7 +259,7 @@ public class ProjectLoader : IProjectLoader
     /// into those lists. Mirrors the per-element error model used by <see cref="DetectSilentlyDroppedContent"/>.
     /// </summary>
     private static List<ErrorResult> DetectConflictMarkers(
-        GumProjectSave project, string projectDirectory)
+        GumProjectSave project, string projectDirectory, bool isJsonFormat)
     {
         var errors = new List<ErrorResult>();
 
@@ -279,19 +279,23 @@ public class ProjectLoader : IProjectLoader
 
         foreach (var reference in project.ScreenReferences)
         {
-            Check(reference.Name, ElementReference.ScreenSubfolder, GumProjectSave.ScreenExtension);
+            Check(reference.Name, ElementReference.ScreenSubfolder,
+                isJsonFormat ? GumProjectSave.ScreenJsonExtension : GumProjectSave.ScreenExtension);
         }
         foreach (var reference in project.ComponentReferences)
         {
-            Check(reference.Name, ElementReference.ComponentSubfolder, GumProjectSave.ComponentExtension);
+            Check(reference.Name, ElementReference.ComponentSubfolder,
+                isJsonFormat ? GumProjectSave.ComponentJsonExtension : GumProjectSave.ComponentExtension);
         }
         foreach (var reference in project.StandardElementReferences)
         {
-            Check(reference.Name, ElementReference.StandardSubfolder, GumProjectSave.StandardExtension);
+            Check(reference.Name, ElementReference.StandardSubfolder,
+                isJsonFormat ? GumProjectSave.StandardJsonExtension : GumProjectSave.StandardExtension);
         }
         foreach (var reference in project.BehaviorReferences)
         {
-            Check(reference.Name, BehaviorReference.Subfolder, BehaviorReference.Extension);
+            Check(reference.Name, BehaviorReference.Subfolder,
+                isJsonFormat ? BehaviorReference.JsonExtension : BehaviorReference.Extension);
         }
 
         return errors;


### PR DESCRIPTION
## Summary
- `gumcli pack` resolved element/behavior files with hardcoded XML extensions regardless of the loaded project's actual format, so a JSON-format project (`.gumj`) reported every screen/component/standard/behavior as missing.
- Audited for the same hardcoded-extension pattern elsewhere and fixed two more: `ProjectManager.CopyLinkedComponents` (tool-side `CopyLocally` file linking) and `ProjectLoader.DetectConflictMarkers` (git-conflict-marker check silently skipped JSON element files).
- Added `ElementReference.GetExtension(bool isJsonFormat)` (mirrors the existing `BehaviorReference.GetRelativeFilePath(bool isJsonFormat)`) and threaded `isJsonFormat` through the walker's core-file resolution, including instance-BaseType core files.

Closes #4345

## Test plan
- [x] New/updated unit tests, all red before the fix, green after (`Gum.Bundle.Tests`, `Gum.Cli.Tests`, `Gum.Presentation.Tests`, `Gum.ProjectServices.Tests`)
- [x] Full relevant suites pass (Bundle 71, Cli 66, Presentation 792, ProjectServices 474)
- [x] `GumFull.sln` builds clean
- [x] FRB canary: pass (`GumCore.DesktopGlNet6.csproj`, 0 errors)
- Manual test: not needed — CLI/headless behavior fully covered by unit tests (including an end-to-end `gumcli new`/`convert-to-json`/`pack` regression test); no tool-UI-visible surface changed.
