### PR TITLE
Add grid overlay and snap-to-grid to the main editor canvas

### DIFF
--- a/Gum/Commands/WireframeCommands.cs
+++ b/Gum/Commands/WireframeCommands.cs
@@ -63,4 +63,26 @@ public class WireframeCommands : IWireframeCommands
             _pluginManager.WireframePropertyChanged(nameof(AreHighlightsVisible));
         }
     }
+
+    bool isGridOverlayVisible;
+    public bool IsGridOverlayVisible
+    {
+        get => isGridOverlayVisible;
+        set
+        {
+            isGridOverlayVisible = value;
+            _pluginManager.WireframePropertyChanged(nameof(IsGridOverlayVisible));
+        }
+    }
+
+    int gridSize = 16;
+    public int GridSize
+    {
+        get => gridSize;
+        set
+        {
+            gridSize = value;
+            _pluginManager.WireframePropertyChanged(nameof(GridSize));
+        }
+    }
 }

--- a/Gum/Controls/GridSnapWarningBar.xaml
+++ b/Gum/Controls/GridSnapWarningBar.xaml
@@ -1,0 +1,15 @@
+<UserControl
+    x:Class="Gum.Controls.GridSnapWarningBar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="30"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+    <Label
+        Background="Orange"
+        Content="{Binding GridSnapWarningText}"
+        Foreground="Black"
+        Visibility="{Binding HasGridSnapWarning, Converter={StaticResource BoolToVisibilityConverter}}" />
+</UserControl>

--- a/Gum/Controls/GridSnapWarningBar.xaml.cs
+++ b/Gum/Controls/GridSnapWarningBar.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+
+namespace Gum.Controls
+{
+    /// <summary>
+    /// Shows the "Snap to Grid: X uses non-pixel units..." warning above the main editor canvas.
+    /// Its bindings are relative, so it inherits whatever DataContext the host control sets - that
+    /// DataContext's type must expose HasGridSnapWarning/GridSnapWarningText (see EditorViewModel).
+    /// Placeholder styling - colors/layout are expected to be revisited in a follow-up visual pass.
+    /// </summary>
+    public partial class GridSnapWarningBar : UserControl
+    {
+        public GridSnapWarningBar()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesControl.xaml.cs
@@ -64,6 +64,9 @@ public partial class ProjectPropertiesControl : UserControl
         DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowCanvasOutline), "Guides");
         DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowCheckerBackground), "Guides");
 
+        DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowGrid), "Grid");
+        DataGrid.MoveMemberToCategory(nameof(ViewModel.SnapToGrid), "Grid");
+        DataGrid.MoveMemberToCategory(nameof(ViewModel.GridSize), "Grid");
 
         DataGrid.MoveMemberToCategory(nameof(ViewModel.SinglePixelTextureFile), "Single Pixel Texture");
         DataGrid.MoveMemberToCategory(nameof(ViewModel.SinglePixelTextureLeft), "Single Pixel Texture");

--- a/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesControl.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesControl.xaml.cs
@@ -64,9 +64,6 @@ public partial class ProjectPropertiesControl : UserControl
         DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowCanvasOutline), "Guides");
         DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowCheckerBackground), "Guides");
 
-        DataGrid.MoveMemberToCategory(nameof(ViewModel.ShowGrid), "Grid");
-        DataGrid.MoveMemberToCategory(nameof(ViewModel.SnapToGrid), "Grid");
-        DataGrid.MoveMemberToCategory(nameof(ViewModel.GridSize), "Grid");
 
         DataGrid.MoveMemberToCategory(nameof(ViewModel.SinglePixelTextureFile), "Single Pixel Texture");
         DataGrid.MoveMemberToCategory(nameof(ViewModel.SinglePixelTextureLeft), "Single Pixel Texture");

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -229,6 +229,21 @@ public class GumProjectSave
         set;
     }
 
+    /// <summary>
+    /// Whether the grid overlay is drawn on the main editor canvas.
+    /// </summary>
+    public bool ShowGrid { get; set; }
+
+    /// <summary>
+    /// Whether dragging (move/resize) snaps pixel-unit objects to the grid.
+    /// </summary>
+    public bool SnapToGrid { get; set; }
+
+    /// <summary>
+    /// The size, in pixels, of each grid cell used by <see cref="ShowGrid"/> and <see cref="SnapToGrid"/>.
+    /// </summary>
+    public int GridSize { get; set; }
+
     public bool RestrictFileNamesForAndroid { get; set; } = false;
 
     public List<GuideRectangle> Guides
@@ -435,6 +450,8 @@ public class GumProjectSave
 
         // I think people want this on by default:
         RestrictToUnitValues = true;
+
+        GridSize = 16;
 
         Guides = new List<GuideRectangle>();
         FavoriteComponents = new List<string>();

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -230,17 +230,15 @@ public class GumProjectSave
     }
 
     /// <summary>
-    /// Whether the grid overlay is drawn on the main editor canvas.
-    /// </summary>
-    public bool ShowGrid { get; set; }
-
-    /// <summary>
-    /// Whether dragging (move/resize) snaps pixel-unit objects to the grid.
+    /// Whether dragging (move/resize) snaps pixel-unit objects to the grid. The grid overlay is
+    /// drawn on the canvas whenever this is on - there's no separate visibility toggle, since the
+    /// checkerboard background already conveys canvas structure and a second grid toggle was just
+    /// UI noise on top of it.
     /// </summary>
     public bool SnapToGrid { get; set; }
 
     /// <summary>
-    /// The size, in pixels, of each grid cell used by <see cref="ShowGrid"/> and <see cref="SnapToGrid"/>.
+    /// The size, in pixels, of each grid cell used by <see cref="SnapToGrid"/>.
     /// </summary>
     public int GridSize { get; set; }
 

--- a/GumDataTypes/Serialization/Json/GumProjectSaveJson.cs
+++ b/GumDataTypes/Serialization/Json/GumProjectSaveJson.cs
@@ -31,6 +31,9 @@ internal sealed class GumProjectSaveJson
     public string TextureFilter { get; set; } = "";
     public bool ConvertVariablesOnUnitTypeChange { get; set; }
     public bool RestrictToUnitValues { get; set; }
+    public bool ShowGrid { get; set; }
+    public bool SnapToGrid { get; set; }
+    public int GridSize { get; set; }
     public bool RestrictFileNamesForAndroid { get; set; }
     public List<GuideRectangle> Guides { get; set; } = new List<GuideRectangle>();
     public List<string> FavoriteComponents { get; set; } = new List<string>();
@@ -73,6 +76,9 @@ internal static class GumProjectSaveJsonMapper
             TextureFilter = source.TextureFilter,
             ConvertVariablesOnUnitTypeChange = source.ConvertVariablesOnUnitTypeChange,
             RestrictToUnitValues = source.RestrictToUnitValues,
+            ShowGrid = source.ShowGrid,
+            SnapToGrid = source.SnapToGrid,
+            GridSize = source.GridSize,
             RestrictFileNamesForAndroid = source.RestrictFileNamesForAndroid,
             Guides = new List<GuideRectangle>(source.Guides),
             FavoriteComponents = new List<string>(source.FavoriteComponents),
@@ -114,6 +120,9 @@ internal static class GumProjectSaveJsonMapper
             TextureFilter = dto.TextureFilter,
             ConvertVariablesOnUnitTypeChange = dto.ConvertVariablesOnUnitTypeChange,
             RestrictToUnitValues = dto.RestrictToUnitValues,
+            ShowGrid = dto.ShowGrid,
+            SnapToGrid = dto.SnapToGrid,
+            GridSize = dto.GridSize,
             RestrictFileNamesForAndroid = dto.RestrictFileNamesForAndroid,
             Guides = new List<GuideRectangle>(dto.Guides),
             FavoriteComponents = new List<string>(dto.FavoriteComponents),

--- a/GumDataTypes/Serialization/Json/GumProjectSaveJson.cs
+++ b/GumDataTypes/Serialization/Json/GumProjectSaveJson.cs
@@ -31,7 +31,6 @@ internal sealed class GumProjectSaveJson
     public string TextureFilter { get; set; } = "";
     public bool ConvertVariablesOnUnitTypeChange { get; set; }
     public bool RestrictToUnitValues { get; set; }
-    public bool ShowGrid { get; set; }
     public bool SnapToGrid { get; set; }
     public int GridSize { get; set; }
     public bool RestrictFileNamesForAndroid { get; set; }
@@ -76,7 +75,6 @@ internal static class GumProjectSaveJsonMapper
             TextureFilter = source.TextureFilter,
             ConvertVariablesOnUnitTypeChange = source.ConvertVariablesOnUnitTypeChange,
             RestrictToUnitValues = source.RestrictToUnitValues,
-            ShowGrid = source.ShowGrid,
             SnapToGrid = source.SnapToGrid,
             GridSize = source.GridSize,
             RestrictFileNamesForAndroid = source.RestrictFileNamesForAndroid,
@@ -120,7 +118,6 @@ internal static class GumProjectSaveJsonMapper
             TextureFilter = dto.TextureFilter,
             ConvertVariablesOnUnitTypeChange = dto.ConvertVariablesOnUnitTypeChange,
             RestrictToUnitValues = dto.RestrictToUnitValues,
-            ShowGrid = dto.ShowGrid,
             SnapToGrid = dto.SnapToGrid,
             GridSize = dto.GridSize,
             RestrictFileNamesForAndroid = dto.RestrictFileNamesForAndroid,

--- a/MonoGameGum.Tests/RenderingLibraries/Math/Geometry/LineGridTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/Math/Geometry/LineGridTests.cs
@@ -1,0 +1,26 @@
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Math.Geometry;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries.Math.Geometry;
+
+public class LineGridTests : BaseTestClass
+{
+    [Fact]
+    public void X_And_Y_ShouldRoundTrip()
+    {
+        // Regression: X/Y used to be hardcoded no-op stubs (always 0), which made it impossible to
+        // reposition a LineGrid overlay - needed so the grid-snap overlay (issue #4137) can be kept
+        // aligned to the canvas grid as the camera pans.
+        LineGrid sut = new(SystemManagers.Default);
+        IPositionedSizedObject ipso = sut;
+
+        ipso.X = 32;
+        ipso.Y = -16;
+
+        ipso.X.ShouldBe(32);
+        ipso.Y.ShouldBe(-16);
+    }
+}

--- a/RenderingLibrary/Math/Geometry/LineGrid.cs
+++ b/RenderingLibrary/Math/Geometry/LineGrid.cs
@@ -142,11 +142,12 @@ public class LineGrid : SpriteBatchRenderableBase, IRenderableIpso
     {
         get
         {
-            return 0;
+            return mLinePrimitive.Position.X;
         }
 
         set
         {
+            mLinePrimitive.Position = new System.Numerics.Vector2(value, mLinePrimitive.Position.Y);
         }
     }
 
@@ -154,11 +155,12 @@ public class LineGrid : SpriteBatchRenderableBase, IRenderableIpso
     {
         get
         {
-            return 0;
+            return mLinePrimitive.Position.Y;
         }
 
         set
         {
+            mLinePrimitive.Position = new System.Numerics.Vector2(mLinePrimitive.Position.X, value);
         }
     }
 
@@ -248,11 +250,11 @@ public class LineGrid : SpriteBatchRenderableBase, IRenderableIpso
         Visible = true;
         if (managers != null)
         {
-            mLinePrimitive = new LinePrimitive(managers.Renderer.SinglePixelTexture);
+            mLinePrimitive = new LinePrimitive(managers.Renderer.TryGetSinglePixelTexture());
         }
         else
         {
-            mLinePrimitive = new LinePrimitive(Renderer.Self.SinglePixelTexture);
+            mLinePrimitive = new LinePrimitive(Renderer.Self.TryGetSinglePixelTexture());
         }
 
         mLinePrimitive.BreakIntoSegments = true;

