### PR TITLE
Show state-editing indicator bar in Alignment tab

### DIFF
--- a/Direction/treeview-wpf-port.md
+++ b/Direction/treeview-wpf-port.md
@@ -118,8 +118,6 @@ consumer, so the whole file goes.
 
 ### Dead code to remove alongside
 
-- `PluginManager.StateWindowTreeNodeSelected` — no callers, and its `(ITreeNode)` cast of a WinForms
-  `TreeNode` would throw if there were.
 - `InternalsVisibleTo("EditorTabPlugin_XNA")` in `CommonFormsAndControls/Properties/AssemblyInfo.cs`
   — its stated reason (that plugin calling `ExtractDraggedNodes`) is no longer true.
 - `TreeNodeExtensionMethods` (the WinForms-`TreeNode` predicate + `GetFullFilePath` class at the

--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -178,7 +178,7 @@ public class MainCodeOutputPlugin : PluginBase
 
         this.AfterUndo += () => HandleRefreshAndExport();
 
-        this.StateWindowTreeNodeSelected += HandleStateSelected;
+        this.ReactToStateSaveSelected += HandleStateSelected;
         this.StateRename += HandleStateRename;
         this.StateAdd += HandleStateAdd;
         this.StateDelete += HandleStateDelete;
@@ -234,7 +234,7 @@ public class MainCodeOutputPlugin : PluginBase
         HandleElementSelected(null);
     }
 
