### PR TITLE
Fix wireframe/texture canvases reacting to clicks while the Gum window is inactive

### DIFF
--- a/InputLibrary/WpfInputHostAdapter.cs
+++ b/InputLibrary/WpfInputHostAdapter.cs
@@ -24,10 +24,13 @@ namespace InputLibrary
             _element = element;
         }
 
-        // Requires _element to be connected to a live PresentationSource (i.e. hosted in a shown
-        // window) to reflect real keyboard focus - not unit-testable without spinning up a real WPF
-        // window, so this is exercised by the manual/runtime check instead.
-        public bool Focused => _element.IsFocused;
+        // IsKeyboardFocused (not IsFocused) is required here: IsFocused reflects WPF's logical
+        // focus-scope state, which does not clear when the containing window loses OS activation,
+        // so clicks would keep registering while another window sits on top. IsKeyboardFocused
+        // tracks real OS keyboard focus. Requires _element to be connected to a live
+        // PresentationSource (i.e. hosted in a shown window) - not unit-testable without spinning
+        // up a real WPF window, so this is exercised by the manual/runtime check instead.
+        public bool Focused => _element.IsKeyboardFocused;
 
         public int Width => (int)_element.ActualWidth;
 


### PR DESCRIPTION
## Summary
Fixes #4353. `WpfInputHostAdapter.Focused` used `FrameworkElement.IsFocused` (WPF logical focus-scope state, sticky across window deactivation) instead of `IsKeyboardFocused` (real OS keyboard focus). `Cursor.PrimaryClick`/`PrimaryDown`/etc. gate on this flag, so once the wireframe/texture canvas ever held focus, clicks kept registering while another window was on top. The WinForms adapter this replaced used `Control.Focused`, which is correctly tied to real Win32 focus.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings
- [x] `dotnet test` on `WpfInputHostAdapterTests` — green
- Manual test: needed (see PR comment / conversation)
