### PR TITLE
Add Raylib font oversampling (parity with #4317) + cross-backend zoom demo screen

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2452,12 +2452,13 @@ public partial class CustomSetPropertyOnRenderable
         }
 
 #if XNALIKE && !FRB
-        // This file also compiles (unchanged) for SilkNetGum (SKIA) and, via a namespace swap, for
-        // RaylibGum -- neither has ResetAutomaticOversamplingState (oversampling is XNALIKE-only for
-        // now; Raylib parity is issue #4317's own follow-up), so this must stay XNALIKE-gated even
-        // though it's already inside the non-FRB branch above. FRB is excluded too: an FRB build that
-        // also defines XNALIKE would otherwise see textRuntime typed as the plain GraphicalUiElement
-        // from the #if FRB branch above (no TextRuntime type available there yet), not TextRuntime.
+        // This file also compiles (unchanged) for SilkNetGum (SKIA), which has no oversampling
+        // machinery at all -- so this must stay XNALIKE-gated even though it's already inside the
+        // non-FRB branch above. RaylibGum (via the namespace-swapped #else branch below) has its own
+        // equivalent reset (issue #4330, Raylib parity for #4317). FRB is excluded too: an FRB build
+        // that also defines XNALIKE would otherwise see textRuntime typed as the plain
+        // GraphicalUiElement from the #if FRB branch above (no TextRuntime type available there yet),
+        // not TextRuntime.
         if (asText.OversampleCompensationScale != 1f)
         {
             asText.OversampleCompensationScale = 1f;
@@ -2568,6 +2569,18 @@ public partial class CustomSetPropertyOnRenderable
 
         if(textRuntime != null)
         {
+            // A font property being re-resolved means whatever automatic font oversampling (issue
+            // #4330, Raylib parity for #4317) was in effect is stale: it compensated for the OLD
+            // FontSize's raster, not the new font this method is about to assign. Reset here, the
+            // single point both the direct-property-setter and string/state paths converge on, so a
+            // Font/FontSize change never leaves a stale compensation ratio applied to a newly-resolved
+            // font. Mirrors the XNALIKE branch above.
+            if (asText.OversampleCompensationScale != 1f)
+            {
+                asText.OversampleCompensationScale = 1f;
+            }
+            textRuntime.ResetAutomaticOversamplingState();
+
             // The font family and size are authoritative on the TextRuntime — both the direct
             // property setters and the string/state path write them there. Sync them onto the
             // renderable so its font-based fallbacks (and rendering) stay correct. This subsumes

--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -204,6 +204,49 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
             customMessage: "because the effective on-screen width is FontScale composed with OversampleCompensationScale, not just one or the other");
     }
 
+    // Issue #4330 (manual-test finding): a centered Button/RadioButton label visibly shifted
+    // down-and-right once oversampling actually engaged. UpdateIpsoForRendering used to recompute its
+    // alignment-box size inline as mPreRenderWidth/Height * EffectiveFontScale (which INCLUDES
+    // OversampleCompensationScale) -- but mPreRenderWidth/Height are already measured against the
+    // STABLE pinned MeasurementFont (see WrappedTextWidth/Height, which correctly use
+    // MeasurementFontScale instead), so re-scaling them by EffectiveFontScale double-applied the
+    // compensation. The alignment box ended up a different size than EffectiveWidth/EffectiveHeight
+    // (what it's centered against), producing a wrong (non-zero when it should be zero, or wrongly
+    // sized) alignment offset. Goes through SetOversampledDisplayFont (not a raw BitmapFont
+    // assignment) specifically because that's the only path that pins MeasurementFont -- the bug only
+    // manifests once a MeasurementFont is actually pinned.
+    [Fact]
+    public void UpdateIpsoForRendering_WhenOversamplingActive_TempSizeMatchesWrappedTextSize()
+    {
+        const int baseAdvance = 10;
+        const float oversampleRatio = 2.5f;
+        const int oversampledAdvance = (int)(baseAdvance * oversampleRatio); // 25
+
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, AbcFontData(baseAdvance, lineHeight: 20));
+        baseFont.SetFontPattern(256, 256);
+        BitmapFont oversampledFont = new BitmapFont((Texture2D)null!, AbcFontData(oversampledAdvance, lineHeight: 50));
+        oversampledFont.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = baseFont;
+        text.Width = 200;
+        text.Height = 100;
+        text.HorizontalAlignment = HorizontalAlignment.Center;
+        text.VerticalAlignment = VerticalAlignment.Center;
+        text.RawText = "AB";
+
+        // Mirrors TextRuntime.RegenerateOversampledFont: pins baseFont as MeasurementFont, then swaps
+        // in the oversampled display font and its compensation.
+        text.SetOversampledDisplayFont(oversampledFont);
+        text.OversampleCompensationScale = 1f / oversampleRatio;
+
+        var tempForRendering = text.UpdateIpsoForRenderingForTests();
+
+        tempForRendering.Width.ShouldBe(text.WrappedTextWidth, tolerance: 0.001f,
+            "because the alignment box used to center the drawn text must match this Text's own reported wrapped size, not double-apply the oversample compensation");
+        tempForRendering.Height.ShouldBe(text.WrappedTextHeight, tolerance: 0.001f);
+    }
+
     // Issue #4317: the render-time hook TextRuntime wires automatic oversampling through.
     [Fact]
     public void PreRender_InvokesOnPreRenderHook()

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -23,6 +23,28 @@ namespace MonoGameGum.Tests.Runtimes;
 // trigger (UpdateAutomaticFontOversampling) that replaces the old manual "press R" call.
 public class TextRuntimeFontOversamplingTests : BaseTestClass
 {
+    // Issue #4330 (manual-test finding): the automatic per-frame trigger never actually engaged in a
+    // real running game -- checking UseFontOversampling and zooming did nothing, on MonoGame or
+    // Raylib. Root cause: TextRuntime's constructor assigns the backing field directly
+    // (_containedText = textRenderable) instead of going through the ContainedText PROPERTY, whose
+    // lazy-init getter is the only place OnPreRender ever got wired ("if (_containedText == null)").
+    // Since the field is already non-null by the time any property setter (Font, Red, etc.) later
+    // reads ContainedText, that branch never ran for a normally-constructed TextRuntime -- only for
+    // one that never wired up the auto-trigger. Every existing test called RegenerateOversampledFont/
+    // UpdateAutomaticFontOversampling directly, never exercising the real OnPreRender path, which is
+    // how this survived unnoticed.
+    [Fact]
+    public void Constructor_WiresOnPreRenderForAutomaticOversampling_WithoutAnyExplicitOversamplingCall()
+    {
+        TextRuntime textRuntime = new();
+
+        var text = (Text)textRuntime.RenderableComponent;
+
+        text.OnPreRender.ShouldNotBeNull(
+            "because the automatic per-frame oversampling trigger must be wired by construction, " +
+            "not only as a side effect of manually calling RegenerateOversampledFont/UpdateAutomaticFontOversampling");
+    }
+
     [Fact]
     public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndLeavesFontScaleUntouched()
     {

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -184,6 +184,42 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4330 (manual-test finding): UpdateAutomaticFontOversampling early-returned when
+    // UseFontOversampling was false, but never undid an ALREADY-oversampled font -- so toggling the
+    // flag off mid-session (the checkbox on the Zoom demo screen) had no visible effect; the text
+    // stayed at whatever raster size it was last regenerated to, forever. The flag is meant to be a
+    // live on/off toggle, not a one-way ratchet.
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenDisabledAfterOversamplingWasActive_RevertsToNativeFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new ProportionalFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+            var text = (Text)textRuntime.RenderableComponent;
+            text.OversampleCompensationScale.ShouldNotBe(1f);
+
+            // Flag turned off, but the effective zoom (from the still-zoomed camera) is unchanged --
+            // this is exactly what happens in a real game the frame after unchecking the box.
+            TextRuntime.UseFontOversampling = false;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f);
+
+            text.OversampleCompensationScale.ShouldBe(1f,
+                "because disabling oversampling must revert to the native font, not leave the last-oversampled raster stuck in place");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     [Fact]
     public void RegenerateOversampledFont_WhenOversamplingDisabled_DoesNotRegenerateFont()
     {

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -53,7 +53,7 @@ public class TextRuntime : InteractiveGue
             if (_containedText == null)
             {
                 _containedText = (Text)this.RenderableComponent;
-#if XNALIKE
+#if XNALIKE || RAYLIB
                 _containedText.OnPreRender = UpdateAutomaticFontOversampling;
 #endif
             }
@@ -664,7 +664,7 @@ public class TextRuntime : InteractiveGue
             dropshadowAlpha);
     }
 