--- a/Tests/Gum.Presentation.Tests/GrabbedStateTrueOffsetTests.cs
+++ b/Tests/Gum.Presentation.Tests/GrabbedStateTrueOffsetTests.cs
@@ -1,0 +1,79 @@
+using Gum.DataTypes;
+using Gum.Input;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins GrabbedState's true-offset accumulators, which let grid-snap track where an object would
+/// be with no snapping applied, independent of the live (already-snapped) GraphicalUiElement value
+/// - see issue #4137 review feedback ("movement fights you").
+/// </summary>
+public class GrabbedStateTrueOffsetTests
+{
+    private static GrabbedState CreateSut()
+    {
+        return new GrabbedState(
+            Mock.Of<ISelectedState>(),
+            Mock.Of<IWireframeObjectManager>(),
+            Mock.Of<IGumCursorState>());
+    }
+
+    [Fact]
+    public void AccumulateTruePositionOffset_ShouldAccumulateAcrossMultipleCalls_ForComponent()
+    {
+        GrabbedState sut = CreateSut();
+
+        sut.AccumulateTruePositionOffset(instance: null, deltaX: 1.5f, deltaY: 2f);
+        sut.AccumulateTruePositionOffset(instance: null, deltaX: 0.5f, deltaY: -1f);
+
+        sut.GetTruePositionOffset(instance: null).X.ShouldBe(2f);
+        sut.GetTruePositionOffset(instance: null).Y.ShouldBe(1f);
+    }
+
+    [Fact]
+    public void AccumulateTruePositionOffset_ShouldAccumulatePerInstance_Independently()
+    {
+        GrabbedState sut = CreateSut();
+        InstanceSave instanceA = new InstanceSave { Name = "A" };
+        InstanceSave instanceB = new InstanceSave { Name = "B" };
+
+        sut.AccumulateTruePositionOffset(instanceA, deltaX: 3f, deltaY: 0f);
+        sut.AccumulateTruePositionOffset(instanceB, deltaX: 10f, deltaY: 0f);
+        sut.AccumulateTruePositionOffset(instanceA, deltaX: 2f, deltaY: 0f);
+
+        sut.GetTruePositionOffset(instanceA).X.ShouldBe(5f);
+        sut.GetTruePositionOffset(instanceB).X.ShouldBe(10f);
+    }
+
+    [Fact]
+    public void GetTruePositionOffset_ShouldReturnZero_WhenInstanceNeverAccumulated()
+    {
+        GrabbedState sut = CreateSut();
+        InstanceSave instance = new InstanceSave { Name = "Untouched" };
+
+        sut.GetTruePositionOffset(instance).X.ShouldBe(0);
+        sut.GetTruePositionOffset(instance).Y.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HandlePush_ShouldResetAllTrueOffsets()
+    {
+        GrabbedState sut = CreateSut();
+        InstanceSave instance = new InstanceSave { Name = "A" };
+        sut.AccumulateTruePositionOffset(null, 5f, 5f);
+        sut.AccumulateTruePositionOffset(instance, 5f, 5f);
+        sut.AccumulateTrueSizeOffset(null, 5f, 5f);
+        sut.AccumulateTrueSizeOffset(instance, 5f, 5f);
+
+        sut.HandlePush();
+
+        sut.GetTruePositionOffset(null).X.ShouldBe(0);
+        sut.GetTruePositionOffset(instance).X.ShouldBe(0);
+        sut.GetTrueSizeOffset(null).X.ShouldBe(0);
+        sut.GetTrueSizeOffset(instance).X.ShouldBe(0);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/GridOverlayCalculatorTests.cs
+++ b/Tests/Gum.Presentation.Tests/GridOverlayCalculatorTests.cs
@@ -1,0 +1,57 @@
+using Gum.Wireframe.Editors;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins GridOverlayCalculator, which sizes/positions the grid overlay to cover the camera's
+/// visible world rect without visually shifting as the camera pans (issue #4137).
+/// </summary>
+public class GridOverlayCalculatorTests
+{
+    [Fact]
+    public void Calculate_ShouldAlignOriginToGridLineAtOrBeforeVisibleLeftAndTop()
+    {
+        GridOverlayCalculator.Calculate(
+            visibleLeft: 20, visibleTop: 40, visibleRight: 100, visibleBottom: 100, gridSize: 16,
+            out float originX, out float originY, out int columnCount, out int rowCount);
+
+        originX.ShouldBe(16);
+        originY.ShouldBe(32);
+    }
+
+    [Fact]
+    public void Calculate_ShouldCoverVisibleRectWithOneExtraLine()
+    {
+        // Visible width is exactly 80 (5 grid cells) starting from an aligned origin -
+        // still needs a trailing line to cover the right/bottom edge.
+        GridOverlayCalculator.Calculate(
+            visibleLeft: 0, visibleTop: 0, visibleRight: 80, visibleBottom: 80, gridSize: 16,
+            out float originX, out float originY, out int columnCount, out int rowCount);
+
+        columnCount.ShouldBe(6);
+        rowCount.ShouldBe(6);
+    }
+
+    [Fact]
+    public void Calculate_ShouldAlignOrigin_WhenVisibleRectIsInNegativeSpace()
+    {
+        GridOverlayCalculator.Calculate(
+            visibleLeft: -20, visibleTop: -5, visibleRight: 10, visibleBottom: 10, gridSize: 16,
+            out float originX, out float originY, out int columnCount, out int rowCount);
+
+        originX.ShouldBe(-32);
+        originY.ShouldBe(-16);
+    }
+
+    [Fact]
+    public void Calculate_ShouldReturnNoCells_WhenGridSizeIsZeroOrNegative()
+    {
+        GridOverlayCalculator.Calculate(
+            visibleLeft: 0, visibleTop: 0, visibleRight: 100, visibleBottom: 100, gridSize: 0,
+            out float originX, out float originY, out int columnCount, out int rowCount);
+
+        columnCount.ShouldBe(0);
+        rowCount.ShouldBe(0);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/GridSnapWarningServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/GridSnapWarningServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using Gum.Converters;
+using Gum.Services;
+using Gum.Wireframe;
+using Moq;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class GridSnapWarningServiceTests : BaseTestClass
+{
+    [Fact]
+    public void GetInfo_HasNoWarning_WhenSnapToGridIsDisabled()
+    {
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.Setup(s => s.SnapToGrid).Returns(false);
+        selectionManager.Setup(s => s.HasSelection).Returns(true);
+        var service = new GridSnapWarningService(selectionManager.Object);
+
+        var info = service.GetInfo();
+
+        info.HasWarning.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetInfo_HasNoWarning_WhenNothingIsSelected()
+    {
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.Setup(s => s.SnapToGrid).Returns(true);
+        selectionManager.Setup(s => s.HasSelection).Returns(false);
+        var service = new GridSnapWarningService(selectionManager.Object);
+
+        var info = service.GetInfo();
+
+        info.HasWarning.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetInfo_HasNoWarning_WhenSelectionUsesOnlyPixelUnits()
+    {
+        GraphicalUiElement gue = new(new InvisibleRenderable())
+        {
+            Name = "MySprite",
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            YUnits = GeneralUnitType.PixelsFromSmall,
+            WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute,
+            HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute
+        };
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.Setup(s => s.SnapToGrid).Returns(true);
+        selectionManager.Setup(s => s.HasSelection).Returns(true);
+        selectionManager.Setup(s => s.SelectedGues).Returns(new List<GraphicalUiElement> { gue });
+        var service = new GridSnapWarningService(selectionManager.Object);
+
+        var info = service.GetInfo();
+
+        info.HasWarning.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetInfo_ReturnsWarningNamingTheInstance_WhenOneSelectedObjectUsesANonPixelUnit()
+    {
+        GraphicalUiElement gue = new(new InvisibleRenderable())
+        {
+            Name = "MySprite",
+            XUnits = GeneralUnitType.Percentage,
+            YUnits = GeneralUnitType.PixelsFromSmall,
+            WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute,
+            HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute
+        };
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.Setup(s => s.SnapToGrid).Returns(true);
+        selectionManager.Setup(s => s.HasSelection).Returns(true);
+        selectionManager.Setup(s => s.SelectedGues).Returns(new List<GraphicalUiElement> { gue });
+        var service = new GridSnapWarningService(selectionManager.Object);
+
+        var info = service.GetInfo();
+
+        info.HasWarning.ShouldBeTrue();
+        info.WarningText.ShouldBe("Snap to Grid: MySprite uses non-pixel units and won't fully snap");
+    }
+
+    [Fact]
+    public void GetInfo_ReturnsGenericWarning_WhenMultipleObjectsAreSelectedAndAnyUsesANonPixelUnit()
+    {
+        GraphicalUiElement pixelGue = new(new InvisibleRenderable())
+        {
+            Name = "PixelObject",
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            YUnits = GeneralUnitType.PixelsFromSmall,
+            WidthUnits = Gum.DataTypes.DimensionUnitType.Absolute,
+            HeightUnits = Gum.DataTypes.DimensionUnitType.Absolute
+        };
+        GraphicalUiElement percentageGue = new(new InvisibleRenderable())
+        {
+            Name = "PercentageObject",
+            XUnits = GeneralUnitType.Percentage,
+            YUnits = GeneralUnitType.Percentage,
+            WidthUnits = Gum.DataTypes.DimensionUnitType.PercentageOfParent,
+            HeightUnits = Gum.DataTypes.DimensionUnitType.PercentageOfParent
+        };
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.Setup(s => s.SnapToGrid).Returns(true);
+        selectionManager.Setup(s => s.HasSelection).Returns(true);
+        selectionManager.Setup(s => s.SelectedGues).Returns(new List<GraphicalUiElement> { pixelGue, percentageGue });
+        var service = new GridSnapWarningService(selectionManager.Object);
+
+        var info = service.GetInfo();
+
+        info.HasWarning.ShouldBeTrue();
+        info.WarningText.ShouldBe("Snap to Grid: one or more selected objects use non-pixel units and won't fully snap");
+    }
+}

--- a/Tests/Gum.Presentation.Tests/GridSnapperTests.cs
+++ b/Tests/Gum.Presentation.Tests/GridSnapperTests.cs
@@ -56,4 +56,44 @@ public class GridSnapperTests
 
         result.ShouldBe(23);
     }
+
+    [Fact]
+    public void SnapRound_ShouldRoundDown_WhenValueIsBelowTheMidpoint()
+    {
+        float result = GridSnapper.SnapRound(value: 20, gridSize: 16);
+
+        result.ShouldBe(16);
+    }
+
+    [Fact]
+    public void SnapRound_ShouldRoundUp_WhenValueIsAboveTheMidpoint()
+    {
+        float result = GridSnapper.SnapRound(value: 26, gridSize: 16);
+
+        result.ShouldBe(32);
+    }
+
+    [Fact]
+    public void SnapRound_ShouldRoundAwayFromZero_AtExactMidpoint()
+    {
+        float result = GridSnapper.SnapRound(value: 24, gridSize: 16);
+
+        result.ShouldBe(32);
+    }
+
+    [Fact]
+    public void SnapRound_ShouldRoundTowardNegativeInfinity_WhenValueIsNegativeAndPastMidpoint()
+    {
+        float result = GridSnapper.SnapRound(value: -26, gridSize: 16);
+
+        result.ShouldBe(-32);
+    }
+
+    [Fact]
+    public void SnapRound_ShouldReturnOriginalValue_WhenGridSizeIsZeroOrNegative()
+    {
+        float result = GridSnapper.SnapRound(value: 23, gridSize: 0);
+
+        result.ShouldBe(23);
+    }
 }

--- a/Tests/Gum.Presentation.Tests/GridSnapperTests.cs
+++ b/Tests/Gum.Presentation.Tests/GridSnapperTests.cs
@@ -1,0 +1,59 @@
+using Gum.Wireframe.Editors;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins GridSnapper's floor-based snap math, including negative-coordinate handling.
+/// </summary>
+public class GridSnapperTests
+{
+    [Fact]
+    public void Snap_ShouldReturnLowerGridLine_WhenValueIsBetweenTwoGridLines()
+    {
+        float result = GridSnapper.Snap(value: 20, gridSize: 16);
+
+        result.ShouldBe(16);
+    }
+
+    [Fact]
+    public void Snap_ShouldReturnSameValue_WhenValueIsAlreadyOnGridLine()
+    {
+        float result = GridSnapper.Snap(value: 32, gridSize: 16);
+
+        result.ShouldBe(32);
+    }
+
+    [Fact]
+    public void Snap_ShouldFloorTowardNegativeInfinity_WhenValueIsNegative()
+    {
+        // -5 sits between the -16 and 0 grid lines; floor-based snapping picks -16, not 0.
+        float result = GridSnapper.Snap(value: -5, gridSize: 16);
+
+        result.ShouldBe(-16);
+    }
+
+    [Fact]
+    public void Snap_ShouldReturnSameValue_WhenValueIsNegativeAndAlreadyOnGridLine()
+    {
+        float result = GridSnapper.Snap(value: -32, gridSize: 16);
+
+        result.ShouldBe(-32);
+    }
+
+    [Fact]
+    public void Snap_ShouldReturnZero_WhenValueIsZero()
+    {
+        float result = GridSnapper.Snap(value: 0, gridSize: 16);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Snap_ShouldReturnOriginalValue_WhenGridSizeIsZeroOrNegative()
+    {
+        float result = GridSnapper.Snap(value: 23, gridSize: 0);
+
+        result.ShouldBe(23);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/MoveInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/MoveInputHandlerGridSnapTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Gum.DataTypes;
 using Gum.Converters;
 using Gum.Wireframe;
@@ -10,8 +11,13 @@ namespace Gum.Presentation.Tests;
 /// <summary>
 /// Pins MoveInputHandler.GetDifferenceToGrid, the pure math behind grid-snap-on-move: which axes
 /// participate (pixel-based units only, per the maintainer's scoping on issue #4137) and how the
-/// world-space anchor position (AbsoluteX/AbsoluteY) is used so a parented, non-grid-aligned child
-/// still lands visually on-grid.
+/// world-space anchor position is used so a parented, non-grid-aligned child still lands visually
+/// on-grid.
+///
+/// Snap is computed from grabStartLocal + trueOffsetSinceGrab (the object's position with NO
+/// snapping ever applied), not from the live gue.X/Y - reading the live value would read back
+/// whatever the previous frame's snap already wrote, so a small drag gets silently reverted every
+/// frame instead of accumulating (issue #4137 review: "movement fights you").
 /// </summary>
 public class MoveInputHandlerGridSnapTests
 {
@@ -27,6 +33,7 @@ public class MoveInputHandlerGridSnapTests
         };
 
         MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            grabStartLocal: new Vector2(20, 5), trueOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridX, out float differenceToGridY);
 
         differenceToGridX.ShouldBe(-4); // 20 -> 16
@@ -45,6 +52,7 @@ public class MoveInputHandlerGridSnapTests
         };
 
         MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            grabStartLocal: new Vector2(32, 48), trueOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridX, out float differenceToGridY);
 
         differenceToGridX.ShouldBe(0);
@@ -63,6 +71,7 @@ public class MoveInputHandlerGridSnapTests
         };
 
         MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            grabStartLocal: new Vector2(20, 5), trueOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridX, out float differenceToGridY);
 
         differenceToGridX.ShouldBe(0);
@@ -89,9 +98,37 @@ public class MoveInputHandlerGridSnapTests
         };
 
         MoveInputHandler.GetDifferenceToGrid(childGue, gridSize: 16,
+            grabStartLocal: new Vector2(20, 0), trueOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridX, out float _);
 
         // World X = 5 + 20 = 25 -> snaps down to 16, a delta of -9.
         differenceToGridX.ShouldBe(-9);
+    }
+
+    [Fact]
+    public void GetDifferenceToGrid_ShouldSnapFromTrueOffset_NotFromLiveValueAlreadySnappedThisDrag()
+    {
+        // Simulates the bug: the object was already snapped to X=16 earlier this same drag (its
+        // live X no longer reflects raw cursor movement), but the user has since dragged further
+        // (trueOffsetSinceGrab keeps accumulating the real, unsnapped movement). The next snap
+        // must target the grid line nearest the TRUE position (20 + 10 = 30 -> floors to 16... use
+        // a value that crosses into the next cell to prove live X is ignored).
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 16, // already snapped from an earlier frame this drag
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            YUnits = GeneralUnitType.PixelsFromSmall
+        };
+
+        // Grabbed at local X=20; true (unsnapped) cursor movement since grab totals +18 -> true
+        // position is 38, which is in the next grid cell up from where the live X (16) sits.
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            grabStartLocal: new Vector2(20, 0), trueOffsetSinceGrab: new Vector2(18, 0),
+            out float differenceToGridX, out float _);
+
+        // True world X = 38 -> snaps down to 32. Delta is relative to the LIVE X (16), i.e. 32-16=16,
+        // not relative to the true value - GetDifferenceToGrid always returns "how far to move the
+        // live object," which callers apply via ModifyVariable.
+        differenceToGridX.ShouldBe(16);
     }
 }

