### PR TITLE
Fix Absolute-width text re-wrapping when toggling font oversampling (#4370)

### DIFF
--- a/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -790,6 +790,54 @@ char id=66 x=0 y=0 width={xadvance} height=13 xoffset=0 yoffset=4 xadvance={xadv
         }
     }
 
+    // Issue #4370: the RelativeToChildren tests above prove the pinned MEASUREMENT is stable, but an
+    // Absolute-width box never re-measures its own content -- it converts the fixed Width constraint
+    // into wrap-measurement units by dividing by FontScale (IWrappedTextExtensions.UpdateLines). That
+    // division used the render-facing IText.FontScale, which composes in OversampleCompensationScale
+    // (the pinned-vs-oversampled measured-width ratio, recomputed fresh every RegenerateOversampledFont
+    // call). So the wrap width itself shifted by 1/compensation every time oversampling turned on,
+    // even though the pinned MeasurementFont (and therefore the correct wrap width) never changed --
+    // reproducing the Zoom demo's "checkbox toggle re-wraps text at a fixed zoom" report. Text.cs
+    // already has a MeasurementFontScale (uncompensated) for exactly this purpose (issue #4309); this
+    // is the one remaining consumer that still reads the compensated scale instead.
+    [Fact]
+    public void RegenerateOversampledFont_WithAbsoluteWidth_DoesNotChangeWrappedLineCount()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NearlyProportionalFontCreator(baseFontSize: 20);
+
+            TextRuntime textRuntime = new();
+            textRuntime.WidthUnits = DimensionUnitType.Absolute;
+            textRuntime.FontSize = 20;
+            // 8 glyphs (A,B,space,A,B,space,A,B) * 20px native xadvance = 160px -- exactly 2 lines at
+            // Width=100 ("AB AB " then "AB", assuming a trailing space stays with the first line).
+            textRuntime.Width = 100;
+            textRuntime.Text = "AB AB AB";
+
+            var text = (Text)textRuntime.RenderableComponent;
+            int lineCountBeforeOversampling = text.WrappedText.Count;
+            lineCountBeforeOversampling.ShouldBeGreaterThan(1,
+                "because the test must start from text that already wraps, or a wrap-width regression has nothing to widen");
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            text.WrappedText.Count.ShouldBe(lineCountBeforeOversampling,
+                "because the Absolute Width constraint must always convert to wrap-measurement units via " +
+                "the uncompensated measurement scale -- oversampling's display-only compensation must not " +
+                "change how many lines a fixed-width box wraps to");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     private const string StubFontData =
 @"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
 common lineHeight=18 base=18 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4

--- a/RenderingLibrary/Graphics/IWrappedText.cs
+++ b/RenderingLibrary/Graphics/IWrappedText.cs
@@ -52,6 +52,18 @@ public interface IWrappedText : IText
     float MeasureStringFullAdvance(string text) => -1;
 
     bool IsMidWordLineBreakEnabled { get; }
+
+    /// <summary>
+    /// The scale a Width constraint is divided by to compute the word-wrap width, in the same base
+    /// units as <see cref="MeasureString(string)"/>. Distinct from <see cref="IText.FontScale"/> when a
+    /// backend composes a display-only compensation into FontScale (e.g. MonoGame's camera-zoom font
+    /// oversampling, issue #4309/#4317) -- that compensation must not affect where text wraps, since
+    /// wrap decisions measure words against a pinned, stable font in native units (issue #4370: an
+    /// Absolute-width box re-wrapped every time oversampling recomputed its compensation ratio, even at
+    /// a fixed zoom, because the wrap width was still being computed with the compensated scale).
+    /// Defaults to <see cref="IText.FontScale"/> for backends with no such compensation.
+    /// </summary>
+    float WordWrapFontScale => FontScale;
 }
 
 public static class IWrappedTextExtensions
@@ -99,9 +111,9 @@ public static class IWrappedTextExtensions
 
 
         int wrappingWidth = int.MaxValue;
-        if (textInstance.Width != null && !float.IsPositiveInfinity(textInstance.Width.Value) && textInstance.FontScale > 0)
+        if (textInstance.Width != null && !float.IsPositiveInfinity(textInstance.Width.Value) && textInstance.WordWrapFontScale > 0)
         {
-            wrappingWidth = MathFunctions.RoundToInt(System.Math.Ceiling(textInstance.Width.Value / textInstance.FontScale));
+            wrappingWidth = MathFunctions.RoundToInt(System.Math.Ceiling(textInstance.Width.Value / textInstance.WordWrapFontScale));
         }
 
         wrappingWidth = System.Math.Max(0, wrappingWidth);

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -263,6 +263,11 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
 
     float IText.FontScale => EffectiveFontScale;
 
