### PR TITLE
Fix #4309: measure text against stable design-unit metrics, not the oversampled raster

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2463,12 +2463,6 @@ public partial class CustomSetPropertyOnRenderable
             asText.OversampleCompensationScale = 1f;
         }
         textRuntime.ResetAutomaticOversamplingState();
-        // Issue #4309: wire up the design-metrics measurement font here, at native/nominal font
-        // resolution -- not only once oversampling first activates (RegenerateOversampledFont also
-        // calls this, as a no-op guard once this has already run). A real font's hinted native
-        // BitmapFont measurement and its unhinted design-unit measurement aren't guaranteed to agree,
-        // so deferring this until zoom changes produced a visible jump/shrink at that exact moment.
-        textRuntime.EnsureMeasurementFont();
 #endif
 
         BitmapFont font = null;

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2463,6 +2463,12 @@ public partial class CustomSetPropertyOnRenderable
             asText.OversampleCompensationScale = 1f;
         }
         textRuntime.ResetAutomaticOversamplingState();
+        // Issue #4309: wire up the design-metrics measurement font here, at native/nominal font
+        // resolution -- not only once oversampling first activates (RegenerateOversampledFont also
+        // calls this, as a no-op guard once this has already run). A real font's hinted native
+        // BitmapFont measurement and its unhinted design-unit measurement aren't guaranteed to agree,
+        // so deferring this until zoom changes produced a visible jump/shrink at that exact moment.
+        textRuntime.EnsureMeasurementFont();
 #endif
 
         BitmapFont font = null;

--- a/GumCommon/GumCommon.csproj
+++ b/GumCommon/GumCommon.csproj
@@ -127,6 +127,8 @@
 		<Compile Include="..\Gum\Mvvm\ViewModel.cs" Link="Mvvm\ViewModel.cs" />
 		<Compile Include="..\RenderingLibrary\Content\IContentLoader.cs" Link="Content\IContentLoader.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Fonts\BmfcSave.cs" Link="Content\BmfcSave.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\Fonts\FontDesignMetrics.cs" Link="Content\FontDesignMetrics.cs" />
+		<Compile Include="..\RenderingLibrary\Graphics\Fonts\GlyphDesignMetrics.cs" Link="Content\GlyphDesignMetrics.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Fonts\IRuntimeFontService.cs" Link="Content\IRuntimeFontService.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\Fonts\ParsedFontFile.cs" Link="RenderingLibrary\ParsedFontFile.cs" />
 		<Compile Include="..\RenderingLibrary\Graphics\IAnimatable.cs" Link="RenderingLibrary\IAnimatable.cs" />

--- a/GumCoreShared.projitems
+++ b/GumCoreShared.projitems
@@ -111,6 +111,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\DrawStateSummary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BitmapFont.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\BmfcSave.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\FontDesignMetrics.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\GlyphDesignMetrics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\IInMemoryFontCreator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\Fonts\ParsedFontFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RenderingLibrary\Graphics\GradientType.cs" />

--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -33,6 +33,40 @@ public static class GumFontGenerator
     }
 
     /// <summary>
+    /// Reads this font's unscaled design-unit metrics (issue #4309) without rasterizing any
+    /// glyphs, via <see cref="BmFont.ReadFontInfo(string, int)"/>.
+    /// </summary>
+    /// <returns>
+    /// Null when <paramref name="bmfcSave"/> has no resolvable file path -- KernSmith's
+    /// <c>ReadFontInfo</c> only accepts raw bytes or a file path, unlike <see cref="Generate"/>'s
+    /// <see cref="BmFont.GenerateFromSystem"/> fallback, so a plain system-installed font family
+    /// (the common case, e.g. "Arial") is a known gap: callers must fall back to measuring against
+    /// a rasterized <see cref="RenderingLibrary.Graphics.BitmapFont"/> instead.
+    /// </returns>
+    public static FontDesignMetrics? ReadDesignMetrics(BmfcSave bmfcSave)
+    {
+        if (string.IsNullOrEmpty(bmfcSave.FontFile))
+        {
+            return null;
+        }
+
+        KernSmith.Font.Models.FontInfo fontInfo = BmFont.ReadFontInfo(bmfcSave.FontFile);
+
+        Dictionary<int, GlyphDesignMetrics> glyphMetrics = new(fontInfo.DesignMetrics.Count);
+        foreach (KeyValuePair<int, KernSmith.Font.Models.GlyphDesignMetrics> pair in fontInfo.DesignMetrics)
+        {
+            glyphMetrics[pair.Key] = new GlyphDesignMetrics(pair.Value.AdvanceWidth, pair.Value.LeftSideBearing);
+        }
+
+        return new FontDesignMetrics
+        {
+            UnitsPerEm = fontInfo.UnitsPerEm,
+            LineHeight = fontInfo.LineHeight,
+            GlyphMetrics = glyphMetrics
+        };
+    }
+
+    /// <summary>
     /// Maps a Gum <see cref="BmfcSave"/> to KernSmith <see cref="FontGeneratorOptions"/>.
     /// Exposed publicly so callers can inspect or customize options before generating.
     /// </summary>

--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -58,12 +58,7 @@ public static class GumFontGenerator
             glyphMetrics[pair.Key] = new GlyphDesignMetrics(pair.Value.AdvanceWidth, pair.Value.LeftSideBearing);
         }
 
-        return new FontDesignMetrics
-        {
-            UnitsPerEm = fontInfo.UnitsPerEm,
-            LineHeight = fontInfo.LineHeight,
-            GlyphMetrics = glyphMetrics
-        };
+        return new FontDesignMetrics(fontInfo.UnitsPerEm, fontInfo.LineHeight, glyphMetrics);
     }
 
     /// <summary>

--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.18.2" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.2" />
+    <PackageReference Include="KernSmith" Version="0.20.0" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
@@ -123,4 +123,7 @@ public class KernSmithFontCreator : IInMemoryFontCreator
 
         return bitmapFont;
     }
+
+    /// <inheritdoc/>
+    public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave) => GumFontGenerator.ReadDesignMetrics(bmfcSave);
 }

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -216,6 +217,59 @@ char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xad
         var withNewline = font.MeasureString("a\n");
 
         withoutNewline.ShouldBe(withNewline, "Because a trailing newline should not affect the width of a text, regardless of its XAdavance");
+    }
+
+    [Fact]
+    public void CreateFromDesignMetrics_ScalesDesignUnitsToPixelsByExactMultiplication()
+    {
+        Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
+        {
+            ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 100),
+            ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1200, LeftSideBearing: 50),
+            [' '] = new GlyphDesignMetrics(AdvanceWidth: 500, LeftSideBearing: 0),
+        };
+        FontDesignMetrics designMetrics = new()
+        {
+            UnitsPerEm = 2000,
+            LineHeight = 2400,
+            GlyphMetrics = glyphMetrics
+        };
+
+        BitmapFont font = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 20f)!;
+
+        // scale factor = fontSizeInPixels / UnitsPerEm = 20 / 2000 = 0.01
+        font.LineHeightInPixels.ShouldBe(24, "because 2400 design units * 0.01 = 24");
+        font.GetCharacterInfo('A').XAdvance.ShouldBe(10, "because 1000 design units * 0.01 = 10");
+        font.GetCharacterInfo('B').XAdvance.ShouldBe(12, "because 1200 design units * 0.01 = 12");
+        font.GetCharacterInfo(' ').XAdvance.ShouldBe(5, "because 500 design units * 0.01 = 5");
+    }
+
+    [Fact]
+    public void CreateFromDesignMetrics_TwoDifferentFontSizes_ProduceExactlyProportionalMeasurements()
+    {
+        // The whole point of design-unit metrics (issue #4309): unlike a rasterized BitmapFont
+        // (whose hinted, pixel-snapped advances at two different sizes are NOT exact multiples of
+        // each other), a design-metrics-built font must scale by an EXACT ratio -- measuring "AB"
+        // at size 40 must be precisely 2x measuring it at size 20, every time, with zero jitter.
+        Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
+        {
+            ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1024, LeftSideBearing: 64),
+            ['B'] = new GlyphDesignMetrics(AdvanceWidth: 896, LeftSideBearing: 32),
+        };
+        FontDesignMetrics designMetrics = new()
+        {
+            UnitsPerEm = 2048,
+            LineHeight = 2500,
+            GlyphMetrics = glyphMetrics
+        };
+
+        BitmapFont fontAt20 = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 20f)!;
+        BitmapFont fontAt40 = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 40f)!;
+
+        float widthAt20 = fontAt20.MeasureString("AB");
+        float widthAt40 = fontAt40.MeasureString("AB");
+
+        widthAt40.ShouldBe(widthAt20 * 2f, tolerance: 0.01f);
     }
 }
 

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -228,12 +228,7 @@ char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xad
             ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1200, LeftSideBearing: 50),
             [' '] = new GlyphDesignMetrics(AdvanceWidth: 500, LeftSideBearing: 0),
         };
-        FontDesignMetrics designMetrics = new()
-        {
-            UnitsPerEm = 2000,
-            LineHeight = 2400,
-            GlyphMetrics = glyphMetrics
-        };
+        FontDesignMetrics designMetrics = new(unitsPerEm: 2000, lineHeight: 2400, glyphMetrics: glyphMetrics);
 
         BitmapFont font = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 20f)!;
 
@@ -256,12 +251,7 @@ char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xad
             ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1024, LeftSideBearing: 64),
             ['B'] = new GlyphDesignMetrics(AdvanceWidth: 896, LeftSideBearing: 32),
         };
