### PR TITLE
Fix GumBundleLoader.Resolve to detect .gumj bundle entries, not just .gumx

### DIFF
--- a/GumCommon/Bundle/GumBundleLoader.cs
+++ b/GumCommon/Bundle/GumBundleLoader.cs
@@ -16,6 +16,11 @@ namespace Gum.Bundle;
 /// </summary>
 public static class GumBundleLoader
 {
+    // XML first: a project written by an older `gumcli pack` before JSON support only ever
+    // produced a ".gumx" entry, so checking it first keeps existing bundles resolving without
+    // a JSON probe.
+    private static readonly string[] GumxCandidateExtensions = { ".gumx", ".gumj" };
+
     /// <summary>
     /// Returns a <see cref="ProjectResolution"/> describing how to load <paramref name="projectPath"/>.
     /// The extension picks the mode: <c>.gumx</c>/<c>.gumj</c> = loose, <c>.gumpkg</c> = bundle. Any
@@ -70,15 +75,6 @@ public static class GumBundleLoader
         // .gumpkg loading requires System.Formats.Tar (net7+).
         throw new NotSupportedException(".gumpkg loading requires net7.0 or greater.");
 #else
-        // The bundle stores its own .gumx by name; the path we hand to GumProjectSave.Load is
-        // the sibling .gumx path, and the hook below intercepts that read so it's served from
-        // the bundle stream. Callers never need to know the .gumx name themselves.
-        string? directory = Path.GetDirectoryName(resolvedPath);
-        string nameWithoutExtension = Path.GetFileNameWithoutExtension(resolvedPath);
-        string gumxPath = string.IsNullOrEmpty(directory)
-            ? nameWithoutExtension + ".gumx"
-            : Path.Combine(directory!, nameWithoutExtension + ".gumx");
-
         // Read the bundle through the same file seam as the rest of the loader. On desktop
         // this is File.OpenRead; on TitleContainer-backed platforms (Blazor WASM / Android /
         // iOS) the host-installed CustomGetStreamFromFile hook routes the read through
@@ -96,6 +92,36 @@ public static class GumBundleLoader
         {
             bundle = GumBundleReader.Read(bundleStream);
         }
+
+        // The bundle stores its own top-level project file by name (see
+        // GumProjectDependencyWalker.TryGetGumxRelativePath, which preserves the packed
+        // project's real extension) - it may be an XML ".gumx" or a JSON ".gumj" project
+        // (issue #4350). Probe both instead of assuming XML; the path we hand to
+        // GumProjectSave.Load is the sibling path with whichever extension the bundle
+        // actually contains, and the hook below intercepts that read so it's served from
+        // the bundle stream. Callers never need to know the project entry's name themselves.
+        string? directory = Path.GetDirectoryName(resolvedPath);
+        string nameWithoutExtension = Path.GetFileNameWithoutExtension(resolvedPath);
+        string? gumxEntryName = null;
+        foreach (string candidateExtension in GumxCandidateExtensions)
+        {
+            string candidateEntry = nameWithoutExtension + candidateExtension;
+            if (bundle.Entries.ContainsKey(candidateEntry))
+            {
+                gumxEntryName = candidateEntry;
+                break;
+            }
+        }
+        if (gumxEntryName == null)
+        {
+            throw new FileNotFoundException(
+                $"The Gum bundle '{resolvedPath}' does not contain a top-level project file " +
+                $"named '{nameWithoutExtension}.gumx' or '{nameWithoutExtension}.gumj'.",
+                resolvedPath);
+        }
+        string gumxPath = string.IsNullOrEmpty(directory)
+            ? gumxEntryName
+            : Path.Combine(directory!, gumxEntryName);
 
         BundleGumFileProvider provider = new BundleGumFileProvider(bundle);
         string projectRoot = string.IsNullOrEmpty(directory) ? "." : directory!;

--- a/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumBundleLoaderTests.cs
@@ -191,6 +191,32 @@ public class GumBundleLoaderTests : IDisposable
     }
 
     [Fact]
