### PR TITLE
Add + buttons for categories and states in the States tree

### DIFF
--- a/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/MainStatePlugin.cs
@@ -58,7 +58,8 @@ public class MainStatePlugin : PriorityPlugin
             _stateTreeViewRightClickService,
             _selectedState,
             ObjectFinder.Self,
-            variableInCategoryPropagationLogic);
+            variableInCategoryPropagationLogic,
+            dialogService);
     }
 
     public override void StartUp()

--- a/Gum/Plugins/InternalPlugins/StatePlugin/Views/StateTreeView.xaml
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/Views/StateTreeView.xaml
@@ -22,8 +22,7 @@
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
-      <Setter Property="Opacity" Value="0" />
+      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground.Subtle}" />
       <Setter Property="Template">
         <Setter.Value>
           <ControlTemplate TargetType="Button">
@@ -32,7 +31,7 @@
             </Border>
             <ControlTemplate.Triggers>
               <Trigger Property="IsMouseOver" Value="True">
-                <Setter TargetName="border" Property="Background" Value="#3D3D44" />
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Frb.Brushes.Surface.Fill}" />
               </Trigger>
             </ControlTemplate.Triggers>
           </ControlTemplate>
@@ -46,13 +45,22 @@
       <Setter Property="Background" Value="Transparent" />
       <Setter Property="BorderThickness" Value="0" />
       <Setter Property="Cursor" Value="Hand" />
-      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
-      <Setter Property="Opacity" Value="0.55" />
-      <Style.Triggers>
-        <Trigger Property="IsMouseOver" Value="True">
-          <Setter Property="Opacity" Value="1" />
-        </Trigger>
-      </Style.Triggers>
+      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground.Subtle}" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border x:Name="border" Background="Transparent">
+              <ContentPresenter HorizontalAlignment="Left" VerticalAlignment="Center" />
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="border" Property="Background" Value="{DynamicResource Frb.Brushes.Surface.Fill}" />
+                <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
     </Style>
   </UserControl.Resources>
   <Grid>
@@ -114,7 +122,7 @@
               <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource Frb.Brushes.Border.Secondary}" />
             </DataTrigger>
             <Trigger SourceName="bd" Property="IsMouseOver" Value="True">
-              <Setter TargetName="AddStateButton" Property="Opacity" Value="1" />
+              <Setter TargetName="AddStateButton" Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
             </Trigger>
           </DataTemplate.Triggers>
         </HierarchicalDataTemplate>

--- a/Gum/Plugins/InternalPlugins/StatePlugin/Views/StateTreeView.xaml
+++ b/Gum/Plugins/InternalPlugins/StatePlugin/Views/StateTreeView.xaml
@@ -14,10 +14,55 @@
   <UserControl.Resources>
     <converters:BackgroundConverter x:Key="BackgroundConverter" />
 
+    <Style x:Key="RowAddButtonStyle" TargetType="Button">
+      <Setter Property="Width" Value="17" />
+      <Setter Property="Height" Value="17" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="Margin" Value="4,0,0,0" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
+      <Setter Property="Opacity" Value="0" />
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border x:Name="border" Background="Transparent" CornerRadius="3">
+              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="border" Property="Background" Value="#3D3D44" />
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <Style x:Key="AddCategoryGhostRowStyle" TargetType="Button">
+      <Setter Property="HorizontalContentAlignment" Value="Left" />
+      <Setter Property="Padding" Value="6,4" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Cursor" Value="Hand" />
+      <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
+      <Setter Property="Opacity" Value="0.55" />
+      <Style.Triggers>
+        <Trigger Property="IsMouseOver" Value="True">
+          <Setter Property="Opacity" Value="1" />
+        </Trigger>
+      </Style.Triggers>
+    </Style>
   </UserControl.Resources>
   <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
     <TreeView
       x:Name="TreeViewInstance"
+      Grid.Row="0"
       HorizontalContentAlignment="Stretch"
       Grid.IsSharedSizeScope="True"
       ItemsSource="{Binding Items}"