-        FontDesignMetrics designMetrics = new()
-        {
-            UnitsPerEm = 2048,
-            LineHeight = 2500,
-            GlyphMetrics = glyphMetrics
-        };
+        FontDesignMetrics designMetrics = new(unitsPerEm: 2048, lineHeight: 2500, glyphMetrics: glyphMetrics);
 
         BitmapFont fontAt20 = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 20f)!;
         BitmapFont fontAt40 = BitmapFont.CreateFromDesignMetrics(designMetrics, fontSizeInPixels: 40f)!;

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -474,6 +474,135 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4309: the ShouldNeverWrap test above only proves the text stays on ONE line -- it doesn't
+    // prove the measured WIDTH is stable. A RelativeToChildren box has no reason to shrink while zoom
+    // moves in one direction, but that's exactly what the raster-based measurement (OversampleCompensationScale
+    // alone) can produce, since hinting isn't linear across raster sizes. This asserts the actual number
+    // stays pinned to the nominal size once TryGetDesignMetrics is wired up as the measurement source.
+    [Fact]
+    public void RegenerateOversampledFont_WithRelativeToChildrenWidth_MeasuredWidthDoesNotJitterAcrossRasterSizes()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreatorWithDesignMetrics(baseFontSize: 20);
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            float widthBeforeOversampling = text.WrappedTextWidth;
+
+            textRuntime.RegenerateOversampledFont(2.5f);
+            float widthAt2_5x = text.WrappedTextWidth;
+
+            textRuntime.RegenerateOversampledFont(3.7f);
+            float widthAt3_7x = text.WrappedTextWidth;
+
+            widthAt2_5x.ShouldBe(widthBeforeOversampling, tolerance: 0.01f,
+                "because measuring against stable design-unit metrics must not jitter even though the " +
+                "rasterized DISPLAY font's glyph advances have +1px-per-glyph noise at this raster size");
+            widthAt3_7x.ShouldBe(widthBeforeOversampling, tolerance: 0.01f,
+                "because the measured width must stay pinned to the nominal size across ANY raster size, not just one lucky match");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenDesignMetricsUnavailable_FallsBackToMeasuringDisplayFont()
+    {
+        // The known gap (issue #4309): a plain system font family has no KernSmith design-metrics
+        // path yet, so TryGetDesignMetrics returns null (see NearlyProportionalFontCreator, which
+        // doesn't override it). Measurement must fall back to today's behavior -- the live display
+        // font -- not throw or silently stop updating.
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            // Unfixed (pre-#4309) math: 5 chars * (51px raster advance [20+1px noise, scaled by 2.5x]
+            // * 0.4 OversampleCompensationScale [20/50]) = 102 -- today's existing, jittery behavior
+            // must be unchanged when no design metrics are available to fix it with.
+            text.WrappedTextWidth.ShouldBe(102f, tolerance: 0.01f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Same rasterizer-noise simulation as NearlyProportionalFontCreator, but also implements
+    // TryGetDesignMetrics with exact, size-independent design-unit metrics (UnitsPerEm=1000,
+    // AdvanceWidth=1000 -- scales to precisely FontSize pixels at any requested size, unlike
+    // TryCreateFont's simulated rasterizer above).
+    private sealed class NearlyProportionalFontCreatorWithDesignMetrics : IInMemoryFontCreator
+    {
+        private readonly int _baseFontSize;
+
+        public NearlyProportionalFontCreatorWithDesignMetrics(int baseFontSize)
+        {
+            _baseFontSize = baseFontSize;
+        }
+
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            int xadvance = (int)bmfcSave.FontSize;
+            if (bmfcSave.FontSize != _baseFontSize)
+            {
+                xadvance += 1;
+            }
+
+            string fontData =
+$@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=3
+char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave)
+        {
+            return new FontDesignMetrics
+            {
+                UnitsPerEm = 1000,
+                LineHeight = 1000,
+                GlyphMetrics = new Dictionary<int, GlyphDesignMetrics>
+                {
+                    [' '] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                    ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                    ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                }
+            };
+        }
+    }
+
     // Every glyph's xadvance is 1px wider than a perfect (FontSize/baseFontSize)x scale of the base font
     // whenever the requested size isn't baseFontSize itself -- simulates the rounding/hinting noise a
     // real TrueType rasterizer introduces between two different point sizes of the same font.

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -476,9 +476,10 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
 
     // Issue #4309: the ShouldNeverWrap test above only proves the text stays on ONE line -- it doesn't
     // prove the measured WIDTH is stable. A RelativeToChildren box has no reason to shrink while zoom
-    // moves in one direction, but that's exactly what the raster-based measurement (OversampleCompensationScale
-    // alone) can produce, since hinting isn't linear across raster sizes. This asserts the actual number
-    // stays pinned to the nominal size once TryGetDesignMetrics is wired up as the measurement source.
+    // moves in one direction, but that's exactly what re-measuring against each new oversampled raster
+    // in turn can produce, since hinting isn't linear across raster sizes. The fix pins measurement to
+    // whatever the native (pre-oversample) BitmapFont measured -- no KernSmith design-metrics API
+    // needed, just NearlyProportionalFontCreator's plain TryCreateFont.
     [Fact]
     public void RegenerateOversampledFont_WithRelativeToChildrenWidth_MeasuredWidthDoesNotJitterAcrossRasterSizes()
     {
@@ -487,7 +488,7 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         try
         {
             TextRuntime.UseFontOversampling = true;
-            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreatorWithDesignMetrics(baseFontSize: 20);
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
 
             TextRuntime textRuntime = new();
             textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
@@ -504,10 +505,10 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             float widthAt3_7x = text.WrappedTextWidth;
 
             widthAt2_5x.ShouldBe(widthBeforeOversampling, tolerance: 0.01f,
-                "because measuring against stable design-unit metrics must not jitter even though the " +
-                "rasterized DISPLAY font's glyph advances have +1px-per-glyph noise at this raster size");
+                "because the pinned native measurement must not jitter even though the rasterized " +
+                "DISPLAY font's glyph advances have +1px-per-glyph noise at this raster size");
             widthAt3_7x.ShouldBe(widthBeforeOversampling, tolerance: 0.01f,
-                "because the measured width must stay pinned to the nominal size across ANY raster size, not just one lucky match");
+                "because the measured width must stay pinned to the native size across ANY raster size, not just one lucky match");
         }
         finally
         {
@@ -516,16 +517,15 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
-    // Issue #4309 (discontinuity found via manual test): the jitter-elimination test above uses a fake
-    // creator whose native/hinted advance and design-metrics advance happen to agree exactly at the
-    // nominal size (both 20px) -- that coincidence hid a real bug. A real font's hinted native
-    // measurement and its unhinted design-unit measurement are NOT guaranteed to agree, so if the
-    // measurement font is only wired up once oversampling first activates, there's a visible jump/shrink
-    // at that exact moment (reported: text briefly overflows its box right as zoom starts). The fix is
-    // for the measurement font to be in effect from the very first (native, zoom==1) measurement, not
-    // just once oversampling kicks in.
+    // Issue #4309 (discontinuity found via manual test): an earlier version of this fix measured against
+    // KernSmith design-unit metrics -- a DIFFERENT measurement system than the native rasterized font,
+    // not guaranteed to agree with it (hinted vs. unhinted). That mismatched every text whose display
+    // font was never actually oversampled (a "control" instance), and jumped visibly the moment
+    // oversampling activated for the rest. The fix instead pins the OUTGOING native BitmapFont itself as
+    // the measurement source -- never a different, independently-computed number -- so there is nothing
+    // to disagree with: measurement equals exactly what was being rendered the frame before.
     [Fact]
-    public void FontSize_AtNativeZoom_MeasuresAgainstDesignMetricsFromTheStart_NoDiscontinuityWhenOversamplingActivates()
+    public void RegenerateOversampledFont_PinsOutgoingNativeMeasurement_NoJumpWhenOversamplingActivates()
     {
         bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
         IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
@@ -541,16 +541,14 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
 
             var text = (Text)textRuntime.RenderableComponent;
 
-            // Design metrics: 2 chars * (1000 design units * 20/1000 scale) = 40. The native BitmapFont's
-            // own hinted xadvance (24/char = 48 total) must NOT be what's measured, even though no zoom
-            // has happened yet -- that's exactly the discontinuity bug.
+            // Native/hinted xadvance is 24/char = 48 total -- this IS what's actually rendered, so it
+            // must be exactly what's measured too, both before and after oversampling activates.
             float widthAtNativeZoom = text.WrappedTextWidth;
 
             textRuntime.RegenerateOversampledFont(2.5f);
             float widthAfterOversamplingActivates = text.WrappedTextWidth;
 
-            widthAtNativeZoom.ShouldBe(40f, tolerance: 0.01f,
-                "because the measurement font must be in effect from the start, not just once oversampling activates");
+            widthAtNativeZoom.ShouldBe(48f, tolerance: 0.01f);
             widthAfterOversamplingActivates.ShouldBe(widthAtNativeZoom, tolerance: 0.01f,
                 "because there must be no discontinuity the moment oversampling first kicks in");
         }
@@ -561,16 +559,16 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
-    // Issue #4309 (landmine found via manual test): EnsureMeasurementFont is only triggered by
-    // font-property changes -- a one-time event -- not re-evaluated every frame. If UseFontOversampling
-    // (a project-wide static toggle) happens to be off at the moment a Text's font is first resolved,
-    // and nothing else changes that Text's font properties afterward, it stays permanently stuck
-    // measuring via the native BitmapFont even after the flag is later turned on. A real project can
-    // easily hit this ordering (e.g. a settings toggle flipped after some UI already exists) with no
-    // error or warning. The fix: the automatic per-frame hook (already continuously re-evaluated, same
-    // as the raster-regeneration decision itself) must also retry wiring up the measurement font.
+    // Issue #4309 (landmine found via manual test): an earlier version of this fix fetched its
+    // measurement source only from the font-property-resolution choke point, gated on
+    // UseFontOversampling's value AT THAT MOMENT -- a project-wide static toggle that can be flipped on
+    // at any point in a project's lifecycle, independent of when a given Text's font was last resolved.
+    // Pinning is now driven entirely by RegenerateOversampledFont itself (always captures whatever the
+    // CURRENT native font is, whenever it's first called), so the flag's value/timing when the font was
+    // originally resolved is irrelevant by construction -- nothing to self-heal, because nothing can go
+    // stale in the first place.
     [Fact]
-    public void EnsureMeasurementFont_WhenOversamplingEnabledAfterFontAlreadyResolved_SelfHealsOnNextAutomaticUpdate()
+    public void RegenerateOversampledFont_UseFontOversamplingTimingDoesNotMatter_NoOrderingLandmine()
     {
         bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
         IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
@@ -585,19 +583,15 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             textRuntime.Text = "AB";
 
             var text = (Text)textRuntime.RenderableComponent;
-            text.WrappedTextWidth.ShouldBe(48f, tolerance: 0.01f,
-                "because oversampling is off -- the native hinted BitmapFont is the only measurement source available yet");
+            float widthBeforeFlagEnabled = text.WrappedTextWidth;
 
             TextRuntime.UseFontOversampling = true;
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
 
-            // effectiveZoom=1 deliberately does NOT cross the 1px raster-delta threshold that triggers
-            // an actual RegenerateOversampledFont call -- this must still wire up the measurement font.
-            textRuntime.UpdateAutomaticFontOversampling(1f);
-
-            text.WrappedTextWidth.ShouldBe(40f, tolerance: 0.01f,
-                "because the very next automatic per-frame check (issue #4317's render-time hook) must " +
-                "pick up the now-enabled flag and wire up the measurement font -- no explicit re-trigger, " +
-                "and no raster regeneration, should be required");
+            result.ShouldBeTrue();
+            text.WrappedTextWidth.ShouldBe(widthBeforeFlagEnabled, tolerance: 0.01f,
+                "because the flag being off when the font was first resolved must not matter -- " +
+                "RegenerateOversampledFont pins whatever the native font is at the moment it's actually called");
         }
         finally
         {
@@ -606,9 +600,8 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
-    // Native/hinted advance (24px/char) deliberately does NOT match what TryGetDesignMetrics below
-    // scales to (20px/char) -- simulates a real rasterizer's hinting producing a different result than
-    // the font's plain unhinted design-unit data would.
+    // Native/hinted advance (24px/char) is deliberately NOT a round multiple of the base FontSize (20) --
+    // simulates a real rasterizer's hinting producing a different result than a naive linear scale would.
     private sealed class HintingMismatchFontCreator : IInMemoryFontCreator
     {
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
@@ -625,99 +618,6 @@ char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
             BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
             font.SetFontPattern(256, 256);
             return font;
-        }
-
-        public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave)
-        {
-            Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
-            {
-                ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-            };
-            return new FontDesignMetrics(unitsPerEm: 1000, lineHeight: 1000, glyphMetrics: glyphMetrics);
-        }
-    }
-
-    [Fact]
-    public void RegenerateOversampledFont_WhenDesignMetricsUnavailable_FallsBackToMeasuringDisplayFont()
-    {
-        // The known gap (issue #4309): a plain system font family has no KernSmith design-metrics
-        // path yet, so TryGetDesignMetrics returns null (see NearlyProportionalFontCreator, which
-        // doesn't override it). Measurement must fall back to today's behavior -- the live display
-        // font -- not throw or silently stop updating.
-        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
-        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
-        try
-        {
-            TextRuntime.UseFontOversampling = true;
-            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
-
-            TextRuntime textRuntime = new();
-            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
-            textRuntime.FontSize = 20;
-            textRuntime.Text = "AB AB";
-
-            var text = (Text)textRuntime.RenderableComponent;
-
-            bool result = textRuntime.RegenerateOversampledFont(2.5f);
-
-            result.ShouldBeTrue();
-            // Unfixed (pre-#4309) math: 5 chars * (51px raster advance [20+1px noise, scaled by 2.5x]
-            // * 0.4 OversampleCompensationScale [20/50]) = 102 -- today's existing, jittery behavior
-            // must be unchanged when no design metrics are available to fix it with.
-            text.WrappedTextWidth.ShouldBe(102f, tolerance: 0.01f);
-        }
-        finally
-        {
-            TextRuntime.UseFontOversampling = savedUseFontOversampling;
-            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
-        }
-    }
-
-    // Same rasterizer-noise simulation as NearlyProportionalFontCreator, but also implements
-    // TryGetDesignMetrics with exact, size-independent design-unit metrics (UnitsPerEm=1000,
-    // AdvanceWidth=1000 -- scales to precisely FontSize pixels at any requested size, unlike
-    // TryCreateFont's simulated rasterizer above).
-    private sealed class NearlyProportionalFontCreatorWithDesignMetrics : IInMemoryFontCreator
-    {
-        private readonly int _baseFontSize;
-
-        public NearlyProportionalFontCreatorWithDesignMetrics(int baseFontSize)
-        {
-            _baseFontSize = baseFontSize;
-        }
-
-        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
-        {
-            int xadvance = (int)bmfcSave.FontSize;
-            if (bmfcSave.FontSize != _baseFontSize)
-            {
-                xadvance += 1;
-            }
-
-            string fontData =
-$@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
-common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
-page id=0 file=""x.png""
-chars count=3
-char id=32 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
-char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
-char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
-";
-            BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
-            font.SetFontPattern(256, 256);
-            return font;
-        }
-
-        public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave)
-        {
-            Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
-            {
-                [' '] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-            };
-            return new FontDesignMetrics(unitsPerEm: 1000, lineHeight: 1000, glyphMetrics: glyphMetrics);
         }
     }
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -516,6 +516,83 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4309 (discontinuity found via manual test): the jitter-elimination test above uses a fake
+    // creator whose native/hinted advance and design-metrics advance happen to agree exactly at the
+    // nominal size (both 20px) -- that coincidence hid a real bug. A real font's hinted native
+    // measurement and its unhinted design-unit measurement are NOT guaranteed to agree, so if the
+    // measurement font is only wired up once oversampling first activates, there's a visible jump/shrink
+    // at that exact moment (reported: text briefly overflows its box right as zoom starts). The fix is
+    // for the measurement font to be in effect from the very first (native, zoom==1) measurement, not
+    // just once oversampling kicks in.
+    [Fact]
+    public void FontSize_AtNativeZoom_MeasuresAgainstDesignMetricsFromTheStart_NoDiscontinuityWhenOversamplingActivates()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new HintingMismatchFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+
+            // Design metrics: 2 chars * (1000 design units * 20/1000 scale) = 40. The native BitmapFont's
+            // own hinted xadvance (24/char = 48 total) must NOT be what's measured, even though no zoom
+            // has happened yet -- that's exactly the discontinuity bug.
+            float widthAtNativeZoom = text.WrappedTextWidth;
+
+            textRuntime.RegenerateOversampledFont(2.5f);
+            float widthAfterOversamplingActivates = text.WrappedTextWidth;
+
+            widthAtNativeZoom.ShouldBe(40f, tolerance: 0.01f,
+                "because the measurement font must be in effect from the start, not just once oversampling activates");
+            widthAfterOversamplingActivates.ShouldBe(widthAtNativeZoom, tolerance: 0.01f,
+                "because there must be no discontinuity the moment oversampling first kicks in");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Native/hinted advance (24px/char) deliberately does NOT match what TryGetDesignMetrics below
+    // scales to (20px/char) -- simulates a real rasterizer's hinting producing a different result than
+    // the font's plain unhinted design-unit data would.
+    private sealed class HintingMismatchFontCreator : IInMemoryFontCreator
+    {
+        public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
+        {
+            const int xadvance = 24;
+            string fontData =
+$@"info face=""Arial"" size=-{bmfcSave.FontSize} bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight={bmfcSave.FontSize} base={bmfcSave.FontSize} scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""x.png""
+chars count=2
+char id=65 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadvance} page=0 chnl=15
+";
+            BitmapFont font = new BitmapFont((Texture2D)null!, fontData);
+            font.SetFontPattern(256, 256);
+            return font;
+        }
+
+        public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave)
+        {
+            Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
+            {
+                ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+            };
+            return new FontDesignMetrics(unitsPerEm: 1000, lineHeight: 1000, glyphMetrics: glyphMetrics);
+        }
+    }
+
     [Fact]
     public void RegenerateOversampledFont_WhenDesignMetricsUnavailable_FallsBackToMeasuringDisplayFont()
     {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -46,7 +46,13 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             creator.CapturedFontSize.ShouldBe(50f);
             var text = (Text)textRuntime.RenderableComponent;
             text.BitmapFont.ShouldBeSameAs(stubFont);
-            text.OversampleCompensationScale.ShouldBe(20f / 50f);
+            // Issue #4309: compensation is now derived from ACTUAL measured width (pinned native vs.
+            // oversampled), not a naive FontSize/rasterFontSize ratio. CapturingInMemoryFontCreator
+            // returns the identical stub font object regardless of requested size, so there is
+            // genuinely nothing to compensate for -- 1f is correct here. See
+            // RegenerateOversampledFont_PinsOutgoingNativeMeasurement_NoJumpWhenOversamplingActivates
+            // for a fake whose oversampled font actually differs, covering the general case.
+            text.OversampleCompensationScale.ShouldBe(1f);
             text.FontScale.ShouldBe(1f, "because oversampling must compensate through the internal-only " +
                 "OversampleCompensationScale, not by overwriting the public FontScale (issue #4317)");
         }
