### PR TITLE
Populate PropertyChangedArgs.OldValue in DataUiGrid.PropertyChange

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Controls/DataUiGridPropertyChangeOldValueTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/DataUiGridPropertyChangeOldValueTests.cs
@@ -1,0 +1,49 @@
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+using WpfDataUi;
+using WpfDataUi.DataTypes;
+using WpfDataUi.EventArguments;
+
+namespace GumToolUnitTests.Controls;
+
+/// <summary>
+/// Pins DataUiGrid.PropertyChange populating PropertyChangedArgs.OldValue (#4387). Previously OldValue
+/// was always left at its default null, even though the value existed on the InstanceMember immediately
+/// before the UI-driven assignment.
+/// </summary>
+public class DataUiGridPropertyChangeOldValueTests : BaseTestClass
+{
+    class SimplePropertyOwner
+    {
+        public bool Flag { get; set; }
+    }
+
+    [StaFact]
+    public void PropertyChange_PopulatesOldValue_WhenValueSetThroughTrySetValueOnInstance()
+    {
+        var owner = new SimplePropertyOwner { Flag = true };
+        var instanceMember = new InstanceMember(nameof(SimplePropertyOwner.Flag), owner);
+
+        var category = new MemberCategory("Category");
+        category.Members.Add(instanceMember);
+
+        var grid = new DataUiGrid();
+        grid.SetCategories(new List<MemberCategory> { category });
+
+        PropertyChangedArgs? capturedArgs = null;
+        grid.PropertyChange += (name, args) => capturedArgs = args;
+
+        object? newValueOnUi = false;
+        var mockDataUi = new Mock<IDataUi>();
+        mockDataUi.SetupGet(d => d.InstanceMember).Returns(instanceMember);
+        mockDataUi.Setup(d => d.TryGetValueOnUi(out newValueOnUi)).Returns(ApplyValueResult.Success);
+
+        mockDataUi.Object.TrySetValueOnInstance();
+
+        capturedArgs.ShouldNotBeNull();
+        capturedArgs!.OldValue.ShouldBe(true);
+        capturedArgs.NewValue.ShouldBe(false);
+        capturedArgs.PropertyName.ShouldBe(nameof(SimplePropertyOwner.Flag));
+    }
+}

--- a/WpfDataUi/DataTypes/InstanceMember.cs
+++ b/WpfDataUi/DataTypes/InstanceMember.cs
@@ -112,6 +112,13 @@ namespace WpfDataUi.DataTypes
             set;
         }
 
+        /// <summary>
+        /// The value Value held immediately before the most recent UI-driven assignment
+        /// (see IDataUiExtensionMethods.TrySetValueOnInstance and MenuItemExposedClick.MakeDefault).
+        /// Used to populate PropertyChangedArgs.OldValue when DataUiGrid.PropertyChange fires.
+        /// </summary>
+        public object OldValue { get; set; }
+
         public object Value
         {
             get

--- a/WpfDataUi/DataUiGrid.cs
+++ b/WpfDataUi/DataUiGrid.cs
@@ -506,6 +506,7 @@ public class DataUiGrid : ItemsControl, INotifyPropertyChanged
             // This assumes reflection, which is bad...
             //args.NewValue = LateBinder.GetValueStatic(this.Instance, ((InstanceMember)sender).Name);
 
+            args.OldValue = senderInstanceMember.OldValue;
             args.NewValue = senderInstanceMember.Value;
             args.PropertyName = senderInstanceMember.Name;
 

--- a/WpfDataUi/IDataUiExtensionMethods.cs
+++ b/WpfDataUi/IDataUiExtensionMethods.cs
@@ -23,6 +23,7 @@ public class MenuItemExposedClick : MenuItem
 
     private void MakeDefault(object? sender, RoutedEventArgs e)
     {
+        Owner.InstanceMember.OldValue = Owner.InstanceMember.Value;
         Owner.InstanceMember.IsDefault = true;
         Owner.Refresh();
 
@@ -93,6 +94,7 @@ public static class IDataUiExtensionMethods
                 // Why not protect against spammed same-value assignments?
                 if(dataUi.InstanceMember.Value != valueOnUi)
                 {
+                    dataUi.InstanceMember.OldValue = dataUi.InstanceMember.Value;
                     //dataUi.InstanceMember.Value = valueOnUi;
                     result = dataUi.InstanceMember.SetValue(valueOnUi, SetPropertyCommitType.Full);
                     if(result == ApplyValueResult.Success)
@@ -120,6 +122,7 @@ public static class IDataUiExtensionMethods
         {
             if (AreEqual(dataUi.InstanceMember.Value, valueToSet) == false || commitType == SetPropertyCommitType.Full)
             {
+                dataUi.InstanceMember.OldValue = dataUi.InstanceMember.Value;
                 //dataUi.InstanceMember.Value = valueToSet;
                 result = dataUi.InstanceMember.SetValue(valueToSet, commitType);
                 dataUi.InstanceMember.CallAfterSetByUi();


### PR DESCRIPTION
## Summary
`DataUiGrid.HandleInstanceMemberSetByUi` always left `PropertyChangedArgs.OldValue` at its default `null`. `InstanceMember` now has an `OldValue` property, set at each UI-driven assignment site (both `TrySetValueOnInstance` overloads and `MakeDefault`) right before the underlying property changes — covering all control types (checkbox, combobox, textbox, etc.), not just text boxes via the `Before`/`After` event pair. `DataUiGrid` reads it when firing `PropertyChange`.

Closes #4387

## Test plan
- [x] New unit test pins `PropertyChange.OldValue` through `TrySetValueOnInstance` (verified red without the fix, green with it)
- [x] `dotnet test Tool/Tests/GumToolUnitTests` — 1229 passed
- [x] `dotnet build GumFull.sln` — 0 errors
- Manual test: not needed — no in-tree consumer reads `PropertyChange.OldValue`, so no tool-observable behavior changes; the unit test exercises the exact plumbing path