--- a/Tests/Gum.Presentation.Tests/MoveInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/MoveInputHandlerGridSnapTests.cs
@@ -1,0 +1,97 @@
+using Gum.DataTypes;
+using Gum.Converters;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors.Handlers;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins MoveInputHandler.GetDifferenceToGrid, the pure math behind grid-snap-on-move: which axes
+/// participate (pixel-based units only, per the maintainer's scoping on issue #4137) and how the
+/// world-space anchor position (AbsoluteX/AbsoluteY) is used so a parented, non-grid-aligned child
+/// still lands visually on-grid.
+/// </summary>
+public class MoveInputHandlerGridSnapTests
+{
+    [Fact]
+    public void GetDifferenceToGrid_ShouldReturnOffsetToLowerGridLine_WhenPixelBasedAndOffGrid()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 20,
+            Y = 5,
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            YUnits = GeneralUnitType.PixelsFromSmall
+        };
+
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            out float differenceToGridX, out float differenceToGridY);
+
+        differenceToGridX.ShouldBe(-4); // 20 -> 16
+        differenceToGridY.ShouldBe(-5); // 5 -> 0
+    }
+
+    [Fact]
+    public void GetDifferenceToGrid_ShouldReturnZero_WhenAlreadyOnGrid()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 32,
+            Y = 48,
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            YUnits = GeneralUnitType.PixelsFromSmall
+        };
+
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            out float differenceToGridX, out float differenceToGridY);
+
+        differenceToGridX.ShouldBe(0);
+        differenceToGridY.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetDifferenceToGrid_ShouldSkipAxis_WhenUnitsAreNotPixelBased()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 20,
+            Y = 5,
+            XUnits = GeneralUnitType.Percentage,
+            YUnits = GeneralUnitType.Percentage
+        };
+
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize: 16,
+            out float differenceToGridX, out float differenceToGridY);
+
+        differenceToGridX.ShouldBe(0);
+        differenceToGridY.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetDifferenceToGrid_ShouldSnapWorldSpaceAnchor_WhenParentIsNotGridAligned()
+    {
+        // Parent sits at an off-grid world position; the child's own local X (20) happens to land
+        // it exactly on a grid line locally, but the maintainer's scoping requires the snap to be
+        // computed in world space, so the child should still be nudged to compensate for the
+        // parent's offset and land visually on-grid.
+        GraphicalUiElement parentGue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 5,
+            XUnits = GeneralUnitType.PixelsFromSmall
+        };
+        GraphicalUiElement childGue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            X = 20,
+            XUnits = GeneralUnitType.PixelsFromSmall,
+            Parent = parentGue
+        };
+
+        MoveInputHandler.GetDifferenceToGrid(childGue, gridSize: 16,
+            out float differenceToGridX, out float _);
+
+        // World X = 5 + 20 = 25 -> snaps down to 16, a delta of -9.
+        differenceToGridX.ShouldBe(-9);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ProjectPropertiesViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectPropertiesViewModelTests.cs
@@ -53,4 +53,40 @@ public class ProjectPropertiesViewModelTests
 
         viewModel.AutoSave.ShouldBeTrue();
     }
+
+    [Fact]
+    public void SetFrom_ReadsGridSettingsFromGumProjectSave()
+    {
+        ProjectPropertiesViewModel viewModel = new();
+        GumProjectSave gumProject = new()
+        {
+            ShowGrid = true,
+            SnapToGrid = true,
+            GridSize = 32
+        };
+
+        viewModel.SetFrom(autoSave: false, gumProject);
+
+        viewModel.ShowGrid.ShouldBeTrue();
+        viewModel.SnapToGrid.ShouldBeTrue();
+        viewModel.GridSize.ShouldBe(32);
+    }
+
+    [Fact]
+    public void ApplyToModelObjects_WritesGridSettingsBackToGumProjectSave()
+    {
+        ProjectPropertiesViewModel viewModel = new();
+        GumProjectSave gumProject = new();
+        viewModel.SetFrom(autoSave: false, gumProject);
+
+        viewModel.ShowGrid = true;
+        viewModel.SnapToGrid = true;
+        viewModel.GridSize = 32;
+
+        viewModel.ApplyToModelObjects();
+
+        gumProject.ShowGrid.ShouldBeTrue();
+        gumProject.SnapToGrid.ShouldBeTrue();
+        gumProject.GridSize.ShouldBe(32);
+    }
 }

--- a/Tests/Gum.Presentation.Tests/ProjectPropertiesViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectPropertiesViewModelTests.cs
@@ -53,40 +53,4 @@ public class ProjectPropertiesViewModelTests
 
         viewModel.AutoSave.ShouldBeTrue();
     }
-
-    [Fact]
-    public void SetFrom_ReadsGridSettingsFromGumProjectSave()
-    {
-        ProjectPropertiesViewModel viewModel = new();
-        GumProjectSave gumProject = new()
-        {
-            ShowGrid = true,
-            SnapToGrid = true,
-            GridSize = 32
-        };
-
-        viewModel.SetFrom(autoSave: false, gumProject);
-
-        viewModel.ShowGrid.ShouldBeTrue();
-        viewModel.SnapToGrid.ShouldBeTrue();
-        viewModel.GridSize.ShouldBe(32);
-    }
-
-    [Fact]
-    public void ApplyToModelObjects_WritesGridSettingsBackToGumProjectSave()
-    {
-        ProjectPropertiesViewModel viewModel = new();
-        GumProjectSave gumProject = new();
-        viewModel.SetFrom(autoSave: false, gumProject);
-
-        viewModel.ShowGrid = true;
-        viewModel.SnapToGrid = true;
-        viewModel.GridSize = 32;
-
-        viewModel.ApplyToModelObjects();
-
-        gumProject.ShowGrid.ShouldBeTrue();
-        gumProject.SnapToGrid.ShouldBeTrue();
-        gumProject.GridSize.ShouldBe(32);
-    }
 }

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Gum.Converters;
 using Gum.DataTypes;
 using Gum.Wireframe;
@@ -10,7 +11,9 @@ namespace Gum.Presentation.Tests;
 /// <summary>
 /// Pins ResizeInputHandler.GetDifferenceToGridForSize, the local Width/Height half of resize
 /// grid-snap (issue #4137) — the X/Y half reuses MoveInputHandler.GetDifferenceToGrid, already
-/// pinned by MoveInputHandlerGridSnapTests.
+/// pinned by MoveInputHandlerGridSnapTests. Snap is computed from grabStartSize + trueSizeOffset
+/// (the size with no snapping ever applied), not from the live gue.Width/Height, for the same
+/// "movement fights you" reason documented on GetDifferenceToGrid.
 /// </summary>
 public class ResizeInputHandlerGridSnapTests
 {
@@ -26,6 +29,7 @@ public class ResizeInputHandlerGridSnapTests
         };
 
         ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            grabStartSize: new Vector2(30, 50), trueSizeOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridWidth, out float differenceToGridHeight);
 
         differenceToGridWidth.ShouldBe(2); // 30 -> 32 (nearest), not 16 (floor)
@@ -44,6 +48,7 @@ public class ResizeInputHandlerGridSnapTests
         };
 
         ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            grabStartSize: new Vector2(32, 64), trueSizeOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridWidth, out float differenceToGridHeight);
 
         differenceToGridWidth.ShouldBe(0);
@@ -62,9 +67,30 @@ public class ResizeInputHandlerGridSnapTests
         };
 
         ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            grabStartSize: new Vector2(30, 50), trueSizeOffsetSinceGrab: Vector2.Zero,
             out float differenceToGridWidth, out float differenceToGridHeight);
 
         differenceToGridWidth.ShouldBe(0);
         differenceToGridHeight.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetDifferenceToGridForSize_ShouldSnapFromTrueOffset_NotFromLiveValueAlreadySnappedThisDrag()
+    {
+        // Live Width (16) was already snapped earlier this drag, but the true (unsnapped) size has
+        // since grown further via trueSizeOffsetSinceGrab, crossing into the next grid cell.
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            Width = 16,
+            WidthUnits = DimensionUnitType.Absolute
+        };
+
+        // Grabbed at Width=20; true growth since grab totals +18 -> true width is 38.
+        ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            grabStartSize: new Vector2(20, 0), trueSizeOffsetSinceGrab: new Vector2(18, 0),
+            out float differenceToGridWidth, out float _);
+
+        // True width 38 -> nearest grid line is 32. Delta is relative to the LIVE Width (16).
+        differenceToGridWidth.ShouldBe(16);
     }
 }

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
@@ -1,0 +1,70 @@
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors.Handlers;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins ResizeInputHandler.GetDifferenceToGridForSize, the local Width/Height half of resize
+/// grid-snap (issue #4137) — the X/Y half reuses MoveInputHandler.GetDifferenceToGrid, already
+/// pinned by MoveInputHandlerGridSnapTests.
+/// </summary>
+public class ResizeInputHandlerGridSnapTests
+{
+    [Fact]
+    public void GetDifferenceToGridForSize_ShouldReturnOffsetToLowerGridLine_WhenPixelBasedAndOffGrid()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            Width = 30,
+            Height = 50,
+            WidthUnits = DimensionUnitType.Absolute,
+            HeightUnits = DimensionUnitType.Absolute
+        };
+
+        ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            out float differenceToGridWidth, out float differenceToGridHeight);
+
+        differenceToGridWidth.ShouldBe(-14); // 30 -> 16
+        differenceToGridHeight.ShouldBe(-2); // 50 -> 48
+    }
+
+    [Fact]
+    public void GetDifferenceToGridForSize_ShouldReturnZero_WhenAlreadyOnGrid()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            Width = 32,
+            Height = 64,
+            WidthUnits = DimensionUnitType.Absolute,
+            HeightUnits = DimensionUnitType.Absolute
+        };
+
+        ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            out float differenceToGridWidth, out float differenceToGridHeight);
+
+        differenceToGridWidth.ShouldBe(0);
+        differenceToGridHeight.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetDifferenceToGridForSize_ShouldSkipAxis_WhenUnitsAreNotPixelBased()
+    {
+        GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+        {
+            Width = 30,
+            Height = 50,
+            WidthUnits = DimensionUnitType.PercentageOfParent,
+            HeightUnits = DimensionUnitType.PercentageOfParent
+        };
+
+        ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
+            out float differenceToGridWidth, out float differenceToGridHeight);
+
+        differenceToGridWidth.ShouldBe(0);
+        differenceToGridHeight.ShouldBe(0);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
@@ -15,7 +15,7 @@ namespace Gum.Presentation.Tests;
 public class ResizeInputHandlerGridSnapTests
 {
     [Fact]
-    public void GetDifferenceToGridForSize_ShouldReturnOffsetToLowerGridLine_WhenPixelBasedAndOffGrid()
+    public void GetDifferenceToGridForSize_ShouldRoundToNearestGridLine_WhenPixelBasedAndOffGrid()
     {
         GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
         {
@@ -28,8 +28,8 @@ public class ResizeInputHandlerGridSnapTests
         ResizeInputHandler.GetDifferenceToGridForSize(gue, gridSize: 16,
             out float differenceToGridWidth, out float differenceToGridHeight);
 
-        differenceToGridWidth.ShouldBe(-14); // 30 -> 16
-        differenceToGridHeight.ShouldBe(-2); // 50 -> 48
+        differenceToGridWidth.ShouldBe(2); // 30 -> 32 (nearest), not 16 (floor)
+        differenceToGridHeight.ShouldBe(-2); // 50 -> 48 (nearest)
     }
 
     [Fact]

--- a/Tool/EditorTabPlugin_XNA/GridOverlayManager.cs
+++ b/Tool/EditorTabPlugin_XNA/GridOverlayManager.cs
@@ -1,0 +1,61 @@
+using Gum.Wireframe.Editors;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Math.Geometry;
+using Color = System.Drawing.Color;
+
+namespace Gum.Plugins.InternalPlugins.EditorTab.Views;
+
+/// <summary>
+/// Owns the LineGrid overlay drawn on the main editor canvas, keeping it aligned to the
+/// canvas-space grid and covering the camera's visible area as it pans/zooms (issue #4137).
+/// </summary>
+public class GridOverlayManager
+{
+    private readonly LineGrid _lineGrid;
+
+    public bool IsVisible { get; set; }
+    public int GridSize { get; set; } = 16;
+
+    public GridOverlayManager(SystemManagers systemManagers)
+    {
+        _lineGrid = new LineGrid(systemManagers);
+        _lineGrid.Z = 1;
+
+        var alpha = (int)(.2f * 0xFF);
+        // premultiplied
+        _lineGrid.Color = Color.FromArgb(alpha, alpha, alpha, alpha);
+    }
+
+    public void AddToLayer(Layer layer)
+    {
+        ShapeManager.Self.Add(_lineGrid, layer);
+    }
+
+    /// <summary>
+    /// Recomputes the overlay's position and cell counts from the current camera view. Call after
+    /// <see cref="IsVisible"/>/<see cref="GridSize"/> change and whenever the camera pans or zooms.
+    /// </summary>
+    public void Refresh(Camera camera)
+    {
+        _lineGrid.Visible = IsVisible && GridSize > 0;
+
+        if (!_lineGrid.Visible)
+        {
+            return;
+        }
+
+        GridOverlayCalculator.Calculate(
+            camera.AbsoluteLeft, camera.AbsoluteTop, camera.AbsoluteRight, camera.AbsoluteBottom, GridSize,
+            out float originX, out float originY, out int columnCount, out int rowCount);
+
+        var ipso = (IPositionedSizedObject)_lineGrid;
+        ipso.X = originX;
+        ipso.Y = originY;
+
+        _lineGrid.ColumnWidth = GridSize;
+        _lineGrid.RowWidth = GridSize;
+        _lineGrid.ColumnCount = columnCount;
+        _lineGrid.RowCount = rowCount;
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/GridOverlayManager.cs
+++ b/Tool/EditorTabPlugin_XNA/GridOverlayManager.cs
@@ -22,7 +22,7 @@ public class GridOverlayManager
         _lineGrid = new LineGrid(systemManagers);
         _lineGrid.Z = 1;
 
-        var alpha = (int)(.2f * 0xFF);
+        var alpha = (int)(.1f * 0xFF);
         // premultiplied
         _lineGrid.Color = Color.FromArgb(alpha, alpha, alpha, alpha);
     }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -270,7 +270,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _pluginManager,
             _fileCommands,
             _wireframeObjectManager,
-            _gridSnapWarningService);
+            _gridSnapWarningService,
+            _projectManager);
 
         messenger.RegisterAll(this);
     }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -578,7 +578,8 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         _selectionManager.SnapToGrid = save.SnapToGrid;
         _selectionManager.GridSize = save.GridSize;