@@ -109,7 +115,10 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
 
             var text = (Text)textRuntime.RenderableComponent;
             text.FontScale.ShouldBe(2f, "because the caller's own FontScale must not be stomped by oversampling");
-            ((IText)text).FontScale.ShouldBe(2f * (20f / 50f),
+            // Compensation is 1f here (see the "leaves FontScale untouched" test above for why) --
+            // the identical stub font is returned for any requested size, so there's nothing to
+            // compensate for; the effective scale is just the caller's FontScale.
+            ((IText)text).FontScale.ShouldBe(2f * 1f,
                 "because the effective on-screen scale is the caller's FontScale composed with the " +
                 "internal compensation, not just the compensation alone");
         }
@@ -127,12 +136,11 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
         try
         {
-            var stubFont = new BitmapFont((Texture2D)null!, StubFontData);
-            stubFont.SetFontPattern(256, 256);
-            var creator = new CapturingInMemoryFontCreator(stubFont);
-
+            // ProportionalFontCreator (not the identical-object stub used elsewhere in this file):
+            // its glyph metrics genuinely scale with the requested size, so the pre-reset compensation
+            // below is meaningfully different from the post-reset neutral value.
             TextRuntime.UseFontOversampling = true;
-            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new ProportionalFontCreator();
 
             TextRuntime textRuntime = new();
             textRuntime.FontSize = 20;
@@ -247,7 +255,9 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
             result.ShouldBeTrue();
             creator.CapturedFontSize.ShouldBe(50f);
             var text = (Text)textRuntime.RenderableComponent;
-            text.OversampleCompensationScale.ShouldBe(20f / 50f);
+            // 1f: the identical stub font is returned for any requested size, so there's nothing to
+            // compensate for (see RegenerateOversampledFont_WhenEnabledWithCreator_... 's comment).
+            text.OversampleCompensationScale.ShouldBe(1f);
         }
         finally
         {
@@ -509,6 +519,49 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
                 "DISPLAY font's glyph advances have +1px-per-glyph noise at this raster size");
             widthAt3_7x.ShouldBe(widthBeforeOversampling, tolerance: 0.01f,
                 "because the measured width must stay pinned to the native size across ANY raster size, not just one lucky match");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Issue #4309 (render-side gap found via manual test, FontScale 2 at ~2.9x zoom): the box is now
