### PR TITLE
Document TextRuntime.UseFontOversampling / RegenerateOversampledFont

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -127,9 +127,13 @@ This applies to: "as of <date>", "starting in <date>", "before <date>", "in vers
 
 ## Flag Release Status for New Features
 
-Before documenting a new feature or behavior, confirm whether it has already shipped, is out in preview, or hasn't shipped yet — ask the user if it's not clear from context. Then flag accordingly in a `{% hint style="info" %}` block (same pattern as dated content above):
+Before documenting a new feature or behavior, ask the user whether it has already shipped, is out in preview, or hasn't shipped yet — they usually know offhand, which is faster than investigating. Only investigate yourself when they don't know: walk the feature's commits with `git merge-base --is-ancestor <commit> <sha>` against the commit each candidate NuGet build was made from, then confirm against the live NuGet feed.
 
-- **Not yet shipped** — `Coming in <Month Year>` (the target release).
+**"Shipped" means published to NuGet (stable or preview), not merged to `main`.** Runtime NuGet packages publish on a separate, manually-triggered workflow (`dotnet-nuget.yaml`) from the Tool's near-daily GitHub Releases (`build-and-release.yml`) — a feature on `main`, or even bundled into a dated Tool release, can sit unpublished to NuGet for days.
+
+Then flag accordingly in a `{% hint style="info" %}` block (same pattern as dated content above):
+
+- **Not yet shipped** — `Available in <next calendar month> <year>, or now if building Gum from source.` Next month is always the target; don't ask the user which release.
 - **Shipped in preview** — note that it's a preview feature.
 - **Fully shipped** — no flag; write it as current behavior.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -332,6 +332,7 @@
     * [Font Localization](code/files-and-fonts/font-localization.md)
     * [Font Cache](code/files-and-fonts/font-cache.md)
     * [Advanced Font Effects](code/files-and-fonts/advanced-font-effects.md)
+    * [Font Oversampling](code/files-and-fonts/font-oversampling.md)
   * [File Loading](code/files-and-fonts/file-loading.md)
   * [Animation Chains](code/files-and-fonts/animation-chains.md)
   * [BitmapFont](code/files-and-fonts/bitmapfont.md)

