### PR TITLE
Fix raylib/SkiaGum renderers ignoring LayerCameraSettings when drawing

### DIFF
--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1666,6 +1666,11 @@ public class CircleRuntime : GraphicalUiElement
         // RenderableComponent on next access. The fill slot's Color/Radius/etc. were copied
         // by Circle.Clone (ICloneable, MemberwiseClone) so the clone's fill matches source.
         toReturn.containedLineCircle = null!;
+        // The fill's MemberwiseClone shallow-copies OnPreRender too, so it still points at the
+        // SOURCE runtime's RefreshShapeState. Rebind to the clone's own instance method or the
+        // clone's stroke never gets its Width/Height mirror when added top-level to a Layer
+        // (issue #4367 follow-up).
+        toReturn.ContainedRenderable.OnPreRender = toReturn.RefreshShapeState;
         // Issue #2790: drop the inherited reference to the source's stroke slot and rebuild a
         // fresh one parented to the clone's fill so the clone is fully independent.
         toReturn.ClearStrokeRenderable();
@@ -1760,6 +1765,15 @@ public class CircleRuntime : GraphicalUiElement
             // each route to their own renderable. Without this call the runtime stays on the
             // single-slot legacy model (last-non-null-setter-wins).
             SetStrokeRenderable(new ContainedCircleType());
+
+            // SetContainedObject above (shared with raylib/Sokol) doesn't wire the
+            // OnPreRender hook SetContainedShape would -- wire it explicitly here so the
+            // two-slot stroke Width/Height mirror in SkiaShapeRuntime.RefreshShapeState still
+            // runs when this runtime is a TOP-LEVEL Layer member added via AddToManagers, not
+            // just when nested under a parent (issue #4367 follow-up; see RectangleRuntime's
+            // SKIA branch, which uses SetContainedShape directly since its branch isn't shared
+            // with raylib).
+            circle.OnPreRender = RefreshShapeState;
 
             // Defaults: white fill gated off (IsFilled = false) + white stroke, so a freshly-
             // constructed runtime renders as a stroke-only outline. Because FillColor defaults

--- a/MonoGameGum/GueDeriving/CircleRuntime.cs
+++ b/MonoGameGum/GueDeriving/CircleRuntime.cs
@@ -1786,7 +1786,11 @@ public class CircleRuntime : GraphicalUiElement
             IsFilled = false;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
-            StrokeWidthUnits = DimensionUnitType.ScreenPixel;
+            // Issue #4367 follow-up: Absolute (the implicit default MonoGame/raylib's
+            // CircleRuntime already use, since they never set this explicitly) so the stroke
+            // visually thickens as the camera zooms, matching the rest of the shape and the other
+            // two backends. Mirrors the RectangleRuntime fix.
+            StrokeWidthUnits = DimensionUnitType.Absolute;
 
             // Dropshadow is off by default; pre-seed alpha + offset/blur so toggling
             // HasDropshadow = true at runtime produces a visible shadow without further setup.

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -1904,7 +1904,12 @@ public class RectangleRuntime : GraphicalUiElement
             IsFilled = false;
             StrokeColor = SKColors.White;
             StrokeWidth = 1;
-            StrokeWidthUnits = DimensionUnitType.ScreenPixel;
+            // Issue #4367 follow-up: Absolute (the implicit default MonoGame/raylib's
+            // RectangleRuntime already use, since they never set this explicitly) so the stroke
+            // visually thickens as the camera zooms, matching the rest of the shape and the other
+            // two backends. A prior explicit ScreenPixel default here made this the one shape
+            // property that DIDN'T scale with zoom on Skia, a visible cross-backend mismatch.
+            StrokeWidthUnits = DimensionUnitType.Absolute;
 
             // Dropshadow off by default; pre-seed alpha/offset/blur so toggling HasDropshadow =
             // true at runtime produces a visible shadow without further setup. Use the scalar

--- a/MonoGameGum/GueDeriving/RectangleRuntime.cs
+++ b/MonoGameGum/GueDeriving/RectangleRuntime.cs
@@ -1796,6 +1796,11 @@ public class RectangleRuntime : GraphicalUiElement
         // RenderableComponent on next access. The fill slot color/dimensions were copied
         // by RoundedRectangle.Clone (ICloneable, MemberwiseClone).
         toReturn.containedLineRectangle = null!;
+        // The fill's MemberwiseClone shallow-copies OnPreRender too, so it still points at the
+        // SOURCE runtime's RefreshShapeState. Rebind to the clone's own instance method or the
+        // clone's stroke never gets its Width/Height mirror when added top-level to a Layer
+        // (issue #4367 follow-up).
+        toReturn.ContainedRenderable.OnPreRender = toReturn.RefreshShapeState;
         // Issue #2790 recipe - drop the inherited stroke-slot reference and rebuild a fresh
         // one parented to the clone fill so the clone is fully independent.
         toReturn.ClearStrokeRenderable();
@@ -1879,7 +1884,7 @@ public class RectangleRuntime : GraphicalUiElement
             // radii reach the renderer; CornerRadius default of 0 keeps the historical
             // hard-cornered visual (RoundedRectangle's own ctor defaults to 5).
             var rectangle = new ContainedLineRectangle { CornerRadius = 0 };
-            SetContainedObject(rectangle);
+            SetContainedShape(rectangle);
             containedLineRectangle = rectangle;
 
             SetStrokeRenderable(new ContainedLineRectangle { CornerRadius = 0 });

--- a/RenderingLibrary/Graphics/Layer.cs
+++ b/RenderingLibrary/Graphics/Layer.cs
@@ -203,15 +203,16 @@ namespace RenderingLibrary.Graphics
         }
 
         /// <summary>
-        /// Builds the world-to-screen matrix for this layer, factoring in LayerCameraSettings
-        /// (position, zoom, IsInScreenSpace) on top of the main camera. Both ScreenToWorld and
-        /// WorldToScreen route through this so their behavior cannot drift apart.
+        /// Resolves the effective camera position and zoom for this layer, factoring in
+        /// LayerCameraSettings (position, zoom, IsInScreenSpace) on top of the main camera.
+        /// This is the single source of truth for that resolution — ScreenToWorld/WorldToScreen
+        /// (hit-testing) and every backend's per-layer draw-time camera transform (rendering)
+        /// all route through this so they cannot drift apart (issue #4367).
         /// </summary>