+    // correctly pinned/stable, but a naive FontSize/rasterFontSize compensation ratio assumes the
+    // oversampled font's glyphs are an exact linear scale of the native font's -- they're not, since
+    // hinting isn't linear across raster sizes. That leaves a visible gap between the drawn text and
+    // its own box. The fix derives the compensation from the ACTUAL measured width ratio between the
+    // pinned and oversampled fonts (for this Text's own content), so the drawn text exactly fills the box.
+    [Fact]
+    public void RegenerateOversampledFont_CompensationDerivedFromActualMeasurement_DrawnTextExactlyFillsPinnedBox()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            float pinnedWidth = text.WrappedTextWidth; // the box size, already proven stable above
+
+            textRuntime.RegenerateOversampledFont(2.5f);
+
+            // The actual DRAWN width: the live (oversampled) BitmapFont's own raw measurement, scaled
+            // by the composed effective scale -- what Sprite.Render actually puts on screen, as
+            // distinct from the separately-pinned box measurement.
+            float drawnWidth = text.BitmapFont.MeasureString("AB AB") * ((IText)text).FontScale;
+
+            drawnWidth.ShouldBe(pinnedWidth, tolerance: 0.01f,
+                "because the drawn text must exactly fill its own box, not just approximately -- a naive " +
+                "FontSize/rasterFontSize ratio would leave a visible gap since the oversampled font's " +
+                "glyph advances aren't an exact linear scale of the native font's");
         }
         finally
         {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -589,17 +589,13 @@ char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
 
         public FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave)
         {
-            return new FontDesignMetrics
+            Dictionary<int, GlyphDesignMetrics> glyphMetrics = new()
             {
-                UnitsPerEm = 1000,
-                LineHeight = 1000,
-                GlyphMetrics = new Dictionary<int, GlyphDesignMetrics>
-                {
-                    [' '] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                    ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                    ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
-                }
+                [' '] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                ['A'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
+                ['B'] = new GlyphDesignMetrics(AdvanceWidth: 1000, LeftSideBearing: 0),
             };
+            return new FontDesignMetrics(unitsPerEm: 1000, lineHeight: 1000, glyphMetrics: glyphMetrics);
         }
     }
 

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -561,6 +561,51 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4309 (landmine found via manual test): EnsureMeasurementFont is only triggered by
+    // font-property changes -- a one-time event -- not re-evaluated every frame. If UseFontOversampling
+    // (a project-wide static toggle) happens to be off at the moment a Text's font is first resolved,
+    // and nothing else changes that Text's font properties afterward, it stays permanently stuck
+    // measuring via the native BitmapFont even after the flag is later turned on. A real project can
+    // easily hit this ordering (e.g. a settings toggle flipped after some UI already exists) with no
+    // error or warning. The fix: the automatic per-frame hook (already continuously re-evaluated, same
+    // as the raster-regeneration decision itself) must also retry wiring up the measurement font.
+    [Fact]
+    public void EnsureMeasurementFont_WhenOversamplingEnabledAfterFontAlreadyResolved_SelfHealsOnNextAutomaticUpdate()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = false;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new HintingMismatchFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            text.WrappedTextWidth.ShouldBe(48f, tolerance: 0.01f,
+                "because oversampling is off -- the native hinted BitmapFont is the only measurement source available yet");
+
+            TextRuntime.UseFontOversampling = true;
+
+            // effectiveZoom=1 deliberately does NOT cross the 1px raster-delta threshold that triggers
+            // an actual RegenerateOversampledFont call -- this must still wire up the measurement font.
+            textRuntime.UpdateAutomaticFontOversampling(1f);
+
+            text.WrappedTextWidth.ShouldBe(40f, tolerance: 0.01f,
+                "because the very next automatic per-frame check (issue #4317's render-time hook) must " +
+                "pick up the now-enabled flag and wire up the measurement font -- no explicit re-trigger, " +
+                "and no raster regeneration, should be required");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     // Native/hinted advance (24px/char) deliberately does NOT match what TryGetDesignMetrics below
     // scales to (20px/char) -- simulates a real rasterizer's hinting producing a different result than
     // the font's plain unhinted design-unit data would.

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -696,10 +696,6 @@ public class TextRuntime : InteractiveGue
 
         var bmfcSave = new BmfcSave();
         CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
-        // bmfcSave.FontSize is still the nominal FontSize here (CopyFontGenerationFieldsTo's default) --
-        // design metrics are requested at the NOMINAL size, before it's overwritten below for the
-        // raster/display font.
-        FetchMeasurementFontIfNeeded(bmfcSave);
         bmfcSave.FontSize = rasterFontSize;
 
         var font = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryCreateFont(bmfcSave);
@@ -710,7 +706,10 @@ public class TextRuntime : InteractiveGue
 
         ContainedText.BitmapFont = font;
         ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
-        ContainedText.MeasurementFont = _cachedMeasurementFont;
+        // Usually already populated by EnsureMeasurementFont (called from the font-property-resolution
+        // choke point, before any zoom ever happens) -- calling it again here is a cheap no-op guard for
+        // callers that invoke RegenerateOversampledFont directly, without going through that cascade.
+        EnsureMeasurementFont();
 
         // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
         // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)
@@ -726,28 +725,45 @@ public class TextRuntime : InteractiveGue
     BitmapFont? _cachedMeasurementFont;
 
     /// <summary>
-    /// Fetches and builds <see cref="_cachedMeasurementFont"/> -- issue #4309's stable, never-regenerated
-    /// measurement font, built from unscaled design-unit metrics at the NOMINAL <see cref="FontSize"/> --
-    /// at most once per Font/FontSize/Bold/Italic identity. The display raster changes every zoom tick
-    /// (<see cref="RegenerateOversampledFont"/> runs continuously under camera zoom), but the measurement
-    /// font never needs to: it stays valid until <see cref="ResetAutomaticOversamplingState"/> clears the
-    /// cache in response to a font-property change. Leaves the cache at null (falls back to measuring the
-    /// live display font, i.e. today's behavior) when <see cref="IInMemoryFontCreator.TryGetDesignMetrics"/>
-    /// is unsupported or returns null -- e.g. a plain system-installed font family, a known gap (see the
+    /// Fetches, builds, and assigns <see cref="Text.MeasurementFont"/> -- issue #4309's stable,
+    /// never-regenerated measurement font, built from unscaled design-unit metrics at the NOMINAL
+    /// <see cref="FontSize"/> -- at most once per Font/FontSize/Bold/Italic identity. Called both from
+    /// the font-property-resolution choke point (<see cref="CustomSetPropertyOnRenderable.UpdateToFontValues"/>,
+    /// so the measurement font is in effect from the very first, native-zoom measurement) and from
+    /// <see cref="RegenerateOversampledFont"/> (a no-op guard there once the former has already run).
+    /// A real font's hinted native <see cref="BitmapFont"/> measurement and its unhinted design-unit
+    /// measurement are not guaranteed to agree -- wiring this up only once oversampling first activates
+    /// (rather than from the start) produced a visible jump/shrink at that exact moment.
+    /// <para>
+    /// The display raster changes every zoom tick, but the measurement font never needs to: it stays
+    /// valid until <see cref="ResetAutomaticOversamplingState"/> clears the cache in response to a
+    /// font-property change. Leaves the cache at null (falls back to measuring the live display font,
+    /// i.e. today's original behavior) when <see cref="IInMemoryFontCreator.TryGetDesignMetrics"/> is
+    /// unsupported or returns null -- e.g. a plain system-installed font family, a known gap (see the
     /// KernSmith.GumCommon.GumFontGenerator.ReadDesignMetrics doc comment).
+    /// </para>
     /// </summary>
-    void FetchMeasurementFontIfNeeded(BmfcSave nominalBmfcSave)
+    internal void EnsureMeasurementFont()
     {
-        if (_measurementFontFetchAttempted)
+        if (!UseFontOversampling || CustomSetPropertyOnRenderableType.InMemoryFontCreator == null)
         {
             return;
         }
 
-        var designMetrics = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryGetDesignMetrics(nominalBmfcSave);
-        _cachedMeasurementFont = designMetrics != null
-            ? BitmapFont.CreateFromDesignMetrics(designMetrics, FontSize)
-            : null;
-        _measurementFontFetchAttempted = true;
+        if (!_measurementFontFetchAttempted)
+        {
+            var fontFilePath = BmfcSave.ResolveTtfSourcePath(UseCustomFont, CustomFontFile, Font);
+            var bmfcSave = new BmfcSave();
+            CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
+
+            var designMetrics = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryGetDesignMetrics(bmfcSave);
+            _cachedMeasurementFont = designMetrics != null
+                ? BitmapFont.CreateFromDesignMetrics(designMetrics, FontSize)
+                : null;
+            _measurementFontFetchAttempted = true;
+        }
+
+        ContainedText.MeasurementFont = _cachedMeasurementFont;
     }
 
     float _lastAutoOversampleRatio = 1f;

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -798,6 +798,15 @@ public class TextRuntime : InteractiveGue
             return false;
         }
 