@@ -55,12 +100,22 @@
                 Icon="PuzzlePiece"
                 Style="{StaticResource BiggerIcon}"
                 Visibility="{Binding IsRequiredBySelectedBehavior, Converter={StaticResource BoolToVisibilityHiddenConverter}}" />
+              <Button
+                x:Name="AddStateButton"
+                Grid.Column="3"
+                Command="{Binding AddStateCommand}"
+                Content="+"
+                Style="{StaticResource RowAddButtonStyle}"
+                ToolTip="{Binding Title, StringFormat='Add state to {0}'}" />
             </Grid>
           </Border>
           <DataTemplate.Triggers>
             <DataTrigger Binding="{Binding IsRequiredBySelectedBehavior}" Value="True">
               <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource Frb.Brushes.Border.Secondary}" />
             </DataTrigger>
+            <Trigger SourceName="bd" Property="IsMouseOver" Value="True">
+              <Setter TargetName="AddStateButton" Property="Opacity" Value="1" />
+            </Trigger>
           </DataTemplate.Triggers>
         </HierarchicalDataTemplate>
 
@@ -115,5 +170,10 @@
         </Style>
       </TreeView.ItemContainerStyle>
     </TreeView>
+    <Button
+      Grid.Row="1"
+      Command="{Binding AddCategoryCommand}"
+      Content="+ New category"
+      Style="{StaticResource AddCategoryGhostRowStyle}" />
   </Grid>
 </UserControl>

--- a/Tests/Gum.Presentation.Tests/CategoryViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/CategoryViewModelTests.cs
@@ -1,0 +1,20 @@
+using Gum.DataTypes.Variables;
+using Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class CategoryViewModelTests
+{
+    [Fact]
+    public void AddStateCommand_Execute_RaisesAddStateRequestedWithSelf()
+    {
+        CategoryViewModel categoryVm = new() { Data = new StateSaveCategory { Name = "Category" } };
+        object? raisedSender = null;
+        categoryVm.AddStateRequested += (sender, _) => raisedSender = sender;
+
+        categoryVm.AddStateCommand.Execute(null);
+
+        raisedSender.ShouldBe(categoryVm);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/StateTreeControllerTests.cs
+++ b/Tests/Gum.Presentation.Tests/StateTreeControllerTests.cs
@@ -3,6 +3,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Managers;
 using Gum.PropertyGridHelpers;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
 using Shouldly;
@@ -25,12 +26,14 @@ public class StateTreeControllerTests
         var rightClickService = new Mock<IStateTreeViewRightClickService>();
         var selectedState = new Mock<ISelectedState>();
         var propagationLogic = new Mock<IVariableInCategoryPropagationLogic>();
+        var dialogService = new Mock<IDialogService>();
 
         var controller = new StateTreeController(
             rightClickService.Object,
             selectedState.Object,
             ObjectFinder.Self,
-            propagationLogic.Object);
+            propagationLogic.Object,
+            dialogService.Object);
 
         return (controller, rightClickService, selectedState, propagationLogic);
     }

--- a/Tests/Gum.Presentation.Tests/StateTreeViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/StateTreeViewModelTests.cs
@@ -1,6 +1,10 @@
+using System.Linq;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using Moq;
 
@@ -21,7 +25,8 @@ public class StateTreeViewModelTests
     {
         Mock<IStateTreeViewRightClickService> rightClickService = new();
         Mock<ISelectedState> selectedState = new();
-        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object);
+        Mock<IDialogService> dialogService = new();
+        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object, dialogService.Object);
         StateSaveCategory category = new() { Name = "Category" };
         StateSave state = new() { Name = "State" };
         category.States.Add(state);
@@ -39,12 +44,48 @@ public class StateTreeViewModelTests
     {
         Mock<IStateTreeViewRightClickService> rightClickService = new();
         Mock<ISelectedState> selectedState = new();
-        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object);
+        Mock<IDialogService> dialogService = new();
+        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object, dialogService.Object);
         StateSaveCategory category = new() { Name = "Category" };
         viewModel.Categories.Add(new CategoryViewModel { Data = category });
 
         viewModel.HandleRename(category);
 
         rightClickService.Verify(x => x.PopulateContextMenu(), Times.Once);