-        _wireframeCommands.IsGridOverlayVisible = save.ShowGrid;
+        // No separate "show grid" setting - the overlay is only visible while snap is on.
+        _wireframeCommands.IsGridOverlayVisible = save.SnapToGrid;
         _wireframeCommands.GridSize = save.GridSize;
         _editorViewModel.RefreshGridSnapWarning();
 
@@ -603,14 +604,12 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _wireframeCommands.IsBackgroundGridVisible =
                 _projectManager.GumProjectSave.ShowCheckerBackground;
         }
-        else if (propertyName == nameof(GumProjectSave.ShowGrid))
-        {
-            _wireframeCommands.IsGridOverlayVisible =
-                _projectManager.GumProjectSave.ShowGrid;
-        }
         else if (propertyName == nameof(GumProjectSave.SnapToGrid))
         {
+            // No separate "show grid" setting - the overlay is only visible while snap is on.
             _selectionManager.SnapToGrid =
+                _projectManager.GumProjectSave.SnapToGrid;
+            _wireframeCommands.IsGridOverlayVisible =
                 _projectManager.GumProjectSave.SnapToGrid;
             _editorViewModel.RefreshGridSnapWarning();
         }

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -135,6 +135,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private readonly IUiSettingsService _uiSettingsService;
     private readonly IProjectManager _projectManager;
     private EditorViewModel _editorViewModel;
+    private IGridSnapWarningService _gridSnapWarningService;
     private readonly FileLocations _fileLocations;
     private readonly IThemingService _themingService;
     private IDragDropManager _dragDropManager;
@@ -263,11 +264,13 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _screenshotService = new ScreenshotService(_selectionManager, _wireframeCommands, _guiCommands);
         _singlePixelTextureService = new SinglePixelTextureService();
         _backgroundManager = new BackgroundManager(_wireframeCommands, messenger, _themingService);
+        _gridSnapWarningService = new GridSnapWarningService(_selectionManager);
 
         _editorViewModel = new EditorViewModel(
             _pluginManager,
             _fileCommands,
-            _wireframeObjectManager);
+            _wireframeObjectManager,
+            _gridSnapWarningService);
 
         messenger.RegisterAll(this);
     }
@@ -494,6 +497,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
     private void HandleVariableSet(ElementSave save1, InstanceSave save2, string arg3, object arg4)
     {
         _selectionManager.Refresh();
+        _editorViewModel.RefreshGridSnapWarning();
 
     }
 
@@ -547,6 +551,16 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             _wireframeControl.CanvasBoundsVisible =
                 _wireframeCommands.AreCanvasBoundsVisible;
         }
+        else if (name == nameof(WireframeCommands.IsGridOverlayVisible))
+        {
+            _wireframeControl.IsGridOverlayVisible =
+                _wireframeCommands.IsGridOverlayVisible;
+        }
+        else if (name == nameof(WireframeCommands.GridSize))
+        {
+            _wireframeControl.GridSize =
+                _wireframeCommands.GridSize;
+        }
     }
 
     private void HandleProjectLoad(GumProjectSave save)
@@ -560,6 +574,12 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         _wireframeCommands.IsBackgroundGridVisible =
             save.ShowCheckerBackground;
+
+        _selectionManager.SnapToGrid = save.SnapToGrid;
+        _selectionManager.GridSize = save.GridSize;
+        _wireframeCommands.IsGridOverlayVisible = save.ShowGrid;
+        _wireframeCommands.GridSize = save.GridSize;
+        _editorViewModel.RefreshGridSnapWarning();
 
         _wireframeObjectManager.RefreshAll(true);
 
@@ -581,6 +601,24 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         {
             _wireframeCommands.IsBackgroundGridVisible =
                 _projectManager.GumProjectSave.ShowCheckerBackground;
+        }
+        else if (propertyName == nameof(GumProjectSave.ShowGrid))
+        {
+            _wireframeCommands.IsGridOverlayVisible =
+                _projectManager.GumProjectSave.ShowGrid;
+        }
+        else if (propertyName == nameof(GumProjectSave.SnapToGrid))
+        {
+            _selectionManager.SnapToGrid =
+                _projectManager.GumProjectSave.SnapToGrid;
+            _editorViewModel.RefreshGridSnapWarning();
+        }
+        else if (propertyName == nameof(GumProjectSave.GridSize))
+        {
+            _selectionManager.GridSize =
+                _projectManager.GumProjectSave.GridSize;
+            _wireframeCommands.GridSize =
+                _projectManager.GumProjectSave.GridSize;
         }
         else if (propertyName == nameof(GumProjectSave.SinglePixelTextureFile) ||
             propertyName == nameof(GumProjectSave.SinglePixelTextureTop) ||
@@ -825,6 +863,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         _editingManager.RefreshContextMenu();
         _selectionManager.WireframeEditor?.UpdateAspectRatioForGrabbedIpso();
         _selectionManager.Refresh();
+        _editorViewModel.RefreshGridSnapWarning();
     }
 
     private void HandleXnaInitialized()
@@ -1422,11 +1461,16 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
 
         System.Windows.Controls.Grid wpfGrid = new();
         wpfGrid.RowDefinitions.Add(new () { Height = GridLength.Auto});
+        wpfGrid.RowDefinitions.Add(new () { Height = GridLength.Auto});
         wpfGrid.RowDefinitions.Add(new () { Height = new (1, GridUnitType.Star) });
 
         _editorControls = new EditorControls();
         wpfGrid.Children.Add(_editorControls);
         Grid.SetRow(_editorControls, 0);
+
+        Gum.Controls.GridSnapWarningBar gridSnapWarningBar = new();
+        wpfGrid.Children.Add(gridSnapWarningBar);
+        Grid.SetRow(gridSnapWarningBar, 1);
 
         wpfGrid.Children.Add(CreateCanvasGrid());
 
@@ -1473,7 +1517,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
         canvasGrid.Children.Add(horizontalScrollBar);
         Grid.SetRow(horizontalScrollBar, 1);
 
-        Grid.SetRow(canvasGrid, 1);
+        Grid.SetRow(canvasGrid, 2);
         return canvasGrid;
     }
 

--- a/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
+++ b/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
@@ -29,6 +29,7 @@ public partial class EditorViewModel : ViewModel, IZoomController
     private readonly IFileCommands _fileCommands;
     private readonly IWireframeObjectManager _wireframeObjectManager;
     private readonly IGridSnapWarningService _gridSnapWarningService;
+    private readonly IProjectManager _projectManager;
 
     public bool HasGridSnapWarning
     {
@@ -51,6 +52,55 @@ public partial class EditorViewModel : ViewModel, IZoomController
         var info = _gridSnapWarningService.GetInfo();
         HasGridSnapWarning = info.HasWarning;
         GridSnapWarningText = info.WarningText;
+    }
+
+    public bool ShowGrid
+    {
+        get => Get<bool>();
+        set
+        {
+            if (Set(value))
+            {
+                ApplyGridSettingToProject(nameof(GumProjectSave.ShowGrid), gumProject => gumProject.ShowGrid = value);
+            }
+        }
+    }
+
+    public bool SnapToGrid
+    {
+        get => Get<bool>();
+        set
+        {
+            if (Set(value))
+            {
+                ApplyGridSettingToProject(nameof(GumProjectSave.SnapToGrid), gumProject => gumProject.SnapToGrid = value);
+            }
+        }
+    }
+
+    public int GridSize
+    {
+        get => Get<int>();
+        set
+        {
+            if (Set(value))
+            {
+                ApplyGridSettingToProject(nameof(GumProjectSave.GridSize), gumProject => gumProject.GridSize = value);
+            }
+        }
+    }
+
+    private void ApplyGridSettingToProject(string propertyName, Action<GumProjectSave> applyToProject)
+    {
+        var project = _projectManager.GumProjectSave;
+        if (project == null)
+        {
+            return;
+        }
+
+        applyToProject(project);
+        _pluginManager.ProjectPropertySet(propertyName);
+        _fileCommands.TryAutoSaveProject();
     }
 
     SystemManagers? SystemManagers
@@ -250,12 +300,14 @@ public partial class EditorViewModel : ViewModel, IZoomController
     public EditorViewModel(IPluginManager pluginManager,
         IFileCommands fileCommands,
         IWireframeObjectManager wireframeObjectManager,
-        IGridSnapWarningService gridSnapWarningService)
+        IGridSnapWarningService gridSnapWarningService,
+        IProjectManager projectManager)
     {
         _pluginManager = pluginManager;
         _fileCommands = fileCommands;
         _wireframeObjectManager = wireframeObjectManager;
         _gridSnapWarningService = gridSnapWarningService;
+        _projectManager = projectManager;
         PercentZoomLevel = ZoomLevels.First(item => item.Value == 100);
 
         CustomCanvasSizes = DefaultCanvasSizes;
@@ -330,6 +382,10 @@ public partial class EditorViewModel : ViewModel, IZoomController
         this.CustomCanvasSizes = save.CustomCanvasSizes.ToArray();
 
         this.SelectedCustomCanvasSize = this.CustomCanvasSizes[0];
+
+        SetWithoutNotifying(save.ShowGrid, nameof(ShowGrid));
+        SetWithoutNotifying(save.SnapToGrid, nameof(SnapToGrid));
+        SetWithoutNotifying(save.GridSize, nameof(GridSize));
     }
 }
 

--- a/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
+++ b/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
@@ -6,6 +6,7 @@ using Gum.Mvvm;
 using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.EditorTab.Services;
 using Gum.Plugins.InternalPlugins.EditorTab.Views;
+using Gum.Services;
 using Gum.Wireframe;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -27,6 +28,30 @@ public partial class EditorViewModel : ViewModel, IZoomController
     private readonly IPluginManager _pluginManager;
     private readonly IFileCommands _fileCommands;
     private readonly IWireframeObjectManager _wireframeObjectManager;
+    private readonly IGridSnapWarningService _gridSnapWarningService;
+
+    public bool HasGridSnapWarning
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
+
+    public string? GridSnapWarningText
+    {
+        get => Get<string?>();
+        set => Set(value);
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="HasGridSnapWarning"/>/<see cref="GridSnapWarningText"/>. Call after
+    /// selection changes, a variable is set, or Snap to Grid is toggled.
+    /// </summary>
+    public void RefreshGridSnapWarning()
+    {
+        var info = _gridSnapWarningService.GetInfo();
+        HasGridSnapWarning = info.HasWarning;
+        GridSnapWarningText = info.WarningText;
+    }
 
     SystemManagers? SystemManagers
     {
@@ -224,11 +249,13 @@ public partial class EditorViewModel : ViewModel, IZoomController
 
     public EditorViewModel(IPluginManager pluginManager,
         IFileCommands fileCommands,
-        IWireframeObjectManager wireframeObjectManager)
+        IWireframeObjectManager wireframeObjectManager,
+        IGridSnapWarningService gridSnapWarningService)
     {
         _pluginManager = pluginManager;
         _fileCommands = fileCommands;
         _wireframeObjectManager = wireframeObjectManager;
+        _gridSnapWarningService = gridSnapWarningService;
         PercentZoomLevel = ZoomLevels.First(item => item.Value == 100);
 
         CustomCanvasSizes = DefaultCanvasSizes;

--- a/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
+++ b/Tool/EditorTabPlugin_XNA/ViewModels/EditorViewModel.cs
@@ -54,18 +54,6 @@ public partial class EditorViewModel : ViewModel, IZoomController
         GridSnapWarningText = info.WarningText;
     }
 
-    public bool ShowGrid
-    {
-        get => Get<bool>();
-        set
-        {
-            if (Set(value))
-            {
-                ApplyGridSettingToProject(nameof(GumProjectSave.ShowGrid), gumProject => gumProject.ShowGrid = value);
-            }
-        }
-    }
-
     public bool SnapToGrid
     {
         get => Get<bool>();
@@ -383,7 +371,6 @@ public partial class EditorViewModel : ViewModel, IZoomController
 
         this.SelectedCustomCanvasSize = this.CustomCanvasSizes[0];
 
-        SetWithoutNotifying(save.ShowGrid, nameof(ShowGrid));
         SetWithoutNotifying(save.SnapToGrid, nameof(SnapToGrid));
         SetWithoutNotifying(save.GridSize, nameof(GridSize));
     }

--- a/Tool/EditorTabPlugin_XNA/Views/EditorControls.xaml
+++ b/Tool/EditorTabPlugin_XNA/Views/EditorControls.xaml
@@ -68,11 +68,6 @@
         <CheckBox
             Margin="20,0,0,0"
             VerticalAlignment="Center"
-            Content="Show Grid"
-            IsChecked="{Binding ShowGrid}" />
-        <CheckBox
-            Margin="10,0,0,0"
-            VerticalAlignment="Center"
             Content="Snap to Grid"
             IsChecked="{Binding SnapToGrid}" />
         <TextBlock

--- a/Tool/EditorTabPlugin_XNA/Views/EditorControls.xaml
+++ b/Tool/EditorTabPlugin_XNA/Views/EditorControls.xaml
@@ -65,5 +65,24 @@
             Content="+"
             Style="{StaticResource MaterialDesignToolForegroundButton}" />
 
+        <CheckBox
+            Margin="20,0,0,0"
+            VerticalAlignment="Center"
+            Content="Show Grid"
+            IsChecked="{Binding ShowGrid}" />
+        <CheckBox
+            Margin="10,0,0,0"
+            VerticalAlignment="Center"
+            Content="Snap to Grid"
+            IsChecked="{Binding SnapToGrid}" />
+        <TextBlock
+            Margin="10,0,4,0"
+            VerticalAlignment="Center"
+            Text="Grid Size:" />
+        <TextBox
+            Width="40"
+            VerticalAlignment="Center"
+            Text="{Binding GridSize}" />
+
     </StackPanel>
 </UserControl>

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -245,7 +245,6 @@ public class WireframeControl : WpfGraphicsDeviceControl
             }
             _cameraController.Initialize(Camera, editorViewModel, hotkeyManager);
             _cameraController.CameraChanged += () => CameraChanged?.Invoke();