-        private Matrix GetEffectiveTransformationMatrix(Camera camera, out float effectiveZoom)
+        public void GetEffectiveCamera(Camera camera, out float effectiveCameraX, out float effectiveCameraY, out float effectiveZoom)
         {
             // When IsInScreenSpace is true the main camera is ignored entirely, including its
-            // zoom — a screen-space HUD should not scale when the world camera zooms. This must
-            // match SpriteRenderer.GetZoomAndMatrix so rendering and hit-testing agree.
+            // zoom — a screen-space HUD should not scale when the world camera zooms.
             if (LayerCameraSettings?.IsInScreenSpace == true)
             {
                 effectiveZoom = LayerCameraSettings.Zoom ?? 1;
@@ -221,8 +222,8 @@ namespace RenderingLibrary.Graphics
                 effectiveZoom = LayerCameraSettings?.Zoom ?? camera.Zoom;
             }
 
-            float effectiveCameraX = camera.X;
-            float effectiveCameraY = camera.Y;
+            effectiveCameraX = camera.X;
+            effectiveCameraY = camera.Y;
 
             if (LayerCameraSettings?.IsInScreenSpace == true)
             {
@@ -235,6 +236,16 @@ namespace RenderingLibrary.Graphics
                 effectiveCameraX += layerPosition.X;
                 effectiveCameraY += layerPosition.Y;
             }
+        }
+
+        /// <summary>
+        /// Builds the world-to-screen matrix for this layer, factoring in LayerCameraSettings
+        /// (position, zoom, IsInScreenSpace) on top of the main camera. Both ScreenToWorld and
+        /// WorldToScreen route through this so their behavior cannot drift apart.
+        /// </summary>
+        private Matrix GetEffectiveTransformationMatrix(Camera camera, out float effectiveZoom)
+        {
+            GetEffectiveCamera(camera, out float effectiveCameraX, out float effectiveCameraY, out effectiveZoom);
 
             if (camera.CameraCenterOnScreen == RenderingLibrary.CameraCenterOnScreen.Center)
             {

--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -181,6 +181,17 @@ public class Renderer : IRenderer
     public Layer MainLayer => _layers[0];
     public ReadOnlyCollection<Layer> Layers => _layersReadOnly;
 
+    public Layer AddLayer()
+    {
+        Layer layer = new Layer();
+        _layers.Add(layer);
+        return layer;
+    }
+
+    public void AddLayer(Layer layer) => _layers.Add(layer);
+
+    public void RemoveLayer(Layer layer) => _layers.Remove(layer);
+
     public Renderer()
     {
         _layers = new List<Layer>();
@@ -240,16 +251,6 @@ public class Renderer : IRenderer
         _camera.ClientWidth = Raylib.GetRenderWidth();
         _camera.ClientHeight = Raylib.GetRenderHeight();
 
-        var camera2D = new Camera2D
-        {
-            Zoom = _camera.Zoom,
-            Target = new System.Numerics.Vector2(_camera.X, _camera.Y),
-            Offset = _camera.CameraCenterOnScreen == CameraCenterOnScreen.Center
-                ? new System.Numerics.Vector2(_camera.ClientWidth / 2f, _camera.ClientHeight / 2f)
-                : System.Numerics.Vector2.Zero,
-            Rotation = 0,
-        };
-
         // Substitute our owned RenderBatch for raylib's default so its draw counter can be read,
         // then route the mode/scissor state changes below through the counter so each batch flush
         // is banked into RenderStateChangeStatistics.DrawCallCount.
@@ -282,11 +283,6 @@ public class Renderer : IRenderer
             }
         }
 
-        // Record the outer camera so a mid-walk offscreen consumer can re-establish it after its
-        // own EndTextureMode resets the modelview (issue #3460).
-        ActiveCamera2D = camera2D;
-        BatchDrawCallCounter.BeginMode2D(camera2D);
-
         for (int i = 0; i < layers.Count; i++)
         {
             Layer layer = layers[i];
@@ -298,12 +294,43 @@ public class Renderer : IRenderer
             {
                 //mRenderStateVariables.Filtering = TextureFilter == TextureFilter.Linear;
             }
+
+            // Each layer gets its own Camera2D built from its LayerCameraSettings (position/zoom/
+            // IsInScreenSpace) falling back to the main camera when unset, so a screen-space HUD
+            // layer actually renders fixed on screen instead of panning/zooming with everything
+            // else (#4367). Record the active one so a mid-walk offscreen consumer can re-establish
+            // it after its own EndTextureMode resets the modelview (issue #3460).
+            Camera2D layerCamera2D = GetCamera2DForLayer(layer);
+            ActiveCamera2D = layerCamera2D;
+            BatchDrawCallCounter.BeginMode2D(layerCamera2D);
+
             RenderLayer(managers, layer, prerender: false);
+
+            BatchDrawCallCounter.EndMode2D();
         }
 
-        BatchDrawCallCounter.EndMode2D();
         BatchDrawCallCounter.EndPass();
     }