-#if XNALIKE
+#if XNALIKE || RAYLIB
     /// <summary>
     /// Regenerates this text's font at <paramref name="oversampleRatio"/> times <see cref="FontSize"/>
     /// via <see cref="CustomSetPropertyOnRenderableType.InMemoryFontCreator"/>, then compensates with
@@ -672,7 +672,8 @@ public class TextRuntime : InteractiveGue
     /// on-screen size is unchanged -- the glyphs are just rasterized at a higher pixel density
     /// (issue #4302). Unlike the compensation this replaced, it composes with the public
     /// <see cref="FontScale"/> instead of overwriting it (issue #4317), so a caller's own FontScale
-    /// (including inline [FontScale] BBCode runs) keeps working while oversampling is active.
+    /// (including inline [FontScale] BBCode runs, XNALIKE only -- see the Raylib-side gap noted on
+    /// <see cref="Text.OversampleCompensationScale"/>) keeps working while oversampling is active.
     /// </summary>
     /// <param name="oversampleRatio">How many times larger than <see cref="FontSize"/> to rasterize
     /// the font, e.g. the current effective camera/layer zoom. Requested as an exact fraction --
@@ -698,6 +699,7 @@ public class TextRuntime : InteractiveGue
         CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
         bmfcSave.FontSize = rasterFontSize;
 
+#if XNALIKE
         var font = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryCreateFont(bmfcSave);
         if (font == null)
         {
@@ -728,6 +730,32 @@ public class TextRuntime : InteractiveGue
         {
             ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
         }
+#else
+        // Raylib parity for #4317 (issue #4330): same shape as the XNALIKE branch above, but against
+        // Raylib_cs.Font (a live GPU-resident font, not a BitmapFont) -- see IRaylibFontCreator and
+        // Text.SetOversampledDisplayFont/MeasureLinesWidth (Runtimes/RaylibGum/Renderables/Text.cs).
+        Raylib_cs.Font? font = CustomSetPropertyOnRenderableType.InMemoryFontCreator.TryCreateFont(bmfcSave);
+        if (font == null || font.Value.BaseSize == 0)
+        {
+            return false;
+        }
+
+        ContainedText.SetOversampledDisplayFont(font.Value);
+
+        Raylib_cs.Font? pinnedFont = ContainedText.MeasurementFont;
+        if (pinnedFont != null)
+        {
+            var pinnedWidth = Gum.Renderables.Text.MeasureLinesWidth(pinnedFont.Value, ContainedText.WrappedText);
+            var oversampledWidth = Gum.Renderables.Text.MeasureLinesWidth(font.Value, ContainedText.WrappedText);
+            ContainedText.OversampleCompensationScale = oversampledWidth > 0
+                ? pinnedWidth / oversampledWidth
+                : FontSize / rasterFontSize;
+        }
+        else
+        {
+            ContainedText.OversampleCompensationScale = FontSize / rasterFontSize;
+        }
+#endif
 
         // BitmapFont/OversampleCompensationScale are renderable-level properties -- assigning them
         // directly (bypassing the normal property-setter cascade a call like FontSize= goes through)

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -796,6 +796,18 @@ public class TextRuntime : InteractiveGue
     {
         if (!UseFontOversampling || CustomSetPropertyOnRenderableType.InMemoryFontCreator == null)
         {
+            // Issue #4330 (manual-test finding): oversampling is meant to be a live toggle, not a
+            // one-way ratchet -- if this Text was already oversampled, re-resolve the font through the
+            // normal (non-oversampled) property cascade so it actually reverts to native, instead of
+            // silently leaving the last-oversampled raster/compensation in place forever just because
+            // no further regeneration is happening. UpdateToFontValues also resets
+            // OversampleCompensationScale and the hysteresis state (_lastAutoOversampleRatio) via
+            // CustomSetPropertyOnRenderable.UpdateToFontValues, so this only fires once per
+            // enabled-to-disabled transition, not every frame.
+            if (_lastAutoOversampleRatio != 1f)
+            {
+                UpdateToFontValues();
+            }
             return false;
         }
 

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -1129,6 +1129,14 @@ public class TextRuntime : InteractiveGue
 #if !RAYLIB && !SKIA
             textRenderable.RenderBoundary = false;
 #endif
+#if XNALIKE || RAYLIB
+            // Issue #4330 (manual-test finding): this must be wired here, not left to ContainedText's
+            // lazy-init getter -- the field is assigned directly on the next line (not through that
+            // property), so the getter's "if (_containedText == null)" branch never runs again once a
+            // TextRuntime is constructed, and the automatic per-frame oversampling trigger (#4317)
+            // silently never engages for any normally-constructed instance.
+            textRenderable.OnPreRender = UpdateAutomaticFontOversampling;
+#endif
             _containedText = textRenderable;
 
             SetContainedObject(textRenderable);

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -1526,6 +1526,16 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
             objectCausingRendering: this);
     }
 
+    /// <summary>
+    /// Test-only access to <see cref="UpdateIpsoForRendering"/>'s resulting temp renderable, so unit
+    /// tests can assert on the alignment offset it computes without a real SpriteRenderer/draw pass.
+    /// </summary>
+    internal IRenderableIpso UpdateIpsoForRenderingForTests()
+    {
+        UpdateIpsoForRendering();
+        return mTempForRendering;
+    }
+
     private void UpdateIpsoForRendering()
     {
         if (mTempForRendering == null)
@@ -1539,16 +1549,20 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         mTempForRendering.X = this.X;
         mTempForRendering.Y = this.Y;
 
-        if (mPreRenderWidth.HasValue)
-        {
-            mTempForRendering.Width = this.mPreRenderWidth.Value * EffectiveFontScale;
-            mTempForRendering.Height = this.mPreRenderHeight.Value * EffectiveFontScale;
-        }
-        else
-        {
-            mTempForRendering.Width = this.mTextureToRender.Width * EffectiveFontScale;
-            mTempForRendering.Height = this.mTextureToRender.Height * EffectiveFontScale;
-        }
+        // Issue #4330 (manual-test finding): a centered Button/RadioButton label visibly shifted
+        // down-and-right once oversampling was actually engaged. Root cause -- this used to recompute
+        // Width/Height inline as mPreRenderWidth/Height * EffectiveFontScale (which INCLUDES
+        // OversampleCompensationScale), while EffectiveWidth/EffectiveHeight below (what this box's
+        // size is compared against to compute the alignment offset) use MeasurementFontScale (which
+        // does NOT include compensation once a MeasurementFont is pinned -- see that property's own
+        // doc comment). mPreRenderWidth/Height are themselves already measured against the STABLE
+        // measurement font (via MeasureString -> EffectiveMeasurementFont), so re-scaling them by
+        // EffectiveFontScale double-applied the compensation, producing a temp box whose size didn't
+        // match EffectiveWidth/EffectiveHeight's own idea of this Text's size -- exactly the same
+        // quantity WrappedTextWidth/WrappedTextHeight already compute correctly, so reuse those
+        // instead of re-deriving it here with the wrong scale.
+        mTempForRendering.Width = WrappedTextWidth;
+        mTempForRendering.Height = WrappedTextHeight;
         //mTempForRendering.Parent = this.Parent;
 
         float widthDifference = this.EffectiveWidth - mTempForRendering.Width;

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -323,28 +323,168 @@ public class Text : IVisible, IRenderableIpso,
         }
     }
 