-            _cameraController.CameraChanged += () => _gridOverlayManager.Refresh(Camera);
 
             InputLibrary.Cursor.Self.Initialize(new InputLibrary.WpfInputHostAdapter(this));
 
@@ -389,6 +388,14 @@ public class WireframeControl : WpfGraphicsDeviceControl
             {
                 InputLibrary.Cursor.Self.StartCursorSettingFrameStart();
                 TimeManager.Self.Activity();
+
+                // Camera.ClientWidth/Height come from the GraphicsDevice viewport, which isn't
+                // valid yet the first time a project loads (before the first XNA frame has run) -
+                // a one-shot Refresh() at load time can compute against a 0x0 viewport and leave
+                // the grid invisible even though IsGridOverlayVisible is true. Refreshing here
+                // every frame keeps it in sync once the viewport (and therefore the camera) is
+                // actually valid, with no extra event wiring needed.
+                _gridOverlayManager.Refresh(Camera);
 
                 SpriteManager.Self.Activity(TimeManager.Self.CurrentTime);
 

--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -40,6 +40,7 @@ public class WireframeControl : WpfGraphicsDeviceControl
     private IToolFontService _toolFontService;
     private IToolLayerService _toolLayerService;
     LineRectangle mCanvasBounds;
+    GridOverlayManager _gridOverlayManager;
 
     public Color ScreenBoundsColor = Color.LightBlue;
 
@@ -66,6 +67,26 @@ public class WireframeControl : WpfGraphicsDeviceControl
         {
             LeftRuler.Visible = value;
             TopRuler.Visible = value;
+        }
+    }
+
+    public bool IsGridOverlayVisible
+    {
+        get => _gridOverlayManager.IsVisible;
+        set
+        {
+            _gridOverlayManager.IsVisible = value;
+            _gridOverlayManager.Refresh(Camera);
+        }
+    }
+
+    public int GridSize
+    {
+        get => _gridOverlayManager.GridSize;
+        set
+        {
+            _gridOverlayManager.GridSize = value;
+            _gridOverlayManager.Refresh(Camera);
         }
     }
 
@@ -224,6 +245,7 @@ public class WireframeControl : WpfGraphicsDeviceControl
             }
             _cameraController.Initialize(Camera, editorViewModel, hotkeyManager);
             _cameraController.CameraChanged += () => CameraChanged?.Invoke();
+            _cameraController.CameraChanged += () => _gridOverlayManager.Refresh(Camera);
 
             InputLibrary.Cursor.Self.Initialize(new InputLibrary.WpfInputHostAdapter(this));
 
@@ -233,6 +255,8 @@ public class WireframeControl : WpfGraphicsDeviceControl
             mCanvasBounds.Width = 800;
             mCanvasBounds.Height = 600;
             mCanvasBounds.Color = ScreenBoundsColor;
+
+            _gridOverlayManager = new GridOverlayManager(SystemManagers.Default);
 
 
             var camera = SystemManagers.Default.Renderer.Camera;
@@ -329,6 +353,7 @@ public class WireframeControl : WpfGraphicsDeviceControl
     {
 
         ShapeManager.Self.Add(mCanvasBounds, layerService.OverlayLayer);
+        _gridOverlayManager.AddToLayer(layerService.OverlayLayer);
 
 
         TopRuler = new Ruler(

--- a/Tool/Tests/GumToolUnitTests/ViewModels/EditorViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/EditorViewModelTests.cs
@@ -41,16 +41,6 @@ public class EditorViewModelTests
     }
 
     [Fact]
-    public void ShowGrid_WritesToGumProjectSave_AndNotifiesAndAutosaves()
-    {
-        _sut.ShowGrid = true;
-
-        _gumProject.ShowGrid.ShouldBeTrue();
-        _pluginManager.Verify(p => p.ProjectPropertySet(nameof(GumProjectSave.ShowGrid)), Times.Once);
-        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
-    }
-
-    [Fact]
     public void SnapToGrid_WritesToGumProjectSave_AndNotifiesAndAutosaves()
     {
         _sut.SnapToGrid = true;
@@ -71,9 +61,9 @@ public class EditorViewModelTests
     }
 
     [Fact]
-    public void ShowGrid_DoesNothing_WhenValueIsUnchanged()
+    public void SnapToGrid_DoesNothing_WhenValueIsUnchanged()
     {
-        _sut.ShowGrid = false;
+        _sut.SnapToGrid = false;
 
         _pluginManager.Verify(p => p.ProjectPropertySet(It.IsAny<string>()), Times.Never);
         _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Never);
@@ -84,7 +74,6 @@ public class EditorViewModelTests
     {
         GumProjectSave loadedProject = new()
         {
-            ShowGrid = true,
             SnapToGrid = true,
             GridSize = 24,
             CustomCanvasSizes = new List<CustomCanvasSize>
@@ -95,7 +84,6 @@ public class EditorViewModelTests
 
         _sut.HandleProjectLoad(loadedProject);
 
-        _sut.ShowGrid.ShouldBeTrue();
         _sut.SnapToGrid.ShouldBeTrue();
         _sut.GridSize.ShouldBe(24);
         _pluginManager.Verify(p => p.ProjectPropertySet(It.IsAny<string>()), Times.Never);

--- a/Tool/Tests/GumToolUnitTests/ViewModels/EditorViewModelTests.cs
+++ b/Tool/Tests/GumToolUnitTests/ViewModels/EditorViewModelTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using EditorTabPlugin_XNA.ViewModels;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.Services;
+using Gum.Wireframe;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.ViewModels;
+
+/// <summary>
+/// Pins EditorViewModel's grid-toolbar properties (moved out of Project Properties per #4137 review
+/// feedback): setting them writes back to the loaded GumProjectSave, notifies plugins via
+/// ProjectPropertySet, and autosaves - mirroring how ProjectPropertiesChangeLogic already treats
+/// RestrictToUnitValues/ShowCheckerBackground.
+/// </summary>
+public class EditorViewModelTests
+{
+    private readonly Mock<IPluginManager> _pluginManager = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IWireframeObjectManager> _wireframeObjectManager = new();
+    private readonly Mock<IGridSnapWarningService> _gridSnapWarningService = new();
+    private readonly Mock<IProjectManager> _projectManager = new();
+    private readonly GumProjectSave _gumProject = new();
+    private readonly EditorViewModel _sut;
+
+    public EditorViewModelTests()
+    {
+        _gridSnapWarningService.Setup(s => s.GetInfo()).Returns(new GridSnapWarningInfo(false, null));
+        _projectManager.SetupGet(p => p.GumProjectSave).Returns(_gumProject);
+
+        _sut = new EditorViewModel(
+            _pluginManager.Object,
+            _fileCommands.Object,
+            _wireframeObjectManager.Object,
+            _gridSnapWarningService.Object,
+            _projectManager.Object);
+    }
+
+    [Fact]
+    public void ShowGrid_WritesToGumProjectSave_AndNotifiesAndAutosaves()
+    {
+        _sut.ShowGrid = true;
+
+        _gumProject.ShowGrid.ShouldBeTrue();
+        _pluginManager.Verify(p => p.ProjectPropertySet(nameof(GumProjectSave.ShowGrid)), Times.Once);
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public void SnapToGrid_WritesToGumProjectSave_AndNotifiesAndAutosaves()
+    {
+        _sut.SnapToGrid = true;
+
+        _gumProject.SnapToGrid.ShouldBeTrue();
+        _pluginManager.Verify(p => p.ProjectPropertySet(nameof(GumProjectSave.SnapToGrid)), Times.Once);
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public void GridSize_WritesToGumProjectSave_AndNotifiesAndAutosaves()
+    {
+        _sut.GridSize = 32;
+
+        _gumProject.GridSize.ShouldBe(32);
+        _pluginManager.Verify(p => p.ProjectPropertySet(nameof(GumProjectSave.GridSize)), Times.Once);
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public void ShowGrid_DoesNothing_WhenValueIsUnchanged()
+    {
+        _sut.ShowGrid = false;
+
+        _pluginManager.Verify(p => p.ProjectPropertySet(It.IsAny<string>()), Times.Never);
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public void HandleProjectLoad_SeedsGridPropertiesFromProject_WithoutNotifyingOrAutosaving()
+    {
+        GumProjectSave loadedProject = new()
+        {
+            ShowGrid = true,
+            SnapToGrid = true,
+            GridSize = 24,
+            CustomCanvasSizes = new List<CustomCanvasSize>
+            {
+                new() { FriendlyName = "Project Default" }
+            }
+        };
+
+        _sut.HandleProjectLoad(loadedProject);
+
+        _sut.ShowGrid.ShouldBeTrue();
+        _sut.SnapToGrid.ShouldBeTrue();
+        _sut.GridSize.ShouldBe(24);
+        _pluginManager.Verify(p => p.ProjectPropertySet(It.IsAny<string>()), Times.Never);
+        _fileCommands.Verify(f => f.TryAutoSaveProject(It.IsAny<bool>()), Times.Never);
+    }
+}

--- a/Tools/Gum.Presentation/Commands/IWireframeCommands.cs
+++ b/Tools/Gum.Presentation/Commands/IWireframeCommands.cs
@@ -7,4 +7,15 @@ public interface IWireframeCommands
     bool AreCanvasBoundsVisible { get; set; }
     bool IsBackgroundGridVisible { get; set; }
     bool AreHighlightsVisible { get; set; }
+
+    /// <summary>
+    /// Whether the grid line overlay is drawn on the canvas. Distinct from <see cref="IsBackgroundGridVisible"/>,
+    /// which controls the transparency checkerboard.
+    /// </summary>
+    bool IsGridOverlayVisible { get; set; }
+
+    /// <summary>
+    /// The size, in pixels, of each grid cell drawn by the grid overlay.
+    /// </summary>
+    int GridSize { get; set; }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs
@@ -82,6 +82,16 @@ public class EditorContext
     public bool IsRotationEnabled { get; set; } = true;
     public bool RestrictToUnitValues { get; set; }
 
+    /// <summary>
+    /// Whether move/resize dragging snaps pixel-unit objects to the grid.
+    /// </summary>
+    public bool SnapToGrid { get; set; }
+
+    /// <summary>
+    /// The size, in pixels, of each grid cell used by <see cref="SnapToGrid"/>.
+    /// </summary>
+    public int GridSize { get; set; } = 16;
+
     #endregion
 
     #region Editing State

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridOverlayCalculator.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridOverlayCalculator.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Gum.Wireframe.Editors;
+
+/// <summary>
+/// Sizes and positions the grid overlay to cover a camera's visible world rect, aligned to the
+/// canvas-space grid so it doesn't visually shift as the camera pans or zooms.
+/// </summary>
+public static class GridOverlayCalculator
+{
+    /// <summary>
+    /// Computes the grid-aligned origin and cell counts needed to cover the given visible world
+    /// rect. <paramref name="originX"/>/<paramref name="originY"/> are the world position of the
+    /// first (top-left) grid line at or before the visible rect; <paramref name="columnCount"/>/
+    /// <paramref name="rowCount"/> include one extra line so the rect's right/bottom edge is
+    /// always covered.
+    /// </summary>
+    public static void Calculate(
+        float visibleLeft, float visibleTop, float visibleRight, float visibleBottom, float gridSize,
+        out float originX, out float originY, out int columnCount, out int rowCount)
+    {
+        if (gridSize <= 0)
+        {
+            originX = 0;
+            originY = 0;
+            columnCount = 0;
+            rowCount = 0;
+            return;
+        }
+
+        originX = GridSnapper.Snap(visibleLeft, gridSize);
+        originY = GridSnapper.Snap(visibleTop, gridSize);
+
+        float visibleWidth = visibleRight - originX;
+        float visibleHeight = visibleBottom - originY;
+
+        columnCount = (int)Math.Ceiling(visibleWidth / gridSize) + 1;
+        rowCount = (int)Math.Ceiling(visibleHeight / gridSize) + 1;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridSnapper.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridSnapper.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Gum.Wireframe.Editors;
+
+/// <summary>
+/// Floor-based snapping to the nearest grid line at or below a value, with correct handling of
+/// negative coordinates (which C# integer truncation gets wrong).
+/// </summary>
+public static class GridSnapper
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> snapped down to the nearest multiple of <paramref name="gridSize"/>.
+    /// Returns <paramref name="value"/> unchanged if <paramref name="gridSize"/> is not positive.
+    /// </summary>
+    public static float Snap(float value, float gridSize)
+    {
+        if (gridSize <= 0)
+        {
+            return value;
+        }
+
+        return (float)Math.Floor(value / gridSize) * gridSize;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridSnapper.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/GridSnapper.cs
@@ -21,4 +21,19 @@ public static class GridSnapper
 
         return (float)Math.Floor(value / gridSize) * gridSize;
     }
+
+    /// <summary>
+    /// Returns <paramref name="value"/> snapped to the nearest multiple of <paramref name="gridSize"/>,
+    /// rounding away from zero at the exact midpoint (matches <c>MathFunctions.RoundToInt</c>).
+    /// Returns <paramref name="value"/> unchanged if <paramref name="gridSize"/> is not positive.
+    /// </summary>
+    public static float SnapRound(float value, float gridSize)
+    {
+        if (gridSize <= 0)
+        {
+            return value;
+        }
+
+        return (float)Math.Round(value / gridSize, MidpointRounding.AwayFromZero) * gridSize;
+    }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
@@ -87,6 +87,12 @@ public class MoveInputHandler : InputHandlerBase
                 SnapSelectedToUnitValues();
             }
 
+            // Snap to grid if enabled
+            if (Context.SnapToGrid)
+            {
+                SnapSelectedToGrid();
+            }
+
             Context.DoEndOfSettingValuesLogic();
         }
 
@@ -332,6 +338,88 @@ public class MoveInputHandler : InputHandlerBase
         if (wasAnythingModified)
         {
             Context.GuiCommands.RefreshVariables(true);
+        }
+    }
+
+    private void SnapSelectedToGrid()
+    {
+        bool wasAnythingModified = false;
+        float gridSize = Context.GridSize;
+
+        if (Context.SelectedState.SelectedInstances.Count() == 0 &&
+            (Context.SelectedState.SelectedComponent != null || Context.SelectedState.SelectedStandardElement != null))
+        {
+            GraphicalUiElement gue = Context.SelectionManager.SelectedGue;
+
+            GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
+
+            if (differenceToGridX != 0)
+            {
+                gue.X = Context.ElementCommands.ModifyVariable("X", differenceToGridX, Context.SelectedState.SelectedElement);
+                wasAnythingModified = true;
+            }
+            if (differenceToGridY != 0)
+            {
+                gue.Y = Context.ElementCommands.ModifyVariable("Y", differenceToGridY, Context.SelectedState.SelectedElement);
+                wasAnythingModified = true;
+            }
+        }
+        else if (Context.SelectedState.SelectedInstances.Count() != 0)
+        {
+            var gues = Context.SelectionManager.SelectedGues.ToArray();
+            foreach (var gue in gues)
+            {
+                var instanceSave = gue.Tag as InstanceSave;
+
+                if (instanceSave != null && !instanceSave.Locked && !Context.ElementCommands.ShouldSkipDraggingMovementOn(instanceSave))
+                {
+                    GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
+
+                    if (differenceToGridX != 0)
+                    {
+                        gue.X = Context.ElementCommands.ModifyVariable("X", differenceToGridX, instanceSave);
+                        wasAnythingModified = true;
+                    }
+                    if (differenceToGridY != 0)
+                    {
+                        gue.Y = Context.ElementCommands.ModifyVariable("Y", differenceToGridY, instanceSave);
+                        wasAnythingModified = true;
+                    }
+                }
+            }
+        }
+
+        if (wasAnythingModified)
+        {
+            Context.GuiCommands.RefreshVariables(true);
+        }
+    }
+
+    /// <summary>
+    /// Computes the delta to apply to <paramref name="gue"/>'s local X/Y so its world-space anchor
+    /// (<see cref="GraphicalUiElement.AbsoluteX"/>/<see cref="GraphicalUiElement.AbsoluteY"/>, which
+    /// already accounts for XOrigin/YOrigin and rotation) lands on the nearest grid line at or below
+    /// its current position. Axes using non-pixel units are left untouched (0 difference) - grid
+    /// snap only applies to pixel-based positioning.
+    /// </summary>
+    internal static void GetDifferenceToGrid(GraphicalUiElement gue, float gridSize,
+        out float differenceToGridX, out float differenceToGridY)
+    {
+        differenceToGridX = 0;
+        differenceToGridY = 0;
+
+        if (gue.XUnits.GetIsPixelBased())
+        {
+            float absoluteX = gue.AbsoluteX;
+            float snappedAbsoluteX = GridSnapper.Snap(absoluteX, gridSize);
+            differenceToGridX = snappedAbsoluteX - absoluteX;
+        }
+
+        if (gue.YUnits.GetIsPixelBased())
+        {
+            float absoluteY = gue.AbsoluteY;
+            float snappedAbsoluteY = GridSnapper.Snap(absoluteY, gridSize);
+            differenceToGridY = snappedAbsoluteY - absoluteY;
         }
     }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
@@ -87,12 +87,6 @@ public class MoveInputHandler : InputHandlerBase
                 SnapSelectedToUnitValues();
             }
 
-            // Snap to grid if enabled
-            if (Context.SnapToGrid)
-            {
-                SnapSelectedToGrid();
-            }
-
             Context.DoEndOfSettingValuesLogic();
         }
 
@@ -163,6 +157,14 @@ public class MoveInputHandler : InputHandlerBase
         if (didMove)
         {
             ApplyAxisLockIfNeeded();
+
+            // Snap to grid live, as the object is dragged - not deferred to release, so the user
+            // sees exactly where it will land instead of having to guess and re-grab.
+            if (Context.SnapToGrid)
+            {
+                SnapSelectedToGrid();
+            }
+
             MarkAsChanged();
         }
     }
@@ -391,7 +393,9 @@ public class MoveInputHandler : InputHandlerBase
 
         if (wasAnythingModified)
         {
-            Context.GuiCommands.RefreshVariables(true);
+            // Not forced (true) - this runs on every drag tick, not just once at release, so a
+            // full grid rebuild here would be needlessly expensive.
+            Context.GuiCommands.RefreshVariables();
         }
     }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs
@@ -122,6 +122,11 @@ public class MoveInputHandler : InputHandlerBase
         Context.GrabbedState.AccumulatedXOffset += xToMoveBy;
         Context.GrabbedState.AccumulatedYOffset += yToMoveBy;
 
+        if (Context.SnapToGrid)
+        {
+            AccumulateTrueOffsetForGridSnap(xToMoveBy, yToMoveBy);
+        }
+
         var shouldSnapX = Context.SelectionManager.SelectedGues.Any(
             item => item.XUnits.GetIsPixelBased());
         var shouldSnapY = Context.SelectionManager.SelectedGues.Any(
@@ -166,6 +171,22 @@ public class MoveInputHandler : InputHandlerBase
             }
 
             MarkAsChanged();
+        }
+    }
+
+    private void AccumulateTrueOffsetForGridSnap(float deltaX, float deltaY)
+    {
+        if (Context.SelectedState.SelectedInstances.Count() == 0 &&
+            (Context.SelectedState.SelectedComponent != null || Context.SelectedState.SelectedStandardElement != null))
+        {
+            Context.GrabbedState.AccumulateTruePositionOffset(instance: null, deltaX, deltaY);
+        }
+        else
+        {
+            foreach (var instance in Context.SelectedState.SelectedInstances)
+            {
+                Context.GrabbedState.AccumulateTruePositionOffset(instance, deltaX, deltaY);
+            }
         }
     }
 