+
+    // Builds the Camera2D used to draw a single layer, factoring in LayerCameraSettings on top of
+    // the main camera (#4367). The Offset (where the target maps to on screen) always follows the
+    // main camera's CameraCenterOnScreen -- LayerCameraSettings has no center-mode override of its
+    // own -- matching Layer.GetEffectiveCamera's ground truth already used for hit-testing/scissor.
+    private Camera2D GetCamera2DForLayer(Layer layer)
+    {
+        layer.GetEffectiveCamera(_camera, out float effectiveX, out float effectiveY, out float effectiveZoom);
+
+        return new Camera2D
+        {
+            Zoom = effectiveZoom,
+            Target = new System.Numerics.Vector2(effectiveX, effectiveY),
+            Offset = _camera.CameraCenterOnScreen == CameraCenterOnScreen.Center
+                ? new System.Numerics.Vector2(_camera.ClientWidth / 2f, _camera.ClientHeight / 2f)
+                : System.Numerics.Vector2.Zero,
+            Rotation = 0,
+        };
+    }
+
     public void RenderLayer(ISystemManagers managers, Layer layer, bool prerender = true)
     {
 

--- a/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/RoundedRectangleRuntime.cs
@@ -215,6 +215,11 @@ public class RoundedRectangleRuntime
         toReturn._containedRoundedRectangle = null;
 
 #if SKIA
+        // The fill's MemberwiseClone shallow-copies OnPreRender too, so it still points at the
+        // SOURCE runtime's RefreshShapeState. Rebind to the clone's own instance method or the
+        // clone's PreRender-driven state (stroke Width/Height mirror, ScreenPixel corner radii)
+        // never runs when the clone is added top-level to a Layer (issue #4367 follow-up).
+        toReturn.ContainedRenderable.OnPreRender = toReturn.RefreshShapeState;
         // Issue #2814 recipe (mirror of CircleRuntime.Clone): drop the inherited reference to
         // the source stroke slot and rebuild a fresh one parented to the clone fill so the
         // clone is fully independent.

--- a/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
+++ b/Runtimes/SkiaGum/GueDeriving/SkiaShapeRuntime.cs
@@ -747,19 +747,44 @@ public abstract class SkiaShapeRuntime : InteractiveGue
     #endregion
 
     /// <summary>
-    /// Passthrough to <see cref="GraphicalUiElement.SetContainedObject"/>. Exists for symmetry
-    /// with <c>AposShapeRuntime.SetContainedShape</c>, which also hooks the renderable's PreRender
-    /// callback so unit-bearing properties (e.g. ScreenPixel stroke width) re-resolve each frame.
-    /// Skia doesn't need that hook, so this overload just forwards. Having the same method name
-    /// available on both runtimes lets unified shape-runtime files (e.g. RoundedRectangleRuntime)
-    /// share one constructor without #if-gating the contained-object setup.
+    /// Passthrough to <see cref="GraphicalUiElement.SetContainedObject"/> that ALSO wires the
+    /// fill slot's <see cref="RenderableShapeBase.OnPreRender"/> hook to <see cref="RefreshShapeState"/>,
+    /// mirroring <c>AposShapeRuntime.SetContainedShape</c> (XNALIKE). The hook is what makes
+    /// <see cref="RefreshShapeState"/> (the two-slot stroke Width/Height mirror,
+    /// <c>StrokeWidthUnits.ScreenPixel</c> resolution) run even when this runtime is a TOP-LEVEL
+    /// <see cref="RenderingLibrary.Graphics.Layer"/> member added via <c>AddToManagers</c> — in
+    /// that case only the raw fill renderable (not this GUE wrapper) is registered on the Layer,
+    /// so <see cref="PreRender"/>'s own override is otherwise unreachable from the render walk
+    /// (issue #4367 follow-up). A NESTED (tree-parented) instance still reaches
+    /// <see cref="RefreshShapeState"/> the original way too, through its own <see cref="PreRender"/>
+    /// override — the hook just adds the top-level path; <see cref="RefreshShapeState"/> is
+    /// idempotent so running twice in that case is harmless. Callers MUST use this instead of
+    /// calling <c>SetContainedObject</c> directly for any shape whose <see cref="PreRender"/>
+    /// override does real work — a direct <c>SetContainedObject</c> call silently skips this
+    /// wiring, which is exactly how the top-level bug shipped. Having the same method name
+    /// available on both runtimes also lets unified shape-runtime files (e.g.
+    /// RoundedRectangleRuntime) share one constructor without #if-gating the contained-object
+    /// setup.
     /// </summary>
     protected void SetContainedShape(RenderableShapeBase shape)
     {
         SetContainedObject(shape);
+        shape.OnPreRender = RefreshShapeState;
     }
 
-    public override void PreRender()
+    /// <summary>
+    /// Per-frame PreRender logic shared by every two-slot/dropshadow-capable Skia shape runtime.
+    /// Reached two ways: (1) a derived runtime's own <c>PreRender()</c> override calling
+    /// <c>base.PreRender()</c>, which chains up to <see cref="PreRender"/> below; (2) the fill
+    /// slot's <see cref="RenderableShapeBase.OnPreRender"/> hook (wired in
+    /// <see cref="SetContainedShape"/>), which fires even when this runtime is a top-level Layer
+    /// member and path (1) is unreachable. See <see cref="SetContainedShape"/>'s remarks.
+    /// <c>protected</c> (not <c>private</c>) so a derived runtime's <c>Clone()</c> override can
+    /// rebind <see cref="RenderableShapeBase.OnPreRender"/> to the CLONE's own instance — the
+    /// fill's <c>MemberwiseClone</c> shallow-copies that delegate, so without rebinding it would
+    /// still point at the source runtime.
+    /// </summary>
+    protected void RefreshShapeState()
     {
         var strokeWidth = StrokeWidth;
 
@@ -791,7 +816,17 @@ public abstract class SkiaShapeRuntime : InteractiveGue
         }
 
         ApplyDropshadow();
+    }
 
+    /// <summary>
+    /// Runs <see cref="RefreshShapeState"/> for the GUE-nested reach path (see its remarks), then
+    /// forwards to the base <see cref="GraphicalUiElement.PreRender"/>, which calls
+    /// <c>.PreRender()</c> on the contained fill renderable — firing <see cref="RefreshShapeState"/>
+    /// a second, harmless time via <see cref="SetContainedShape"/>'s <c>OnPreRender</c> hook.
+    /// </summary>
+    public override void PreRender()
+    {
+        RefreshShapeState();
         base.PreRender();
     }
 }

--- a/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
+++ b/Runtimes/SkiaGum/Renderables/RenderableShapeBase.cs
@@ -665,7 +665,22 @@ public class RenderableShapeBase : IRenderableIpso, IVisible, IDisposable
 
     public bool IsRenderTarget => false;
 
-    public void PreRender() {}
+    /// <summary>
+    /// Optional callback invoked at the end of <see cref="PreRender"/>, wired by the owning
+    /// GraphicalUiElement runtime (see <c>SkiaShapeRuntime.SetContainedShape</c>) so per-frame,
+    /// GUE-level PreRender logic (e.g. the two-slot stroke Width/Height mirror, or
+    /// <c>StrokeWidthUnits.ScreenPixel</c> resolution) still runs even when this renderable is a
+    /// TOP-LEVEL <see cref="RenderingLibrary.Graphics.Layer"/> member added via
+    /// <c>GraphicalUiElement.AddToManagers</c>. In that case only this raw renderable (the fill
+    /// slot, <c>mContainedObjectAsIpso</c>) is registered on the Layer -- the GUE wrapper's own
+    /// <c>PreRender()</c> override is otherwise unreachable, since the render walk only calls
+    /// <c>.PreRender()</c> on whatever object is actually a Layer/Children member (issue #4367
+    /// follow-up). Mirrors the XNALIKE <c>RenderableShapeBase</c> / <c>AposShapeRuntime</c>
+    /// <c>OnPreRender</c> hook (see the gum-monogame-rendering skill).
+    /// </summary>
+    public Action? OnPreRender { get; set; }
+
+    public void PreRender() => OnPreRender?.Invoke();
 
     public void Render(ISystemManagers managers)
     {

--- a/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/Renderer.cs
@@ -24,9 +24,20 @@ namespace RenderingLibrary.Graphics
             }
         }
 
-        public Layer MainLayer => 
+        public Layer MainLayer =>
             // Not sure if we have any layers in skia so do a FirstOrDefault
             _layers.FirstOrDefault();
+
+        public Layer AddLayer()
+        {
+            Layer layer = new Layer();
+            _layers.Add(layer);
+            return layer;
+        }
+
+        public void AddLayer(Layer layer) => _layers.Add(layer);
+
+        public void RemoveLayer(Layer layer) => _layers.Remove(layer);
 
         /// <summary>
         /// Whether renderable objects should call Render