+    public void Resolve_with_gumpkg_extension_finds_gumj_entry_when_packed_project_was_json_format()
+    {
+        // A bundle packed from a JSON-format (.gumj) project stores its top-level project entry
+        // under its real name/extension (see GumProjectDependencyWalker.TryGetGumxRelativePath),
+        // not ".gumx". Resolve must not assume XML - see issue #4350.
+        byte[] gumjBytes = Encoding.UTF8.GetBytes("{}");
+        string gumpkgPath = Path.Combine(_tempDir, "Project.gumpkg");
+        string expectedProjectPath = Path.Combine(_tempDir, "Project.gumj");
+        WriteBundle(gumpkgPath, new (string, byte[])[]
+        {
+            ("Project.gumj", gumjBytes),
+        });
+
+        ProjectResolution resolution = GumBundleLoader.Resolve(gumpkgPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        resolution.ResolvedGumxPath.ShouldBe(expectedProjectPath);
+        FileManager.CustomGetStreamFromFile.ShouldNotBeNull();
+
+        using Stream stream = FileManager.CustomGetStreamFromFile!(expectedProjectPath);
+        using MemoryStream copy = new MemoryStream();
+        stream.CopyTo(copy);
+        copy.ToArray().ShouldBe(gumjBytes);
+    }
+
+    [Fact]
     public void Resolve_with_gumj_extension_is_treated_as_loose_like_gumx()
     {
         // .gumj (JSON) projects are loose-file projects exactly like .gumx (issue #4180) -

--- a/Tests/Gum.Cli.Tests/PackCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/PackCommandTests.cs
@@ -1,16 +1,22 @@
 using Gum.Bundle;
+using Gum.DataTypes;
 using Shouldly;
+using ToolsUtilities;
 
 namespace Gum.Cli.Tests;
 
 public class PackCommandTests : IDisposable
 {
     private readonly string _tempDirectory;
+    private readonly Func<string, Stream>? _previousHook;
 
     public PackCommandTests()
     {
         _tempDirectory = Path.Combine(Path.GetTempPath(), "GumCliPackTests_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDirectory);
+        // GumBundleLoader.Resolve installs FileManager.CustomGetStreamFromFile as global mutable
+        // state; stash/restore around it so this test class stays isolated from others.
+        _previousHook = FileManager.CustomGetStreamFromFile;
     }
 
     [Fact]
@@ -234,6 +240,44 @@ public class PackCommandTests : IDisposable
     }
 
     [Fact]
+    public void Pack_of_JSON_format_project_loads_back_through_GumBundleLoader_Resolve()
+    {
+        // Regression guard for #4350: gumcli pack succeeding (and gumcli check passing) is not
+        // proof the resulting .gumpkg can actually be loaded - GumBundleLoader.Resolve used to
+        // hardcode ".gumx" for the bundle's internal project entry, so a bundle packed from a
+        // JSON-format (.gumj) project failed to load with a FileNotFoundException even though
+        // packing it reported success.
+        string projectDir = Path.Combine(_tempDirectory, "JsonLoadProject");
+        string projectPath = Path.Combine(projectDir, "JsonLoadProject.gumx");
+        CliTestHelper.Run("new", projectPath, "--template", "empty").ExitCode.ShouldBe(0);
+        CliTestHelper.Run("convert-to-json", projectPath).ExitCode.ShouldBe(0);
+        string gumjPath = Path.Combine(projectDir, "JsonLoadProject.gumj");
+        // GumBundleLoader.Resolve derives the internal project entry's base name from the
+        // .gumpkg's own base name, so the two must match - use the project's name, not "out".
+        string outputPath = Path.Combine(projectDir, "JsonLoadProject.gumpkg");
+
+        string[] xmlExtensions = { "gumx", "gusx", "gucx", "gutx", "behx", "ganx" };
+        foreach (string xmlFile in Directory.EnumerateFiles(projectDir, "*.*", SearchOption.AllDirectories)
+                     .Where(f => xmlExtensions.Contains(Path.GetExtension(f).TrimStart('.'), StringComparer.OrdinalIgnoreCase)))
+        {
+            File.Delete(xmlFile);
+        }
+
+        CliTestHelper.Run("pack", gumjPath, "-o", outputPath, "--include", "core").ExitCode.ShouldBe(0);
+
+        ProjectResolution resolution = GumBundleLoader.Resolve(outputPath);
+
+        resolution.UsedBundle.ShouldBeTrue();
+        resolution.ResolvedGumxPath.ShouldBe(Path.Combine(projectDir, "JsonLoadProject.gumj"));
+
+        GumProjectSave? loaded = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult loadResult);
+
+        loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+        loadResult.MissingFiles.ShouldBeEmpty();
+        loaded.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void Pack_writes_output_to_default_path_when_no_dash_o()
     {
         string projectPath = CreateCleanProject("DefaultOut");
@@ -351,6 +395,7 @@ public class PackCommandTests : IDisposable
 
     public void Dispose()
     {
+        FileManager.CustomGetStreamFromFile = _previousHook;
         if (Directory.Exists(_tempDirectory))
         {
             try


### PR DESCRIPTION
## Summary
`GumBundleLoader.Resolve` always synthesized the bundle's internal project entry as `<name>.gumx`, regardless of what format was actually packed. Bundles packed from JSON (`.gumj`) projects contain a `.gumj` entry (per `GumProjectDependencyWalker.TryGetGumxRelativePath`), so `Resolve` couldn't find it and threw `FileNotFoundException` on load even though `gumcli pack`/`check` succeeded.

Fix: `Resolve` now probes both `.gumx` and `.gumj` against the bundle's actual entries (XML first, for back-compat with older bundles) instead of assuming XML.

## Test plan
- [x] `Tests/Gum.Bundle.Tests` — new unit test for `Resolve` locating a `.gumj` entry (confirmed red before the fix)
- [x] `Tests/Gum.Cli.Tests` — new end-to-end test: packs a JSON-format project, then loads the resulting bundle back through `GumBundleLoader.Resolve` + `GumProjectSave.Load` (the gap the original issue called out — prior JSON coverage only asserted `pack` succeeded, never that the bundle could be loaded)
- [x] Full `Gum.Bundle.Tests` (72), `Gum.Cli.Tests` (67), and relevant `MonoGameGum.Tests` bundle tests green

Closes #4350