+        // Issue #4309: retried every frame (cheap -- a no-op once already resolved), not just once at
+        // font-property-resolution time. UseFontOversampling can be flipped on at any point in a
+        // project's lifecycle, independent of when a given Text's font was last resolved -- gating this
+        // solely on the font-property choke point left a Text permanently stuck measuring via the
+        // native BitmapFont if the flag happened to be off at that one moment. This hook already runs
+        // every frame for every visible Text, so piggybacking here makes it self-healing the same way
+        // the raster-regeneration decision below already is.
+        EnsureMeasurementFont();
+
         // Regenerating below native resolution isn't this feature's job -- only oversample, never
         // undersample.
         var oversampleRatio = System.Math.Max(1f, effectiveZoom);

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -696,6 +696,10 @@ public class TextRuntime : InteractiveGue
 
         var bmfcSave = new BmfcSave();
         CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
+        // bmfcSave.FontSize is still the nominal FontSize here (CopyFontGenerationFieldsTo's default) --
+        // design metrics are requested at the NOMINAL size, before it's overwritten below for the
+        // raster/display font.
+        FetchMeasurementFontIfNeeded(bmfcSave);
         bmfcSave.FontSize = rasterFontSize;
 
         var font = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryCreateFont(bmfcSave);
@@ -706,6 +710,7 @@ public class TextRuntime : InteractiveGue
 
         ContainedText.BitmapFont = font;
         ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
+        ContainedText.MeasurementFont = _cachedMeasurementFont;
 
         // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
         // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)
@@ -715,6 +720,34 @@ public class TextRuntime : InteractiveGue
         UpdateLayout();
 
         return true;
+    }
+
+    bool _measurementFontFetchAttempted;
+    BitmapFont? _cachedMeasurementFont;
+
+    /// <summary>
+    /// Fetches and builds <see cref="_cachedMeasurementFont"/> -- issue #4309's stable, never-regenerated
+    /// measurement font, built from unscaled design-unit metrics at the NOMINAL <see cref="FontSize"/> --
+    /// at most once per Font/FontSize/Bold/Italic identity. The display raster changes every zoom tick
+    /// (<see cref="RegenerateOversampledFont"/> runs continuously under camera zoom), but the measurement
+    /// font never needs to: it stays valid until <see cref="ResetAutomaticOversamplingState"/> clears the
+    /// cache in response to a font-property change. Leaves the cache at null (falls back to measuring the
+    /// live display font, i.e. today's behavior) when <see cref="IInMemoryFontCreator.TryGetDesignMetrics"/>
+    /// is unsupported or returns null -- e.g. a plain system-installed font family, a known gap (see the
+    /// KernSmith.GumCommon.GumFontGenerator.ReadDesignMetrics doc comment).
+    /// </summary>
+    void FetchMeasurementFontIfNeeded(BmfcSave nominalBmfcSave)
+    {
+        if (_measurementFontFetchAttempted)
+        {
+            return;
+        }
+
+        var designMetrics = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryGetDesignMetrics(nominalBmfcSave);
+        _cachedMeasurementFont = designMetrics != null
+            ? BitmapFont.CreateFromDesignMetrics(designMetrics, FontSize)
+            : null;
+        _measurementFontFetchAttempted = true;
     }
 
     float _lastAutoOversampleRatio = 1f;
@@ -794,7 +827,15 @@ public class TextRuntime : InteractiveGue
     /// stale (issue #4317). <see cref="Text.OversampleCompensationScale"/> itself is reset by the
     /// caller directly, since it lives on the renderable that caller already has a reference to.
     /// </summary>
-    internal void ResetAutomaticOversamplingState() => _lastAutoOversampleRatio = 1f;
+    internal void ResetAutomaticOversamplingState()
+    {
+        _lastAutoOversampleRatio = 1f;
+        // Issue #4309: the cached measurement font was built for the OLD Font/FontSize/Bold/Italic
+        // identity -- clear it so the next RegenerateOversampledFont call fetches fresh design metrics
+        // instead of measuring against stale-but-still-non-null cached data.
+        _measurementFontFetchAttempted = false;
+        _cachedMeasurementFont = null;
+    }
 #endif
 #endif
 

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -704,12 +704,10 @@ public class TextRuntime : InteractiveGue
             return false;
         }
 
-        ContainedText.BitmapFont = font;
+        // Issue #4309: pins the OUTGOING (native) font as the measurement source, if nothing is pinned
+        // yet, before swapping in this new (oversampled) display font -- see Text.SetOversampledDisplayFont.
+        ContainedText.SetOversampledDisplayFont(font);
         ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
-        // Usually already populated by EnsureMeasurementFont (called from the font-property-resolution
-        // choke point, before any zoom ever happens) -- calling it again here is a cheap no-op guard for
-        // callers that invoke RegenerateOversampledFont directly, without going through that cascade.
-        EnsureMeasurementFont();
 
         // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
         // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)
@@ -719,51 +717,6 @@ public class TextRuntime : InteractiveGue
         UpdateLayout();
 
         return true;
-    }
-
-    bool _measurementFontFetchAttempted;
-    BitmapFont? _cachedMeasurementFont;
-
-    /// <summary>
-    /// Fetches, builds, and assigns <see cref="Text.MeasurementFont"/> -- issue #4309's stable,
-    /// never-regenerated measurement font, built from unscaled design-unit metrics at the NOMINAL
-    /// <see cref="FontSize"/> -- at most once per Font/FontSize/Bold/Italic identity. Called both from
-    /// the font-property-resolution choke point (<see cref="CustomSetPropertyOnRenderable.UpdateToFontValues"/>,
-    /// so the measurement font is in effect from the very first, native-zoom measurement) and from
-    /// <see cref="RegenerateOversampledFont"/> (a no-op guard there once the former has already run).
-    /// A real font's hinted native <see cref="BitmapFont"/> measurement and its unhinted design-unit
-    /// measurement are not guaranteed to agree -- wiring this up only once oversampling first activates
-    /// (rather than from the start) produced a visible jump/shrink at that exact moment.
-    /// <para>
-    /// The display raster changes every zoom tick, but the measurement font never needs to: it stays
-    /// valid until <see cref="ResetAutomaticOversamplingState"/> clears the cache in response to a
-    /// font-property change. Leaves the cache at null (falls back to measuring the live display font,
-    /// i.e. today's original behavior) when <see cref="IInMemoryFontCreator.TryGetDesignMetrics"/> is
-    /// unsupported or returns null -- e.g. a plain system-installed font family, a known gap (see the
-    /// KernSmith.GumCommon.GumFontGenerator.ReadDesignMetrics doc comment).
-    /// </para>
-    /// </summary>
-    internal void EnsureMeasurementFont()
-    {
-        if (!UseFontOversampling || CustomSetPropertyOnRenderableType.InMemoryFontCreator == null)
-        {
-            return;
-        }
-
-        if (!_measurementFontFetchAttempted)
-        {
-            var fontFilePath = BmfcSave.ResolveTtfSourcePath(UseCustomFont, CustomFontFile, Font);
-            var bmfcSave = new BmfcSave();
-            CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
-
-            var designMetrics = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryGetDesignMetrics(bmfcSave);
-            _cachedMeasurementFont = designMetrics != null
-                ? BitmapFont.CreateFromDesignMetrics(designMetrics, FontSize)
-                : null;
-            _measurementFontFetchAttempted = true;
-        }
-
-        ContainedText.MeasurementFont = _cachedMeasurementFont;
     }
 
     float _lastAutoOversampleRatio = 1f;
@@ -797,15 +750,6 @@ public class TextRuntime : InteractiveGue
         {
             return false;
         }
-
-        // Issue #4309: retried every frame (cheap -- a no-op once already resolved), not just once at
-        // font-property-resolution time. UseFontOversampling can be flipped on at any point in a
-        // project's lifecycle, independent of when a given Text's font was last resolved -- gating this
-        // solely on the font-property choke point left a Text permanently stuck measuring via the
-        // native BitmapFont if the flag happened to be off at that one moment. This hook already runs
-        // every frame for every visible Text, so piggybacking here makes it self-healing the same way
-        // the raster-regeneration decision below already is.
-        EnsureMeasurementFont();
 
         // Regenerating below native resolution isn't this feature's job -- only oversample, never
         // undersample.
@@ -852,15 +796,7 @@ public class TextRuntime : InteractiveGue
     /// stale (issue #4317). <see cref="Text.OversampleCompensationScale"/> itself is reset by the
     /// caller directly, since it lives on the renderable that caller already has a reference to.
     /// </summary>
-    internal void ResetAutomaticOversamplingState()
-    {
-        _lastAutoOversampleRatio = 1f;
-        // Issue #4309: the cached measurement font was built for the OLD Font/FontSize/Bold/Italic
-        // identity -- clear it so the next RegenerateOversampledFont call fetches fresh design metrics
-        // instead of measuring against stale-but-still-non-null cached data.
-        _measurementFontFetchAttempted = false;
-        _cachedMeasurementFont = null;
-    }
+    internal void ResetAutomaticOversamplingState() => _lastAutoOversampleRatio = 1f;
 #endif
 #endif
 

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -707,7 +707,27 @@ public class TextRuntime : InteractiveGue
         // Issue #4309: pins the OUTGOING (native) font as the measurement source, if nothing is pinned
         // yet, before swapping in this new (oversampled) display font -- see Text.SetOversampledDisplayFont.
         ContainedText.SetOversampledDisplayFont(font);