@@ -117,7 +128,7 @@ namespace RenderingLibrary.Graphics
         {
             foreach(var layer in layers)
             {
-                Draw(layer.Renderables, managers, isTopLevelDraw: true);
+                Draw(layer.Renderables, managers, isTopLevelDraw: true, layer: layer);
             }
         }
 
@@ -138,7 +149,7 @@ namespace RenderingLibrary.Graphics
             Draw(whatToRender, managers, true);
         }
 
-        void Draw(IList<IRenderableIpso> whatToRender, SystemManagers managers, bool isTopLevelDraw = false)
+        void Draw(IList<IRenderableIpso> whatToRender, SystemManagers managers, bool isTopLevelDraw = false, Layer layer = null)
         {
             if (isTopLevelDraw)
             {
@@ -176,13 +187,27 @@ namespace RenderingLibrary.Graphics
                 // ("everything off screen") within a couple of seconds.
                 managers.Canvas.Save();
 
-                if (Camera.Zoom != 1)
+                // Each layer gets its own effective camera position/zoom from LayerCameraSettings
+                // (falling back to the main camera when the layer has none set), so a screen-space
+                // HUD layer actually renders fixed on screen instead of panning/zooming with
+                // everything else (#4367). A null layer (the public Draw(IList<...>)/Draw
+                // (ObservableCollection<...>) overloads, which have no Layer to consult) keeps the
+                // prior main-camera-only behavior.
+                float effectiveZoom = Camera.Zoom;
+                float effectiveCameraX = Camera.X;
+                float effectiveCameraY = Camera.Y;
+                if (layer != null)
                 {
-                    managers.Canvas.Scale(Camera.Zoom);
+                    layer.GetEffectiveCamera(Camera, out effectiveCameraX, out effectiveCameraY, out effectiveZoom);
                 }
 
-                var translateX = -Camera.X;
-                var translateY = -Camera.Y;
+                if (effectiveZoom != 1)
+                {
+                    managers.Canvas.Scale(effectiveZoom);
+                }
+
+                var translateX = -effectiveCameraX;
+                var translateY = -effectiveCameraY;
 
                 if(Camera.CameraCenterOnScreen == CameraCenterOnScreen.Center)
                 {

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Game1.cs
@@ -106,6 +106,7 @@ namespace MonoGameGumInCode
             AddNavButton("Render Target", () => ShowScreen<RenderTargetScreen>());
             AddNavButton("RT Shader", () => ShowScreen<RenderTargetShaderScreen>());
             AddNavButton("Zoom", () => ShowScreen<ZoomScreen>());
+            AddNavButton("Layer Camera", () => ShowScreen<LayerCameraSettingsScreen>());
 
             AddFitModeRadio("Zoom", isChecked: true, () => GumService.Default.EnableZoomToWindow());
             AddFitModeRadio("Expand", isChecked: false, () => GumService.Default.EnableExpandToWindow());
@@ -136,9 +137,12 @@ namespace MonoGameGumInCode
                 _currentScreen.RemoveFromRoot();
             }
 
-            // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
-            // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+            // ZoomScreen and LayerCameraSettingsScreen both drive the shared main Camera directly
+            // (issues #4330, #4367) -- reset it here so leaving either screen zoomed/panned never
+            // leaks into whichever screen is shown next.
             SystemManagers.Default.Renderer.Camera.Zoom = 1f;
+            SystemManagers.Default.Renderer.Camera.X = 0f;
+            SystemManagers.Default.Renderer.Camera.Y = 0f;
 
             _currentScreen = new T();
             // Offset the screen so it doesn't sit underneath the nav strip. The screen's

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/LayerCameraSettingsScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/LayerCameraSettingsScreen.cs
@@ -155,5 +155,20 @@ internal class LayerCameraSettingsScreen : FrameworkElement
         hudLabel.Blue = 255;
         hudLabel.Alpha = 255;
         hudLabel.AddToManagers(SystemManagers.Default, _hudLayer);
+
+        // Clean up when this screen is navigated AWAY from. RemoveFromRoot (called by every sample's
+        // screen-switch code) sets this.Visual.Parent = null, which detaches the screen's own child
+        // tree -- but hudBackground/hudLabel above are NOT children of this screen (they're top-level
+        // members of _hudLayer via AddToManagers), so that detach never reaches them. Without this,
+        // the HUD layer + its two renderables keep rendering on top of every screen shown afterward,
+        // forever, until the user happens to revisit this screen (confirmed by manual test).
+        this.Visual.ParentChanged += (_, _) =>
+        {
+            if (this.Visual.Parent == null && _hudLayer != null)
+            {
+                SystemManagers.Default.Renderer.RemoveLayer(_hudLayer);
+                _hudLayer = null;
+            }
+        };
     }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/LayerCameraSettingsScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/LayerCameraSettingsScreen.cs
@@ -1,0 +1,159 @@
+using Gum.DataTypes;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+#if RAYLIB
+using Color = Raylib_cs.Color;
+#elif SKIA
+using Color = SkiaSharp.SKColor;
+#else
+using Color = Microsoft.Xna.Framework.Color;
+#endif
+
+#if RAYLIB
+namespace Examples.Shapes;
+#elif SKIA
+namespace SilkNetGum.Screens;
+#else
+namespace MonoGameGumInCode.Screens;
+#endif
+
+// Issue #4367 manual-test rig (mirrored across MonoGame/raylib/SilkNetGum -- see the gum-samples
+// skill): before the fix, raylib's and SkiaGum's Renderer both built ONE camera matrix for the
+// whole frame and applied it to every layer, so a Layer.LayerCameraSettings override was honored
+// by Layer.ScreenToWorld/WorldToScreen (hit-testing) but never consulted when actually drawing --
+// only the XNALIKE renderer respected it. This screen puts the SAME content on two layers side by
+// side so the difference is visible with the naked eye:
+//
+//   - The crimson "World content" square is an ordinary child of this screen -- it renders through
+//     the main camera, so the zoom slider and pan button both move/scale it.
+//   - The blue "HUD" panel is added directly to a dedicated Layer with
+//     LayerCameraSettings.IsInScreenSpace = true (NOT a child of this screen -- see AddToManagers
+//     below). Before the fix, on raylib/SkiaGum, it moved/scaled right along with the world content
+//     (the bug). After the fix, it must stay pixel-fixed at the bottom-left corner on ALL THREE
+//     backends no matter how far the slider is zoomed or whether the camera is panned.
+//
+// The HUD panel is intentionally non-interactive (no Slider/Button on it) -- the fix is about the
+// RENDER transform. Cursor hit-testing already routed through Layer.ScreenToWorld correctly even
+// before this fix (that's what made the bug a silent rendering/hit-testing DISAGREEMENT rather than
+// an obvious total break), so there's nothing new to prove on the input side.
+internal class LayerCameraSettingsScreen : FrameworkElement
+{
+    // Tracks the screen-space HUD layer created by the most recently-constructed instance of this
+    // screen. A fresh instance is created every time the user navigates back to this screen (see
+    // each sample's ShowScreen/LoadScreen), and RemoveFromRoot (called on the OLD screen when
+    // navigating away) only detaches that screen's own visual-tree parent link -- it has no idea
+    // about a renderable added directly to a Layer via AddToManagers, since that's a top-level layer
+    // member, not a child of the screen. Without this, the HUD panel from every previous visit would
+    // keep piling up as an extra Layer + extra renderables.
+    private static Layer? _hudLayer;
+
+    public LayerCameraSettingsScreen() : base(new ContainerRuntime())
+    {
+        if (_hudLayer != null)
+        {
+            SystemManagers.Default.Renderer.RemoveLayer(_hudLayer);
+            _hudLayer = null;
+        }
+
+        Dock(Gum.Wireframe.Dock.Fill);
+
+        // --- World content: a normal child of this screen, rendered through the main camera. ---
+        var worldRectangle = new RectangleRuntime();
+        worldRectangle.X = 300;
+        worldRectangle.Y = 160;
+        worldRectangle.Width = 140;
+        worldRectangle.Height = 140;
+        worldRectangle.IsFilled = true;
+        worldRectangle.FillColor = new Color(220, 20, 60, 255); // Crimson
+        this.AddChild(worldRectangle);
+
+        var worldLabel = new TextRuntime();
+        worldLabel.Text = "World content\n(moves & scales with the camera)";
+        worldLabel.X = 300;
+        worldLabel.Y = 310;
+        worldLabel.WidthUnits = DimensionUnitType.Absolute;
+        worldLabel.Width = 220;
+        worldLabel.Red = 255;
+        worldLabel.Green = 255;
+        worldLabel.Blue = 255;
+        worldLabel.Alpha = 255;
+        this.AddChild(worldLabel);
+
+        // --- Camera controls: ordinary Forms controls, also rendered through the main camera. ---
+        var controlsPanel = new StackPanel();
+        controlsPanel.Orientation = Orientation.Vertical;
+        controlsPanel.Spacing = 6;
+        controlsPanel.Visual.X = 16;
+        controlsPanel.Visual.Y = 16;
+        this.AddChild(controlsPanel);
+
+        var zoomLabel = new Label();
+        zoomLabel.Width = 260;
+        controlsPanel.AddChild(zoomLabel);
+
+        var zoomSlider = new Slider();
+        zoomSlider.Width = 260;
+        zoomSlider.Minimum = 1;
+        zoomSlider.Maximum = 3;
+        zoomSlider.Value = 1;
+        controlsPanel.AddChild(zoomSlider);
+
+        void UpdateZoomLabel(double value) => zoomLabel.Text = $"Camera Zoom: {value:0.00}x";
+
+        zoomSlider.ValueChanged += (_, _) => UpdateZoomLabel(zoomSlider.Value);
+        // Commit on release only -- see ZoomScreen's own comment for why: the slider's own drag math
+        // divides the cursor position by the very Camera.Zoom this handler would otherwise write on
+        // every intermediate tick, which is a real feedback loop, not just cosmetic jitter.
+        zoomSlider.ValueChangeCompleted += (_, _) =>
+        {
+            SystemManagers.Default.Renderer.Camera.Zoom = (float)zoomSlider.Value;
+        };
+        UpdateZoomLabel(zoomSlider.Value);
+
+        var panButton = new Button();
+        panButton.Width = 260;
+        bool isPanned = false;
+        void UpdatePanButtonText() => panButton.Text = isPanned ? "Pan Camera (panned - click to reset)" : "Pan Camera";
+        panButton.Click += (_, _) =>
+        {
+            isPanned = !isPanned;
+            SystemManagers.Default.Renderer.Camera.X = isPanned ? 220 : 0;
+            SystemManagers.Default.Renderer.Camera.Y = isPanned ? 140 : 0;
+            UpdatePanButtonText();
+        };
+        UpdatePanButtonText();
+        controlsPanel.AddChild(panButton);
+
+        // --- HUD content: added directly to a dedicated screen-space Layer, NOT a child of this
+        // screen, so LayerCameraSettings.IsInScreenSpace actually applies to it (see class comment
+        // above for why nesting under `this` wouldn't work -- Layers are a frame-level render pass,
+        // not something a nested child can independently opt into). ---
+        _hudLayer = SystemManagers.Default.Renderer.AddLayer();
+        _hudLayer.Name = "HUD (screen space)";
+        _hudLayer.LayerCameraSettings = new LayerCameraSettings { IsInScreenSpace = true };
+
+        var hudBackground = new RectangleRuntime();
+        hudBackground.X = 16;
+        hudBackground.Y = 520;
+        hudBackground.Width = 260;
+        hudBackground.Height = 90;
+        hudBackground.IsFilled = true;
+        hudBackground.FillColor = new Color(20, 90, 160, 220);
+        hudBackground.AddToManagers(SystemManagers.Default, _hudLayer);
+
+        var hudLabel = new TextRuntime();
+        hudLabel.Text = "HUD layer (IsInScreenSpace = true)\nMust stay fixed regardless of zoom/pan.";
+        hudLabel.X = 24;
+        hudLabel.Y = 528;
+        hudLabel.WidthUnits = DimensionUnitType.Absolute;
+        hudLabel.Width = 244;
+        hudLabel.Red = 255;
+        hudLabel.Green = 255;
+        hudLabel.Blue = 255;
+        hudLabel.Alpha = 255;
+        hudLabel.AddToManagers(SystemManagers.Default, _hudLayer);
+    }
+}

--- a/Samples/SilkNetGum/SilkNetGumSample/Program.cs
+++ b/Samples/SilkNetGum/SilkNetGumSample/Program.cs
@@ -86,6 +86,7 @@ unsafe class Program
         () => new SilkNetGum.Screens.RenderTargetShaderScreen(),
         () => new GumSamples.Screens.FormsScreen(),
         () => new SilkNetGum.Screens.ZoomScreen(),
+        () => new SilkNetGum.Screens.LayerCameraSettingsScreen(),
     };
 
     // Parallel to codeScreenFactories, used as nav-strip button labels.
