### PR TITLE
Fix TextRuntime.RegenerateOversampledFont leaking the previous font on re-rasterize (#4364)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/TextTests.cs
@@ -247,6 +247,38 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
         tempForRendering.Height.ShouldBe(text.WrappedTextHeight, tolerance: 0.001f);
     }
 
+    // Issue #4364: SetOversampledDisplayFont pins the outgoing NATIVE font as MeasurementFont on the
+    // FIRST swap, but a continuous zoom gesture calls it again on every hysteresis-gated frame after
+    // that -- and every one of those later swaps used to drop the PREVIOUSLY oversampled font with no
+    // disposal. That font isn't shared/cached anywhere (KernSmithFontCreator builds it fresh via
+    // `new BitmapFont(textures, ...)`), so its GPU textures leaked on every re-rasterize past the first.
+    [Fact]
+    public void SetOversampledDisplayFont_WhenReplacingAPreviouslyOversampledFont_DisposesTheSupersededFont()
+    {
+        BitmapFont baseFont = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        baseFont.SetFontPattern(256, 256);
+
+        BitmapFont firstOversampledFont = new BitmapFont(new Texture2D[] { null! }, basicBMFontFileData);
+        firstOversampledFont.SetFontPattern(256, 256);
+
+        BitmapFont secondOversampledFont = new BitmapFont(new Texture2D[] { null! }, basicBMFontFileData);
+        secondOversampledFont.SetFontPattern(256, 256);
+
+        Text text = new Text();
+        text.BitmapFont = baseFont;
+        text.RawText = "AB";
+
+        // Mirrors two hysteresis-gated re-rasterizes during one continuous zoom gesture.
+        text.SetOversampledDisplayFont(firstOversampledFont);
+        text.SetOversampledDisplayFont(secondOversampledFont);
+
+        firstOversampledFont.IsDisposed.ShouldBeTrue(
+            "because the superseded oversampled font isn't shared or cached anywhere else, so it must " +
+            "be disposed when replaced or its GPU textures leak (issue #4364)");
+        baseFont.IsDisposed.ShouldBeFalse(
+            "because the pinned MeasurementFont is still actively used for layout measurement and must never be disposed while active");
+    }
+
     // Issue #4317: the render-time hook TextRuntime wires automatic oversampling through.
     [Fact]
     public void PreRender_InvokesOnPreRenderHook()

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -55,6 +55,17 @@ public class BitmapFont : IDisposable
     int mOutlineThickness;
 
     private ParsedFontFile _ParsedFontFile;
+
+    // True only for fonts built directly from pre-generated textures (e.g. an IInMemoryFontCreator like
+    // KernSmith) -- those textures are exclusive to this BitmapFont, unlike the string-path constructors,
+    // which resolve textures through LoaderManager's shared cache and must not have them disposed here.
+    private readonly bool _ownsTextures;
+
+    /// <summary>
+    /// True once <see cref="Dispose"/> has run. A disposed font's owned textures (if any) have been
+    /// released and it must not be used again.
+    /// </summary>
+    public bool IsDisposed { get; private set; }
     #endregion
 
     #region Properties
@@ -316,6 +327,8 @@ public class BitmapFont : IDisposable
         _ParsedFontFile = new ParsedFontFile(fntContent);
 
         SetFontPattern();
+
+        _ownsTextures = true;
     }
 
     /// <summary>
@@ -1292,7 +1305,23 @@ public class BitmapFont : IDisposable
 
     public void Dispose()
     {
-        // Do nothing, the loader will handle disposing the texture.
+        if (IsDisposed)
+        {
+            return;
+        }
+        IsDisposed = true;
+
+        if (_ownsTextures)
+        {
+            // Issue #4364: only a font built directly from pre-generated textures (see _ownsTextures)
+            // owns them exclusively -- string-path fonts share theirs through LoaderManager's cache,
+            // which still handles disposing those.
+            foreach (Texture2D texture in mTextures)
+            {
+                texture?.Dispose();
+            }
+            ShadowFont?.Dispose();
+        }
     }
 
     public override string ToString()

--- a/RenderingLibrary/Graphics/Text.cs
+++ b/RenderingLibrary/Graphics/Text.cs
@@ -648,6 +648,14 @@ public class Text : SpriteBatchRenderableBase, IRenderableIpso, IVisible, IWrapp
         {
             MeasurementFont = mBitmapFont;
         }