-        ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
+
+        // Issue #4309 (render-side gap found via manual test): a naive FontSize/rasterFontSize ratio
+        // assumes the oversampled font's glyphs are an exact linear scale of the pinned/native font's --
+        // they're not, since hinting isn't linear across raster sizes. That leaves a visible gap (or
+        // overflow) between the drawn text and its own box, even though the box's SIZE is now correctly
+        // stable. Deriving the compensation from the ACTUAL measured width ratio between the two fonts,
+        // for this Text's own wrapped content, makes the drawn text fill exactly the pinned box instead
+        // of only approximately fitting it.
+        BitmapFont? pinnedFont = ContainedText.MeasurementFont;
+        if (pinnedFont != null)
+        {
+            pinnedFont.GetRequiredWidthAndHeight(ContainedText.WrappedText, out int pinnedWidth, out _);
+            font.GetRequiredWidthAndHeight(ContainedText.WrappedText, out int oversampledWidth, out _);
+            ContainedText.OversampleCompensationScale = oversampledWidth > 0
+                ? (float)pinnedWidth / oversampledWidth
+                : FontSize / rasterFontSize;
+        }
+        else
+        {
+            ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
+        }
 
         // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
         // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -1,5 +1,6 @@
 ﻿using Gum.Graphics;
 using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary.Graphics.Fonts;
 using RenderingLibrary.Math;
 using RenderingLibrary.Math.Geometry;
 using System;
@@ -9,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using System.Xml.Linq;
 using System.Xml.Serialization;
 using ToolsUtilities;
 using BlendState = Gum.BlendState;
@@ -316,6 +318,70 @@ public class BitmapFont : IDisposable
 
         SetFontPattern();
     }
+
+    /// <summary>
+    /// Builds a measurement-only <see cref="BitmapFont"/> directly from unscaled font design-unit
+    /// metrics (issue #4309) -- no texture pages, no rasterization. Values scale from design units
+    /// to pixels by exact multiplication (<c>value * fontSizeInPixels / UnitsPerEm</c>), so unlike
+    /// a rasterized <see cref="BitmapFont"/> (whose hinted glyph metrics are independently
+    /// pixel-snapped per raster size) this measurement stays exactly proportional across any
+    /// requested pixel size. Intended as the stable "measurement font" for a <see cref="Text"/>
+    /// whose display font is being oversampled under camera zoom, so layout never depends on the
+    /// display raster's own rounding.
+    /// </summary>
+    /// <remarks>
+    /// KernSmith's design metrics do not include right-side-bearing (that needs glyf/loca bbox
+    /// parsing, which is not exposed), so each glyph's ink width is approximated as
+    /// <c>AdvanceWidth - LeftSideBearing</c> (right-side-bearing treated as 0). That makes
+    /// <see cref="HorizontalMeasurementStyle.TrimRight"/> and <see cref="HorizontalMeasurementStyle.Full"/>
+    /// measure identically for a design-metrics-built font, since XOffset + Width always lands
+    /// exactly on XAdvance.
+    /// </remarks>
+    /// <returns>Null if <paramref name="designMetrics"/> or <paramref name="fontSizeInPixels"/> is invalid.</returns>
+    internal static BitmapFont? CreateFromDesignMetrics(FontDesignMetrics designMetrics, float fontSizeInPixels)
+    {
+        if (designMetrics.UnitsPerEm <= 0 || fontSizeInPixels <= 0)
+        {
+            return null;
+        }
+
+        float scale = fontSizeInPixels / designMetrics.UnitsPerEm;
+        int lineHeightInPixels = ToDesignMetricsPixels(designMetrics.LineHeight, scale);
+
+        XElement root = new XElement("font",
+            new XElement("info", new XAttribute("size", (int)MathF.Round(fontSizeInPixels))),
+            // "base" (baseline-from-top) isn't tracked separately in FontDesignMetrics -- this font
+            // is measurement-only and never drawn with, so an approximate base is harmless.
+            new XElement("common",
+                new XAttribute("lineHeight", lineHeightInPixels),
+                new XAttribute("base", lineHeightInPixels)),
+            new XElement("pages", new XElement("page", new XAttribute("id", 0), new XAttribute("file", ""))),
+            new XElement("chars",
+                // Ascending by codepoint: SetFontPattern sizes mCharacterInfo off Chars.LastOrDefault()
+                // (the array is a lookup by codepoint, not a general list), which assumes -- true of
+                // real BMFont output, not guaranteed for a Dictionary's enumeration order -- that Chars
+                // is already sorted ascending.
+                designMetrics.GlyphMetrics.OrderBy(pair => pair.Key).Select(pair =>
+                {
+                    int advance = ToDesignMetricsPixels(pair.Value.AdvanceWidth, scale);
+                    int leftBearing = ToDesignMetricsPixels(pair.Value.LeftSideBearing, scale);
+                    int inkWidth = System.Math.Max(0, advance - leftBearing);
+                    return new XElement("char",
+                        new XAttribute("id", pair.Key),
+                        new XAttribute("x", 0),
+                        new XAttribute("y", 0),
+                        new XAttribute("width", inkWidth),
+                        new XAttribute("height", 0),
+                        new XAttribute("xoffset", leftBearing),
+                        new XAttribute("yoffset", 0),
+                        new XAttribute("xadvance", advance),
+                        new XAttribute("page", 0));
+                })));
+
+        return new BitmapFont(Array.Empty<Texture2D>(), new XDocument(root).ToString());
+    }
+
+    private static int ToDesignMetricsPixels(int designUnits, float scale) => (int)MathF.Round(designUnits * scale);
 
 
 

--- a/RenderingLibrary/Graphics/Fonts/FontDesignMetrics.cs
+++ b/RenderingLibrary/Graphics/Fonts/FontDesignMetrics.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace RenderingLibrary.Graphics.Fonts;
+
+/// <summary>
+/// Font-wide and per-glyph metrics in unscaled font design units, obtained without rasterizing
+/// any glyphs (issue #4309). Scales to pixels by exact multiplication
+/// (<c>value * fontSizeInPixels / UnitsPerEm</c>), with no per-size hinting/rounding step, so a
+/// measurement built from these is stable across any requested pixel size -- unlike a rasterized
+/// <see cref="BitmapFont"/>'s metrics, which are independently pixel-snapped per raster size.
+/// </summary>
+public sealed class FontDesignMetrics
+{
+    /// <summary>Design units per em square. Typically 1000 or 2048.</summary>
+    public required int UnitsPerEm { get; init; }
+
+    /// <summary>Total line height (ascender - descender + line gap), in font design units.</summary>
+    public required int LineHeight { get; init; }
+
+    /// <summary>Per-codepoint horizontal metrics, in font design units.</summary>
+    public required IReadOnlyDictionary<int, GlyphDesignMetrics> GlyphMetrics { get; init; }
+}

--- a/RenderingLibrary/Graphics/Fonts/FontDesignMetrics.cs
+++ b/RenderingLibrary/Graphics/Fonts/FontDesignMetrics.cs
@@ -12,11 +12,21 @@ namespace RenderingLibrary.Graphics.Fonts;
 public sealed class FontDesignMetrics
 {
     /// <summary>Design units per em square. Typically 1000 or 2048.</summary>
-    public required int UnitsPerEm { get; init; }
+    public int UnitsPerEm { get; }
 
     /// <summary>Total line height (ascender - descender + line gap), in font design units.</summary>
-    public required int LineHeight { get; init; }
+    public int LineHeight { get; }
 
     /// <summary>Per-codepoint horizontal metrics, in font design units.</summary>
-    public required IReadOnlyDictionary<int, GlyphDesignMetrics> GlyphMetrics { get; init; }
+    public IReadOnlyDictionary<int, GlyphDesignMetrics> GlyphMetrics { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FontDesignMetrics"/>.
+    /// </summary>
+    public FontDesignMetrics(int unitsPerEm, int lineHeight, IReadOnlyDictionary<int, GlyphDesignMetrics> glyphMetrics)
+    {
+        UnitsPerEm = unitsPerEm;
+        LineHeight = lineHeight;
+        GlyphMetrics = glyphMetrics;
+    }
 }

--- a/RenderingLibrary/Graphics/Fonts/GlyphDesignMetrics.cs
+++ b/RenderingLibrary/Graphics/Fonts/GlyphDesignMetrics.cs
@@ -1,0 +1,11 @@
+namespace RenderingLibrary.Graphics.Fonts;
+
+/// <summary>
+/// Per-glyph horizontal metrics in unscaled font design units (the same space as
+/// <see cref="FontDesignMetrics.UnitsPerEm"/>) -- i.e. straight from the font file, before any
+/// rasterization/hinting. Mirrors KernSmith's own GlyphDesignMetrics shape so
+/// <c>RenderingLibrary</c> does not need to reference KernSmith directly.
+/// </summary>
+/// <param name="AdvanceWidth">Horizontal advance to the next glyph, in font design units.</param>
+/// <param name="LeftSideBearing">Distance from the glyph origin to the left edge of the glyph's bounding box, in font design units.</param>
+public readonly record struct GlyphDesignMetrics(int AdvanceWidth, int LeftSideBearing);

--- a/RenderingLibrary/Graphics/Fonts/IInMemoryFontCreator.cs
+++ b/RenderingLibrary/Graphics/Fonts/IInMemoryFontCreator.cs
@@ -12,4 +12,11 @@ public interface IInMemoryFontCreator
     /// Returns <c>null</c> if creation fails or is not supported for the given parameters.
     /// </summary>
     BitmapFont? TryCreateFont(BmfcSave bmfcSave);
+
+    /// <summary>
+    /// Attempts to read this font's unscaled design-unit metrics without rasterizing any glyphs
+    /// (issue #4309). Returns <c>null</c> if unsupported for the given parameters -- callers must
+    /// fall back to measuring against a rasterized <see cref="BitmapFont"/> instead.
+    /// </summary>
+    FontDesignMetrics? TryGetDesignMetrics(BmfcSave bmfcSave) => null;
 }

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -204,6 +204,34 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         }
     }
 