@@ -353,7 +374,9 @@ public class MoveInputHandler : InputHandlerBase
         {
             GraphicalUiElement gue = Context.SelectionManager.SelectedGue;
 
-            GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
+            GetDifferenceToGrid(gue, gridSize,
+                Context.GrabbedState.ComponentPosition, Context.GrabbedState.TrueComponentPositionOffset,
+                out float differenceToGridX, out float differenceToGridY);
 
             if (differenceToGridX != 0)
             {
@@ -375,7 +398,13 @@ public class MoveInputHandler : InputHandlerBase
 
                 if (instanceSave != null && !instanceSave.Locked && !Context.ElementCommands.ShouldSkipDraggingMovementOn(instanceSave))
                 {
-                    GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
+                    Vector2 grabStartLocal = Context.GrabbedState.InstancePositions.TryGetValue(instanceSave, out var grabbedPosition)
+                        ? new Vector2(grabbedPosition.AbsoluteX, grabbedPosition.AbsoluteY) // despite the field name, these are local X/Y at grab
+                        : new Vector2(gue.X, gue.Y);
+                    Vector2 trueOffset = Context.GrabbedState.GetTruePositionOffset(instanceSave);
+
+                    GetDifferenceToGrid(gue, gridSize, grabStartLocal, trueOffset,
+                        out float differenceToGridX, out float differenceToGridY);
 
                     if (differenceToGridX != 0)
                     {
@@ -401,29 +430,41 @@ public class MoveInputHandler : InputHandlerBase
 
     /// <summary>
     /// Computes the delta to apply to <paramref name="gue"/>'s local X/Y so its world-space anchor
-    /// (<see cref="GraphicalUiElement.AbsoluteX"/>/<see cref="GraphicalUiElement.AbsoluteY"/>, which
-    /// already accounts for XOrigin/YOrigin and rotation) lands on the nearest grid line at or below
-    /// its current position. Axes using non-pixel units are left untouched (0 difference) - grid
-    /// snap only applies to pixel-based positioning.
+    /// lands on the nearest grid line at or below where it would be with NO snapping ever applied
+    /// this drag (<paramref name="grabStartLocal"/> + <paramref name="trueOffsetSinceGrab"/>).
+    /// Snapping from the live <c>gue.X</c>/<c>gue.Y</c> instead would read back whatever the
+    /// previous frame's snap already wrote, silently reverting every small drag back to the same
+    /// grid line instead of letting the true position accumulate - the object would only move once
+    /// a single frame's raw delta was big enough to cross into the next grid cell (issue #4137
+    /// review: "movement fights you"). The live value is still what the returned delta is relative
+    /// to, since that's what the caller applies via <c>ModifyVariable</c>. Axes using non-pixel
+    /// units are left untouched (0 difference) - grid snap only applies to pixel-based positioning.
     /// </summary>
     internal static void GetDifferenceToGrid(GraphicalUiElement gue, float gridSize,
+        Vector2 grabStartLocal, Vector2 trueOffsetSinceGrab,
         out float differenceToGridX, out float differenceToGridY)
     {
         differenceToGridX = 0;
         differenceToGridY = 0;
 
+        // The parent's own absolute offset doesn't change during this drag (only this object
+        // moves), so live AbsoluteX/Y minus live X/Y always yields the current parent offset -
+        // valid at any point in the drag, not just at grab time.
+        float parentOffsetX = gue.AbsoluteX - gue.X;
+        float parentOffsetY = gue.AbsoluteY - gue.Y;
+
         if (gue.XUnits.GetIsPixelBased())
         {
-            float absoluteX = gue.AbsoluteX;
-            float snappedAbsoluteX = GridSnapper.Snap(absoluteX, gridSize);
-            differenceToGridX = snappedAbsoluteX - absoluteX;
+            float trueWorldX = grabStartLocal.X + trueOffsetSinceGrab.X + parentOffsetX;
+            float snappedWorldX = GridSnapper.Snap(trueWorldX, gridSize);
+            differenceToGridX = snappedWorldX - gue.AbsoluteX;
         }
 
         if (gue.YUnits.GetIsPixelBased())
         {
-            float absoluteY = gue.AbsoluteY;
-            float snappedAbsoluteY = GridSnapper.Snap(absoluteY, gridSize);
-            differenceToGridY = snappedAbsoluteY - absoluteY;
+            float trueWorldY = grabStartLocal.Y + trueOffsetSinceGrab.Y + parentOffsetY;
+            float snappedWorldY = GridSnapper.Snap(trueWorldY, gridSize);
+            differenceToGridY = snappedWorldY - gue.AbsoluteY;
         }
     }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -196,7 +196,9 @@ public class ResizeInputHandler : InputHandlerBase
             Context.SelectedState.SelectedInstances.Count() == 0)
         {
             var gue = Context.WireframeObjectManager.GetRepresentation(elementStack.Last().Element) as GraphicalUiElement;
-            SnapInstanceToGrid(gue, instanceSave: null, gridSize);
+            SnapInstanceToGrid(gue, instanceSave: null, gridSize,
+                Context.GrabbedState.ComponentPosition, Context.GrabbedState.ComponentSize,
+                Context.GrabbedState.TrueComponentPositionOffset, Context.GrabbedState.TrueComponentSizeOffset);
         }
 
         foreach (InstanceSave save in Context.SelectedState.SelectedInstances)
@@ -207,19 +209,36 @@ public class ResizeInputHandler : InputHandlerBase
             }
 
             var gue = Context.WireframeObjectManager.GetRepresentation(save, elementStack) as GraphicalUiElement;
-            SnapInstanceToGrid(gue, save, gridSize);
+            if (gue == null)
+            {
+                continue;
+            }
+
+            Vector2 grabStartPosition = Context.GrabbedState.InstancePositions.TryGetValue(save, out var grabbedPosition)
+                ? new Vector2(grabbedPosition.AbsoluteX, grabbedPosition.AbsoluteY) // despite the field name, these are local X/Y at grab
+                : new Vector2(gue.X, gue.Y);
+            Vector2 grabStartSize = Context.GrabbedState.InstanceSizes.TryGetValue(save, out var grabbedSize)
+                ? grabbedSize
+                : new Vector2(gue.Width, gue.Height);
+
+            SnapInstanceToGrid(gue, save, gridSize,
+                grabStartPosition, grabStartSize,
+                Context.GrabbedState.GetTruePositionOffset(save), Context.GrabbedState.GetTrueSizeOffset(save));
         }
     }
 