+    }
+
+    [Fact]
+    public void AddCategoryCommand_Execute_ShowsAddCategoryDialog()
+    {
+        Mock<IStateTreeViewRightClickService> rightClickService = new();
+        Mock<ISelectedState> selectedState = new();
+        Mock<IDialogService> dialogService = new();
+        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object, dialogService.Object);
+
+        viewModel.AddCategoryCommand.Execute(null);
+
+        dialogService.Verify(
+            x => x.Show<AddCategoryDialogViewModel>(null, out It.Ref<AddCategoryDialogViewModel>.IsAny),
+            Times.Once);
+    }
+
+    [Fact]
+    public void CategoryAddStateRequested_SetsSelectedCategoryThenShowsAddStateDialog()
+    {
+        Mock<IStateTreeViewRightClickService> rightClickService = new();
+        Mock<ISelectedState> selectedState = new();
+        Mock<IDialogService> dialogService = new();
+        StateTreeViewModel viewModel = new(rightClickService.Object, selectedState.Object, dialogService.Object);
+        StateSaveCategory category = new() { Name = "Category" };
+        ComponentSave stateContainer = new();
+        stateContainer.Categories.Add(category);
+
+        viewModel.AddMissingItems(stateContainer, selectedState.Object);
+        viewModel.Categories.Single().AddStateCommand.Execute(null);
+
+        selectedState.VerifySet(s => s.SelectedStateCategorySave = category, Times.Once);
+        dialogService.Verify(
+            x => x.Show<AddStateDialogViewModel>(null, out It.Ref<AddStateDialogViewModel>.IsAny),
+            Times.Once);
     }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeController.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeController.cs
@@ -4,6 +4,7 @@ using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
 using Gum.Plugins.InternalPlugins.StatePlugin.ViewModels;
 using Gum.PropertyGridHelpers;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 
 namespace Gum.Managers;
@@ -47,14 +48,15 @@ public class StateTreeController
         IStateTreeViewRightClickService rightClickService,
         ISelectedState selectedState,
         ObjectFinder objectFinder,
-        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic)
+        IVariableInCategoryPropagationLogic variableInCategoryPropagationLogic,
+        IDialogService dialogService)
     {
         _rightClickService = rightClickService;
         _selectedState = selectedState;
         _objectFinder = objectFinder;
         _variableInCategoryPropagationLogic = variableInCategoryPropagationLogic;
 
-        ViewModel = new StateTreeViewModel(rightClickService, selectedState);
+        ViewModel = new StateTreeViewModel(rightClickService, selectedState, dialogService);
     }
 
     public void HandleElementDeleted(ElementSave save) => RefreshUI(_selectedState.SelectedStateContainer);

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/ViewModels/CategoryViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/ViewModels/CategoryViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes.Variables;
+﻿using CommunityToolkit.Mvvm.Input;
+using Gum.DataTypes.Variables;
 using Gum.Mvvm;
 using System;
 using System.Collections.Generic;
@@ -45,4 +46,18 @@ public class CategoryViewModel : StateTreeViewItem
     public ObservableCollection<StateViewModel> States { get; set; } = new ObservableCollection<StateViewModel>();
 
     public override string Title => Data?.Name;
+
+    /// <summary>
+    /// Raised when the user clicks this category's "+" button. The owning <see cref="StateTreeViewModel"/>
+    /// subscribes to this to select the category and show the Add State dialog, since this view model
+    /// has no dependencies of its own to do that directly.
+    /// </summary>
+    public event EventHandler? AddStateRequested;
+
+    public RelayCommand AddStateCommand { get; }
+
+    public CategoryViewModel()
+    {
+        AddStateCommand = new RelayCommand(() => AddStateRequested?.Invoke(this, EventArgs.Empty));
+    }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/ViewModels/StateTreeViewModel.cs
@@ -1,7 +1,10 @@
-﻿using Gum.DataTypes;
+﻿using CommunityToolkit.Mvvm.Input;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
+using Gum.Dialogs;
 using Gum.Managers;
 using Gum.Mvvm;