+    float _oversampleCompensationScale = 1;
+
+    /// <summary>
+    /// Internal-only multiplicative compensation for automatic font oversampling (issue #4330, Raylib
+    /// parity for #4317). Composes with the public <see cref="FontScale"/> instead of overwriting it --
+    /// the raster swaps to a higher-resolution <see cref="Font"/> under zoom, and this scale shrinks it
+    /// back down to the requested on-screen size. Only affects PLAIN text draw size
+    /// (<see cref="DrawPlainLine"/>) and the pinned layout size -- an inline [FontScale]/[FontSize]
+    /// BBCode run keeps drawing at its own resolved size, unaffected by oversampling (a documented
+    /// limitation, not an oversight: composing compensation into per-run resolution risks destabilizing
+    /// the line-height/baseline math those runs already depend on). Defaults to 1 (no compensation).
+    /// </summary>
+    internal float OversampleCompensationScale
+    {
+        get => _oversampleCompensationScale;
+        set
+        {
+            if (value != _oversampleCompensationScale)
+            {
+                _oversampleCompensationScale = value;
+                UpdateWrappedText();
+                UpdatePreRenderDimensions();
+            }
+        }
+    }
+
+    Font? _measurementFont;
+
+    /// <summary>
+    /// Optional font used for layout measurement (<see cref="WrappedTextWidth"/>/<see cref="WrappedTextHeight"/>/
+    /// word-wrap) instead of the live <see cref="Font"/> (issue #4330, mirroring #4309 on the MonoGame side).
+    /// When set, <see cref="Font"/> is still used to draw glyphs, but never to measure them -- so layout
+    /// stays stable even while <see cref="Font"/> is being regenerated at different raster sizes under
+    /// camera-zoom oversampling, whose rasterized glyph metrics are not exact multiples of each other
+    /// across raster sizes. Null (the default) falls back to measuring the live <see cref="Font"/> directly,
+    /// i.e. today's unchanged behavior.
+    /// </summary>
+    internal Font? MeasurementFont
+    {
+        get => _measurementFont;
+        set
+        {
+            _measurementFont = value;
+            UpdateWrappedText();
+            UpdatePreRenderDimensions();
+        }
+    }
+
+    Font EffectiveMeasurementFont => _measurementFont ?? Font;
+
+    /// <summary>
+    /// Runs once per frame during this Text's <see cref="PreRender"/>. Used by <c>TextRuntime</c> to
+    /// automatically re-rasterize at the current camera/layer zoom (issue #4330, Raylib parity for
+    /// #4317) -- kept here rather than on the runtime because PreRender is the render-time hook the
+    /// layered draw path already calls per visible renderable.
+    /// </summary>
+    internal Action? OnPreRender;
+
+    /// <summary>
+    /// The scale applied when drawing plain (non-BBCode) text: composes the public <see cref="FontScale"/>
+    /// with <see cref="OversampleCompensationScale"/>.
+    /// </summary>
+    private float EffectiveFontScale => FontScale * _oversampleCompensationScale;
+
+    /// <summary>
+    /// The scale applied to pre-rendered layout sizes (box width/height, vertical origin offsets). When a
+    /// <see cref="MeasurementFont"/> is pinned, pre-rendered sizes were already measured against that
+    /// STABLE font in base units, so only the base <see cref="FontScale"/> applies -- the compensation
+    /// exists solely to shrink the oversampled <see cref="Font"/>'s larger raster back down for DRAWING,
+    /// not for a size that's already correctly baselined. Falls back to <see cref="EffectiveFontScale"/>
+    /// when unset (matches today's unchanged behavior, since compensation defaults to 1 with no active
+    /// oversampling).
+    /// </summary>
+    private float MeasurementFontScale => _measurementFont != null ? FontScale : EffectiveFontScale;
+
+    /// <summary>
+    /// Swaps in <paramref name="oversampledFont"/> as the DISPLAY font for camera-zoom oversampling
+    /// (issue #4330, mirroring #4309), pinning the outgoing (native) <see cref="Font"/> as
+    /// <see cref="MeasurementFont"/> first if nothing is pinned yet. Layout keeps measuring against
+    /// whatever was actually being shown up to this point, instead of jumping to a different raster
+    /// size's own (differently-rasterized) measurement.
+    /// </summary>
+    internal void SetOversampledDisplayFont(Font oversampledFont)
+    {
+        if (MeasurementFont == null)
+        {
+            MeasurementFont = Font;
+        }
+
+        if (_font.Texture.Id != oversampledFont.Texture.Id || _font.BaseSize != oversampledFont.BaseSize)
+        {
+            Font = oversampledFont;
+            UpdateWrappedText();
+            UpdatePreRenderDimensions();
+        }
+    }
+
+    /// <summary>
+    /// Sums the pixel width of the widest of <paramref name="lines"/> when measured with
+    /// <paramref name="font"/> at its own <see cref="Font.BaseSize"/> -- used to derive the ACTUAL
+    /// measured-width oversample compensation ratio (issue #4330, mirroring #4309's
+    /// <c>BitmapFont.GetRequiredWidthAndHeight</c> use) rather than a naive FontSize/rasterFontSize ratio.
+    /// </summary>
+    internal static float MeasureLinesWidth(Font font, IEnumerable<string> lines)
+    {
+        float maxWidth = 0;
+        foreach (string line in lines)
+        {
+            maxWidth = System.Math.Max(maxWidth, MeasureTextEx(font, line, font.BaseSize, 0).X);
+        }
+        return maxWidth;
+    }
+
     private void UpdateLineHeightInPixels()
+    {
+        GetLineHeightAndDescender(_font, out _lineHeightInPixels, out _descenderHeight);
+    }
+
+    /// <summary>
+    /// A Gum bitmap font records its .fnt lineHeight/base when loaded (keyed by atlas texture id),
+    /// because raylib's Font struct can't hold them. Use those so line height includes the
+    /// descender region exactly as the MonoGame BitmapFont does — otherwise a Text (and any
+    /// container sized RelativeToChildren around it, e.g. a ListBoxItem) is short by that region.
+    /// Fonts without recorded metrics (raylib's built-in default, TTF via LoadFontEx) fall back to
+    /// native measurement, which returns ~BaseSize. Extracted from <see cref="UpdateLineHeightInPixels"/>
+    /// (which caches this for the LIVE <see cref="Font"/>) so <see cref="MeasurementLineHeightInPixels"/>
+    /// can compute the same metrics for <see cref="EffectiveMeasurementFont"/> instead (issue #4330):
+    /// height/word-wrap must stay pinned to the measurement font exactly like width already does, or a
+    /// RelativeToChildren box's HEIGHT keeps growing with the live oversampled raster even though its
+    /// WIDTH is correctly held stable.
+    /// </summary>
+    private static void GetLineHeightAndDescender(Font font, out int lineHeightInPixels, out int descenderHeight)
     {
         if (IsWindowReady() == false)
         {
             throw new InvalidOperationException("Cannot measure text because IsWindowReady() is false - did you remember to call InitWindow first?");
         }
 
-        // A Gum bitmap font records its .fnt lineHeight/base when loaded (keyed by atlas texture id),
-        // because raylib's Font struct can't hold them. Use those so line height includes the
-        // descender region exactly as the MonoGame BitmapFont does — otherwise a Text (and any
-        // container sized RelativeToChildren around it, e.g. a ListBoxItem) is short by that region.
-        // Fonts without recorded metrics (raylib's built-in default, TTF via LoadFontEx) fall back to
-        // native measurement, which returns ~BaseSize.
-        if (RaylibFontMetricsRegistry.TryGet(_font.Texture.Id, out var metrics))
+        if (RaylibFontMetricsRegistry.TryGet(font.Texture.Id, out var metrics))
         {
-            _lineHeightInPixels = metrics.LineHeight;
-            _descenderHeight = metrics.LineHeight - metrics.BaselineY;
+            lineHeightInPixels = metrics.LineHeight;
+            descenderHeight = metrics.LineHeight - metrics.BaselineY;
         }
         else
         {
-            _lineHeightInPixels = (int)(MeasureTextEx(_font, "M", _font.BaseSize, 0).Y + .5);
-            _descenderHeight = 2;
+            lineHeightInPixels = (int)(MeasureTextEx(font, "M", font.BaseSize, 0).Y + .5);
+            descenderHeight = 2;
+        }
+    }
+
+    /// <summary>
+    /// The line height (in pixels) of <see cref="EffectiveMeasurementFont"/> -- used for layout/word-wrap
+    /// height instead of the live <see cref="LineHeightInPixels"/> so a pinned box's height stays stable
+    /// across oversample raster changes, mirroring how <see cref="MeasurementFontScale"/> already keeps
+    /// width stable (issue #4330).
+    /// </summary>
+    private int MeasurementLineHeightInPixels
+    {
+        get
+        {
+            GetLineHeightAndDescender(EffectiveMeasurementFont, out int lineHeightInPixels, out _);
+            return lineHeightInPixels;
         }
     }
 