-    private void SnapInstanceToGrid(GraphicalUiElement? gue, InstanceSave? instanceSave, float gridSize)
+    private void SnapInstanceToGrid(GraphicalUiElement? gue, InstanceSave? instanceSave, float gridSize,
+        Vector2 grabStartPosition, Vector2 grabStartSize, Vector2 truePositionOffset, Vector2 trueSizeOffset)
     {
         if (gue == null)
         {
             return;
         }
 
-        MoveInputHandler.GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
-        GetDifferenceToGridForSize(gue, gridSize, out float differenceToGridWidth, out float differenceToGridHeight);
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize, grabStartPosition, truePositionOffset,
+            out float differenceToGridX, out float differenceToGridY);
+        GetDifferenceToGridForSize(gue, gridSize, grabStartSize, trueSizeOffset,
+            out float differenceToGridWidth, out float differenceToGridHeight);
 
         if (differenceToGridX != 0)
         {
@@ -250,11 +269,14 @@ public class ResizeInputHandler : InputHandlerBase
     /// <summary>
     /// Computes the delta to apply to <paramref name="gue"/>'s Width/Height so each lands on the
     /// nearest grid line (rounded, not floored - a resize should grow/shrink to whichever grid
-    /// line is closest, not always down). This is local (not world-space) rounding; the
-    /// world-space anchor snap lives in <see cref="MoveInputHandler.GetDifferenceToGrid"/> and is
-    /// reused for X/Y. Axes using non-pixel units are left untouched.
+    /// line is closest, not always down), based on where the size would be with NO snapping ever
+    /// applied this drag (<paramref name="grabStartSize"/> + <paramref name="trueSizeOffsetSinceGrab"/>)
+    /// rather than the live <c>gue.Width</c>/<c>gue.Height</c> - see the "movement fights you"
+    /// explanation on <see cref="MoveInputHandler.GetDifferenceToGrid"/>, which is reused for X/Y.
+    /// This is local (not world-space) rounding. Axes using non-pixel units are left untouched.
     /// </summary>
     internal static void GetDifferenceToGridForSize(GraphicalUiElement gue, float gridSize,
+        Vector2 grabStartSize, Vector2 trueSizeOffsetSinceGrab,
         out float differenceToGridWidth, out float differenceToGridHeight)
     {
         differenceToGridWidth = 0;
@@ -262,16 +284,16 @@ public class ResizeInputHandler : InputHandlerBase
 
         if (gue.WidthUnits.GetIsPixelBased())
         {
-            float width = gue.Width;
-            float snappedWidth = GridSnapper.SnapRound(width, gridSize);
-            differenceToGridWidth = snappedWidth - width;
+            float trueWidth = grabStartSize.X + trueSizeOffsetSinceGrab.X;
+            float snappedWidth = GridSnapper.SnapRound(trueWidth, gridSize);
+            differenceToGridWidth = snappedWidth - gue.Width;
         }
 
         if (gue.HeightUnits.GetIsPixelBased())
         {
-            float height = gue.Height;
-            float snappedHeight = GridSnapper.SnapRound(height, gridSize);
-            differenceToGridHeight = snappedHeight - height;
+            float trueHeight = grabStartSize.Y + trueSizeOffsetSinceGrab.Y;
+            float snappedHeight = GridSnapper.SnapRound(trueHeight, gridSize);
+            differenceToGridHeight = snappedHeight - gue.Height;
         }
     }
 
@@ -409,6 +431,13 @@ public class ResizeInputHandler : InputHandlerBase
             {
                 Context.ElementCommands.ModifyVariable("Width", cursorXChange * widthMultiplier, elementStack.Last().Element);
             }
+        }
+
+        if (Context.SnapToGrid)
+        {
+            Context.GrabbedState.AccumulateTruePositionOffset(instanceSave, reposition.X, reposition.Y);
+            Context.GrabbedState.AccumulateTrueSizeOffset(instanceSave,
+                cursorXChange * widthMultiplier, cursorYChange * heightMultiplier);
         }
 
         return hasChange;

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -160,6 +160,13 @@ public class ResizeInputHandler : InputHandlerBase
 
         if (hasChange)
         {
+            // Snap to grid live, as the object is dragged - not deferred to release, so the user
+            // sees exactly where it will land instead of having to guess and re-grab.
+            if (Context.SnapToGrid)
+            {
+                SnapSelectedToGrid();
+            }
+
             Context.GuiCommands.RefreshVariables();
             MarkAsChanged();
         }
@@ -169,28 +176,27 @@ public class ResizeInputHandler : InputHandlerBase
     {
         if (Context.HasChangedAnythingSinceLastPush)
         {
-            if (Context.SnapToGrid)
-            {
-                SnapSelectedToGrid();
-            }
-
             DoEndOfSettingValuesLogic();
         }
 
         _sideGrabbed = ResizeSide.None;
     }
 
+    /// <summary>
+    /// Snaps the current selection's position/size to the grid. Called live from
+    /// <see cref="OnDrag"/> on every tick that changes something - the caller refreshes the
+    /// Variables grid afterward, so this doesn't refresh itself.
+    /// </summary>
     private void SnapSelectedToGrid()
     {
         float gridSize = Context.GridSize;
-        bool wasAnythingModified = false;
         var elementStack = Context.SelectedState.GetTopLevelElementStack();
 
         if (Context.SelectionManager.HasSelection &&
             Context.SelectedState.SelectedInstances.Count() == 0)
         {
             var gue = Context.WireframeObjectManager.GetRepresentation(elementStack.Last().Element) as GraphicalUiElement;
-            wasAnythingModified |= SnapInstanceToGrid(gue, instanceSave: null, gridSize);
+            SnapInstanceToGrid(gue, instanceSave: null, gridSize);
         }
 
         foreach (InstanceSave save in Context.SelectedState.SelectedInstances)
@@ -201,23 +207,16 @@ public class ResizeInputHandler : InputHandlerBase
             }
 
             var gue = Context.WireframeObjectManager.GetRepresentation(save, elementStack) as GraphicalUiElement;
-            wasAnythingModified |= SnapInstanceToGrid(gue, save, gridSize);
-        }
-
-        if (wasAnythingModified)
-        {
-            Context.GuiCommands.RefreshVariables();
+            SnapInstanceToGrid(gue, save, gridSize);
         }
     }
 
-    private bool SnapInstanceToGrid(GraphicalUiElement? gue, InstanceSave? instanceSave, float gridSize)
+    private void SnapInstanceToGrid(GraphicalUiElement? gue, InstanceSave? instanceSave, float gridSize)
     {
         if (gue == null)
         {
-            return false;
+            return;
         }
-
-        bool wasModified = false;
 
         MoveInputHandler.GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
         GetDifferenceToGridForSize(gue, gridSize, out float differenceToGridWidth, out float differenceToGridHeight);
@@ -227,39 +226,33 @@ public class ResizeInputHandler : InputHandlerBase
             gue.X = instanceSave != null
                 ? Context.ElementCommands.ModifyVariable("X", differenceToGridX, instanceSave)
                 : Context.ElementCommands.ModifyVariable("X", differenceToGridX, Context.SelectedState.SelectedElement);
-            wasModified = true;
         }
         if (differenceToGridY != 0)
         {
             gue.Y = instanceSave != null
                 ? Context.ElementCommands.ModifyVariable("Y", differenceToGridY, instanceSave)
                 : Context.ElementCommands.ModifyVariable("Y", differenceToGridY, Context.SelectedState.SelectedElement);
-            wasModified = true;
         }
         if (differenceToGridWidth != 0)
         {
             gue.Width = instanceSave != null
                 ? Context.ElementCommands.ModifyVariable("Width", differenceToGridWidth, instanceSave)
                 : Context.ElementCommands.ModifyVariable("Width", differenceToGridWidth, Context.SelectedState.SelectedElement);
-            wasModified = true;
         }
         if (differenceToGridHeight != 0)
         {
             gue.Height = instanceSave != null
                 ? Context.ElementCommands.ModifyVariable("Height", differenceToGridHeight, instanceSave)
                 : Context.ElementCommands.ModifyVariable("Height", differenceToGridHeight, Context.SelectedState.SelectedElement);
-            wasModified = true;
         }
-
-        return wasModified;
     }
 
     /// <summary>
     /// Computes the delta to apply to <paramref name="gue"/>'s Width/Height so each lands on the
-    /// nearest grid line at or below its current value. This is local (not world-space) rounding,
-    /// mirroring how the analogous unit-snap already treats Width/Height - the world-space anchor
-    /// snap lives in <see cref="MoveInputHandler.GetDifferenceToGrid"/> and is reused for X/Y.
-    /// Axes using non-pixel units are left untouched.
+    /// nearest grid line (rounded, not floored - a resize should grow/shrink to whichever grid
+    /// line is closest, not always down). This is local (not world-space) rounding; the
+    /// world-space anchor snap lives in <see cref="MoveInputHandler.GetDifferenceToGrid"/> and is
+    /// reused for X/Y. Axes using non-pixel units are left untouched.
     /// </summary>
     internal static void GetDifferenceToGridForSize(GraphicalUiElement gue, float gridSize,
         out float differenceToGridWidth, out float differenceToGridHeight)
@@ -270,14 +263,14 @@ public class ResizeInputHandler : InputHandlerBase
         if (gue.WidthUnits.GetIsPixelBased())
         {
             float width = gue.Width;
-            float snappedWidth = GridSnapper.Snap(width, gridSize);
+            float snappedWidth = GridSnapper.SnapRound(width, gridSize);
             differenceToGridWidth = snappedWidth - width;
         }
 
         if (gue.HeightUnits.GetIsPixelBased())
         {
             float height = gue.Height;
-            float snappedHeight = GridSnapper.Snap(height, gridSize);
+            float snappedHeight = GridSnapper.SnapRound(height, gridSize);
             differenceToGridHeight = snappedHeight - height;
         }
     }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -169,10 +169,117 @@ public class ResizeInputHandler : InputHandlerBase
     {
         if (Context.HasChangedAnythingSinceLastPush)
         {
+            if (Context.SnapToGrid)
+            {
+                SnapSelectedToGrid();
+            }
+
             DoEndOfSettingValuesLogic();
         }
 
         _sideGrabbed = ResizeSide.None;
+    }
+
+    private void SnapSelectedToGrid()
+    {
+        float gridSize = Context.GridSize;
+        bool wasAnythingModified = false;
+        var elementStack = Context.SelectedState.GetTopLevelElementStack();
+
+        if (Context.SelectionManager.HasSelection &&
+            Context.SelectedState.SelectedInstances.Count() == 0)
+        {
+            var gue = Context.WireframeObjectManager.GetRepresentation(elementStack.Last().Element) as GraphicalUiElement;
+            wasAnythingModified |= SnapInstanceToGrid(gue, instanceSave: null, gridSize);
+        }
+
+        foreach (InstanceSave save in Context.SelectedState.SelectedInstances)
+        {
+            if (save.Locked)
+            {
+                continue;
+            }
+
+            var gue = Context.WireframeObjectManager.GetRepresentation(save, elementStack) as GraphicalUiElement;
+            wasAnythingModified |= SnapInstanceToGrid(gue, save, gridSize);
+        }
+
+        if (wasAnythingModified)
+        {
+            Context.GuiCommands.RefreshVariables();
+        }
+    }
+
+    private bool SnapInstanceToGrid(GraphicalUiElement? gue, InstanceSave? instanceSave, float gridSize)
+    {
+        if (gue == null)
+        {
+            return false;
+        }
+
+        bool wasModified = false;
+
+        MoveInputHandler.GetDifferenceToGrid(gue, gridSize, out float differenceToGridX, out float differenceToGridY);
+        GetDifferenceToGridForSize(gue, gridSize, out float differenceToGridWidth, out float differenceToGridHeight);
+
+        if (differenceToGridX != 0)
+        {
+            gue.X = instanceSave != null
+                ? Context.ElementCommands.ModifyVariable("X", differenceToGridX, instanceSave)
+                : Context.ElementCommands.ModifyVariable("X", differenceToGridX, Context.SelectedState.SelectedElement);
+            wasModified = true;
+        }
+        if (differenceToGridY != 0)
+        {
+            gue.Y = instanceSave != null
+                ? Context.ElementCommands.ModifyVariable("Y", differenceToGridY, instanceSave)
+                : Context.ElementCommands.ModifyVariable("Y", differenceToGridY, Context.SelectedState.SelectedElement);
+            wasModified = true;
+        }
+        if (differenceToGridWidth != 0)
+        {
+            gue.Width = instanceSave != null
+                ? Context.ElementCommands.ModifyVariable("Width", differenceToGridWidth, instanceSave)
+                : Context.ElementCommands.ModifyVariable("Width", differenceToGridWidth, Context.SelectedState.SelectedElement);
+            wasModified = true;
+        }
+        if (differenceToGridHeight != 0)
+        {
+            gue.Height = instanceSave != null
+                ? Context.ElementCommands.ModifyVariable("Height", differenceToGridHeight, instanceSave)
+                : Context.ElementCommands.ModifyVariable("Height", differenceToGridHeight, Context.SelectedState.SelectedElement);
+            wasModified = true;
+        }
+
+        return wasModified;
+    }
+
+    /// <summary>
+    /// Computes the delta to apply to <paramref name="gue"/>'s Width/Height so each lands on the
+    /// nearest grid line at or below its current value. This is local (not world-space) rounding,
+    /// mirroring how the analogous unit-snap already treats Width/Height - the world-space anchor
+    /// snap lives in <see cref="MoveInputHandler.GetDifferenceToGrid"/> and is reused for X/Y.
+    /// Axes using non-pixel units are left untouched.
+    /// </summary>
+    internal static void GetDifferenceToGridForSize(GraphicalUiElement gue, float gridSize,
+        out float differenceToGridWidth, out float differenceToGridHeight)
+    {
+        differenceToGridWidth = 0;
+        differenceToGridHeight = 0;
+
+        if (gue.WidthUnits.GetIsPixelBased())
+        {
+            float width = gue.Width;
+            float snappedWidth = GridSnapper.Snap(width, gridSize);
+            differenceToGridWidth = snappedWidth - width;
+        }
+
+        if (gue.HeightUnits.GetIsPixelBased())
+        {
+            float height = gue.Height;
+            float snappedHeight = GridSnapper.Snap(height, gridSize);
+            differenceToGridHeight = snappedHeight - height;
+        }
     }
 
     public override void OnSelectionChanged()

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/WireframeEditor.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/WireframeEditor.cs
@@ -36,6 +36,18 @@ public abstract class WireframeEditor
         set => _context.RestrictToUnitValues = value;
     }
 
