### PR TITLE
Fix NullReferenceException selecting instances with no tree node

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -1320,16 +1320,11 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
                 }
             }
 
-            List<GumTreeNode> treeNodeList = new List<GumTreeNode>();
-
-            foreach (var item in list)
-            {
-                if(parentContainer != null)
-                {
-                    GumTreeNode itemTreeNode = GetTreeNodeFor(item, parentContainer);
-                    treeNodeList.Add(itemTreeNode);
-                }
-            }
+            List<GumTreeNode> treeNodeList = parentContainer != null
+                ? GetReselectableNodes(list.ToList(), item => GetTreeNodeFor(item, parentContainer))
+                    .Cast<GumTreeNode>()
+                    .ToList()
+                : new List<GumTreeNode>();
 
             Select(treeNodeList);
         }


### PR DESCRIPTION
## Summary
Fixes a `NullReferenceException` when selecting/deleting instances whose base component was deleted out from under them. `ElementTreeViewManager.Select(IEnumerable<InstanceSave>)` was pushing `null` tree-node lookups straight into the selection list; the multi-node `Select()` overload then called `EnsureVisible` on that `null` unguarded, crashing `MainTreeViewPlugin`.

Reuses `GetReselectableNodes` (already used by `SelectRecordedSelection` for the same null-filtering) instead of duplicating the logic — covered by its existing tests.

Closes #4368

## Test plan
- [x] `dotnet test Tool/Tests/GumToolUnitTests` — 1225 passed, 0 failed
- [x] `dotnet build GumFull.sln` — 0 errors
- [ ] Manual: delete a component with instances on a screen, then delete the now-broken instances — should not crash