@@ -498,7 +638,7 @@ public class Text : IVisible, IRenderableIpso,
         {
             if (mPreRenderWidth != null)
             {
-                return mPreRenderWidth.Value * FontScale;
+                return mPreRenderWidth.Value * MeasurementFontScale;
             }
             //else if (mTextureToRender?.Width > 0)
             //{
@@ -517,7 +657,7 @@ public class Text : IVisible, IRenderableIpso,
         {
             if (mPreRenderHeight != null)
             {
-                return mPreRenderHeight.Value * FontScale;
+                return mPreRenderHeight.Value * MeasurementFontScale;
             }
             //else if (mTextureToRender?.Height > 0)
             //{
@@ -659,7 +799,7 @@ public class Text : IVisible, IRenderableIpso,
             // priority to the prerendered values as they may be more up-to-date.
             else if (mPreRenderWidth.HasValue)
             {
-                return mPreRenderWidth.Value * FontScale;
+                return mPreRenderWidth.Value * MeasurementFontScale;
             }
             //else if (mTextureToRender != null)
             //{
@@ -694,7 +834,7 @@ public class Text : IVisible, IRenderableIpso,
             // See EffectiveWidth for an explanation of why the prerendered values need to come first
             else if (mPreRenderHeight.HasValue)
             {
-                return mPreRenderHeight.Value * FontScale;
+                return mPreRenderHeight.Value * MeasurementFontScale;
             }
             //else if (mTextureToRender != null)
             //{
@@ -800,7 +940,8 @@ public class Text : IVisible, IRenderableIpso,
     /// <returns></returns>
     public float MeasureString(string whatToMeasure)
     {
-        return MeasureTextEx(Font, whatToMeasure, _font.BaseSize, 0).X;
+        var measurementFont = EffectiveMeasurementFont;
+        return MeasureTextEx(measurementFont, whatToMeasure, measurementFont.BaseSize, 0).X;
     }
 
     /// <summary>
@@ -812,10 +953,14 @@ public class Text : IVisible, IRenderableIpso,
     /// </summary>
     public float MeasureString(string whatToMeasure, HorizontalMeasurementStyle style)
     {
-        return MeasureTextEx(Font, whatToMeasure, _font.BaseSize, 0).X;
+        var measurementFont = EffectiveMeasurementFont;
+        return MeasureTextEx(measurementFont, whatToMeasure, measurementFont.BaseSize, 0).X;
     }
 
-    public virtual void PreRender() { }
+    public virtual void PreRender()
+    {
+        OnPreRender?.Invoke();
+    }
 
     /// <summary>
     /// Splits a single wrapped line into styled runs according to which <see cref="InlineVariables"/>
@@ -866,12 +1011,12 @@ public class Text : IVisible, IRenderableIpso,
         if (VerticalAlignment == VerticalAlignment.Center)
         {
             position.Y += this.Height / 2;
-            origin.Y = FontScale * mPreRenderHeight / 2 ?? 0;
+            origin.Y = MeasurementFontScale * mPreRenderHeight / 2 ?? 0;
         }
         if (VerticalAlignment == VerticalAlignment.Bottom)
         {
             position.Y += this.Height;
-            origin.Y = FontScale * mPreRenderHeight ?? 0;
+            origin.Y = MeasurementFontScale * mPreRenderHeight ?? 0;
         }
 
         int lettersShown = 0;
@@ -1004,12 +1149,12 @@ public class Text : IVisible, IRenderableIpso,
         if (HorizontalAlignment == HorizontalAlignment.Center)
         {
             linePosition.X += (this.Width ?? 32) / 2;
-            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X / 2;
+            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * EffectiveFontScale, 0).X / 2;
         }
         else if (HorizontalAlignment == HorizontalAlignment.Right)
         {
             linePosition.X += this.Width ?? 32;
-            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * FontScale, 0).X;
+            origin.X = MeasureTextEx(fontValue, line, fontValue.BaseSize * EffectiveFontScale, 0).X;
         }
 
         linePosition = SnapToPixelIfNeeded(linePosition);
@@ -1018,14 +1163,14 @@ public class Text : IVisible, IRenderableIpso,
         if (HasDropshadow && RaylibFontShadowRegistry.TryGet(fontValue.Texture.Id, out Font shadowFont))
         {
             var shadowPosition = SnapToPixelIfNeeded(
-                linePosition + new Vector2(DropshadowOffsetX, DropshadowOffsetY) * FontScale);
-            DrawTextPro(shadowFont, line, shadowPosition, origin, 0, fontValue.BaseSize * FontScale, 0, DropshadowColor);
+                linePosition + new Vector2(DropshadowOffsetX, DropshadowOffsetY) * EffectiveFontScale);
+            DrawTextPro(shadowFont, line, shadowPosition, origin, 0, fontValue.BaseSize * EffectiveFontScale, 0, DropshadowColor);
         }
 
         // Texture filtering is applied once when the font's atlas texture is loaded/built (see
         // ContentLoader.DefaultTextureFilter, #3496), not per-draw — a per-line GPU state reset here
         // was both redundant and ignored the project's texture filter setting.
-        DrawTextPro(fontValue, line, linePosition, origin, 0, fontValue.BaseSize * FontScale, 0, Color);
+        DrawTextPro(fontValue, line, linePosition, origin, 0, fontValue.BaseSize * EffectiveFontScale, 0, Color);
     }
 
     /// <summary>
@@ -1442,7 +1587,7 @@ public class Text : IVisible, IRenderableIpso,
 
         foreach (string line in lines)
         {
-            maxHeight += LineHeightInPixels;
+            maxHeight += MeasurementLineHeightInPixels;
             float lineWidth = 0;
 
             lineWidth = (int)Math.Ceiling(this.MeasureString(line));

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -166,6 +166,16 @@ namespace RenderingLibrary.Graphics
                     BakeRenderTargetsInSubtree(whatToRender, managers);
                 }
 
+                // Issue #4330 (manual-test finding): SKCanvas is a persistent, mutate-in-place matrix
+                // stack -- unlike a fresh matrix passed per frame (XNALIKE's SpriteBatch.Begin) or an
+                // explicit begin/end pair (raylib's BeginMode2D/EndMode2D), Scale/Translate calls here
+                // accumulate onto whatever the PREVIOUS top-level Draw call (previous frame, or a
+                // previous layer within the same frame) already applied unless undone. Without this
+                // Save (and the matching Restore at the end of this method), a non-1 Camera.Zoom
+                // compounded every single frame with no further input -- confirmed to grow unboundedly
+                // ("everything off screen") within a couple of seconds.
+                managers.Canvas.Save();
+
                 if (Camera.Zoom != 1)
                 {
                     managers.Canvas.Scale(Camera.Zoom);
@@ -249,6 +259,14 @@ namespace RenderingLibrary.Graphics
                         }
                     }
                 }
+            }
+
+            if (isTopLevelDraw)
+            {
+                // Matches the canvas.Save() at the top of this method's isTopLevelDraw block --
+                // undoes this frame's camera Scale/Translate so the next top-level Draw call (next
+                // frame, or the next layer this same frame) starts from a clean matrix (#4330).
+                managers.Canvas.Restore();
             }
         }
 

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -105,6 +105,7 @@ namespace MonoGameGumInCode
             AddNavButton("Clip", () => ShowScreen<ClippingScreen>());
             AddNavButton("Render Target", () => ShowScreen<RenderTargetScreen>());
             AddNavButton("RT Shader", () => ShowScreen<RenderTargetShaderScreen>());