+    public bool SnapToGrid
+    {
+        get => _context.SnapToGrid;
+        set => _context.SnapToGrid = value;
+    }
+
+    public int GridSize
+    {
+        get => _context.GridSize;
+        set => _context.GridSize = value;
+    }
+
     #endregion
 
     public WireframeEditor(

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesViewModel.cs
@@ -52,7 +52,25 @@ public class ProjectPropertiesViewModel : ViewModel
     public bool RestrictToUnitValues
     {
         get => Get<bool>();
-        set => Set(value); 
+        set => Set(value);
+    }
+
+    public bool ShowGrid
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
+
+    public bool SnapToGrid
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
+
+    public int GridSize
+    {
+        get => Get<int>();
+        set => Set(value);
     }
 
     public int CanvasWidth
@@ -224,6 +242,9 @@ public class ProjectPropertiesViewModel : ViewModel
             FontGenerator = this.gumProject.FontGenerator;
 
             RestrictToUnitValues = this.gumProject.RestrictToUnitValues;
+            ShowGrid = this.gumProject.ShowGrid;
+            SnapToGrid = this.gumProject.SnapToGrid;
+            GridSize = this.gumProject.GridSize;
             CanvasHeight = this.gumProject.DefaultCanvasHeight;
             CanvasWidth = this.gumProject.DefaultCanvasWidth;
             RestrictFileNamesForAndroid = this.gumProject.RestrictFileNamesForAndroid;
@@ -255,6 +276,9 @@ public class ProjectPropertiesViewModel : ViewModel
 
         this.gumProject.TextureFilter = TextureFilter.ToString();
         this.gumProject.RestrictToUnitValues = RestrictToUnitValues;
+        this.gumProject.ShowGrid = ShowGrid;
+        this.gumProject.SnapToGrid = SnapToGrid;
+        this.gumProject.GridSize = GridSize;
         this.gumProject.DefaultCanvasHeight = CanvasHeight;
         this.gumProject.DefaultCanvasWidth = CanvasWidth;
         this.gumProject.RestrictFileNamesForAndroid = RestrictFileNamesForAndroid;

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/ProjectPropertiesWindowPlugin/ProjectPropertiesViewModel.cs
@@ -55,24 +55,6 @@ public class ProjectPropertiesViewModel : ViewModel
         set => Set(value);
     }
 
-    public bool ShowGrid
-    {
-        get => Get<bool>();
-        set => Set(value);
-    }
-
-    public bool SnapToGrid
-    {
-        get => Get<bool>();
-        set => Set(value);
-    }
-
-    public int GridSize
-    {
-        get => Get<int>();
-        set => Set(value);
-    }
-
     public int CanvasWidth
     {
         get => Get<int>();
@@ -242,9 +224,6 @@ public class ProjectPropertiesViewModel : ViewModel
             FontGenerator = this.gumProject.FontGenerator;
 
             RestrictToUnitValues = this.gumProject.RestrictToUnitValues;
-            ShowGrid = this.gumProject.ShowGrid;
-            SnapToGrid = this.gumProject.SnapToGrid;
-            GridSize = this.gumProject.GridSize;
             CanvasHeight = this.gumProject.DefaultCanvasHeight;
             CanvasWidth = this.gumProject.DefaultCanvasWidth;
             RestrictFileNamesForAndroid = this.gumProject.RestrictFileNamesForAndroid;
@@ -276,9 +255,6 @@ public class ProjectPropertiesViewModel : ViewModel
 
         this.gumProject.TextureFilter = TextureFilter.ToString();
         this.gumProject.RestrictToUnitValues = RestrictToUnitValues;
-        this.gumProject.ShowGrid = ShowGrid;
-        this.gumProject.SnapToGrid = SnapToGrid;
-        this.gumProject.GridSize = GridSize;
         this.gumProject.DefaultCanvasHeight = CanvasHeight;
         this.gumProject.DefaultCanvasWidth = CanvasWidth;
         this.gumProject.RestrictFileNamesForAndroid = RestrictFileNamesForAndroid;

--- a/Tools/Gum.Presentation/Services/GridSnapWarningService.cs
+++ b/Tools/Gum.Presentation/Services/GridSnapWarningService.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Gum.Converters;
+using Gum.DataTypes;
+using Gum.Wireframe;
+
+namespace Gum.Services;
+
+public class GridSnapWarningService : IGridSnapWarningService
+{
+    private readonly ISelectionManager _selectionManager;
+
+    public GridSnapWarningService(ISelectionManager selectionManager)
+    {
+        _selectionManager = selectionManager;
+    }
+
+    public GridSnapWarningInfo GetInfo()
+    {
+        if (!_selectionManager.SnapToGrid || !_selectionManager.HasSelection)
+        {
+            return new GridSnapWarningInfo(false, null);
+        }
+
+        var selectedGues = _selectionManager.SelectedGues;
+
+        bool hasNonPixelUnit = selectedGues.Any(gue =>
+            !gue.XUnits.GetIsPixelBased() ||
+            !gue.YUnits.GetIsPixelBased() ||
+            !gue.WidthUnits.GetIsPixelBased() ||
+            !gue.HeightUnits.GetIsPixelBased());
+
+        if (!hasNonPixelUnit)
+        {
+            return new GridSnapWarningInfo(false, null);
+        }
+
+        string warningText = selectedGues.Count == 1
+            ? $"Snap to Grid: {selectedGues[0].Name} uses non-pixel units and won't fully snap"
+            : "Snap to Grid: one or more selected objects use non-pixel units and won't fully snap";
+
+        return new GridSnapWarningInfo(true, warningText);
+    }
+}

--- a/Tools/Gum.Presentation/Services/IGridSnapWarningService.cs
+++ b/Tools/Gum.Presentation/Services/IGridSnapWarningService.cs
@@ -1,0 +1,13 @@
+namespace Gum.Services;
+
+public record GridSnapWarningInfo(bool HasWarning, string? WarningText);
+
+/// <summary>
+/// Computes the "won't fully snap" warning shown above the main editor canvas when Snap to Grid
+/// is enabled but the current selection includes an object using non-pixel units - grid snap only
+/// applies to pixel-based positioning/sizing (issue #4137).
+/// </summary>
+public interface IGridSnapWarningService
+{
+    GridSnapWarningInfo GetInfo();
+}

--- a/Tools/Gum.Presentation/Wireframe/GrabbedState.cs
+++ b/Tools/Gum.Presentation/Wireframe/GrabbedState.cs
@@ -91,6 +91,67 @@ public class GrabbedState
     } = new Dictionary<InstanceSave, Vector2>();
 
     /// <summary>
+    /// Grid-snap needs to know where an object would be with NO snapping applied, tracked
+    /// continuously across the whole drag - reading the live (already-snapped) X/Y/Width/Height
+    /// every frame causes each small move to be immediately reverted back to the same grid line
+    /// it was already snapped to, so the object only visibly moves once a single frame's raw
+    /// delta is big enough to land in a different grid cell. These accumulate the raw, unsnapped
+    /// per-frame deltas since grab (added to <see cref="ComponentPosition"/>/<see cref="ComponentSize"/>
+    /// or the per-instance grab position/size to get the "true" value) and are never touched by
+    /// the snap correction itself.
+    /// </summary>
+    public Vector2 TrueComponentPositionOffset { get; set; }
+    public Vector2 TrueComponentSizeOffset { get; set; }
+    public Dictionary<InstanceSave, Vector2> TrueInstancePositionOffsets { get; } = new Dictionary<InstanceSave, Vector2>();
+    public Dictionary<InstanceSave, Vector2> TrueInstanceSizeOffsets { get; } = new Dictionary<InstanceSave, Vector2>();
+
+    public void AccumulateTruePositionOffset(InstanceSave? instance, float deltaX, float deltaY)
+    {
+        if (instance == null)
+        {
+            TrueComponentPositionOffset += new Vector2(deltaX, deltaY);
+        }
+        else
+        {
+            TrueInstancePositionOffsets.TryGetValue(instance, out Vector2 current);
+            TrueInstancePositionOffsets[instance] = current + new Vector2(deltaX, deltaY);
+        }
+    }
+
+    public void AccumulateTrueSizeOffset(InstanceSave? instance, float deltaWidth, float deltaHeight)
+    {
+        if (instance == null)
+        {
+            TrueComponentSizeOffset += new Vector2(deltaWidth, deltaHeight);
+        }
+        else
+        {
+            TrueInstanceSizeOffsets.TryGetValue(instance, out Vector2 current);
+            TrueInstanceSizeOffsets[instance] = current + new Vector2(deltaWidth, deltaHeight);
+        }
+    }
+
+    public Vector2 GetTruePositionOffset(InstanceSave? instance)
+    {
+        if (instance == null)
+        {
+            return TrueComponentPositionOffset;
+        }
+        TrueInstancePositionOffsets.TryGetValue(instance, out Vector2 current);
+        return current;
+    }
+
+    public Vector2 GetTrueSizeOffset(InstanceSave? instance)
+    {
+        if (instance == null)
+        {
+            return TrueComponentSizeOffset;
+        }
+        TrueInstanceSizeOffsets.TryGetValue(instance, out Vector2 current);
+        return current;
+    }
+
+    /// <summary>
     /// Returns whether the cursor has moved enough from the initial grab point to start applying movement/sizing.
     /// This is initially false to prevent accidental movement when clicking on an object.
     /// </summary>
@@ -134,6 +195,11 @@ public class GrabbedState
 
         AccumulatedXOffset = 0;
         AccumulatedYOffset = 0;
+
+        TrueComponentPositionOffset = Vector2.Zero;
+        TrueComponentSizeOffset = Vector2.Zero;
+        TrueInstancePositionOffsets.Clear();
+        TrueInstanceSizeOffsets.Clear();
 
         if(_selectedState.SelectedStateSave != null)
         {

--- a/Tools/Gum.Presentation/Wireframe/ISelectionManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/ISelectionManager.cs
@@ -29,6 +29,11 @@ public interface ISelectionManager
     /// </summary>
     List<GraphicalUiElement> SelectedGues { get; }
 
+    /// <summary>
+    /// Whether move/resize dragging snaps pixel-unit objects to the grid.
+    /// </summary>
+    bool SnapToGrid { get; }
+
     void DeselectAll();
     void ToggleSelection(GraphicalUiElement element);
     void Select(IEnumerable<GraphicalUiElement> elements);

--- a/Tools/Gum.Presentation/Wireframe/SelectionManager.cs
+++ b/Tools/Gum.Presentation/Wireframe/SelectionManager.cs
@@ -164,6 +164,34 @@ public class SelectionManager : ISelectionManager
         }
     }
 
+    bool snapToGrid;
+    public bool SnapToGrid
+    {
+        get { return snapToGrid; }
+        set
+        {
+            snapToGrid = value;
+            if (WireframeEditor != null)
+            {
+                WireframeEditor.SnapToGrid = value;
+            }
+        }
+    }
+
+    int gridSize = 16;
+    public int GridSize
+    {
+        get { return gridSize; }
+        set
+        {
+            gridSize = value;
+            if (WireframeEditor != null)
+            {
+                WireframeEditor.GridSize = value;
+            }
+        }
+    }
+
     public bool AreHighlightsVisible
     {
         get => highlightManager.AreHighlightsVisible;
@@ -759,6 +787,8 @@ public class SelectionManager : ISelectionManager
                 WireframeEditor.UpdateToSelection(mSelectedIpsos);
             }
             WireframeEditor.RestrictToUnitValues = RestrictToUnitValues;
+            WireframeEditor.SnapToGrid = SnapToGrid;
+            WireframeEditor.GridSize = GridSize;
         }
     }
 


### PR DESCRIPTION
Closes #4137.

## What's here
- Grid overlay (Project Properties > Grid: Show Grid, Snap to Grid, Grid Size) drawn on the canvas, stable while panning/zooming.
- Snap-to-grid on move/resize, **pixel-unit axes only** — matches the scope agreed in the issue thread. Snap is computed in world space (`GraphicalUiElement.AbsoluteX/Y`) so a child under a non-grid-aligned/rotated parent still lands visually on-grid.
- A warning banner above the canvas when Snap to Grid is on and the selection uses a non-pixel unit, so it's clear why nothing snapped.

## Known v1 limitation (not fixed here)
Resize snap treats Width/Height as local grid-rounding (like the existing unit-snap does), while X/Y snap in world space. For a plain axis-aligned resize with a grid-aligned anchor this lands both edges on-grid; for a rotated object or one whose anchor edge isn't already grid-aligned, the far edge may not land exactly on a grid line. Filed as a follow-up: #4380.

## Boyscout
`LineGrid.X`/`.Y` were hardcoded no-op stubs (always 0) and its constructor called the throwing `Renderer.SinglePixelTexture` instead of `TryGetSinglePixelTexture()` — the convention every sibling line-based renderable already uses. Both blocked repositioning the grid overlay and unit-testing it headlessly; fixed in `RenderingLibrary/Math/Geometry/LineGrid.cs`.

## Visual design
Grid line color/alpha and the warning banner's styling are functional placeholders — the maintainer offered to do a visual pass once this is on screen.

## Testing
- TDD throughout: `GridSnapper`, `GridOverlayCalculator`, `MoveInputHandler`/`ResizeInputHandler` grid-snap math, `GridSnapWarningService`, `LineGrid.X`/`.Y`, project-settings round-trip.
- `dotnet test Tests/Gum.Presentation.Tests` — 828 passed.
- `dotnet test MonoGameGum.Tests -c Release` — 2153 passed.
- `dotnet test Tool/Tests/GumToolUnitTests` — 1224 passed, 2 pre-existing skips.
- `dotnet build GumFull.sln` — clean.
- FRB canary (`GumCore.DesktopGlNet6.csproj`) — pass (LineGrid.cs is FRB1-shared).

Manual test: needed (canvas rendering/UI) — steps in the PR/issue thread, VS is open on this worktree.