-    private void HandleStateSelected(ITreeNode obj)
+    private void HandleStateSelected(StateSave? state)
     {
         if (control != null && _selectedState.SelectedElement != null)
         {

--- a/Gum/Controls/StateEditingIndicatorBar.xaml
+++ b/Gum/Controls/StateEditingIndicatorBar.xaml
@@ -1,0 +1,15 @@
+<UserControl
+    x:Class="Gum.Controls.StateEditingIndicatorBar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="30"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+    <Label
+        Background="{Binding StateBackground, Converter={StaticResource ColorToBrushConverter}}"
+        Content="{Binding StateInformation}"
+        Foreground="{DynamicResource Frb.Brushes.OnLightBanner}"
+        Visibility="{Binding HasStateInformation, Converter={StaticResource BoolToVisibilityConverter}}" />
+</UserControl>

--- a/Gum/Controls/StateEditingIndicatorBar.xaml.cs
+++ b/Gum/Controls/StateEditingIndicatorBar.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+
+namespace Gum.Controls
+{
+    /// <summary>
+    /// Shows the "Editing state X" / "Displaying custom (animated) state" banner. Its bindings are
+    /// relative, so it inherits whatever DataContext the host control sets - that DataContext's
+    /// type must expose HasStateInformation/StateInformation/StateBackground (see MainControlViewModel,
+    /// AlignmentViewModel).
+    /// </summary>
+    public partial class StateEditingIndicatorBar : UserControl
+    {
+        public StateEditingIndicatorBar()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -12,6 +12,7 @@ namespace Gum.Plugins.AlignmentButtons
         private readonly ISelectedState _selectedState;
 
         private AlignmentTabVisibilityCoordinator _coordinator;
+        private AlignmentPluginControl _control;
 
         [ImportingConstructor]
         public AlignmentMainPlugin(ISelectedState selectedState)
@@ -22,9 +23,10 @@ namespace Gum.Plugins.AlignmentButtons
         public override void StartUp()
         {
             AssignEvents();
-            var tab = _tabManager.AddControl(new Gum.Plugins.AlignmentButtons.AlignmentPluginControl(), "Alignment");
+            _control = new Gum.Plugins.AlignmentButtons.AlignmentPluginControl();
+            var tab = _tabManager.AddControl(_control, "Alignment");
             _coordinator = new AlignmentTabVisibilityCoordinator(_selectedState, tab);
-            _coordinator.Refresh();
+            Refresh();
         }
 
         private void AssignEvents()
@@ -34,21 +36,27 @@ namespace Gum.Plugins.AlignmentButtons
             this.InstanceSelected += HandleInstanceSelected;
         }
 
-        private void HandleStateWindowTreeNodeSelected(ITreeNode obj)
+        private void Refresh()
         {
             _coordinator.Refresh();
+            _control.ViewModel.RefreshStateLabel();
+        }
+
+        private void HandleStateWindowTreeNodeSelected(ITreeNode obj)
+        {
+            Refresh();
         }
 
         private void HandleTreeNodeSelected(ITreeNode? treeNode)
         {
-            _coordinator.Refresh();
+            Refresh();
         }
 
         private void HandleInstanceSelected(ElementSave elementSave, InstanceSave instance)
         {
             // Auto-selecting a new instance (e.g. right-click Add Object on an already-selected
             // Screen) only raises InstanceSelected, not TreeNodeSelected - see issue #4067.
-            _coordinator.Refresh();
+            Refresh();
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentMainPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.DataTypes;
+using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.Plugins.BaseClasses;
 using Gum.ToolStates;
@@ -32,7 +33,8 @@ namespace Gum.Plugins.AlignmentButtons
         private void AssignEvents()
         {
             this.TreeNodeSelected += HandleTreeNodeSelected;
-            this.StateWindowTreeNodeSelected += HandleStateWindowTreeNodeSelected;
+            this.ReactToStateSaveSelected += HandleStateSaveSelected;
+            this.ReactToStateSaveCategorySelected += HandleStateSaveCategorySelected;
             this.InstanceSelected += HandleInstanceSelected;
         }
 
@@ -42,7 +44,12 @@ namespace Gum.Plugins.AlignmentButtons
             _control.ViewModel.RefreshStateLabel();
         }
 
-        private void HandleStateWindowTreeNodeSelected(ITreeNode obj)
+        private void HandleStateSaveSelected(StateSave? state)
+        {
+            Refresh();
+        }
+
+        private void HandleStateSaveCategorySelected(StateSaveCategory? category)
         {
             Refresh();
         }

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:gumControls="clr-namespace:Gum.Controls"
     xmlns:local="clr-namespace:Gum.Plugins.AlignmentButtons"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="300"
@@ -19,24 +20,30 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Label VerticalAlignment="Center" Content="Margin" />
+        <gumControls:StateEditingIndicatorBar Grid.ColumnSpan="2" />
+        <Label
+            Grid.Row="1"
+            VerticalAlignment="Center"
+            Content="Margin" />
         <TextBox
+            Grid.Row="1"
             Grid.Column="1"
             Margin="4"
             Text="{Binding DockMarginText, UpdateSourceTrigger=PropertyChanged}" />
         <Label
-            Grid.Row="1"
+            Grid.Row="2"
             VerticalAlignment="Center"
             Content="Anchor" />
         <local:AnchorControl
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="1"
             Margin="4"
             HorizontalAlignment="Left"
             HorizontalContentAlignment="Left" />
         <TextBlock
-            Grid.Row="2"
+            Grid.Row="3"
             Grid.Column="1"
             Margin="4,0,4,4"
             Foreground="Gray"
@@ -44,17 +51,17 @@
             Text="{Binding MarginText}"
             Visibility="{Binding IsMarginTextVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
         <Label
-            Grid.Row="3"
+            Grid.Row="4"
             VerticalAlignment="Center"
             Content="Dock" />
         <local:DockControl
-            Grid.Row="3"
+            Grid.Row="4"
             Grid.Column="1"
             Margin="4"
             HorizontalAlignment="Stretch"
             HorizontalContentAlignment="Stretch" />
         <TextBlock
-            Grid.Row="4"
+            Grid.Row="5"
             Grid.Column="1"
             Margin="4,0,4,4"
             Foreground="Gray"

--- a/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/AlignmentButtons/AlignmentPluginControl.xaml.cs
@@ -9,11 +9,14 @@ namespace Gum.Plugins.AlignmentButtons
     /// </summary>
     public partial class AlignmentPluginControl : UserControl
     {
+        public AlignmentViewModel ViewModel { get; }
+
         public AlignmentPluginControl()
         {
             InitializeComponent();
 
-            this.DataContext = Locator.GetRequiredService<AlignmentViewModel>();
+            ViewModel = Locator.GetRequiredService<AlignmentViewModel>();
+            this.DataContext = ViewModel;
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Behaviors/MainBehaviorsPlugin.cs
@@ -63,20 +63,12 @@ public class MainBehaviorsPlugin : PriorityPlugin
         this.ElementSelected += behaviorsLogic.HandleElementSelected;
         this.InstanceSelected += behaviorsLogic.HandleInstanceSelected;
         this.BehaviorSelected += HandleBehaviorSelected;
-        this.StateWindowTreeNodeSelected += HandleStateSelected;
         this.BehaviorReferencesChanged += behaviorsLogic.HandleBehaviorReferencesChanged;
 
         this.RefreshBehaviorView += behaviorsLogic.HandleRefreshBehaviorView;
 
         this.StateAdd += behaviorsLogic.HandleStateAdd;
         this.StateMovedToCategory += behaviorsLogic.HandleStateMovedToCategory;
-    }
-
-    // A no-op today regardless of type - StateWindowTreeNodeSelected has no live invoker
-    // (PluginManager.StateWindowTreeNodeSelected is never called), so this handler never fires.
-    private void HandleStateSelected(ITreeNode obj)
-    {
-
     }
 
     private void HandleBehaviorSelected(BehaviorSave obj)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
@@ -6,6 +6,7 @@
   xmlns:WpfDataUi="clr-namespace:WpfDataUi;assembly=WpfDataUi"
   xmlns:controls="clr-namespace:WpfDataUi.Controls;assembly=WpfDataUi"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:gumControls="clr-namespace:Gum.Controls"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:variableGrid="clr-namespace:Gum.Plugins.VariableGrid"
   xmlns:wpf="clr-namespace:FluentIcons.Wpf;assembly=FluentIcons.Wpf"
@@ -26,11 +27,7 @@
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
 
-    <Label
-      Background="{Binding StateBackground, Converter={StaticResource ColorToBrushConverter}}"
-      Content="{Binding StateInformation}"
-      Foreground="{DynamicResource Frb.Brushes.OnLightBanner}"
-      Visibility="{Binding HasStateInformation, Converter={StaticResource BoolToVisibilityConverter}}" />
+    <gumControls:StateEditingIndicatorBar />
     <Label
       Grid.Row="1"
       Content="{Binding ErrorInformation}"

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -53,6 +53,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     private readonly IHotkeyManager _hotkeyManager;
     private readonly IVariableSaveLogic _variableSaveLogic;
     private readonly IClipboardService _clipboardService;
+    private readonly IStateEditingIndicatorService _stateEditingIndicatorService;
 
     WpfDataUi.DataUiGrid mVariablesDataGrid;
     MainPropertyGrid mainControl;
@@ -126,7 +127,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         IEditVariableService editVariableService,
         IHotkeyManager hotkeyManager,
         IVariableSaveLogic variableSaveLogic,
-        IClipboardService clipboardService)
+        IClipboardService clipboardService,
+        IStateEditingIndicatorService stateEditingIndicatorService)
     {
         _selectedState = selectedState;
         _exposeVariableService = exposeVariableService;
@@ -149,6 +151,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         _hotkeyManager = hotkeyManager;
         _variableSaveLogic = variableSaveLogic;
         _clipboardService = clipboardService;
+        _stateEditingIndicatorService = stateEditingIndicatorService;
         _stateSaveCategoryDisplayer = new StateSaveCategoryDisplayer(variableInCategoryPropagationLogic);
         _behaviorShowingLogic = new BehaviorShowingLogic(fileCommands, projectState);
     }
@@ -479,7 +482,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
 
             RefreshErrors(element);
 
-            RefreshStateLabel(element, stateCategory, state);
+            RefreshStateLabel();
 
             RefreshCategoryNotification(stateCategory, state);
 
@@ -513,33 +516,12 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         }
     }
 