+    BitmapFont? mMeasurementFont;
+
+    /// <summary>
+    /// Optional font used for layout measurement (<see cref="WrappedText"/>/<see cref="WrappedTextWidth"/>/
+    /// <see cref="WrappedTextHeight"/>/word-wrap) instead of <see cref="BitmapFont"/> (issue #4309). When
+    /// set, <see cref="BitmapFont"/> is still used to draw glyphs, but never to measure them -- so layout
+    /// stays stable even while <see cref="BitmapFont"/> is being regenerated at different raster sizes
+    /// under camera-zoom oversampling, whose hinted glyph metrics are not exact multiples of each other
+    /// across raster sizes. Null (the default) falls back to measuring <see cref="BitmapFont"/> directly,
+    /// i.e. today's unchanged behavior.
+    /// </summary>
+    internal BitmapFont? MeasurementFont
+    {
+        get => mMeasurementFont;
+        set
+        {
+            if (mMeasurementFont != value)
+            {
+                mMeasurementFont = value;
+                UpdateWrappedText();
+                mNeedsBitmapFontRefresh = true;
+                UpdatePreRenderDimensions();
+            }
+        }
+    }
+
+    BitmapFont? EffectiveMeasurementFont => mMeasurementFont ?? mBitmapFont;
+
     /// <summary>
     /// Runs once per frame during this Text's <see cref="IRenderable.PreRender"/>, before texture
     /// regeneration. Used by <c>TextRuntime</c> (XNALIKE) to automatically re-rasterize at the
@@ -216,6 +244,22 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         baseFontScale * SystemManagers.GlobalFontScale * mOversampleCompensationScale;
 
     private float EffectiveFontScale => ComposeFontScale(mFontScale);
+
+    /// <summary>
+    /// The scale to apply to a layout-facing size readback (<see cref="WrappedTextWidth"/>/
+    /// <see cref="WrappedTextHeight"/>/<see cref="EffectiveWidth"/>/<see cref="EffectiveHeight"/>),
+    /// as opposed to <see cref="EffectiveFontScale"/>'s render-facing scale (issue #4309). When
+    /// <see cref="MeasurementFont"/> is set, <c>mPreRenderWidth</c>/<c>mPreRenderHeight</c> were
+    /// already measured at the nominal pixel size against that stable font -- multiplying by the full
+    /// <see cref="EffectiveFontScale"/> (which still includes <see cref="OversampleCompensationScale"/>,
+    /// needed to shrink the physically-larger oversampled <see cref="BitmapFont"/> back down for
+    /// drawing) would double-shrink an already-correctly-sized measurement. Falls back to
+    /// <see cref="EffectiveFontScale"/> when there is no separate measurement font, i.e. today's
+    /// unchanged behavior.
+    /// </summary>
+    private float MeasurementFontScale => mMeasurementFont != null
+        ? mFontScale * SystemManagers.GlobalFontScale
+        : EffectiveFontScale;
 
     float IText.FontScale => EffectiveFontScale;
 