+        else if (mBitmapFont != null && mBitmapFont != MeasurementFont && mBitmapFont != oversampledFont)
+        {
+            // Issue #4364: MeasurementFont is already pinned, so mBitmapFont here is a previously
+            // generated oversampled font being superseded by another re-rasterize (e.g. mid continuous
+            // zoom gesture) -- it isn't shared/cached anywhere else, so it must be disposed here or its
+            // GPU textures leak on every swap.
+            mBitmapFont.Dispose();
+        }
 
         if (mBitmapFont != oversampledFont)
         {

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -420,6 +420,18 @@ public class Text : IVisible, IRenderableIpso,
         {
             MeasurementFont = Font;
         }
+        else if (_font.BaseSize != 0
+            && _font.Texture.Id != MeasurementFont.Value.Texture.Id
+            && _font.Texture.Id != oversampledFont.Texture.Id)
+        {
+            // Issue #4364: MeasurementFont is already pinned, so _font here is a previously generated
+            // oversampled font being superseded by another re-rasterize (e.g. mid continuous zoom
+            // gesture) -- it isn't cached or referenced anywhere else, so its GPU atlas must be unloaded
+            // here or it leaks VRAM on every swap. ManagedFont also unloads its drop-shadow companion
+            // (if any) and clears its line-metrics registry entry, mirroring the cleanup a cached font
+            // gets elsewhere (see RaylibFontShadowRegistry/RaylibFontMetricsRegistry).
+            new ManagedFont(_font).Dispose();
+        }
 
         if (_font.Texture.Id != oversampledFont.Texture.Id || _font.BaseSize != oversampledFont.BaseSize)
         {

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs
@@ -3,6 +3,7 @@ using Gum.GueDeriving;
 using Gum.Wireframe;
 using KernSmith.Gum;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
@@ -243,6 +244,50 @@ public class TextRuntimeFontOversamplingRealFontTests : BaseTestClass
             result.ShouldBeTrue();
             text.WrappedTextWidth.ShouldBe(nativeWidth, tolerance: 0.01f);
             text.WrappedTextHeight.ShouldBe(nativeHeight, tolerance: 0.01f);
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Issue #4364: RegenerateOversampledFont never disposed the font it was replacing on every
+    // re-rasterize during a continuous zoom gesture. BitmapFont is IDisposable and wraps a real,
+    // GPU-backed Texture2D -- nothing else disposes the KernSmith-generated font once it's superseded.
+    // Uses the real GraphicsDevice/Texture2D (not the RenderingLibrary-level fake) so a pass here is
+    // strong evidence the real leak is fixed, not just the disposal-flag plumbing.
+    [Fact]
+    public void RegenerateOversampledFont_WhenReplacingAPreviouslyOversampledFont_DisposesTheSupersededFontsTexture()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(game.GraphicsDevice);
+            TextRuntime.UseFontOversampling = true;
+
+            TextRuntime textRuntime = new();
+            textRuntime.UseCustomFont = true;
+            textRuntime.CustomFontFile = TestFontPath;
+            textRuntime.FontSize = 12;
+            textRuntime.Text = "Stack Ag 12pt";
+            game.GumService.Root.Children.Add(textRuntime);
+
+            textRuntime.RegenerateOversampledFont(2.5f).ShouldBeTrue();
+            Text text = (Text)textRuntime.RenderableComponent;
+            Texture2D firstOversampledTexture = text.BitmapFont.Texture!;
+            firstOversampledTexture.IsDisposed.ShouldBeFalse();
+
+            // Mirrors a continuous zoom gesture re-rasterizing again at a different size.
+            textRuntime.RegenerateOversampledFont(3.5f).ShouldBeTrue();
+
+            firstOversampledTexture.IsDisposed.ShouldBeTrue(
+                "because the superseded oversampled font isn't shared or cached anywhere else, so its " +
+                "real GPU texture must be disposed when replaced or it leaks (issue #4364)");
         }
         finally
         {

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs
@@ -538,6 +538,49 @@ public class TextRuntimeFontOversamplingTests : BaseTestClass
         }
     }
 