-    private void RefreshStateLabel(ElementSave element, StateSaveCategory category, StateSave state)
+    private void RefreshStateLabel()
     {
-        if(element == null)
-        {
-            VariableViewModel.HasStateInformation = false;
-        }
-        else if(state == null || state == element.DefaultState)
-        {
-            VariableViewModel.HasStateInformation = false;
-        }
-        else if(_selectedState.CustomCurrentStateSave != null)
-        {
-            VariableViewModel.HasStateInformation = true;
-            VariableViewModel.StateInformation = $"Displaying custom (animated) state";
-            VariableViewModel.StateBackground = Color.Pink;
-        }
-        else
-        {
-            VariableViewModel.StateBackground = Color.Yellow;
-            VariableViewModel.HasStateInformation = true;
-            string stateName = state.Name;
-            if(category != null)
-            {
-                stateName = category.Name + "/" + stateName;
-            }
-            VariableViewModel.StateInformation = $"Editing state {stateName}";
-        }
+        var info = _stateEditingIndicatorService.GetInfo();
+        VariableViewModel.HasStateInformation = info.HasStateInformation;
+        VariableViewModel.StateInformation = info.StateInformation;
+        VariableViewModel.StateBackground = info.StateBackground;
     }
 
     private void RefreshCategoryNotification(StateSaveCategory? stateCategory, StateSave? state)

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -201,6 +201,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IEditVariableService>(provider => provider.GetRequiredService<EditVariableService>());
         services.AddSingleton<IDeleteVariableService, DeleteVariableService>();
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();
+        services.AddSingleton<IStateEditingIndicatorService, StateEditingIndicatorService>();
         services.AddSingleton<IDragDropManager, DragDropManager>();
         services.AddSingleton<MenuStripManager>();
         services.AddSingleton<ImportLogic>();

