### PR TITLE
Document a hotfix release path in the tool-release process

### DIFF
--- a/.claude/skills/gum-monthly-release/SKILL.md
+++ b/.claude/skills/gum-monthly-release/SKILL.md
@@ -12,6 +12,8 @@ This skill is a **collaboration**. The user has explicitly said: when anything i
 
 Anything you can't resolve mid-draft, capture in the `## Open Questions` block at the bottom of the markdown file. The user will work through that block with you after the file is generated.
 
+**Not for hotfixes.** This skill's fan-out is built for monthly-scale PR volume. A hotfix (emergency single-bug release) gets a short manual note instead — see "Hotfixes" in `docs/contributing/building-and-releasing-gum.md`.
+
 ## Step 1: Front-loaded questions
 
 Before doing any work, ask the user (in a single message, as a numbered list — they can answer all at once):

--- a/.claude/skills/gum-release/SKILL.md
+++ b/.claude/skills/gum-release/SKILL.md
@@ -17,12 +17,14 @@ The release process lives in **[`docs/contributing/building-and-releasing-gum.md
 ## How to run
 
 1. **Read the doc** above and confirm the current step list with the user.
-2. **Track progress** — create one task per step (`TaskCreate`) so nothing is dropped across the long-running release, and mark each `completed` as the user confirms it.
-3. **Walk the steps in order**, one at a time. For each, state what the user needs to do (the doc has the detail) and wait for confirmation before advancing.
-4. **Hand off the automatable step.** Release-notes generation is the only step with real automation, and it lives in **`gum-monthly-release`**. That skill is `disable-model-invocation: true`, so the `Skill` tool refuses it — read `.claude/skills/gum-monthly-release/SKILL.md` and follow it yourself instead. Everything else (NuGet workflow trigger, Build-and-Release workflow, screenshots, migration doc, announcements, FRB FTP upload) is the user's manual action; you confirm and check it off.
+2. **Ask if this is a hotfix** — an emergency tool release for a bad bug, outside the normal cadence. If yes, follow the doc's "Hotfixes" subsection: skip `gum-monthly-release` (write a short manual note instead), skip screenshots and community announcements, and confirm with the user that the fix carries no breaking changes before tagging.
+3. **Track progress** — create one task per step (`TaskCreate`) so nothing is dropped across the long-running release, and mark each `completed` as the user confirms it. For a hotfix, only create tasks for the steps that apply.
+4. **Walk the steps in order**, one at a time. For each, state what the user needs to do (the doc has the detail) and wait for confirmation before advancing.
+5. **Hand off the automatable step (non-hotfix only).** Release-notes generation is the only step with real automation, and it lives in **`gum-monthly-release`**. That skill is `disable-model-invocation: true`, so the `Skill` tool refuses it — read `.claude/skills/gum-monthly-release/SKILL.md` and follow it yourself instead. Everything else (NuGet workflow trigger, Build-and-Release workflow, screenshots, migration doc, announcements, FRB FTP upload) is the user's manual action; you confirm and check it off.
 
 ## Gotchas
 
 - The two processes in the doc — **NuGet publishing** and **tool release** — are independent. Ask which the user is doing; don't assume both.
+- A hotfix is a mode of the tool release, not a separate process — same steps, minus notes/promotion. Don't run `gum-monthly-release` for one.
 - `gum-monthly-release` only writes the notes markdown. It does **not** bump versions, cut the tag, or trigger workflows — those are separate manual steps in the doc.
 - The **Full Changelog** compare link in the notes can only be filled after the tag exists, so it stays a placeholder until the release is cut.

--- a/docs/contributing/building-and-releasing-gum.md
+++ b/docs/contributing/building-and-releasing-gum.md
@@ -34,3 +34,12 @@ The skill writes a draft to `temp/` and walks through any open questions with yo
 3. Add the generated notes and screenshots to the GitHub release. Fill in the **Full Changelog** compare link once the tag exists.
 4. Create or update the [migration documentation](../gum-tool/upgrading/README.md) if there are breaking changes.
 5. Announce the release across the community channels: FRB Discord, MonoGame Discord, MGE Discord, Kni Discord, Twitter, Bluesky, and the MonoGame community forum.
+
+### Hotfixes
+
+A hotfix is an emergency tool release for a bad bug, cut outside the normal release cadence. It skips anything not required to ship the fix:
+
+* Skip `/gum-monthly-release` — that skill is built for monthly-scale PR volume. Write a short, plain note describing the bug and the fix instead.
+* Skip screenshots/GIFs and skip step 5 (community announcements).
+* A hotfix should never carry a breaking change — confirm that before tagging.
+* Still run the Build and Release Gum Tool workflow (step 2) and fill in the GitHub release notes and Full Changelog link.


### PR DESCRIPTION
## Summary
- Adds a "Hotfixes" subsection to `docs/contributing/building-and-releasing-gum.md`: emergency single-bug releases skip `/gum-monthly-release` notes and community announcements, still run the release workflow, and must not carry breaking changes.
- `gum-release` skill asks up front whether the run is a hotfix and short-circuits the affected steps.
- `gum-monthly-release` skill gets a one-line guard pointing hotfixes elsewhere.

## Test plan
- [x] Docs-only change, no build required.