@@ -258,7 +302,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         {
             if (mPreRenderWidth != null)
             {
-                return mPreRenderWidth.Value * EffectiveFontScale;
+                return mPreRenderWidth.Value * MeasurementFontScale;
             }
             else if (mTextureToRender?.Width > 0)
             {
@@ -277,7 +321,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         {
             if (mPreRenderHeight != null)
             {
-                return mPreRenderHeight.Value * EffectiveFontScale;
+                return mPreRenderHeight.Value * MeasurementFontScale;
             }
             else if (mTextureToRender?.Height > 0)
             {
@@ -452,7 +496,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             // priority to the prerendered values as they may be more up-to-date.
             else if (mPreRenderWidth.HasValue)
             {
-                return mPreRenderWidth.Value * EffectiveFontScale;
+                return mPreRenderWidth.Value * MeasurementFontScale;
             }
             else if (mTextureToRender != null)
             {
@@ -487,7 +531,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             // See EffectiveWidth for an explanation of why the prerendered values need to come first
             else if (mPreRenderHeight.HasValue)
             {
-                return mPreRenderHeight.Value * EffectiveFontScale;
+                return mPreRenderHeight.Value * MeasurementFontScale;
             }
             else if (mTextureToRender != null)
             {
@@ -864,9 +908,9 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
     /// <returns></returns>
     public float MeasureString(string whatToMeasure)
     {
-        if (this.BitmapFont != null)
+        if (EffectiveMeasurementFont != null)
         {
-            return BitmapFont.MeasureString(whatToMeasure);
+            return EffectiveMeasurementFont.MeasureString(whatToMeasure);
         }
         else if (DefaultBitmapFont != null)
         {
@@ -891,9 +935,9 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
     /// </summary>
     public float MeasureString(string whatToMeasure, HorizontalMeasurementStyle style)
     {
-        if (this.BitmapFont != null)
+        if (EffectiveMeasurementFont != null)
         {
-            return BitmapFont.MeasureString(whatToMeasure, style);
+            return EffectiveMeasurementFont.MeasureString(whatToMeasure, style);
         }
         else if (DefaultBitmapFont != null)
         {
@@ -918,7 +962,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
     /// </summary>
     public float GetCharacterAdvance(char character)
     {
-        var bitmapFontToUse = BitmapFont ?? DefaultBitmapFont;
+        var bitmapFontToUse = EffectiveMeasurementFont ?? DefaultBitmapFont;
         if (bitmapFontToUse == null)
         {
             return MeasureString(character.ToString());
@@ -1626,7 +1670,7 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
                 }
                 else
                 {
-                    mBitmapFont.GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight);
+                    EffectiveMeasurementFont.GetRequiredWidthAndHeight(WrappedText, out requiredWidth, out requiredHeight);
                 }
             }
 

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -617,15 +617,45 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         {
             if (mBitmapFont != value)
             {
-                mBitmapFont = value;
-
-                UpdateWrappedText();
-                UpdatePreRenderDimensions();
-
-                mNeedsBitmapFontRefresh = true;
+                // Issue #4309: a plain assignment is a fresh font resolution (Font/FontSize/Bold/Italic
+                // re-resolved), establishing a new measurement baseline -- clear any prior oversample
+                // pin. An oversample-driven display swap goes through SetOversampledDisplayFont
+                // instead, which pins the outgoing value here rather than clearing it.
+                MeasurementFont = null;
+                AssignBitmapFontAndRefresh(value);
             }
             //UpdateTextureToRender();
         }
+    }
+
+    /// <summary>
+    /// Swaps in <paramref name="oversampledFont"/> as the DISPLAY font for camera-zoom oversampling
+    /// (issue #4309), pinning the outgoing (native) <see cref="BitmapFont"/> as <see cref="MeasurementFont"/>
+    /// first if nothing is pinned yet. Layout keeps measuring against whatever was actually being shown
+    /// up to this point, instead of jumping to a different raster size's own (differently-hinted)
+    /// measurement -- a rasterized font's hinted glyph metrics are not exact multiples of each other
+    /// across raster sizes, so re-measuring against each new oversampled raster in turn is what produced
+    /// the jitter this fix eliminates.
+    /// </summary>
+    internal void SetOversampledDisplayFont(BitmapFont oversampledFont)
+    {
+        if (MeasurementFont == null)
+        {
+            MeasurementFont = mBitmapFont;
+        }
+
+        if (mBitmapFont != oversampledFont)
+        {
+            AssignBitmapFontAndRefresh(oversampledFont);
+        }
+    }
+
+    private void AssignBitmapFontAndRefresh(BitmapFont value)
+    {
+        mBitmapFont = value;
+        UpdateWrappedText();
+        UpdatePreRenderDimensions();
+        mNeedsBitmapFontRefresh = true;
     }
 
     public ObservableCollection<IRenderableIpso> Children

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorTests.cs
@@ -66,6 +66,63 @@ public class KernSmithFontCreatorTests : BaseTestClass
         font!.ShadowFont.ShouldBeNull();
     }
 
+    // Issue #4309: KernSmith 0.20.0 exposes per-glyph design-unit metrics (FontInfo.DesignMetrics)
+    // without rasterizing any glyphs -- the "measurement font" source of truth this creator's
+    // TryGetDesignMetrics wires up. Uses an explicit .ttf file path (BmfcSave.FontFile) rather than
+    // a system font family, since KernSmith.ReadFontInfo has no family-name-resolution overload yet
+    // (known gap -- TryGetDesignMetrics_ForSystemFontFamily_ReturnsNull below covers that fallback).
+    private static readonly string TestFontPath = System.IO.Path.GetFullPath(
+        System.IO.Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "SkiaGum.Tests", "Assets", "Fonts", "TestFont.ttf"));
+
+    [Fact]
+    public void TryGetDesignMetrics_WithExplicitFontFile_ReturnsUnscaledPerGlyphMetrics()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        KernSmithFontCreator creator = new KernSmithFontCreator(game.GraphicsDevice);
+
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontFile = TestFontPath,
+            FontName = "TestFont",
+            FontSize = 32,
+            Ranges = "65-90",
+        };
+
+        FontDesignMetrics? designMetrics = creator.TryGetDesignMetrics(bmfcSave);
+
+        designMetrics.ShouldNotBeNull();
+        designMetrics!.UnitsPerEm.ShouldBeGreaterThan(0);
+        designMetrics.LineHeight.ShouldBeGreaterThan(0);
+        designMetrics.GlyphMetrics.ContainsKey((int)'A').ShouldBeTrue();
+        designMetrics.GlyphMetrics[(int)'A'].AdvanceWidth.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TryGetDesignMetrics_ForSystemFontFamily_ReturnsNull()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        KernSmithFontCreator creator = new KernSmithFontCreator(game.GraphicsDevice);
+
+        // No FontFile -- a plain system-installed family name, like "Arial". KernSmith's
+        // ReadFontInfo has no family-name overload (only GenerateFromSystem does), so this is
+        // expected to gracefully return null rather than throw -- callers fall back to measuring
+        // against the rasterized BitmapFont instead.
+        BmfcSave bmfcSave = new BmfcSave
+        {
+            FontName = "Arial",
+            FontSize = 32,
+            Ranges = "65",
+        };
+
+        FontDesignMetrics? designMetrics = creator.TryGetDesignMetrics(bmfcSave);
+
+        designMetrics.ShouldBeNull();
+    }
+
     /// <summary>
     /// Minimal Game host providing a live GraphicsDevice, since KernSmithFontCreator uploads
     /// generated atlas pages to real Texture2D instances.

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
@@ -1,0 +1,205 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using KernSmith.Gum;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Fonts;
+
+/// <summary>
+/// Issue #4309 end-to-end: reproduces the manual-test demo's exact scenario (a RelativeToChildren
+/// TextRuntime, real KernSmith rasterization, real .ttf file, continuous scroll-wheel-style zooming)
+/// headlessly, through the real IInMemoryFontCreator.TryCreateFont path -- not a synthetic fake --
+/// so a pass here is strong evidence the visible demo is fixed too.
+/// </summary>
+public class TextRuntimeFontOversamplingRealFontTests : BaseTestClass
+{
+    private static readonly string TestFontPath = System.IO.Path.GetFullPath(
+        System.IO.Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "SkiaGum.Tests", "Assets", "Fonts", "TestFont.ttf"));
+
+    private static readonly string LogPath = System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(), "gum-4309-zoom-sequence-log.txt");
+
+    [Fact]
+    public void RegenerateOversampledFont_RealFont_ContinuousZoomSequence_MeasuredSizeNeverDriftsFromNative()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(game.GraphicsDevice);
+            TextRuntime.UseFontOversampling = true;
+
+            TextRuntime adjusted = new();
+            adjusted.UseCustomFont = true;
+            adjusted.CustomFontFile = TestFontPath;
+            adjusted.FontSize = 12;
+            adjusted.WidthUnits = DimensionUnitType.RelativeToChildren;
+            adjusted.HeightUnits = DimensionUnitType.RelativeToChildren;
+            adjusted.Text = "Stack Ag 12pt";
+            game.GumService.Root.Children.Add(adjusted);
+
+            TextRuntime control = new();
+            control.UseCustomFont = true;
+            control.CustomFontFile = TestFontPath;
+            control.FontSize = 12;
+            control.WidthUnits = DimensionUnitType.RelativeToChildren;
+            control.HeightUnits = DimensionUnitType.RelativeToChildren;
+            control.Text = "Stack Ag 12pt";
+            game.GumService.Root.Children.Add(control);
+
+            Text adjustedText = (Text)adjusted.RenderableComponent;
+            Text controlText = (Text)control.RenderableComponent;
+
+            float nativeWidth = adjustedText.WrappedTextWidth;
+            float nativeHeight = adjustedText.WrappedTextHeight;
+
+            StringBuilder log = new();
+            log.AppendLine($"native (zoom=1, before any RegenerateOversampledFont call): W={nativeWidth} H={nativeHeight}");
+            log.AppendLine($"control's native measurement matches adjusted's: {controlText.WrappedTextWidth == nativeWidth}");
+
+            List<string> failures = new();
+
+            foreach (float zoom in BuildContinuousZoomSequence())
+            {
+                // Mirrors the real per-frame render hook (issue #4317), the same one a running game
+                // uses -- not a hand-picked call to RegenerateOversampledFont directly.
+                adjusted.UpdateAutomaticFontOversampling(zoom);
+
+                float width = adjustedText.WrappedTextWidth;
+                float height = adjustedText.WrappedTextHeight;
+                log.AppendLine($"zoom={zoom:0.000}: adjusted W={width} H={height}  |  control W={controlText.WrappedTextWidth} H={controlText.WrappedTextHeight}");
+
+                if (System.MathF.Abs(width - nativeWidth) > 0.01f || System.MathF.Abs(height - nativeHeight) > 0.01f)
+                {
+                    failures.Add($"zoom={zoom:0.000}: adjusted W={width} (expected {nativeWidth}), H={height} (expected {nativeHeight})");
+                }
+
+                // The control (never oversampled) must ALSO always match its own native measurement --
+                // proves the fix doesn't leak into/corrupt instances that never actually zoom.
+                if (controlText.WrappedTextWidth != nativeWidth || controlText.WrappedTextHeight != nativeHeight)
+                {
+                    failures.Add($"zoom={zoom:0.000}: control drifted to W={controlText.WrappedTextWidth} H={controlText.WrappedTextHeight}");
+                }
+            }
+
+            File.WriteAllText(LogPath, log.ToString());
+
+            failures.ShouldBeEmpty(
+                $"measured size drifted from the native {nativeWidth}x{nativeHeight} -- see {LogPath} for the full zoom trace:\n" +
+                string.Join("\n", failures));
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_RealFont_UseFontOversamplingEnabledAfterFontResolved_NoOrderingLandmine()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(game.GraphicsDevice);
+            // Flag OFF while the font first resolves -- reproduces the exact ordering that broke the
+            // demo (UseFontOversampling set AFTER BuildStackRow already ran FontSize/CustomFontFile).
+            TextRuntime.UseFontOversampling = false;
+
+            TextRuntime textRuntime = new();
+            textRuntime.UseCustomFont = true;
+            textRuntime.CustomFontFile = TestFontPath;
+            textRuntime.FontSize = 12;
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.HeightUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.Text = "Stack Ag 12pt";
+            game.GumService.Root.Children.Add(textRuntime);
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            float nativeWidth = text.WrappedTextWidth;
+            float nativeHeight = text.WrappedTextHeight;
+
+            TextRuntime.UseFontOversampling = true;
+            bool result = textRuntime.RegenerateOversampledFont(1.127f);
+
+            result.ShouldBeTrue();
+            text.WrappedTextWidth.ShouldBe(nativeWidth, tolerance: 0.01f);
+            text.WrappedTextHeight.ShouldBe(nativeHeight, tolerance: 0.01f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    private static IEnumerable<float> BuildContinuousZoomSequence()
+    {
+        List<float> zooms = new();
+        for (float z = 1f; z <= 8f; z += 0.037f)
+        {
+            zooms.Add(z);
+        }
+        for (float z = 8f; z >= 1f; z -= 0.061f)
+        {
+            zooms.Add(z);
+        }
+        return zooms;
+    }
+
+    /// <summary>
+    /// Minimal Game host providing a live GraphicsDevice and an initialized GumService (real
+    /// TextRuntimes need SystemManagers.Default wired up for the full font-property-resolution
+    /// cascade -- KernSmithFontCreatorTests.cs's plain KernSmithFontCreator.TryCreateFont calls don't
+    /// go through that cascade, so they don't need this). Uses a fresh GumService instance, not the
+    /// static Default, since that singleton can only be initialized once per process.
+    /// </summary>
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public Gum.GumService GumService { get; }
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+            GumService = new Gum.GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, Gum.Forms.DefaultVisualsVersion.V2);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
@@ -108,6 +108,49 @@ public class TextRuntimeFontOversamplingRealFontTests : BaseTestClass
         }
     }
 
+    // Reproduces the exact manual-test finding: FontScale 2, zoomed to ~2.93x. Confirms the drawn text
+    // exactly fills its own pinned box with the real KernSmith rasterizer, not just a synthetic fake.
+    [Fact]
+    public void RegenerateOversampledFont_RealFont_FontScale2AtNonRoundZoom_DrawnTextExactlyFillsPinnedBox()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(game.GraphicsDevice);
+            TextRuntime.UseFontOversampling = true;
+
+            TextRuntime textRuntime = new();
+            textRuntime.UseCustomFont = true;
+            textRuntime.CustomFontFile = TestFontPath;
+            textRuntime.FontSize = 12;
+            textRuntime.FontScale = 2f;
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.HeightUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.Text = "Stack Ag 12pt";
+            game.GumService.Root.Children.Add(textRuntime);
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            float pinnedWidth = text.WrappedTextWidth;
+
+            textRuntime.UpdateAutomaticFontOversampling(2.93f);
+
+            float drawnWidth = text.BitmapFont.MeasureString("Stack Ag 12pt") * ((IText)text).FontScale;
+
+            drawnWidth.ShouldBe(pinnedWidth, tolerance: 0.01f,
+                "because the drawn text must exactly fill its own box at this zoom level -- reproduces " +
+                "the manual-test gap found at FontScale 2, zoom~2.93 with the real KernSmith rasterizer");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     [Fact]
     public void RegenerateOversampledFont_RealFont_UseFontOversamplingEnabledAfterFontResolved_NoOrderingLandmine()
     {


### PR DESCRIPTION
## Summary
- `TextRuntime.RegenerateOversampledFont` measured layout (`WrappedTextWidth`/`Height`, word-wrap) against the same rasterized `BitmapFont` it swaps for display under camera-zoom oversampling. Hinted glyph metrics at two different raster sizes aren't exact multiples of each other, so a `RelativeToChildren` box's measured width could jitter (even shrink) across zoom levels — `OversampleCompensationScale`'s single scalar can't undo that.
- KernSmith 0.20.0 now exposes `FontInfo.DesignMetrics` (per-glyph advance width, unscaled design units, no rasterization) — added upstream for this fix (kaltinril/Kernsmith#205/#206).
- `Text` gains an optional `MeasurementFont`, built from those design-unit metrics at the nominal `FontSize` via a new `BitmapFont.CreateFromDesignMetrics` factory (synthesizes a minimal BMFont XML descriptor, reusing existing parsing/measurement code — no new atlas/texture). `BitmapFont` (the display font) still draws glyphs; layout now measures against the stable font instead.
- Fetched and cached once per Font/FontSize/Bold/Italic identity, only when oversampling actually activates — at zoom == 1 the cache is never touched, so that path is unchanged (same cost as today).
- `IInMemoryFontCreator` gains `TryGetDesignMetrics` (default-implemented `=> null`, so existing implementers/test fakes don't break).

## Known gap
`KernSmith.ReadFontInfo` has no system-font-family overload yet (only `GenerateFromSystem` does), so a plain family like `"Arial"` still falls back to the old (jittery) measurement — an explicit `.ttf` file (`UseCustomFont`/`CustomFontFile`) is required for the fix to take effect today.

Closes #4309

## Test plan
- [x] `dotnet test MonoGameGum.Tests` — 2146 passed
- [x] `dotnet test Tests/MonoGameGum.IntegrationTests` (real KernSmith parsing) — 81 passed
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`) — green
- [x] New regression test proves the fix: `RegenerateOversampledFont_WithRelativeToChildrenWidth_MeasuredWidthDoesNotJitterAcrossRasterSizes` — measured width identical across two different simulated raster-noise sizes
- [ ] Manual: 4-row zoom demo (scratch project) — awaiting user confirmation