+using Gum.Services.Dialogs;
 using Gum.ToolStates;
 using System;
 using System.Collections.Generic;
@@ -18,12 +21,15 @@ public class StateTreeViewModel : ViewModel
     #region Fields/Properties
 
     private readonly ISelectedState _selectedState;
-    
+    private readonly IDialogService _dialogService;
+
     [DependsOn(nameof(Categories))]
     [DependsOn(nameof(States))]
     public IEnumerable<StateTreeViewItem> Items => Categories.Concat<StateTreeViewItem>(States);
 
     private readonly IStateTreeViewRightClickService _stateTreeViewRightClickService;
+
+    public RelayCommand AddCategoryCommand { get; }
 
     public ObservableCollection<CategoryViewModel> Categories
     {
@@ -43,12 +49,16 @@ public class StateTreeViewModel : ViewModel
 
     public StateTreeViewModel(
         IStateTreeViewRightClickService stateTreeViewRightClickService,
-        ISelectedState selectedState)
+        ISelectedState selectedState,
+        IDialogService dialogService)
     {
         _selectedState = selectedState;
         _stateTreeViewRightClickService = stateTreeViewRightClickService;
+        _dialogService = dialogService;
         Categories = new ObservableCollection<CategoryViewModel>();
         States = new ObservableCollection<StateViewModel>();
+
+        AddCategoryCommand = new RelayCommand(() => _dialogService.Show<AddCategoryDialogViewModel>());
 
         PropertyChanged += HandlePropertyChanged;
     }
@@ -88,6 +98,20 @@ public class StateTreeViewModel : ViewModel
             }
         }
         
+    }
+
+    /// <summary>
+    /// A category's "+" button was clicked. Selects the category first, since
+    /// <see cref="AddStateDialogViewModel"/> reads <see cref="ISelectedState.SelectedStateCategorySave"/>
+    /// in both its validation and its OnAffirmative handler.
+    /// </summary>
+    private void HandleCategoryAddStateRequested(object? sender, EventArgs e)
+    {
+        if (sender is CategoryViewModel categoryVm)
+        {
+            _selectedState.SelectedStateCategorySave = categoryVm.Data;
+            _dialogService.Show<AddStateDialogViewModel>();
+        }
     }
 
     #region Refresh
@@ -143,6 +167,7 @@ public class StateTreeViewModel : ViewModel
                 var categoryVm = Categories[i];
                         // Remove this so they don't push any changes to Gum
                 categoryVm.PropertyChanged -= HandleItemVmPropertyChanged;
+                categoryVm.AddStateRequested -= HandleCategoryAddStateRequested;
                 Categories.RemoveAt(i);
                 i--;
             }
@@ -183,6 +208,7 @@ public class StateTreeViewModel : ViewModel
             {
                 var categoryVm = new CategoryViewModel() { Data = category };
                 categoryVm.PropertyChanged += HandleItemVmPropertyChanged;
+                categoryVm.AddStateRequested += HandleCategoryAddStateRequested;
 
                 categoryVm.IsSelected = selectedState.SelectedStateSave == null && selectedState.SelectedStateCategorySave == category;
 


### PR DESCRIPTION
Closes #4377

Adds two launchers into the States tree, both routing into the existing dialogs (right-click menu unchanged):

- Each category row gets a `+` on the right edge (visible on hover) → opens Add State, scoped to that category.
- A persistent dim "+ New category" row at the bottom of the tree → opens Add Category.

State rows get no `+` (states can't exist outside a category). Design handoff mockup and rationale from issue #4377.

The Project tree (folders) is intentionally out of scope here — same pattern is planned as a follow-up, tracked separately so this stays a small, reviewable diff.

## Test plan
- [x] Unit tests: `CategoryViewModelTests`, `StateTreeViewModelTests` (new `AddCategoryCommand`/`AddStateRequested` coverage), `StateTreeControllerTests` (updated ctor)
- [x] Manual: verify + buttons/dialogs in the running tool (steps in PR conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)