@@ -102,6 +103,7 @@ unsafe class Program
         "RT Shader",
         "Forms",
         "Zoom",
+        "Layer Camera",
     };
 
     private static void InitializeGum(SKCanvas canvas, IInputContext inputContext)
@@ -223,9 +225,12 @@ unsafe class Program
         currentCodeScreen?.RemoveFromRoot();
         currentCodeScreen = null;
 
-        // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
-        // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+        // ZoomScreen and LayerCameraSettingsScreen both drive the shared main Camera directly
+        // (issues #4330, #4367) -- reset it here so leaving either screen zoomed/panned never leaks
+        // into whichever screen is shown next.
         SystemManagers.Default.Renderer.Camera.Zoom = 1f;
+        SystemManagers.Default.Renderer.Camera.X = 0f;
+        SystemManagers.Default.Renderer.Camera.Y = 0f;
 
         if (currentScreenIndex < gumxScreens.Count)
         {

--- a/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
+++ b/Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj
@@ -62,6 +62,8 @@
 	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\RectanglesScreen.cs" Link="Screens\RectanglesScreen.cs" />
 	  <!-- Camera-zoom font crispness demo shared from MonoGameGumInCode, gated #elif SKIA (#4330). -->
 	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\ZoomScreen.cs" Link="Screens\ZoomScreen.cs" />
+	  <!-- LayerCameraSettings screen-space-vs-world demo shared from MonoGameGumInCode, gated #elif SKIA (#4367). -->
+	  <Compile Include="..\..\MonoGameGumInCode\MonoGameGumInCode\Screens\LayerCameraSettingsScreen.cs" Link="Screens\LayerCameraSettingsScreen.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/raylib/GumTest.csproj
+++ b/Samples/raylib/GumTest.csproj
@@ -18,10 +18,10 @@
     <ProjectReference Include="..\..\Integrations\KernSmith\KernSmith.RaylibGum\KernSmith.RaylibGum.csproj" />
   </ItemGroup>
 
-  <!-- #3640/#3988/#3998/#4024/#4029/#4330: TextScreen.cs, RenderTargetScreen.cs,
-       RenderTargetShaderScreen.cs, CirclesScreen.cs, RectanglesScreen.cs, and ZoomScreen.cs are
-       shared with Samples/MonoGameGumInCode (the canonical copies), gated #if RAYLIB, to stop the
-       mirrors drifting when only one got updated. -->
+  <!-- #3640/#3988/#3998/#4024/#4029/#4330/#4367: TextScreen.cs, RenderTargetScreen.cs,
+       RenderTargetShaderScreen.cs, CirclesScreen.cs, RectanglesScreen.cs, ZoomScreen.cs, and
+       LayerCameraSettingsScreen.cs are shared with Samples/MonoGameGumInCode (the canonical
+       copies), gated #if RAYLIB, to stop the mirrors drifting when only one got updated. -->
   <ItemGroup>
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\TextScreen.cs" Link="Screens\TextScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\RenderTargetScreen.cs" Link="Screens\RenderTargetScreen.cs" />
@@ -29,6 +29,7 @@
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\CirclesScreen.cs" Link="Screens\CirclesScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\RectanglesScreen.cs" Link="Screens\RectanglesScreen.cs" />
     <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\ZoomScreen.cs" Link="Screens\ZoomScreen.cs" />
+    <Compile Include="..\MonoGameGumInCode\MonoGameGumInCode\Screens\LayerCameraSettingsScreen.cs" Link="Screens\LayerCameraSettingsScreen.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -163,6 +163,7 @@ public class BasicShapes
         AddNavButton("Render Target", () => new RenderTargetScreen());
         AddNavButton("RT Shader", () => new RenderTargetShaderScreen());
         AddNavButton("Zoom", () => new ZoomScreen());
+        AddNavButton("Layer Camera", () => new LayerCameraSettingsScreen());
 
         AddFitModeRadio("Zoom", isChecked: true, () =>
         {
@@ -240,9 +241,12 @@ public class BasicShapes
             activeScreen.RemoveFromRoot();
         }
 
-        // ZoomScreen drives the shared main Camera.Zoom directly (issue #4330) -- reset it here so
-        // leaving that screen zoomed in never leaks a non-1 zoom into whichever screen is shown next.
+        // ZoomScreen and LayerCameraSettingsScreen both drive the shared main Camera directly
+        // (issues #4330, #4367) -- reset it here so leaving either screen zoomed/panned never leaks
+        // into whichever screen is shown next.
         SystemManagers.Default.Renderer.Camera.Zoom = 1f;
+        SystemManagers.Default.Renderer.Camera.X = 0f;
+        SystemManagers.Default.Renderer.Camera.Y = 0f;
 
         activeScreen = factory();
         // Offset the screen so it doesn't sit underneath the nav strip — same trick as

--- a/Tests/RaylibGum.Tests/Rendering/LayerCameraSettingsRenderTests.cs
+++ b/Tests/RaylibGum.Tests/Rendering/LayerCameraSettingsRenderTests.cs
@@ -1,0 +1,111 @@
+using System.Numerics;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using static Raylib_cs.Raylib;
+
+namespace RaylibGum.Tests.Rendering;
+
+/// <summary>
+/// Issue #4367: raylib's <see cref="Renderer"/> built a single Camera2D from the main
+/// <see cref="RenderingLibrary.Camera"/> for the whole frame, so a <see cref="Layer.LayerCameraSettings"/>
+/// override (position/zoom/IsInScreenSpace) was honored by <see cref="Layer.ScreenToWorld"/>/
+/// <see cref="Layer.WorldToScreen"/> (hit-testing) but never consulted when actually drawing —
+/// a screen-space HUD layer rendered zoomed/panned with everything else instead of staying fixed.
+/// </summary>
+public class LayerCameraSettingsRenderTests : BaseTestClass
+{
+    [Fact]
+    public void AddLayer_Parameterless_AddsNewLayerToLayers()
+    {
+        int before = Renderer.Self.Layers.Count;
+
+        Layer layer = Renderer.Self.AddLayer();
+
+        Renderer.Self.Layers.Count.ShouldBe(before + 1);
+        Renderer.Self.Layers.ShouldContain(layer);
+
+        Renderer.Self.RemoveLayer(layer);
+    }
+
+    [Fact]
+    public void AddLayer_WithExistingLayerInstance_AddsItToLayers()
+    {
+        Layer layer = new Layer();
+        int before = Renderer.Self.Layers.Count;
+
+        Renderer.Self.AddLayer(layer);
+
+        Renderer.Self.Layers.Count.ShouldBe(before + 1);
+        Renderer.Self.Layers.ShouldContain(layer);
+
+        Renderer.Self.RemoveLayer(layer);
+    }
+
+    [Fact]
+    public void RemoveLayer_RemovesPreviouslyAddedLayer()
+    {
+        Layer layer = Renderer.Self.AddLayer();
+
+        Renderer.Self.RemoveLayer(layer);
+
+        Renderer.Self.Layers.ShouldNotContain(layer);
+    }
+
+    [Fact]
+    public void Draw_LayerWithScreenSpaceCameraSettings_UsesScreenSpaceCameraForDrawing()
+    {
+        Renderer.Self.Camera.Zoom = 3f;
+        Renderer.Self.Camera.X = 500f;
+        Renderer.Self.Camera.Y = 500f;
+
+        Layer hudLayer = Renderer.Self.AddLayer();
+        hudLayer.LayerCameraSettings = new LayerCameraSettings
+        {
+            IsInScreenSpace = true,
+        };
+
+        try
+        {
+            BeginDrawing();
+            GumService.Default.Draw();
+            EndDrawing();
+
+            // The HUD layer is drawn last, so ActiveCamera2D reflects its effective camera after
+            // Draw completes. Before the fix, every layer shared the main camera's Zoom/Target
+            // regardless of LayerCameraSettings.
+            Renderer.Self.ActiveCamera2D.Zoom.ShouldBe(1f);
+            Renderer.Self.ActiveCamera2D.Target.ShouldBe(Vector2.Zero);
+        }
+        finally
+        {
+            Renderer.Self.RemoveLayer(hudLayer);
+            Renderer.Self.Camera.Zoom = 1f;
+            Renderer.Self.Camera.X = 0f;
+            Renderer.Self.Camera.Y = 0f;
+        }
+    }
+
+    [Fact]
+    public void Draw_LayerWithNoCameraSettings_StillUsesMainCamera()
+    {
+        Renderer.Self.Camera.Zoom = 2f;
+        Renderer.Self.Camera.X = 40f;
+        Renderer.Self.Camera.Y = 60f;
+
+        try
+        {
+            BeginDrawing();
+            GumService.Default.Draw();
+            EndDrawing();
+
+            Renderer.Self.ActiveCamera2D.Zoom.ShouldBe(2f);
+            Renderer.Self.ActiveCamera2D.Target.ShouldBe(new Vector2(40f, 60f));
+        }
+        finally
+        {
+            Renderer.Self.Camera.Zoom = 1f;
+            Renderer.Self.Camera.X = 0f;
+            Renderer.Self.Camera.Y = 0f;
+        }
+    }
+}

--- a/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/CircleRuntimeTests.cs
@@ -244,6 +244,17 @@ public class CircleRuntimeTests
         sut.StrokeWidth.ShouldBe(1);
     }
 
+    // Issue #4367 follow-up: a ScreenPixel default made the stroke NOT visually thicken as the
+    // camera zooms in (ScreenPixel divides by Camera.Zoom to hold a constant on-screen pixel size),
+    // while MonoGame/raylib's CircleRuntime has no explicit default and so uses Absolute (which
+    // DOES scale with zoom, same as the rest of the shape). Mirrors the RectangleRuntime fix.
+    [Fact]
+    public void StrokeWidthUnits_ShouldBeAbsolute_ByDefault()
+    {
+        CircleRuntime sut = new();
+        sut.StrokeWidthUnits.ShouldBe(Gum.DataTypes.DimensionUnitType.Absolute);
+    }
+
     [Fact]
     public void Width_ShouldBe32_ByDefault()
     {

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTests.cs
@@ -661,6 +661,19 @@ public class RectangleRuntimeTests
         sut.StrokeWidth.ShouldBe(1);
     }
 
+    // Issue #4367 follow-up: a ScreenPixel default made the stroke NOT visually thicken as the
+    // camera zooms in (ScreenPixel divides by Camera.Zoom to hold a constant on-screen pixel size
+    // -- see DimensionUnitType.ScreenPixel's doc comment), while MonoGame/raylib's RectangleRuntime
+    // has no explicit default and so uses Absolute (which DOES scale with zoom, same as the rest of
+    // the shape). Confirmed via manual cross-backend comparison: MonoGame/raylib outlines visibly
+    // thicken when zoomed; Skia's did not until this default was aligned.
+    [Fact]
+    public void StrokeWidthUnits_ShouldBeAbsolute_ByDefault()
+    {
+        RectangleRuntime sut = new();
+        sut.StrokeWidthUnits.ShouldBe(DimensionUnitType.Absolute);
+    }
+
     // Issue #4029 — corrected contract: gradient follows the ACTIVE body. When both a fill and a
     // stroke are active, the gradient applies to the fill ONLY; the stroke keeps rendering as a
     // plain solid outline on top of it, exactly like it would on top of a solid fill. Previously

--- a/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTopLevelStrokeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/RectangleRuntimeTopLevelStrokeTests.cs
@@ -1,0 +1,71 @@
+using Gum;
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using Shouldly;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.GueDeriving;
+
+/// <summary>
+/// Manual-test follow-up (surfaced while verifying issue #4367's LayerCameraSettings fix): a
+/// <see cref="RectangleRuntime"/> added directly to a <see cref="RenderingLibrary.Graphics.Layer"/>
+/// via <c>AddToManagers</c> (top-level, not nested under a parent) rendered its stroke at the
+/// wrong size on Skia -- a small box near the origin instead of tracing the shape's actual
+/// Width/Height.
+///
+/// Root cause: <c>SkiaShapeRuntime</c>'s two-slot fill+stroke composition mirrors the stroke
+/// slot's Width/Height onto the fill's every frame from <c>SkiaShapeRuntime.PreRender()</c>. The
+/// Skia <see cref="RenderingLibrary.Graphics.Renderer"/>'s per-layer render walk calls
+/// <c>.PreRender()</c> on whatever object is actually registered as a Layer member -- for a
+/// TOP-LEVEL renderable that's the raw contained (fill) <c>RenderableShapeBase</c>
+/// (<c>GraphicalUiElement.AddToManagers</c> registers <c>mContainedObjectAsIpso</c>, not the GUE
+/// wrapper), whose own <c>PreRender()</c> was a no-op -- so the GUE-level override (and its stroke
+/// mirror) was never reached. A NESTED child doesn't hit this: the render walk's
+/// <c>IRenderableIpso.Children</c> holds the child GUE wrapper itself, so its <c>PreRender()</c>
+/// override fires normally (see <c>Render_StrokeWidthZero_DrawsNoVisibleStroke</c> for the
+/// already-covered nested case).
+/// </summary>
+public class RectangleRuntimeTopLevelStrokeTests
+{
+    public RectangleRuntimeTopLevelStrokeTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    [Fact]
+    public void Draw_TwoSlotRectangleAddedDirectlyToLayer_StrokeMatchesFillSize()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+        surface.Canvas.Clear(SKColors.Black);
+
+        RectangleRuntime rectangle = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 50,
+            Height = 50,
+            IsFilled = true,
+            FillColor = SKColors.Red,
+            StrokeColor = SKColors.Lime,
+            StrokeWidth = 4,
+            StrokeWidthUnits = DimensionUnitType.Absolute,
+        };
+        // Top-level: added directly to the Layer, not nested under Root -- the case that exposes
+        // the bug (see class remarks above).
+        rectangle.AddToManagers(SystemManagers.Default, SystemManagers.Default.Renderer.MainLayer);
+
+        GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+
+        // Just inside the rectangle's right edge, where the (correctly-sized) stroke should trace.
+        // Before the fix the stroke stayed at its tiny construction-time default size near the
+        // origin, so this pixel showed the fill's red instead.
+        bitmap.GetPixel(48, 25).ShouldBe(SKColors.Lime,
+            "because the stroke must scale to the rectangle's actual Width/Height (50x50), not stay at its construction-time default size");
+    }
+}

