### PR TITLE
Restore Container outlines in the editor by not registering ContainerRuntime

### DIFF
--- a/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
+++ b/Tool/EditorTabPlugin_XNA/Views/WireframeControl.cs
@@ -301,11 +301,13 @@ public class WireframeControl : WpfGraphicsDeviceControl
     // internal (not private) and static so GumToolUnitTests can verify every standard type the
     // tool needs to render is registered here - this list drifting out of sync with the runtime's
     // own registration (RenderingLibrary.SystemManagers.RegisterComponentRuntimeInstantiations) is
-    // exactly how NineSlice/Container ended up missing: an instance whose type has no registration
+    // exactly how NineSlice ended up missing: an instance whose type has no registration
     // here falls back to a plain GraphicalUiElement wrapping a raw renderable, which most
     // CustomSetPropertyOnRenderable dispatch branches don't handle (they cast to the typed Runtime
     // and silently no-op if that fails) - producing a correctly-valued but unrendered property
     // (e.g. a NineSlice's Red/Green/Blue staying at the renderable's default white).
+    //
+    // Container is the one type that must stay unregistered - see the comment at its spot below.
     internal static void InitializeDefaultTypeInstantiation()
     {
         ElementSaveExtensions.RegisterGueInstantiation(
@@ -316,9 +318,14 @@ public class WireframeControl : WpfGraphicsDeviceControl
             "ColoredRectangle",
             () => new ColoredRectangleRuntime());
 
-        ElementSaveExtensions.RegisterGueInstantiation(
-            "Container",
-            () => new ContainerRuntime());
+        // Container is deliberately absent (issue #4386). Every registered runtime installs its own
+        // renderable in its constructor, so SetGraphicalUiElement sees a non-null RenderableComponent
+        // and skips CreateGraphicalComponent - the only path that consults
+        // GraphicalUiElement.ShowLineRectangles and returns FallbackRenderableFactory's dotted
+        // LineRectangle, which is how the editor draws a Container with Show Outlines checked (the
+        // runtime has no such concept, which is why it does register ContainerRuntime). Registering
+        // ContainerRuntime here replaced that outline with an InvisibleRenderable, making every
+        // Container instance invisible in the editor.
 
         ElementSaveExtensions.RegisterGueInstantiation(
             "NineSlice",

--- a/Tool/Tests/GumToolUnitTests/Wireframe/WireframeControlDefaultTypeInstantiationTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/WireframeControlDefaultTypeInstantiationTests.cs
@@ -28,9 +28,8 @@ public class WireframeControlDefaultTypeInstantiationTests
     // Circle/Polygon are deliberately excluded - their constructors reach RenderingLibrary.Graphics.Renderer.Self,
     // which needs a real graphics context (SystemManagers.Default initialized), unavailable in this
     // headless test process. They were already correctly registered before this fix; this test's
-    // purpose is pinning the two that weren't (Container, NineSlice), not full coverage.
+    // purpose is pinning the one that wasn't (NineSlice), not full coverage.
     [InlineData("ColoredRectangle", typeof(ColoredRectangleRuntime))]
-    [InlineData("Container", typeof(ContainerRuntime))]
     [InlineData("NineSlice", typeof(NineSliceRuntime))]
     [InlineData("Sprite", typeof(SpriteRuntime))]
     public void InitializeDefaultTypeInstantiation_ShouldRegisterEveryStandardType_SoInstancesConstructAsTheTypedRuntime(
@@ -42,5 +41,24 @@ public class WireframeControlDefaultTypeInstantiationTests
         var gue = ElementSaveExtensions.CreateGueForElement(elementSave);
 
         gue.ShouldBeOfType(expectedRuntimeType);
+    }
+
+    /// <summary>
+    /// Container is the one standard type the tool must NOT register (issue #4386). Every registered
+    /// runtime installs its own renderable in its constructor, which makes SetGraphicalUiElement skip
+    /// CreateGraphicalComponent - and CreateGraphicalComponent is the only path that consults
+    /// GraphicalUiElement.ShowLineRectangles and hands back the dotted LineRectangle the editor draws
+    /// for a Container when Show Outlines is checked. Registering ContainerRuntime silently swapped
+    /// that outline for an InvisibleRenderable, making containers invisible in the editor.
+    /// </summary>
+    [Fact]
+    public void InitializeDefaultTypeInstantiation_ShouldLeaveContainerUnregistered_SoShowOutlinesCanBackItWithADottedLineRectangle()
+    {
+        WireframeControl.InitializeDefaultTypeInstantiation();
+
+        StandardElementSave containerElement = new() { Name = "Container" };
+        var gue = ElementSaveExtensions.CreateGueForElement(containerElement);
+
+        gue.RenderableComponent.ShouldBeNull();
     }
 }


### PR DESCRIPTION
## Root cause

PR #4076 added `"Container"` to `WireframeControl.InitializeDefaultTypeInstantiation()` alongside the `NineSlice` registration that actually fixed that report. `ContainerRuntime`'s constructor installs an `InvisibleRenderable`, so `SetGraphicalUiElement` saw a non-null `RenderableComponent` and skipped `CreateGraphicalComponent` — the only path that consults `GraphicalUiElement.ShowLineRectangles` and returns `FallbackRenderableFactory`'s dotted `LineRectangle`. Every `Container` instance therefore rendered nothing in the editor with **Show Outlines** checked.

## Fix

Drop the `Container` registration. It is the one standard type the tool must leave unregistered — the runtime registers `ContainerRuntime` precisely because it has no outline concept, while the editor backs Containers with a `LineRectangle` (which `CustomSetPropertyOnRenderable` already handles for Alpha/Red/Green/Blue/IsRenderTarget/SourceShaderFile). Pinned with a test and commented at both spots so it doesn't get re-added.

Closes #4386