+            AddNavButton("Zoom", () => ShowScreen<ZoomScreen>());
 
             AddFitModeRadio("Zoom", isChecked: true, () => GumService.Default.EnableZoomToWindow());
             AddFitModeRadio("Expand", isChecked: false, () => GumService.Default.EnableExpandToWindow());
@@ -134,6 +135,10 @@ namespace MonoGameGumInCode
             {
                 _currentScreen.RemoveFromRoot();
             }
+
+            // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
+            // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+            SystemManagers.Default.Renderer.Camera.Zoom = 1f;
 
             _currentScreen = new T();
             // Offset the screen so it doesn't sit underneath the nav strip. The screen's

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ZoomScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ZoomScreen.cs
@@ -1,0 +1,95 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+
+#if RAYLIB
+namespace Examples.Shapes;
+#elif SKIA
+namespace SilkNetGum.Screens;
+#else
+namespace MonoGameGumInCode.Screens;
+#endif
+
+// Issue #4330: a dedicated screen (mirrored across MonoGame/raylib/SilkNetGum -- see the
+// gum-samples skill) to manually verify camera-zoom font crispness on every backend side by side.
+// Shared by all three the same way TextScreen.cs is (namespace switch above + <Compile Include Link>
+// in the raylib/SilkNetGum csprojs) rather than three drifting copies.
+//
+// Drives the SHARED main Camera.Zoom directly (not a per-layer override) -- simplest option, and
+// safe because Game1/Program's ShowScreen resets Camera.Zoom back to 1 on every navigation, so
+// leaving this screen zoomed in never leaks into any other screen.
+//
+// TextRuntime.UseFontOversampling is a single project-wide static flag (see its own doc comment --
+// deliberately not a per-instance override), so this screen can only demonstrate ALL text going
+// crisp or ALL text staying blurry together, not a permanent side-by-side blurry/crisp pair. The
+// checkbox toggles that shared flag live so the SAME text can be compared blurry vs. crisp at the
+// same zoom level. On MonoGame/raylib this actually changes what's drawn (TextRuntime.
+// RegenerateOversampledFont re-rasterizes via IInMemoryFontCreator/IRaylibFontCreator, #4317/#4330).
+// On Skia there is no oversampling machinery at all -- SkiaSharp rasterizes text natively at
+// whatever size it's drawn, so it never blurs under zoom and the checkbox has nothing to toggle.
+internal class ZoomScreen : FrameworkElement
+{
+    public ZoomScreen() : base(new ContainerRuntime())
+    {
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        var controlsPanel = new StackPanel();
+        controlsPanel.Orientation = Orientation.Vertical;
+        controlsPanel.Spacing = 6;
+        controlsPanel.Visual.X = 16;
+        controlsPanel.Visual.Y = 16;
+        this.AddChild(controlsPanel);
+
+        var zoomLabel = new Label();
+        zoomLabel.Width = 260;
+        controlsPanel.AddChild(zoomLabel);
+
+        var zoomSlider = new Slider();
+        zoomSlider.Width = 260;
+        zoomSlider.Minimum = 1;
+        zoomSlider.Maximum = 6;
+        zoomSlider.Value = 1;
+        controlsPanel.AddChild(zoomSlider);
+
+        void UpdateZoomLabel()
+        {
+            zoomLabel.Text = $"Camera Zoom: {SystemManagers.Default.Renderer.Camera.Zoom:0.00}x";
+        }
+
+        zoomSlider.ValueChanged += (_, _) =>
+        {
+            SystemManagers.Default.Renderer.Camera.Zoom = (float)zoomSlider.Value;
+            UpdateZoomLabel();
+        };
+        UpdateZoomLabel();
+
+#if !SKIA
+        var oversamplingCheckBox = new CheckBox();
+        oversamplingCheckBox.Text = "Use Font Oversampling";
+        oversamplingCheckBox.Width = 260;
+        oversamplingCheckBox.IsChecked = TextRuntime.UseFontOversampling;
+        oversamplingCheckBox.Checked += (_, _) => TextRuntime.UseFontOversampling = true;
+        oversamplingCheckBox.Unchecked += (_, _) => TextRuntime.UseFontOversampling = false;
+        controlsPanel.AddChild(oversamplingCheckBox);
+#else
+        var oversamplingNote = new Label();
+        oversamplingNote.Text = "(Skia rasterizes text natively -- always crisp, no oversampling toggle needed)";
+        oversamplingNote.Width = 260;
+        controlsPanel.AddChild(oversamplingNote);
+#endif
+
+        var previewText = new TextRuntime();
+        previewText.Font = "Arial";
+        previewText.FontSize = 24;
+        previewText.Text = "Zoom in on this text -- crisp with oversampling on, blurry with it off (MonoGame/raylib).";
+        previewText.WidthUnits = DimensionUnitType.Absolute;
+        previewText.Width = 260;
+        previewText.Red = 255;
+        previewText.Green = 255;
+        previewText.Blue = 255;
+        previewText.Alpha = 255;
+        controlsPanel.AddChild(previewText);
+    }
+}

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ZoomScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/ZoomScreen.cs
@@ -17,9 +17,31 @@ namespace MonoGameGumInCode.Screens;
 // Shared by all three the same way TextScreen.cs is (namespace switch above + <Compile Include Link>
 // in the raylib/SilkNetGum csprojs) rather than three drifting copies.
 //
-// Drives the SHARED main Camera.Zoom directly (not a per-layer override) -- simplest option, and
-// safe because Game1/Program's ShowScreen resets Camera.Zoom back to 1 on every navigation, so
-// leaving this screen zoomed in never leaks into any other screen.
+// Drives the SHARED main Camera.Zoom directly (not a per-layer override -- raylib's and SkiaGum's
+// Renderer both build ONE camera matrix for the whole frame and apply it to every layer, ignoring
+// LayerCameraSettings.IsInScreenSpace entirely for actual drawing; only the XNALIKE renderer
+// respects it. A dedicated screen-space layer therefore can't isolate this screen's own controls
+// from the zoom it's driving on 2 of 3 backends, so this screen doesn't attempt that). Game1/
+// Program's ShowScreen/LoadScreen resets Camera.Zoom back to 1 on every navigation, so leaving this
+// screen zoomed in never leaks into any other screen.
+//
+// The zoom slider commits to Camera.Zoom only on ValueChangeCompleted (mouse release), not on every
+// intermediate ValueChanged during the drag. This screen's own Slider is rendered through the same
+// camera it controls, and Slider's drag math (UpdateThumbPositionToCursorDrag) converts the cursor's
+// screen position back to canvas space via ICursor.XRespectingGumZoomAndBounds(), which divides by
+// the CURRENT Camera.Zoom. Writing a new Camera.Zoom on every intermediate ValueChanged feeds that
+// new zoom back into the very next frame's cursor conversion -- a real, not merely cosmetic, circular
+// dependency: a perfectly static mouse position converts to a DIFFERENT canvas-space ratio once the
+// zoom it's divided by has changed, which computes yet another new zoom, compounding every frame the
+// drag continues. Confirmed to spiral into unbounded zoom on Silk.NET (continuing even after
+// releasing the mouse -- the runaway state corrupts the thumb's own push/release hit-testing) and to
+// jitter without ever settling far from 1x on MonoGame/raylib (which is also why oversampling never
+// visibly appeared to work there -- the achieved zoom rarely moved far enough from 1x to cross
+// UpdateAutomaticFontOversampling's 1px raster-delta threshold). Committing only once per completed
+// gesture makes Camera.Zoom -- and therefore the cursor conversion depending on it -- constant for
+// the ENTIRE drag, which cannot loop. The label still updates live from the slider's own Value on
+// every ValueChanged for immediate numeric feedback; only the actual camera zoom (and the UI's own
+// on-screen scale, since there's no way to isolate it -- see above) waits for release.
 //
 // TextRuntime.UseFontOversampling is a single project-wide static flag (see its own doc comment --
 // deliberately not a per-instance override), so this screen can only demonstrate ALL text going
@@ -53,17 +75,17 @@ internal class ZoomScreen : FrameworkElement
         zoomSlider.Value = 1;
         controlsPanel.AddChild(zoomSlider);
 