--- a/Tests/Gum.Presentation.Tests/AlignmentViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AlignmentViewModelTests.cs
@@ -2,6 +2,7 @@ using Gum.Commands;
 using Gum.Plugins.AlignmentButtons;
 using Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Services;
 using Gum.ToolStates;
 using Gum.Undo;
 using Moq;
@@ -11,7 +12,7 @@ namespace Gum.Presentation.Tests;
 
 public class AlignmentViewModelTests
 {
-    private static AlignmentViewModel CreateViewModel()
+    private static AlignmentViewModel CreateViewModel(IStateEditingIndicatorService? stateEditingIndicatorService = null)
     {
         CommonControlLogic commonControlLogic = new(
             Mock.Of<ISelectedState>(),
@@ -20,7 +21,8 @@ public class AlignmentViewModelTests
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>());
 
-        return new AlignmentViewModel(commonControlLogic, Mock.Of<ISelectedState>(), Mock.Of<IUndoManager>());
+        return new AlignmentViewModel(commonControlLogic, Mock.Of<ISelectedState>(), Mock.Of<IUndoManager>(),
+            stateEditingIndicatorService ?? Mock.Of<IStateEditingIndicatorService>());
     }
 
     [Fact]
@@ -80,5 +82,21 @@ public class AlignmentViewModelTests
         AlignmentViewModel.NormalizeNegativeZero(-5f).ShouldBe(-5f);
         AlignmentViewModel.NormalizeNegativeZero(5f).ShouldBe(5f);
         AlignmentViewModel.NormalizeNegativeZero(-0.001f).ShouldBe(-0.001f);
+    }
+
+    [Fact]
+    public void RefreshStateLabel_CopiesInfoFromStateEditingIndicatorService()
+    {
+        var stateEditingIndicatorService = new Mock<IStateEditingIndicatorService>();
+        stateEditingIndicatorService
+            .Setup(s => s.GetInfo())
+            .Returns(new StateEditingIndicatorInfo(true, "Editing state MyState", System.Drawing.Color.Yellow));
+        AlignmentViewModel viewModel = CreateViewModel(stateEditingIndicatorService.Object);
+
+        viewModel.RefreshStateLabel();
+
+        viewModel.HasStateInformation.ShouldBeTrue();
+        viewModel.StateInformation.ShouldBe("Editing state MyState");
+        viewModel.StateBackground.ShouldBe(System.Drawing.Color.Yellow);
     }
 }