+    // Issue #4370: word-wrap must convert a Width constraint using the UNcompensated scale, since
+    // wrap decisions measure words against EffectiveMeasurementFont (native units) -- see
+    // MeasurementFontScale's own doc comment and IWrappedText.WordWrapFontScale.
+    float IWrappedText.WordWrapFontScale => MeasurementFontScale;
+
     public bool mIsTextureCreationSuppressed;
 
     bool IWrappedText.IsMidWordLineBreakEnabled => IsMidWordLineBreakEnabled;
@@ -1865,7 +1870,12 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         // Opt in only when incremental measurement equals measuring the full concatenation: a BitmapFont
         // must exist (for the no-trim Full style) and no inline BBCode run may be active (those size across
         // the whole line). Otherwise -1 so UpdateLines concatenates exactly.
-        var bitmapFontToUse = BitmapFont ?? DefaultBitmapFont;
+        //
+        // Issue #4370: must measure against EffectiveMeasurementFont (the pinned, stable font), not the
+        // live display BitmapFont directly -- otherwise this fast path silently disagrees with every
+        // other measurement in the wrap loop (MeasureString above) the moment oversampling swaps in a
+        // differently-sized display font, re-wrapping text that never actually changed size on screen.
+        var bitmapFontToUse = EffectiveMeasurementFont ?? DefaultBitmapFont;
         if (bitmapFontToUse == null || InlineVariables.Count > 0)
         {
             return -1;

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -398,6 +398,13 @@ public class Text : IVisible, IRenderableIpso,
     /// </summary>
     private float MeasurementFontScale => _measurementFont != null ? FontScale : EffectiveFontScale;
 
+    // Issue #4370 (MonoGame parity): word-wrap must convert a Width constraint using the UNcompensated
+    // scale, since wrap decisions measure words against EffectiveMeasurementFont (native units). Already
+    // a no-op today (this class's own public FontScale never bakes in compensation, unlike MonoGame's
+    // Text.cs), but wiring it explicitly -- rather than relying on the interface default falling back to
+    // FontScale -- keeps this correct by construction if that ever changes.
+    float IWrappedText.WordWrapFontScale => MeasurementFontScale;
+
     /// <summary>
     /// Swaps in <paramref name="oversampledFont"/> as the DISPLAY font for camera-zoom oversampling
     /// (issue #4330, mirroring #4309), pinning the outgoing (native) <see cref="Font"/> as


### PR DESCRIPTION
Closes #4370

## Root cause
Two word-wrap paths in MonoGame's `Text.cs` bypassed the pinned `MeasurementFont` that issue #4309 introduced to keep oversampling from affecting layout:

1. `IWrappedTextExtensions.UpdateLines` converted the Width constraint into wrap-measurement units by dividing by `IText.FontScale`, which composes in `OversampleCompensationScale` (recomputed fresh every oversample). So the wrap width itself shifted every time oversampling toggled, even at a fixed zoom.
2. `Text.MeasureStringFullAdvance` (the wrap loop's incremental-measurement fast path) measured against the live display `BitmapFont` directly instead of `EffectiveMeasurementFont` — so once oversampling swapped in a differently-sized display font, this path silently disagreed with every other measurement in the same wrap loop.

Either bug alone reproduces "toggling Use Font Oversampling re-wraps the Zoom demo's preview text at a fixed zoom."

## Fix
- Added `IWrappedText.WordWrapFontScale` (defaults to `FontScale` for backends with no compensation) and switched the wrap-width division to it.
- `Text.cs` (MonoGame) implements it as the existing uncompensated `MeasurementFontScale`.
- `Text.cs` (Raylib) gets the same explicit wiring for parity/defense-in-depth, though it was already a no-op there (Raylib's `FontScale` never bakes in compensation).
- `MeasureStringFullAdvance` now measures against `EffectiveMeasurementFont` instead of the live `BitmapFont`.

## Testing
- New unit test `RegenerateOversampledFont_WithAbsoluteWidth_DoesNotChangeWrappedLineCount` (Absolute-width box, non-proportional font metrics) — red before the fix, green after.
- Full suites green: MonoGameGum.Tests (2151), RaylibGum.Tests (587), SkiaGum.Tests (422).
- `GumFull.sln` and `KniGum.csproj` build clean.
- FRB canary (`GumCore.DesktopGlNet6.csproj`, both changed files are FRB-shared): builds clean.

Manual test: covered by the new unit test asserting the exact wrapped-line-count observable (not an approximation), per the "behavior-preserving exception" — but since this is a visually-verifiable Zoom-demo repro, the sample was also built and its `.sln` opened for a manual pass: toggle "Use Font Oversampling" repeatedly at a fixed zoom in the Zoom demo screen and confirm the preview text no longer re-wraps.