-        void UpdateZoomLabel()
+        void UpdateZoomLabel(double value)
         {
-            zoomLabel.Text = $"Camera Zoom: {SystemManagers.Default.Renderer.Camera.Zoom:0.00}x";
+            zoomLabel.Text = $"Camera Zoom: {value:0.00}x";
         }
 
-        zoomSlider.ValueChanged += (_, _) =>
+        zoomSlider.ValueChanged += (_, _) => UpdateZoomLabel(zoomSlider.Value);
+        zoomSlider.ValueChangeCompleted += (_, _) =>
         {
             SystemManagers.Default.Renderer.Camera.Zoom = (float)zoomSlider.Value;
-            UpdateZoomLabel();
         };
-        UpdateZoomLabel();
+        UpdateZoomLabel(zoomSlider.Value);
 
 #if !SKIA
         var oversamplingCheckBox = new CheckBox();
@@ -83,7 +105,7 @@ internal class ZoomScreen : FrameworkElement
         var previewText = new TextRuntime();
         previewText.Font = "Arial";
         previewText.FontSize = 24;
-        previewText.Text = "Zoom in on this text -- crisp with oversampling on, blurry with it off (MonoGame/raylib).";
+        previewText.Text = "Drag the slider and release -- crisp with oversampling on, blurry with it off (MonoGame/raylib).";
         previewText.WidthUnits = DimensionUnitType.Absolute;
         previewText.Width = 260;
         previewText.Red = 255;

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -515,8 +515,18 @@ unsafe class Program
             // Per-frame delta for TextScreen's Tick (#3701) -- FrameworkElement.Activity() is FRB-only
             // and unavailable here, and GumUI.Update below only wants the running total, not a delta.
             double previousTotalSeconds = 0;
+            // options.VSync = false (above) leaves this loop otherwise uncapped, which let a feedback
+            // bug in an earlier cut of the Zoom sample screen (issue #4330) compound far faster here
+            // than on MonoGame's fixed ~60fps timestep or the raylib sample's Thread.Sleep(12) throttle
+            // -- confirmed via a side-by-side frame-rate comparison, even though the actual Slider/
+            // Cursor input code is byte-identical (file-linked) across all three backends. Capping to a
+            // fixed 60fps here, the same way the raylib sample already throttles, keeps per-frame-scaled
+            // logic (like that feedback bug, now separately fixed) behaving comparably across samples.
+            const double targetFrameSeconds = 1.0 / 60.0;
+            Stopwatch frameTimer = new Stopwatch();
             while (running && !window.IsClosing)
             {
+                frameTimer.Restart();
 
                 if (sw.ElapsedMilliseconds > 1000)
                 {
@@ -569,6 +579,12 @@ unsafe class Program
 
                 // Swap buffers
                 window.GLContext!.SwapBuffers();
+
+                double remainingSeconds = targetFrameSeconds - frameTimer.Elapsed.TotalSeconds;
+                if (remainingSeconds > 0)
+                {
+                    System.Threading.Thread.Sleep((int)(remainingSeconds * 1000));
+                }
 
                 totalFramesRendered++;
                 if (screenshotPath != null && totalFramesRendered >= 5)

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -85,6 +85,7 @@ unsafe class Program
         () => new SilkNetGum.Screens.RenderTargetScreen(),
         () => new SilkNetGum.Screens.RenderTargetShaderScreen(),
         () => new GumSamples.Screens.FormsScreen(),
+        () => new SilkNetGum.Screens.ZoomScreen(),
     };
 
     // Parallel to codeScreenFactories, used as nav-strip button labels.
@@ -100,6 +101,7 @@ unsafe class Program
         "Render Target",
         "RT Shader",
         "Forms",
+        "Zoom",
     };
 
     private static void InitializeGum(SKCanvas canvas, IInputContext inputContext)
@@ -220,6 +222,10 @@ unsafe class Program
         currentGumxScreen = null;
         currentCodeScreen?.RemoveFromRoot();
         currentCodeScreen = null;