--- a/Tests/SkiaGum.Tests/Renderer/LayerCameraSettingsRenderTests.cs
+++ b/Tests/SkiaGum.Tests/Renderer/LayerCameraSettingsRenderTests.cs
@@ -1,0 +1,90 @@
+using Gum;
+using Gum.GueDeriving;
+using Gum.Wireframe;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using SkiaSharp;
+
+namespace SkiaGum.Tests.Renderer;
+
+/// <summary>
+/// Issue #4367: SkiaGum's <see cref="RenderingLibrary.Graphics.Renderer"/> applied only the main
+/// <see cref="Camera"/> when drawing, so a <see cref="Layer.LayerCameraSettings"/> override
+/// (position/zoom/IsInScreenSpace) was honored by <see cref="Layer.ScreenToWorld"/>/
+/// <see cref="Layer.WorldToScreen"/> (hit-testing) but never consulted when actually drawing —
+/// a screen-space HUD layer rendered zoomed/panned with everything else instead of staying fixed.
+/// </summary>
+public class LayerCameraSettingsRenderTests
+{
+    public LayerCameraSettingsRenderTests()
+    {
+        GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
+    }
+
+    [Fact]
+    public void AddLayer_Parameterless_AddsNewLayerToLayers()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        int before = SystemManagers.Default.Renderer.Layers.Count;
+
+        Layer layer = SystemManagers.Default.Renderer.AddLayer();
+
+        SystemManagers.Default.Renderer.Layers.Count.ShouldBe(before + 1);
+        SystemManagers.Default.Renderer.Layers.ShouldContain(layer);
+    }
+
+    [Fact]
+    public void RemoveLayer_RemovesPreviouslyAddedLayer()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+
+        Layer layer = SystemManagers.Default.Renderer.AddLayer();
+
+        SystemManagers.Default.Renderer.RemoveLayer(layer);
+
+        SystemManagers.Default.Renderer.Layers.ShouldNotContain(layer);
+    }
+
+    [Fact]
+    public void Draw_LayerWithScreenSpaceCameraSettings_IgnoresMainCameraPositionAndZoom()
+    {
+        using SKSurface surface = SKSurface.Create(new SKImageInfo(64, 64));
+        GumService.Default.Initialize(surface.Canvas, 64, 64);
+        surface.Canvas.Clear(SKColors.Black);
+
+        // A wildly offset/zoomed main camera. If the HUD layer below honors it (the bug), the
+        // rectangle renders far off-screen and pixel (5, 5) stays background.
+        SystemManagers.Default.Renderer.Camera.Zoom = 5f;
+        SystemManagers.Default.Renderer.Camera.X = 1000f;
+        SystemManagers.Default.Renderer.Camera.Y = 1000f;
+
+        Layer hudLayer = SystemManagers.Default.Renderer.AddLayer();
+        hudLayer.LayerCameraSettings = new LayerCameraSettings
+        {
+            IsInScreenSpace = true,
+        };
+
+        RectangleRuntime rectangle = new()
+        {
+            X = 0,
+            Y = 0,
+            Width = 10,
+            Height = 10,
+            IsFilled = true,
+            FillColor = SKColors.Red,
+        };
+        rectangle.AddToManagers(SystemManagers.Default, hudLayer);
+
+        GumService.Default.Draw();
+
+        using SKImage image = surface.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+
+        bitmap.GetPixel(5, 5).ShouldBe(SKColors.Red,
+            "because IsInScreenSpace must render fixed on screen, ignoring the main camera's position and zoom");
+    }
+}


