### PR TITLE
Show State/Category icons on right-click Add State/Add Category

### DIFF
--- a/Gum/Extensions/ContextMenuItemViewModelExtensions.cs
+++ b/Gum/Extensions/ContextMenuItemViewModelExtensions.cs
@@ -1,3 +1,4 @@
+using FluentIcons.Wpf;
 using Gum.ViewModels;
 using System.Windows.Controls;
 
@@ -11,6 +12,8 @@ namespace Gum.Extensions;
 /// </summary>
 public static class ContextMenuItemViewModelExtensions
 {
+    private const double MenuIconSize = 14;
+
     public static Control ToMenuItem(this ContextMenuItemViewModel item)
     {
         if (item.IsSeparator)
@@ -25,6 +28,11 @@ public static class ContextMenuItemViewModelExtensions
             menuItem.InputGestureText = item.Shortcut;
         }
 
+        if (item.IconKey != null)
+        {
+            menuItem.Icon = CreateIcon(item.IconKey);
+        }
+
         if (item.Action != null)
         {
             menuItem.Click += (_, _) => item.Action();
@@ -37,4 +45,16 @@ public static class ContextMenuItemViewModelExtensions
 
         return menuItem;
     }
+
+    /// <summary>
+    /// Matches the icons the States tree itself uses for category/state rows
+    /// (<c>StateTreeView.xaml</c>'s "DatabaseMultiple"/"Database" FluentIcons), so an "Add
+    /// State"/"Add Category" menu item reads as the same concept as the row it will create.
+    /// </summary>
+    private static FluentIcon? CreateIcon(string iconKey) => iconKey switch
+    {
+        ContextMenuIconKeys.Category => new FluentIcon { Icon = FluentIcons.Common.Icon.DatabaseMultiple, FontSize = MenuIconSize },
+        ContextMenuIconKeys.State => new FluentIcon { Icon = FluentIcons.Common.Icon.Database, FontSize = MenuIconSize },
+        _ => null
+    };
 }

--- a/Tests/Gum.Presentation.Tests/ContextMenuItemViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/ContextMenuItemViewModelTests.cs
@@ -19,5 +19,6 @@ public class ContextMenuItemViewModelTests
         viewModel.Action.ShouldBeNull();
         viewModel.IsSeparator.ShouldBeFalse();
         viewModel.Children.ShouldBeEmpty();
+        viewModel.IconKey.ShouldBeNull();
     }
 }

--- a/Tests/Gum.Presentation.Tests/StateTreeRightClickViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/StateTreeRightClickViewModelTests.cs
@@ -97,7 +97,8 @@ public class StateTreeRightClickViewModelTests
 
         List<ContextMenuItemViewModel> result = _sut.GetMenuItems();
 
-        result.Any(item => item.Text == "Add Category").ShouldBeTrue();
+        ContextMenuItemViewModel addCategory = result.First(item => item.Text == "Add Category");
+        addCategory.IconKey.ShouldBe(ContextMenuIconKeys.Category);
     }
 
     [Fact]
@@ -110,7 +111,8 @@ public class StateTreeRightClickViewModelTests
 
         List<ContextMenuItemViewModel> result = _sut.GetMenuItems();
 
-        result.Any(item => item.Text == "Add State").ShouldBeTrue();
+        ContextMenuItemViewModel addState = result.First(item => item.Text == "Add State");
+        addState.IconKey.ShouldBe(ContextMenuIconKeys.State);
     }
 
     [Fact]

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeRightClickViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/StatePlugin/StateTreeRightClickViewModel.cs
@@ -74,6 +74,7 @@ public class StateTreeRightClickViewModel
             items.Add(new ContextMenuItemViewModel
             {
                 Text = "Add State",
+                IconKey = ContextMenuIconKeys.State,
                 Action = () => _dialogService.Show<AddStateDialogViewModel>()
             });
         }
@@ -81,6 +82,7 @@ public class StateTreeRightClickViewModel
         items.Add(new ContextMenuItemViewModel
         {
             Text = "Add Category",
+            IconKey = ContextMenuIconKeys.Category,
             Action = () => _dialogService.Show<AddCategoryDialogViewModel>()
         });
 

--- a/Tools/Gum.Presentation/ViewModels/ContextMenuIconKeys.cs
+++ b/Tools/Gum.Presentation/ViewModels/ContextMenuIconKeys.cs
@@ -1,0 +1,11 @@
+namespace Gum.ViewModels;
+
+/// <summary>
+/// Well-known <see cref="ContextMenuItemViewModel.IconKey"/> values, shared between the headless
+/// view models that set them and the WPF-side renderer that maps them to an actual icon.
+/// </summary>
+public static class ContextMenuIconKeys
+{
+    public const string State = nameof(State);
+    public const string Category = nameof(Category);
+}

--- a/Tools/Gum.Presentation/ViewModels/ContextMenuItemViewModel.cs
+++ b/Tools/Gum.Presentation/ViewModels/ContextMenuItemViewModel.cs
@@ -11,4 +11,11 @@ public class ContextMenuItemViewModel
     public bool IsSeparator { get; set; }
     public bool IsEnabled { get; set; } = true;
     public string? Shortcut { get; set; }
+
+    /// <summary>
+    /// Framework-neutral key identifying which icon this item should show, or null for none.
+    /// <see cref="Gum.Extensions.ContextMenuItemViewModelExtensions"/> maps known keys to the actual
+    /// WPF icon element - this assembly must not reference WPF (ADR-0005).
+    /// </summary>
+    public string? IconKey { get; set; }
 }


### PR DESCRIPTION
Follow-up to #4377/#4379 ("Right-click menu unchanged"). Adds the States tree's own icons (FluentIcons `Database`/`DatabaseMultiple`) to the "Add State"/"Add Category" right-click menu items so they read as the same concept as the row they create.

`ContextMenuItemViewModel` gains a framework-neutral `IconKey` string (headless, ADR-0005-compliant); `ContextMenuItemViewModelExtensions.ToMenuItem` (WPF-side) maps known keys to a `FluentIcon`. Only the States right-click menu sets it — other `ContextMenuItemViewModel` consumers are unaffected.

Closes #4382