--- a/Tests/Gum.Presentation.Tests/StateEditingIndicatorServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/StateEditingIndicatorServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Drawing;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Services;
+using Gum.ToolStates;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class StateEditingIndicatorServiceTests : BaseTestClass
+{
+    [Fact]
+    public void GetInfo_HasNoStateInformation_WhenNoElementIsSelected()
+    {
+        var selectedState = new Mock<ISelectedState>();
+        var service = new StateEditingIndicatorService(selectedState.Object);
+
+        var info = service.GetInfo();
+
+        info.HasStateInformation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetInfo_HasNoStateInformation_WhenSelectedStateIsTheDefaultState()
+    {
+        var element = new ScreenSave();
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(element);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(element.DefaultState);
+        var service = new StateEditingIndicatorService(selectedState.Object);
+
+        var info = service.GetInfo();
+
+        info.HasStateInformation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetInfo_ReturnsPinkCustomStateMessage_WhenACustomCurrentStateSaveIsSet()
+    {
+        var element = new ScreenSave();
+        var nonDefaultState = new StateSave();
+        var customState = new StateSave();
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(element);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(nonDefaultState);
+        selectedState.Setup(s => s.CustomCurrentStateSave).Returns(customState);
+        var service = new StateEditingIndicatorService(selectedState.Object);
+
+        var info = service.GetInfo();
+
+        info.HasStateInformation.ShouldBeTrue();
+        info.StateInformation.ShouldBe("Displaying custom (animated) state");
+        info.StateBackground.ShouldBe(Color.Pink);
+    }
+
+    [Fact]
+    public void GetInfo_ReturnsYellowEditingStateMessage_WhenANonDefaultStateIsSelected()
+    {
+        var element = new ScreenSave();
+        var nonDefaultState = new StateSave { Name = "MyState" };
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(element);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(nonDefaultState);
+        var service = new StateEditingIndicatorService(selectedState.Object);
+
+        var info = service.GetInfo();
+
+        info.HasStateInformation.ShouldBeTrue();
+        info.StateInformation.ShouldBe("Editing state MyState");
+        info.StateBackground.ShouldBe(Color.Yellow);
+    }
+
+    [Fact]
+    public void GetInfo_PrefixesStateNameWithCategoryName_WhenACategoryIsSelected()
+    {
+        var element = new ScreenSave();
+        var category = new StateSaveCategory { Name = "MyCategory" };
+        var nonDefaultState = new StateSave { Name = "MyState" };
+        var selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(s => s.SelectedElement).Returns(element);
+        selectedState.Setup(s => s.SelectedStateSave).Returns(nonDefaultState);
+        selectedState.Setup(s => s.SelectedStateCategorySave).Returns(category);
+        var service = new StateEditingIndicatorService(selectedState.Object);
+
+        var info = service.GetInfo();
+
+        info.StateInformation.ShouldBe("Editing state MyCategory/MyState");
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/WpfPluginBaseTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/WpfPluginBaseTests.cs
@@ -34,19 +34,6 @@ public class WpfPluginBaseTests
     }
 
     [Fact]
-    public void CallStateWindowTreeNodeSelected_InvokesEventWithSameTreeNodeInstance()
-    {
-        TestWpfPlugin plugin = new TestWpfPlugin();
-        ITreeNode? received = null;
-        plugin.StateWindowTreeNodeSelected += node => received = node;
-        FakeTreeNode treeNode = new FakeTreeNode();
-
-        plugin.CallStateWindowTreeNodeSelected(treeNode);
-
-        received.ShouldBeSameAs(treeNode);
-    }
-
-    [Fact]
     public void CallGetWorldCursorPosition_InvokesEventWithSameCursorAndReturnsResult()
     {
         TestWpfPlugin plugin = new TestWpfPlugin();

--- a/Tools/Gum.Presentation/Plugins/BaseClasses/PluginBase.cs
+++ b/Tools/Gum.Presentation/Plugins/BaseClasses/PluginBase.cs
@@ -149,7 +149,6 @@ public abstract class PluginBase : IPlugin
 
     public event Action<ElementSave?>? ElementSelected;
     public event Action<ITreeNode?>? TreeNodeSelected;
-    public event Action<ITreeNode>? StateWindowTreeNodeSelected;
     public event Func<ITreeNode?>? GetTreeNodeOver;
     public event Func<IEnumerable<ITreeNode>>? GetSelectedNodes;
     public event Action? FocusSearch;
@@ -367,8 +366,6 @@ public abstract class PluginBase : IPlugin
     public void CallElementSelected(ElementSave? element) => ElementSelected?.Invoke(element);
 
     public void CallTreeNodeSelected(ITreeNode? treeNode) => TreeNodeSelected?.Invoke(treeNode);
-
-    public void CallStateWindowTreeNodeSelected(ITreeNode treeNode) => StateWindowTreeNodeSelected?.Invoke(treeNode);
 
     public void CallBehaviorSelected(BehaviorSave? behavior) => BehaviorSelected?.Invoke(behavior);
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/AlignmentButtons/ViewModels/AlignmentViewModel.cs
@@ -2,8 +2,10 @@
 using Gum.Managers;
 using Gum.Mvvm;
 using Gum.Plugins.AlignmentButtons;
+using Gum.Services;
 using Gum.ToolStates;
 using Gum.Undo;
+using System.Drawing;
 using System.Globalization;
 
 namespace Gum.Plugins.InternalPlugins.AlignmentButtons.ViewModels;
@@ -13,6 +15,25 @@ public class AlignmentViewModel : ViewModel
     private readonly CommonControlLogic _commonControlLogic;
     private readonly ISelectedState _selectedState;
     private readonly IUndoManager _undoManager;
+    private readonly IStateEditingIndicatorService _stateEditingIndicatorService;
+
+    public bool HasStateInformation
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
+
+    public string? StateInformation
+    {
+        get => Get<string?>();
+        set => Set(value);
+    }
+
+    public Color StateBackground
+    {
+        get => Get<Color>();
+        set => Set(value);
+    }
 
     public float DockMargin
     {
@@ -41,12 +62,21 @@ public class AlignmentViewModel : ViewModel
     public bool IsMarginTextVisible => DockMargin != 0;
 
     public AlignmentViewModel(CommonControlLogic commonControlLogic, ISelectedState selectedState,
-        IUndoManager undoManager)
+        IUndoManager undoManager, IStateEditingIndicatorService stateEditingIndicatorService)
     {
         _commonControlLogic = commonControlLogic;
         _selectedState = selectedState;
         _undoManager = undoManager;
+        _stateEditingIndicatorService = stateEditingIndicatorService;
         DockMarginText = "0";
+    }
+
+    public void RefreshStateLabel()
+    {
+        var info = _stateEditingIndicatorService.GetInfo();
+        HasStateInformation = info.HasStateInformation;
+        StateInformation = info.StateInformation;
+        StateBackground = info.StateBackground;
     }
 
     // When DockMargin is 0, the expression `NormalizeNegativeZero(-DockMargin * 2)` evaluates to IEEE 754

--- a/Tools/Gum.Presentation/Services/IStateEditingIndicatorService.cs
+++ b/Tools/Gum.Presentation/Services/IStateEditingIndicatorService.cs
@@ -1,0 +1,14 @@
+using System.Drawing;
+
+namespace Gum.Services;
+
+public record StateEditingIndicatorInfo(bool HasStateInformation, string? StateInformation, Color StateBackground);
+
+/// <summary>
+/// Computes the "Editing state X" / "Displaying custom (animated) state" banner shown above the
+/// Variables and Alignment tabs when the selected state isn't the element's default state.
+/// </summary>
+public interface IStateEditingIndicatorService
+{
+    StateEditingIndicatorInfo GetInfo();
+}

--- a/Tools/Gum.Presentation/Services/StateEditingIndicatorService.cs
+++ b/Tools/Gum.Presentation/Services/StateEditingIndicatorService.cs
@@ -1,0 +1,35 @@
+using System.Drawing;
+using Gum.ToolStates;
+
+namespace Gum.Services;
+
+public class StateEditingIndicatorService : IStateEditingIndicatorService
+{
+    private readonly ISelectedState _selectedState;
+
+    public StateEditingIndicatorService(ISelectedState selectedState)
+    {
+        _selectedState = selectedState;
+    }
+
+    public StateEditingIndicatorInfo GetInfo()
+    {
+        var element = _selectedState.SelectedElement;
+        var state = _selectedState.SelectedStateSave;
+
+        if (element == null || state == null || state == element.DefaultState)
+        {
+            return new StateEditingIndicatorInfo(false, null, Color.Empty);
+        }
+
+        if (_selectedState.CustomCurrentStateSave != null)
+        {
+            return new StateEditingIndicatorInfo(true, "Displaying custom (animated) state", Color.Pink);
+        }
+
+        var category = _selectedState.SelectedStateCategorySave;
+        var stateName = category != null ? $"{category.Name}/{state.Name}" : state.Name;
+
+        return new StateEditingIndicatorInfo(true, $"Editing state {stateName}", Color.Yellow);
+    }
+}


### PR DESCRIPTION
Closes #4373

Adds the same yellow "Editing state X" / pink "Displaying custom (animated) state" banner to the Alignment tab that the Variables tab already shows.

- Extracted the banner's compute logic out of `PropertyGridManager.RefreshStateLabel` into a new `IStateEditingIndicatorService`, injected into both `PropertyGridManager` and `AlignmentViewModel`, so the two tabs can't drift.
- Extracted the banner's XAML (a `Label` bound to `HasStateInformation`/`StateInformation`/`StateBackground`) into a shared `StateEditingIndicatorBar` control, embedded in both `MainPropertyGrid.xaml` and `AlignmentPluginControl.xaml`.

Manual test: opened VS, verified selecting a non-default state shows the yellow bar on the Alignment tab (and hides on the default state); code paths for the pink custom-state case are shared and covered by unit tests.

FRB canary: not needed - change is WPF-tool-only (`Gum`/`Tools/Gum.Presentation`), no FRB1-shared source touched.