### PR DESCRIPTION
## Problem

`LayerCameraSettings` (per-layer position/zoom/`IsInScreenSpace` overrides) was honored by `Layer.ScreenToWorld`/`WorldToScreen` (hit-testing) on raylib and Skia, but neither backend's `Renderer` consulted it when actually drawing — both built one Camera2D/canvas transform from the main `Camera` for the whole frame. A screen-space HUD layer rendered zoomed/panned with everything else instead of staying fixed, while hit-testing against it was already correct.

## Fix

- `Layer.GetEffectiveTransformationMatrix`'s camera-resolution logic is extracted into a new public `Layer.GetEffectiveCamera` — the single source of truth both hit-testing and rendering now share, so they can't drift apart.
- raylib's `Renderer` now builds a per-layer `Camera2D` instead of one shared `Camera2D` for the whole frame's `BeginMode2D`, plus `AddLayer()`/`AddLayer(Layer)`/`RemoveLayer(Layer)` (mirroring XNALIKE) so a project can create additional layers.
- SkiaGum's `Renderer` threads the drawing `Layer` through its top-level `Draw` so the canvas `Scale`/`Translate` uses that layer's effective camera, plus the same `AddLayer`/`RemoveLayer`.

## Testing

- New `Layer.GetEffectiveCamera` is a pure extraction, covered by the existing 20 `LayerTests` (all pass unchanged).
- raylib: `LayerCameraSettingsRenderTests` asserts the exact `Camera2D` (`Zoom`/`Target`) fed to `BeginMode2D` for a screen-space HUD layer, mirroring the existing `ShadowBlurCameraRestoreTests` precedent of reading the native camera state directly instead of a screenshot.
- Skia: `LayerCameraSettingsRenderTests` does a real pixel readback proving a screen-space rectangle renders at its fixed screen position despite an extreme main-camera pan/zoom.
- Full `RaylibGum.Tests` (592), `SkiaGum.Tests` (425), and `MonoGameGum.Tests` (2151) suites pass.

Manual test: not needed — covered by exact-data unit tests (real pixel readback on Skia, exact native camera-matrix assertion on raylib), not approximated by eye.

FRB canary: pass (`GumCore.DesktopGlNet6.csproj` builds clean; `Layer.cs` is FRB1-shared source via `GumCoreShared.projitems`).

Closes #4367