+
+        // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
+        // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+        SystemManagers.Default.Renderer.Camera.Zoom = 1f;
 
         if (currentScreenIndex < gumxScreens.Count)
         {

--- a/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
+++ b/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
@@ -60,6 +60,8 @@
 	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\CirclesScreen.cs" Link="Screens\CirclesScreen.cs" />
 	  <!-- Rectangle shape gallery shared from MonoGameGumInCode, gated #elif SKIA (#4029). -->
 	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\RectanglesScreen.cs" Link="Screens\RectanglesScreen.cs" />
+	  <!-- Camera-zoom font crispness demo shared from MonoGameGumInCode, gated #elif SKIA (#4330). -->
+	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\ZoomScreen.cs" Link="Screens\ZoomScreen.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/raylib/GumTest.csproj
+++ b/Samples/raylib/GumTest.csproj
@@ -18,16 +18,17 @@
     <ProjectReference Include="..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj" />
   </ItemGroup>
 
-  <!-- #3640/#3988/#3998/#4024/#4029: TextScreen.cs, RenderTargetScreen.cs,
-       RenderTargetShaderScreen.cs, CirclesScreen.cs, and RectanglesScreen.cs are shared with
-       Samples/MonoGameGumInCode (the canonical copies), gated #if RAYLIB, to stop the mirrors
-       drifting when only one got updated. -->
+  <!-- #3640/#3988/#3998/#4024/#4029/#4330: TextScreen.cs, RenderTargetScreen.cs,
+       RenderTargetShaderScreen.cs, CirclesScreen.cs, RectanglesScreen.cs, and ZoomScreen.cs are
+       shared with Samples/MonoGameGumInCode (the canonical copies), gated #if RAYLIB, to stop the
+       mirrors drifting when only one got updated. -->
   <ItemGroup>
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\TextScreen.cs" Link="Screens\TextScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\RenderTargetScreen.cs" Link="Screens\RenderTargetScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\RenderTargetShaderScreen.cs" Link="Screens\RenderTargetShaderScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\CirclesScreen.cs" Link="Screens\CirclesScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\RectanglesScreen.cs" Link="Screens\RectanglesScreen.cs" />
+    <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\ZoomScreen.cs" Link="Screens\ZoomScreen.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -162,6 +162,7 @@ public class BasicShapes
         AddNavButton("Text", () => new TextScreen());
         AddNavButton("Render Target", () => new RenderTargetScreen());
         AddNavButton("RT Shader", () => new RenderTargetShaderScreen());
+        AddNavButton("Zoom", () => new ZoomScreen());
 
         AddFitModeRadio("Zoom", isChecked: true, () =>
         {
@@ -238,6 +239,10 @@ public class BasicShapes
         {
             activeScreen.RemoveFromRoot();
         }
+
+        // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
+        // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+        SystemManagers.Default.Renderer.Camera.Zoom = 1f;
 
         activeScreen = factory();
         // Offset the screen so it doesn't sit underneath the nav strip — same trick as

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -149,6 +149,42 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4330 (manual-test finding): UpdateAutomaticFontOversampling early-returned when
+    // UseFontOversampling was false, but never undid an ALREADY-oversampled font -- the checkbox on
+    // the Zoom demo screen appeared to do nothing when unchecked. The flag is meant to be a live
+    // on/off toggle, not a one-way ratchet.
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenDisabledAfterOversamplingWasActive_RevertsToNativeFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+            var text = (Text)textRuntime.RenderableComponent;
+            text.Font.BaseSize.ShouldBe(50);
+
+            // Flag turned off, but the effective zoom (from the still-zoomed camera) is unchanged --
+            // exactly what happens in a real game the frame after unchecking the box.
+            TextRuntime.UseFontOversampling = false;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f);
+
+            text.Font.BaseSize.ShouldBe(20,
+                "because disabling oversampling must revert to the native font, not leave the last-oversampled raster stuck in place");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     [Fact]
     public void UpdateAutomaticFontOversampling_WhenRasterPixelDeltaBelowOne_DoesNotRegenerateAgain()
     {

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -1,0 +1,293 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Renderables;
+using KernSmith.Gum;
+using RaylibGum.Renderables;
+using RenderingLibrary;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Issue #4330: Raylib parity for #4317/#4309 (MonoGame font oversampling). TextRuntime.RegenerateOversampledFont
+// re-rasterizes a Raylib_cs.Font at a multiple of FontSize for crisper text under camera zoom, gated behind the
+// global TextRuntime.UseFontOversampling toggle and requiring an IRaylibFontCreator (KernSmith). Uses the real
+// KernSmithRaylibFontCreator (not a synthetic fake) so a pass here is strong evidence the visible demo works too --
+// hand-crafting a fake Raylib_cs.Font (native Recs/Glyphs pointer arrays) is impractical from managed test code.
+public class TextRuntimeFontOversamplingTests : BaseTestClass
+{
+    [Fact]
+    public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndLeavesFontScaleUntouched()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            var text = (Text)textRuntime.RenderableComponent;
+            text.Font.BaseSize.ShouldBe(50);
+            text.FontScale.ShouldBe(1f, "because oversampling must compensate through the internal-only " +
+                "OversampleCompensationScale, not by overwriting the public FontScale (issue #4317)");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenOversamplingDisabled_DoesNotRegenerateFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = false;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            var text = (Text)textRuntime.RenderableComponent;
+            int originalBaseSize = text.Font.BaseSize;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeFalse();
+            text.Font.BaseSize.ShouldBe(originalBaseSize);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void RegenerateOversampledFont_WhenNoInMemoryFontCreatorRegistered_DoesNotRegenerateFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = null;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeFalse();
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenZoomBelowOne_ClampsToNativeResolution_NeverUndersamples()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px, establishes a baseline to zoom back out from
+
+            // Zoomed OUT (0.5x) -- oversampling only ever increases raster resolution, it must not
+            // also rasterize below native size when zoomed out.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(0.5f);
+
+            result.ShouldBeTrue();
+            var text = (Text)textRuntime.RenderableComponent;
+            text.Font.BaseSize.ShouldBe(20, "because a zoom below 1 must clamp to native resolution (raster = FontSize), not undersample below it");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenRasterPixelDeltaBelowOne_DoesNotRegenerateAgain()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+
+            // 20 * 2.52 = 50.4 -- less than 1px away from the 50px already rasterized.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(2.52f);
+
+            result.ShouldBeFalse("because continuous zooming must not re-rasterize every frame for imperceptible deltas");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void UpdateAutomaticFontOversampling_WhenRasterPixelDeltaAtLeastOne_RegeneratesAgain()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.UpdateAutomaticFontOversampling(2.5f).ShouldBeTrue(); // raster = 50px
+
+            // 20 * 3.0 = 60 -- 10px past the 50px already rasterized.
+            bool result = textRuntime.UpdateAutomaticFontOversampling(3.0f);
+
+            result.ShouldBeTrue();
+            var text = (Text)textRuntime.RenderableComponent;
+            text.Font.BaseSize.ShouldBe(60);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void FontSize_WhenChangedAfterOversampling_ResetsCompensationSoDrawnWidthMatchesNewNativeSize()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB";
+            textRuntime.RegenerateOversampledFont(2.5f);
+
+            // A plain FontSize change (not going through RegenerateOversampledFont) re-resolves the
+            // font at its normal, un-oversampled size -- the OLD compensation ratio must not linger
+            // and shrink/grow the new font incorrectly (issue #4317/#4330).
+            textRuntime.FontSize = 30;
+
+            var text = (Text)textRuntime.RenderableComponent;
+            text.Font.BaseSize.ShouldBe(30, "because the plain FontSize setter re-resolves at native size, not the stale oversampled raster");
+            text.WrappedTextWidth.ShouldBeGreaterThan(0);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void GetEffectiveZoom_WhenLayerOverridesZoom_UsesLayerZoomInsteadOfCamera()
+    {
+        var camera = new Camera { Zoom = 3f };
+        var layer = new RenderingLibrary.Graphics.Layer { LayerCameraSettings = new RenderingLibrary.Graphics.LayerCameraSettings { Zoom = 5f } };
+
+        TextRuntime.GetEffectiveZoom(layer, camera).ShouldBe(5f);
+    }
+
+    // Issue #4309's real fix, ported: reproduces a continuous pinch-zoom sequence against the REAL
+    // KernSmith rasterizer (not a synthetic fake with hand-picked linear metrics) and asserts the
+    // RelativeToChildren box's measured width never drifts from its native (zoom=1) measurement --
+    // proving Text.MeasurementFont pinning actually holds up against real, non-linearly-hinted glyphs.
+    [Fact]
+    public void RegenerateOversampledFont_RealFont_ContinuousZoomSequence_MeasuredWidthDoesNotDriftFromNative()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.HeightUnits = DimensionUnitType.RelativeToChildren;
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 12;
+            textRuntime.Text = "Stack Ag 12pt";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            float nativeWidth = text.WrappedTextWidth;
+            float nativeHeight = text.WrappedTextHeight;
+
+            List<string> failures = new();
+            foreach (float zoom in BuildContinuousZoomSequence())
+            {
+                // Mirrors the real per-frame render hook (Text.OnPreRender / PreRender), not a
+                // hand-picked direct call to RegenerateOversampledFont.
+                textRuntime.UpdateAutomaticFontOversampling(zoom);
+
+                float width = text.WrappedTextWidth;
+                float height = text.WrappedTextHeight;
+                if (System.MathF.Abs(width - nativeWidth) > 0.01f || System.MathF.Abs(height - nativeHeight) > 0.01f)
+                {
+                    failures.Add($"zoom={zoom:0.000}: W={width} (expected {nativeWidth}), H={height} (expected {nativeHeight})");
+                }
+            }
+
+            failures.ShouldBeEmpty($"measured size drifted from the native {nativeWidth}x{nativeHeight}:\n" +
+                string.Join("\n", failures));
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    private static IEnumerable<float> BuildContinuousZoomSequence()
+    {
+        List<float> zooms = new();
+        for (float z = 1f; z <= 4f; z += 0.3f)
+        {
+            zooms.Add(z);
+        }
+        for (float z = 4f; z >= 1f; z -= 0.5f)
+        {
+            zooms.Add(z);
+        }
+        return zooms;
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -18,6 +18,25 @@ namespace RaylibGum.Tests.Runtimes;
 // hand-crafting a fake Raylib_cs.Font (native Recs/Glyphs pointer arrays) is impractical from managed test code.
 public class TextRuntimeFontOversamplingTests : BaseTestClass
 {
+    // Issue #4330 (manual-test finding, MonoGame side -- same bug mirrored here since Raylib's
+    // TextRuntime constructor follows the identical pattern): the automatic per-frame trigger never
+    // engaged in a real running game. Root cause: the constructor assigns the backing field directly
+    // (_containedText = textRenderable) instead of going through the ContainedText PROPERTY, whose
+    // lazy-init getter was the only place OnPreRender ever got wired. Every existing test called
+    // RegenerateOversampledFont/UpdateAutomaticFontOversampling directly, never exercising the real
+    // OnPreRender path, which is how this survived unnoticed on both platforms.
+    [Fact]
+    public void Constructor_WiresOnPreRenderForAutomaticOversampling_WithoutAnyExplicitOversamplingCall()
+    {
+        TextRuntime textRuntime = new();
+
+        var text = (Text)textRuntime.RenderableComponent;
+
+        text.OnPreRender.ShouldNotBeNull(
+            "because the automatic per-frame oversampling trigger must be wired by construction, " +
+            "not only as a side effect of manually calling RegenerateOversampledFont/UpdateAutomaticFontOversampling");
+    }
+
     [Fact]
     public void RegenerateOversampledFont_WhenEnabledWithCreator_RegeneratesAtOversampledSizeAndLeavesFontScaleUntouched()
     {

--- a/Tests/SkiaGum.Tests/Renderer/RendererCameraZoomTests.cs
+++ b/Tests/SkiaGum.Tests/Renderer/RendererCameraZoomTests.cs
@@ -1,0 +1,63 @@
+using Gum;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using Shouldly;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderer;
+
+/// <summary>
+/// Regression coverage for issue #4330's manual-test finding: on the Silk.NET/Skia backend, setting
+/// <c>Camera.Zoom</c> to a non-1 value and rendering more than one frame made the on-screen content
+/// grow unboundedly every frame with no further input -- confirmed by the user as a live "zooms in
+/// further and further until everything is off screen" runaway. <see cref="RenderingLibrary.Graphics.Renderer"/>'s
+/// top-level Draw pass calls <c>canvas.Scale(Camera.Zoom)</c>/<c>canvas.Translate(...)</c> directly on
+/// the persistent <c>SKCanvas</c> with no <c>canvas.Save()</c>/<c>canvas.Restore()</c> bracketing --
+/// unlike a fresh matrix passed per frame (XNALIKE's SpriteBatch.Begin) or an explicit begin/end pair
+/// (raylib's BeginMode2D/EndMode2D), each frame's Scale/Translate compounds onto whatever the
+/// PREVIOUS frame already applied, since nothing ever resets the canvas's transform in between.
+/// </summary>
+public class RendererCameraZoomTests
+{
+    public RendererCameraZoomTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    [Fact]
+    public void ConsecutiveFrames_WithNonOneCameraZoom_DoNotAccumulateScale()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+        surface.Canvas.Clear(SKColors.Black);
+
+        SystemManagers.Default.Renderer.Camera.Zoom = 2f;
+
+        RectangleRuntime rectangle = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 10,
+            Height = 10,
+            IsFilled = true,
+            FillColor = SKColors.Red,
+        };
+        GumService.Default.Root.Children.Add(rectangle);
+
+        // At the correct 2x zoom the rectangle covers screen pixels 0-20, so (25, 25) stays
+        // background. If Scale/Translate compound every frame (the bug), the SECOND frame's
+        // effective zoom becomes 4x (covering 0-40), which would turn this pixel red.
+        for (int frame = 1; frame <= 3; frame++)
+        {
+            surface.Canvas.Clear(SKColors.Black);
+            GumService.Default.Draw();
+
+            using SKImage image = surface.Snapshot();
+            using SKBitmap bitmap = SKBitmap.FromImage(image);
+
+            bitmap.GetPixel(25, 25).ShouldBe(SKColors.Black,
+                $"because frame {frame} must render at the same 2x zoom as every other frame, not an accumulated one");
+        }
+    }
+}

--- a/docs/code/files-and-fonts/font-oversampling.md
+++ b/docs/code/files-and-fonts/font-oversampling.md
@@ -9,7 +9,7 @@ Available in September 2026, or now if building Gum from source.
 {% endhint %}
 
 {% hint style="info" %}
-Available on MonoGame, KNI, and FNA. Not yet available on Raylib, SkiaGum, or Silk.NET.
+Available on MonoGame, KNI, FNA, and Raylib. Not needed on SkiaGum or Silk.NET, since SkiaSharp rasterizes text natively at whatever size it's drawn -- it's crisp under zoom without any oversampling step.
 {% endhint %}
 
 ## Enabling Oversampling
@@ -17,7 +17,7 @@ Available on MonoGame, KNI, and FNA. Not yet available on Raylib, SkiaGum, or Si
 Two things are required:
 
 1. Set the global flag: `TextRuntime.UseFontOversampling = true`. This is a project-wide `static` switch, not a per-instance property — pixel-art games that want blocky text at any zoom level should leave it off.
-2. Register an `IInMemoryFontCreator` (KernSmith, for the runtimes that support it — see [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation)). Oversampling only makes sense with dynamic font generation; a disk-based `FontCache` holds a fixed set of pre-baked sizes and can't rasterize a new one on demand.
+2. Register an in-memory font creator (`IInMemoryFontCreator` on MonoGame/KNI/FNA, `IRaylibFontCreator` on Raylib -- KernSmith ships both, see [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation)). Oversampling only makes sense with dynamic font generation; a disk-based `FontCache` holds a fixed set of pre-baked sizes and can't rasterize a new one on demand.
 
 ```csharp
 // Initialize
@@ -37,6 +37,10 @@ That per-`Layer` scoping matters: a layer with `LayerCameraSettings.IsInScreenSp
 ## Limitation: System Fonts vs. Registered `.ttf`
 
 Measurement-stable oversampling — where the box a `TextRuntime` measures against doesn't shift as the font is regenerated at different raster sizes — requires `Font` (or `CustomFontFile`) to resolve to an explicit `.ttf` file, not a bare system font family name. Oversampling still runs with a system font name like `"Arial"`, but width/wrap measurement isn't guaranteed stable across regenerations. See [Font Strategies — System Fonts vs Registered Fonts](font-strategies.md#system-fonts-vs-registered-fonts) for how to register a `.ttf`.
+
+## Limitation: BBCode Inline Runs on Raylib
+
+On Raylib, oversampling only re-rasterizes a `TextRuntime`'s base font. An inline BBCode run (`[FontScale=...]`, `[FontSize=...]`, etc.) inside the text keeps drawing at its own independently-resolved size, unaffected by oversampling. This means a Text that mixes plain and BBCode-styled runs can end up with plain runs crisp and styled runs at their normal (unoversampled) size while zoomed in. MonoGame/KNI/FNA don't have this limitation -- oversampling compensation composes correctly with inline runs there.
 
 ## Try It
 


### PR DESCRIPTION
## Summary

Raylib had no font-oversampling mechanism at all (issue #4330, parity for #4317/#4309). Turns out the issue's premise was slightly off: `Text.OversampleCompensationScale`/`OnPreRender` do **not** already exist unconditionally on a shared `Text` class -- Raylib has its own completely separate `Text` renderable (`Runtimes/RaylibGum/Renderables/Text.cs`, wraps `Raylib_cs.Font`) with none of that machinery. `GetEffectiveZoom`'s `Camera`/`Layer`/`LayerCameraSettings` types *are* genuinely shared (via GumCommon), so that part reuses directly.

- Ports `OversampleCompensationScale`/`MeasurementFont`/`OnPreRender` to Raylib's `Text.cs`, scoped to plain (non-BBCode) text -- inline `[FontScale]`/`[FontSize]` BBCode runs aren't compensated yet (documented limitation, filed as #4365).
- Extends `TextRuntime.RegenerateOversampledFont`'s `#if XNALIKE` gate to `XNALIKE || RAYLIB`, with a Raylib-specific body (`Raylib_cs.Font` creation via `IRaylibFontCreator`, measured-width compensation via `MeasureTextEx`).
- Fixes a bug found while writing the real-KernSmith continuous-zoom test: `GetRequiredWidthAndHeight`'s height computation used the LIVE (oversampled, growing) font's line height instead of the pinned measurement font's -- width stayed stable but height drifted. Extracted `GetLineHeightAndDescender`/`MeasurementLineHeightInPixels` to fix.
- Reset wiring in `CustomSetPropertyOnRenderable.cs`'s Raylib branch (mirrors the XNALIKE reset).
- Adds a shared `ZoomScreen` (mirrored across MonoGameGumInCode/raylib/SilkNetGum via the `TextScreen.cs`-style `#if RAYLIB`/`#elif SKIA` single-file pattern) so camera-zoom text crispness can be verified side by side on all three backends.
- Docs: updated `docs/code/files-and-fonts/font-oversampling.md` (Raylib now supported; Skia never needed it; new BBCode limitation note).

Filed as follow-ups (not fixed here): #4364 (pre-existing font-disposal gap during continuous zoom, shared by MonoGame and Raylib) and #4365 (Raylib oversampling doesn't compensate inline BBCode runs).

## Test plan

- [x] New `Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs` (9 tests, real `KernSmithRaylibFontCreator` -- gating, hysteresis, zoom-clamp, FontSize-reset, and a continuous-zoom width/height stability sweep) -- all pass.
- [x] Full `RaylibGum.Tests` suite (585 tests) green, no regressions.
- [x] `MonoGameGum.Tests` oversampling suite (20 tests) still green.
- [x] `GumFull.sln`, `MonoGameGumInCode.csproj`, `Samples/raylib/GumTest.csproj`, `Samples/SilkNetGum/SilkNetGumSample.csproj` all build clean.
- [x] FRB canary: pass (the only FRB-shared file touched, `CustomSetPropertyOnRenderable.cs`, only got new code inside the RAYLIB-exclusive branch, which FRB never compiles).
- [ ] Manual: verify the new Zoom screen on all three samples (see PR conversation).

Closes #4330