--- a/docs/code/files-and-fonts/font-oversampling.md
+++ b/docs/code/files-and-fonts/font-oversampling.md
@@ -1,0 +1,146 @@
+# Font Oversampling
+
+## Introduction
+
+When a camera or layer zooms in, text rasterized at its normal `FontSize` gets stretched along with everything else, so it looks soft or blocky compared to art rendered at native resolution. Font oversampling fixes this by regenerating the font atlas at a higher raster size while zoomed in, then scaling the drawn glyphs back down — so the text occupies the same layout space but its glyphs are rasterized at a higher pixel density, keeping edges crisp.
+
+{% hint style="info" %}
+Available in September 2026, or now if building Gum from source.
+{% endhint %}
+
+{% hint style="info" %}
+Available on MonoGame, KNI, and FNA. Not yet available on Raylib, SkiaGum, or Silk.NET.
+{% endhint %}
+
+## Enabling Oversampling
+
+Two things are required:
+
+1. Set the global flag: `TextRuntime.UseFontOversampling = true`. This is a project-wide `static` switch, not a per-instance property — pixel-art games that want blocky text at any zoom level should leave it off.
+2. Register an `IInMemoryFontCreator` (KernSmith, for the runtimes that support it — see [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation)). Oversampling only makes sense with dynamic font generation; a disk-based `FontCache` holds a fixed set of pre-baked sizes and can't rasterize a new one on demand.
+
+```csharp
+// Initialize
+TextRuntime.UseFontOversampling = true;
+CustomSetPropertyOnRenderable.InMemoryFontCreator =
+    new KernSmithFontCreator(GraphicsDevice);
+```
+
+Once both are set, oversampling runs automatically: every frame, each visible `TextRuntime` checks the effective zoom of the `Layer` it's on and regenerates its font when that zoom has moved by at least a full raster pixel. No manual per-frame code is needed for the common case.
+
+That per-`Layer` scoping matters: a layer with `LayerCameraSettings.IsInScreenSpace = true` (the normal setup for a HUD) is pinned to its own `Zoom` (default 1) regardless of the world camera's zoom, so text on a screen-space layer never regenerates — correctly, since it's never visually zoomed. Only text on a layer that actually tracks the world camera's zoom oversamples. See [Layer — LayerCameraSettings](../gum-code-reference/layer.md#layercamerasettings).
+
+## Manual Control
+
+`RegenerateOversampledFont(oversampleRatio)` is the method the automatic path calls internally; call it directly to force a specific raster ratio outside of camera-driven zoom (for example, a scripted zoom-in cutscene that doesn't go through `Camera.Zoom`). It returns `false` (and does nothing) if `UseFontOversampling` is off, no `IInMemoryFontCreator` is registered, or `oversampleRatio` isn't positive.
+
+## Limitation: System Fonts vs. Registered `.ttf`
+
+Measurement-stable oversampling — where the box a `TextRuntime` measures against doesn't shift as the font is regenerated at different raster sizes — requires `Font` (or `CustomFontFile`) to resolve to an explicit `.ttf` file, not a bare system font family name. Oversampling still runs with a system font name like `"Arial"`, but width/wrap measurement isn't guaranteed stable across regenerations. See [Font Strategies — System Fonts vs Registered Fonts](font-strategies.md#system-fonts-vs-registered-fonts) for how to register a `.ttf`.
+
+## Try It
+
+{% hint style="warning" %}
+Interactive XnaFiddle demo pending — XnaFiddle's pinned Gum package predates font oversampling, so the fiddle link can't be added yet (tracked: [XnaFiddle#127](https://github.com/vchelaru/XnaFiddle/issues/127)). The sample below is a reference you can paste into your own project.
+{% endhint %}
+
+Scroll to zoom the camera; the text stays crisp because it's oversampled. Toggle the checkbox off to compare against undersampled text at the same zoom. The font (`std/DroidSans.ttf`) is XnaFiddle's standard-content Droid Sans — no upload needed.
+
+```csharp
+using MonoGameGum;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
+using MonoGameGum.GueDeriving;
+using Gum.Wireframe;
+using KernSmith;
+using KernSmith.Gum;
+using RenderingLibrary;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+
+public class Game1 : Game
+{
+    GraphicsDeviceManager graphics;
+    GumService GumUI => GumService.Default;
+
+    TextRuntime previewText;
+    Label zoomLabel;
+    int previousScrollWheel;
+
+    public Game1()
+    {
+        graphics = new GraphicsDeviceManager(this);
+    }
+
+    protected override void Initialize()
+    {
+        GumUI.Initialize(this, DefaultVisualsVersion.V3);
+
+        // StbTrueType is required in Blazor WASM -- no native FreeType binary is available there.
+        CustomSetPropertyOnRenderable.InMemoryFontCreator =
+            new KernSmithFontCreator(GraphicsDevice, RasterizerBackend.StbTrueType);
+        KernSmithFontCreator.RegisterFont("Droid Sans",
+            System.IO.Path.Combine(Content.RootDirectory, "std/DroidSans.ttf"));
+
+        TextRuntime.UseFontOversampling = true;
+
+        previewText = new TextRuntime();
+        previewText.Font = "Droid Sans";
+        previewText.FontSize = 28;
+        previewText.Text = "Scroll to zoom the camera";
+        previewText.Anchor(Gum.Wireframe.Anchor.Center);
+        previewText.AddToRoot();
+
+        var oversampleCheck = new CheckBox();
+        oversampleCheck.Text = "Oversampling";
+        oversampleCheck.IsChecked = true;
+        oversampleCheck.Width = 160;
+        oversampleCheck.Anchor(Gum.Wireframe.Anchor.TopLeft);
+        oversampleCheck.X = 8;
+        oversampleCheck.Y = 8;
+        oversampleCheck.Checked += (_, _) => TextRuntime.UseFontOversampling = true;
+        oversampleCheck.Unchecked += (_, _) => TextRuntime.UseFontOversampling = false;
+        oversampleCheck.AddToRoot();
+
+        zoomLabel = new Label();
+        zoomLabel.Text = "Zoom: 1.0x";
+        zoomLabel.Width = 160;
+        zoomLabel.Anchor(Gum.Wireframe.Anchor.TopLeft);
+        zoomLabel.X = 8;
+        zoomLabel.Y = 40;
+        zoomLabel.AddToRoot();
+
+        previousScrollWheel = Mouse.GetState().ScrollWheelValue;
+
+        base.Initialize();
+    }
+
+    protected override void Update(GameTime gameTime)
+    {
+        var mouseState = Mouse.GetState();
+        int scrollDelta = mouseState.ScrollWheelValue - previousScrollWheel;
+        previousScrollWheel = mouseState.ScrollWheelValue;
+
+        var camera = SystemManagers.Default.Renderer.Camera;
+        camera.Zoom = MathHelper.Clamp(camera.Zoom + scrollDelta * 0.001f, 1f, 8f);
+        zoomLabel.Text = $"Zoom: {camera.Zoom:0.0}x";
+
+        GumUI.Update(gameTime);
+        base.Update(gameTime);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        GraphicsDevice.Clear(Color.CornflowerBlue);
+        GumUI.Draw();
+        base.Draw(gameTime);
+    }
+}
+```
+
+## Related Pages
+
+* [Font Strategies](font-strategies.md) — dynamic KernSmith generation and registering `.ttf` fonts.
+* [Camera](../gum-code-reference/camera.md) — zooming the camera.
+* [Layer](../gum-code-reference/layer.md) — `LayerCameraSettings` and screen-space layers.

--- a/docs/code/files-and-fonts/fonts.md
+++ b/docs/code/files-and-fonts/fonts.md
@@ -52,6 +52,7 @@ The Gum tool generates these atlases automatically while you edit your project. 
 * [Fonts on Web](fonts-web.md) — bandwidth vs CPU tradeoffs for web targets.
 * [Font Localization](font-localization.md) — current behavior, known limitations, and the per-locale design that's coming.
 * [Font Cache](font-cache.md) — the build-time `.fnt` atlas system, naming convention, and when to use it.
+* [Font Oversampling](font-oversampling.md) — keeping text crisp under camera/layer zoom.
 
 ## Need Outline Color, Gradients, or Other KernSmith Extras?
 


### PR DESCRIPTION
## Summary
New doc page: `docs/code/files-and-fonts/font-oversampling.md` — what `TextRuntime.UseFontOversampling`/`RegenerateOversampledFont` does, how to enable it, the automatic per-`Layer`/camera-zoom behavior, manual control, and the system-font vs registered-`.ttf` measurement-stability limitation.

The feature hasn't shipped to NuGet yet, confirmed two ways: walking its commits against the last published build's commit, and a live XnaFiddle compile error (`CS0117: 'TextRuntime' does not contain a definition for 'UseFontOversampling'`). So the page has a not-yet-shipped hint, and the interactive fiddle is a TODO pointing at vchelaru/XnaFiddle#127 (bump the pinned Gum package once oversampling ships) instead of a live link.

Also hardens `gum-docs-writing`'s release-status rule: ask the user first whether a feature has shipped, and define "shipped" as published to NuGet — not merged to `main` or bundled in a Tool release, which are separate workflows.

## Test plan
- [x] Manual test not needed — docs-only change.
- [x] XnaFiddle URL re-encoded and diffed against the inserted link to rule out corruption (moot now — link was removed after it failed to compile live).