+    // Issue #4364: RegenerateOversampledFont never disposed the font it was replacing on every
+    // re-rasterize during a continuous zoom gesture. Raylib_cs.Font wraps a live GPU-resident atlas
+    // texture (see IRaylibFontCreator/KernSmithRaylibFontCreator), and this path bypasses the shared
+    // FontCache-keyed cache entirely -- generating a brand new one directly via TryCreateFont -- so
+    // nothing else ever unloaded the superseded font.
+    [Fact]
+    public void RegenerateOversampledFont_WhenReplacingAPreviouslyOversampledFont_UnloadsTheSupersededFont()
+    {
+        bool savedUseFontOversampling = TextRuntime.UseFontOversampling;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 20;
+            textRuntime.Text = "AB";
+
+            textRuntime.RegenerateOversampledFont(2.5f).ShouldBeTrue();
+            var text = (Text)textRuntime.RenderableComponent;
+            uint firstOversampledTextureId = text.Font.Texture.Id;
+            // Every KernSmith-generated font is registered in RaylibFontMetricsRegistry (ContentLoader.
+            // BuildFontFromFntText) and removed only when its owning ManagedFont is disposed -- the same
+            // signal ContentLoaderTests uses to prove a font was actually unloaded.
+            RaylibFontMetricsRegistry.TryGet(firstOversampledTextureId, out _).ShouldBeTrue(
+                "sanity check that the first oversampled font was actually created and registered");
+
+            // Mirrors a continuous zoom gesture re-rasterizing again at a different size.
+            textRuntime.RegenerateOversampledFont(3.0f).ShouldBeTrue();
+
+            RaylibFontMetricsRegistry.TryGet(firstOversampledTextureId, out _).ShouldBeFalse(
+                "because the superseded oversampled font isn't cached or referenced anywhere else, so it " +
+                "must be unloaded (via ManagedFont) when replaced or its GPU atlas texture leaks (issue #4364)");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedUseFontOversampling;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
     private static IEnumerable<float> BuildContinuousZoomSequence()
     {
         List<float> zooms = new();


### PR DESCRIPTION
## Problem

`TextRuntime.RegenerateOversampledFont` re-rasterizes a new font every time the hysteresis gate fires during continuous zoom, but only ever pins/protects the FIRST outgoing font (as `MeasurementFont`). Every later swap dropped the previously displayed font with no disposal:
- MonoGame: the outgoing `BitmapFont`'s `Texture2D` leaked.
- Raylib: worse -- `Raylib_cs.Font` wraps a live GPU texture, and this path bypasses the shared FontCache-keyed cache entirely (creates a fresh font directly via `TryCreateFont`), so a real pinch-zoom/scroll-wheel-zoom session accumulates many undisposed GPU textures.

## Fix

- `BitmapFont` now tracks whether it owns its textures (true only for the in-memory constructor `IInMemoryFontCreator` implementations use) and `Dispose()` actually releases them. Loader-cached fonts are untouched -- `LoaderManager` still owns those.
- `Text.SetOversampledDisplayFont` (both MonoGame `RenderingLibrary/Graphics/Text.cs` and Raylib `Runtimes/RaylibGum/Renderables/Text.cs`) now disposes the outgoing display font once `MeasurementFont` is already pinned, since that font isn't referenced anywhere else. The Raylib side uses the existing `ManagedFont` wrapper so the drop-shadow companion and line-metrics registry entry are cleaned up too.

## Testing

- New regression test in `MonoGameGum.Tests/RenderingLibraries/TextTests.cs` (RenderingLibrary-level, flag-based).
- New regression test in `Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontOversamplingTests.cs` using the real `KernSmithRaylibFontCreator` and a real GPU-resident `Raylib_cs.Font`, verified via `RaylibFontMetricsRegistry` (removed on `ManagedFont.Dispose()`).
- New regression test in `Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/TextRuntimeFontOversamplingRealFontTests.cs` using a real headless `GraphicsDevice`/`Texture2D`.

All three were confirmed red on unpatched code (real texture/font left un-disposed) before the fix, and green after. Full `MonoGameGum.Tests` (2152), `RaylibGum.Tests` (598), and `MonoGameGum.IntegrationTests` (84) suites pass. FRB canary: pass (matches baseline, 0 errors).

Closes #4364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
