### PR TITLE
Flip resize anchor instead of allowing negative Width/Height

### DIFF
--- a/.claude/skills/gum-tool-selection/SKILL.md
+++ b/.claude/skills/gum-tool-selection/SKILL.md
@@ -9,18 +9,20 @@ description: Gum editor selection — click/drag, marquee, input handlers (move/
 
 Selection in the wireframe (XNA) editor is coordinated by `SelectionManager`. It delegates specific interactions to a set of **input handlers**, each responsible for one type of gesture (move, resize, rotate, polygon point editing). A separate **rectangle selector** handles marquee/rubber-band multi-selection. Locking (`InstanceSave.Locked`) cuts across all of these.
 
+This migrated in two parts: `MoveInputHandler`/`ResizeInputHandler`/`RotationInputHandler`/`InputHandlerBase`, `EditorContext`, `SelectionManager`, and `RectangleSelector` now live under the headless `Tools/Gum.Presentation/...`; `PolygonPointInputHandler` and `LockedSelectionVisual` are still under `Tool/EditorTabPlugin_XNA/Editors/...`.
+
 ## Input Handlers
 
-**Base class:** `Tool/EditorTabPlugin_XNA/Editors/Handlers/InputHandlerBase.cs`
+**Base class:** `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/InputHandlerBase.cs`
 
 Each handler represents one interaction mode. Concrete handlers:
 
 | Handler | File | Responsibility |
 |---------|------|----------------|
-| `MoveInputHandler` | `Handlers/MoveInputHandler.cs` | Drag-to-move selected instance(s) |
-| `ResizeInputHandler` | `Handlers/ResizeInputHandler.cs` | Resize handle dragging |
-| `RotationInputHandler` | `Handlers/RotationInputHandler.cs` | Rotation handle dragging |
-| `PolygonPointInputHandler` | `Handlers/PolygonPointInputHandler.cs` | Polygon vertex select/move/add/delete |
+| `MoveInputHandler` | `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs` | Drag-to-move selected instance(s) |
+| `ResizeInputHandler` | `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs` | Resize handle dragging |
+| `RotationInputHandler` | `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/RotationInputHandler.cs` | Rotation handle dragging |
+| `PolygonPointInputHandler` | `Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs` | Polygon vertex select/move/add/delete |
 
 ### Handler Lifecycle
 
@@ -40,7 +42,7 @@ The base class `HandlePush` automatically checks `Context.IsSelectionLocked()` a
 
 ## Rectangle Selector (Marquee Selection)
 
-**File:** `Tool/EditorTabPlugin_XNA/RectangleSelector.cs`
+**File:** `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/RectangleSelector.cs`
 
 The rectangle selector activates on drag when no handler is active and the cursor is not over the element body (or Shift is held for additive selection), after a minimum drag distance is exceeded. `SelectionManager` passes `isHandlerActive` based on whether any handler's `IsActive` is `true`.
 
@@ -48,7 +50,7 @@ The rectangle selector activates on drag when no handler is active and the curso
 
 ## Locking (`InstanceSave.Locked`)
 
-`InstanceSave.Locked` is defined in `GumDataTypes/InstanceSave.cs`. The helper `EditorContext.IsSelectionLocked()` (in `Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs`) returns `true` when the selected instance is locked.
+`InstanceSave.Locked` is defined in `GumDataTypes/InstanceSave.cs`. The helper `EditorContext.IsSelectionLocked()` (in `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs`) returns `true` when the selected instance is locked.
 
 ### Where Locking Is Enforced
 
@@ -117,14 +119,14 @@ User selects instance
 
 | File | Purpose |
 |------|---------|
-| `Tool/EditorTabPlugin_XNA/SelectionManager.cs` | Main coordinator; manages `IsOverBody`, routes events to handlers, passes `isHandlerActive` to rectangle selector |
-| `Tool/EditorTabPlugin_XNA/RectangleSelector.cs` | Marquee selection; activation gated on `isHandlerActive` and `IsOverBody` |
-| `Tool/EditorTabPlugin_XNA/Editors/Handlers/InputHandlerBase.cs` | Base class; provides default `HandlePush` with lock check |
-| `Tool/EditorTabPlugin_XNA/Editors/Handlers/MoveInputHandler.cs` | Move gesture; also handles axis lock and snap-to-unit for multi-selection |
-| `Tool/EditorTabPlugin_XNA/Editors/Handlers/ResizeInputHandler.cs` | Resize handle gestures |
+| `Tools/Gum.Presentation/Wireframe/SelectionManager.cs` | Main coordinator; manages `IsOverBody`, routes events to handlers, passes `isHandlerActive` to rectangle selector |
+| `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/RectangleSelector.cs` | Marquee selection; activation gated on `isHandlerActive` and `IsOverBody` |
+| `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/InputHandlerBase.cs` | Base class; provides default `HandlePush` with lock check |
+| `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/MoveInputHandler.cs` | Move gesture; also handles axis lock and snap-to-unit for multi-selection |
+| `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs` | Resize handle gestures |
 | `Tool/EditorTabPlugin_XNA/Editors/Handlers/PolygonPointInputHandler.cs` | Polygon vertex editing; overrides `HandlePush` (must manage lock manually) |
-| `Tool/EditorTabPlugin_XNA/Editors/EditorContext.cs` | Provides `IsSelectionLocked()` helper used throughout handlers |
+| `Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/EditorContext.cs` | Provides `IsSelectionLocked()` helper used throughout handlers |
 | `Tool/EditorTabPlugin_XNA/Editors/Visuals/LockedSelectionVisual.cs` | Dashed bounding outline for locked selected instances; display-only, no interaction |
 | `GumDataTypes/InstanceSave.cs` | `Locked` property definition |
-| `Gum/ToolCommands/ElementCommands.cs` | `MoveSelectedObjectsBy()`; skips locked instances in multi-move |
+| `Tools/Gum.Presentation/ToolCommands/ElementCommands.cs` | `MoveSelectedObjectsBy()`; skips locked instances in multi-move |
 | `WpfDataUi/Controls/ListBoxDisplay.xaml.cs` | Variable grid list control; respects `IsReadOnly` (driven by `Locked`) |

--- a/Tests/Gum.Presentation.Tests/EditorContextTestHelper.cs
+++ b/Tests/Gum.Presentation.Tests/EditorContextTestHelper.cs
@@ -29,12 +29,13 @@ internal static class EditorContextTestHelper
         IWireframeObjectManager? wireframeObjectManager = null,
         IHotkeyManager? hotkeyManager = null,
         IGumCursorState? cursor = null,
-        Camera? camera = null)
+        Camera? camera = null,
+        IElementCommands? elementCommands = null)
     {
         return new EditorContext(
             selectedState ?? Mock.Of<ISelectedState>(),
             selectionManager ?? Mock.Of<ISelectionManager>(),
-            Mock.Of<IElementCommands>(),
+            elementCommands ?? Mock.Of<IElementCommands>(),
             Mock.Of<IGuiCommands>(),
             Mock.Of<IFileCommands>(),
             Mock.Of<ISetVariableLogic>(),

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipRotationTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipRotationTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Input;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors.Handlers;
+using Gum.Wireframe.Editors.Visuals;
+using Moq;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Math;
+using Shouldly;
+using MathHelper = ToolsUtilitiesStandard.Helpers.MathHelper;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// End-to-end coverage (real GraphicalUiElement, driven through HandlePush/HandleDrag) proving the
+/// #4385 anchor-flip logic composes correctly with a rotated object. Width/Height are resolved in
+/// LOCAL, pre-rotation space (see ResizeInputHandlerFlipTests) and only the resulting X/Y position
+/// delta is rotated - via the pre-existing, unchanged MathFunctions.RotateVector step - into world
+/// space. This test drags a Right handle far enough to cross the anchor on a 90-degree-rotated
+/// object, and checks both that Width still flips correctly (rotation-agnostic) AND that the
+/// resulting position delta lands where the (unchanged) rotation math says it should.
+/// </summary>
+public class ResizeInputHandlerFlipRotationTests
+{
+    private class FakeCursorState : IGumCursorState
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float XChange { get; set; }
+        public float YChange { get; set; }
+        public bool PrimaryDown { get; set; }
+        public bool PrimaryPush { get; set; }
+        public bool PrimaryClick { get; set; }
+        public bool IsInWindow { get; set; } = true;
+        public bool PrimaryDoubleClick { get; set; }
+        public bool SecondaryPush { get; set; }
+        public bool PrimaryDownIgnoringIsInWindow { get; set; }
+        public void SetCursor(GumCursorKind kind) { }
+    }
+
+    [Fact]
+    public void OnDrag_ShouldFlipWidthAndRotatePosition_WhenRightHandleDraggedPastAnchorOnRotatedObject()
+    {
+        // Arrange - a real, 90-degree-rotated GraphicalUiElement: Left-origin, X=5, Width=20 (so
+        // the Left edge, at local X=5, is the anchor for a Right-handle drag).
+        var representation = new GraphicalUiElement();
+        // The X/Y setters no-op without a contained renderable (see GraphicalUiElement.X's
+        // `mContainedObjectAsIpso != null` guard) - attach one so position assignments actually
+        // stick, matching how every real runtime (and generated code) constructs a GUE.
+        representation.SetContainedObject(new InvisibleRenderable());
+        representation.X = 5;
+        representation.Y = 0;
+        representation.Width = 20;
+        representation.Height = 10;
+        representation.Rotation = 90;
+
+        var handlesVisual = new Mock<IResizeHandlesVisual>();
+        handlesVisual.SetupGet(h => h.Visible).Returns(true);
+        handlesVisual.Setup(h => h.GetSideOver(It.IsAny<float>(), It.IsAny<float>())).Returns(ResizeSide.Right);
+
+        var wireframeObjectManager = new Mock<IWireframeObjectManager>();
+        wireframeObjectManager.Setup(w => w.GetRepresentation(It.IsAny<ElementSave>())).Returns(representation);
+
+        var elementCommands = new Mock<IElementCommands>();
+        elementCommands
+            .Setup(e => e.GetCurrentValueForVariable(It.IsAny<string>(), It.IsAny<InstanceSave>()))
+            .Returns((object?)null); // no XOrigin/YOrigin variable set -> defaults to Left/Top
+        elementCommands
+            .Setup(e => e.ModifyVariable(It.IsAny<string>(), It.IsAny<float>(), It.IsAny<ElementSave>()))
+            .Returns((string variableName, float amount, ElementSave elementSave) =>
+            {
+                switch (variableName)
+                {
+                    case "X": representation.X += amount; break;
+                    case "Y": representation.Y += amount; break;
+                    case "Width": representation.Width += amount; break;
+                    case "Height": representation.Height += amount; break;
+                }
+                return 0f;
+            });
+
+        var selectedState = new Mock<ISelectedState>();
+        var selectedElement = new ScreenSave();
+        selectedState.SetupGet(s => s.SelectedElement).Returns(selectedElement);
+        selectedState.SetupGet(s => s.SelectedStateSave).Returns(new StateSave());
+        selectedState.SetupGet(s => s.SelectedInstances).Returns(Array.Empty<InstanceSave>());
+        selectedState.SetupGet(s => s.SelectedInstance).Returns((InstanceSave?)null);
+        // Moq's loose mocks intercept default interface methods too (returning null instead of
+        // running ISelectedState.GetTopLevelElementStack()'s real body), so this needs an explicit setup.
+        selectedState.Setup(s => s.GetTopLevelElementStack())
+            .Returns(new List<ElementWithState> { new ElementWithState(selectedElement) });
+
+        var selectionManager = new Mock<ISelectionManager>();
+        selectionManager.SetupGet(s => s.HasSelection).Returns(true);
+        selectionManager.SetupGet(s => s.SelectedGues).Returns(new List<GraphicalUiElement>());
+
+        var cursor = new FakeCursorState { X = 100, Y = 100, PrimaryPush = true };
+
+        var context = EditorContextTestHelper.Create(
+            selectedState: selectedState.Object,
+            selectionManager: selectionManager.Object,
+            wireframeObjectManager: wireframeObjectManager.Object,
+            cursor: cursor,
+            elementCommands: elementCommands.Object);
+
+        var sut = new ResizeInputHandler(context, handlesVisual.Object);
+
+        // Act
+        sut.UpdateHover(0f, 0f); // sets _sideOver = Right (cursor.PrimaryPush is true)
+
+        context.GrabbedState.HandlePush(); // captures grab-time ComponentPosition/Size (X=5, Width=20)
+        sut.HandlePush(0f, 0f); // claims the gesture; _sideGrabbed = Right
+
+        // Drag the Right handle left by a total of 30 - 10 further than the Left anchor (at
+        // local X=5, Width=20 means the anchor is exactly at the drag origin's Left edge).
+        cursor.PrimaryDown = true;
+        cursor.PrimaryPush = false;
+        cursor.X = 70; // > 6px from the push position, satisfies HasMovedEnough
+        cursor.XChange = -30;
+        cursor.YChange = 0;
+
+        sut.HandleDrag();
+
+        // Assert - Width flips exactly as in the unrotated case (rotation never touches
+        // Width/Height - they're local, pre-rotation dimensions): 20 -> 10.
+        representation.Width.ShouldBe(10);
+        representation.Height.ShouldBe(10); // untouched - Right handle doesn't affect Height
+
+        // The pre-rotation local position delta is (-10, 0) (X: 5 -> -5, matching the unrotated
+        // flip case). Rotating that by the object's own 90-degree rotation through the SAME,
+        // unchanged MathFunctions.RotateVector pipeline this handler already used before #4385
+        // gives the expected world-space delta - computed here the same way the SUT computes it,
+        // to independently confirm composition rather than duplicating its flip math.
+        var expectedRepositionLocal = new System.Numerics.Vector2(-10, 0);
+        expectedRepositionLocal.Y *= -1;
+        MathFunctions.RotateVector(ref expectedRepositionLocal, MathHelper.ToRadians(90));
+        expectedRepositionLocal.Y *= -1;
+
+        representation.X.ShouldBe(5 + expectedRepositionLocal.X, tolerance: 0.01);
+        representation.Y.ShouldBe(0 + expectedRepositionLocal.Y, tolerance: 0.01);
+
+        context.HasChangedAnythingSinceLastPush.ShouldBeTrue();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipRotationTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipRotationTests.cs
@@ -21,9 +21,7 @@ namespace Gum.Presentation.Tests;
 /// #4385 anchor-flip logic composes correctly with a rotated object. Width/Height are resolved in
 /// LOCAL, pre-rotation space (see ResizeInputHandlerFlipTests) and only the resulting X/Y position
 /// delta is rotated - via the pre-existing, unchanged MathFunctions.RotateVector step - into world
-/// space. This test drags a Right handle far enough to cross the anchor on a 90-degree-rotated
-/// object, and checks both that Width still flips correctly (rotation-agnostic) AND that the
-/// resulting position delta lands where the (unchanged) rotation math says it should.
+/// space.
 /// </summary>
 public class ResizeInputHandlerFlipRotationTests
 {
@@ -43,25 +41,29 @@ public class ResizeInputHandlerFlipRotationTests
         public void SetCursor(GumCursorKind kind) { }
     }
 
-    [Fact]
-    public void OnDrag_ShouldFlipWidthAndRotatePosition_WhenRightHandleDraggedPastAnchorOnRotatedObject()
+    /// <summary>
+    /// Builds a ResizeInputHandler wired to a real, grabbed GraphicalUiElement (whole-component
+    /// selection, no instance) with the given grab-time X/Y/Width/Height/Rotation, hovering/grabbed
+    /// on <paramref name="sideGrabbed"/>. The returned cursor starts at the push position
+    /// (100, 100); the caller sets X/XChange/YChange per tick and calls HandleDrag().
+    /// </summary>
+    private static (ResizeInputHandler sut, FakeCursorState cursor, GraphicalUiElement representation) CreateGrabbedSut(
+        float x, float y, float width, float height, float rotation, ResizeSide sideGrabbed)
     {
-        // Arrange - a real, 90-degree-rotated GraphicalUiElement: Left-origin, X=5, Width=20 (so
-        // the Left edge, at local X=5, is the anchor for a Right-handle drag).
         var representation = new GraphicalUiElement();
         // The X/Y setters no-op without a contained renderable (see GraphicalUiElement.X's
         // `mContainedObjectAsIpso != null` guard) - attach one so position assignments actually
         // stick, matching how every real runtime (and generated code) constructs a GUE.
         representation.SetContainedObject(new InvisibleRenderable());
-        representation.X = 5;
-        representation.Y = 0;
-        representation.Width = 20;
-        representation.Height = 10;
-        representation.Rotation = 90;
+        representation.X = x;
+        representation.Y = y;
+        representation.Width = width;
+        representation.Height = height;
+        representation.Rotation = rotation;
 
         var handlesVisual = new Mock<IResizeHandlesVisual>();
         handlesVisual.SetupGet(h => h.Visible).Returns(true);
-        handlesVisual.Setup(h => h.GetSideOver(It.IsAny<float>(), It.IsAny<float>())).Returns(ResizeSide.Right);
+        handlesVisual.Setup(h => h.GetSideOver(It.IsAny<float>(), It.IsAny<float>())).Returns(sideGrabbed);
 
         var wireframeObjectManager = new Mock<IWireframeObjectManager>();
         wireframeObjectManager.Setup(w => w.GetRepresentation(It.IsAny<ElementSave>())).Returns(representation);
@@ -110,20 +112,29 @@ public class ResizeInputHandlerFlipRotationTests
 
         var sut = new ResizeInputHandler(context, handlesVisual.Object);
 
-        // Act
-        sut.UpdateHover(0f, 0f); // sets _sideOver = Right (cursor.PrimaryPush is true)
+        sut.UpdateHover(0f, 0f); // sets _sideOver (cursor.PrimaryPush is true)
+        context.GrabbedState.HandlePush(); // captures grab-time ComponentPosition/Size
+        sut.HandlePush(0f, 0f); // claims the gesture; _sideGrabbed = sideGrabbed
 
-        context.GrabbedState.HandlePush(); // captures grab-time ComponentPosition/Size (X=5, Width=20)
-        sut.HandlePush(0f, 0f); // claims the gesture; _sideGrabbed = Right
-
-        // Drag the Right handle left by a total of 30 - 10 further than the Left anchor (at
-        // local X=5, Width=20 means the anchor is exactly at the drag origin's Left edge).
         cursor.PrimaryDown = true;
         cursor.PrimaryPush = false;
+
+        return (sut, cursor, representation);
+    }
+
+    [Fact]
+    public void OnDrag_ShouldFlipWidthAndRotatePosition_WhenRightHandleDraggedPastAnchorOnRotatedObject()
+    {
+        // Arrange - Left-origin, X=5, Width=20 (so the Left edge, at local X=5, is the anchor for
+        // a Right-handle drag), rotated 90 degrees.
+        var (sut, cursor, representation) = CreateGrabbedSut(
+            x: 5, y: 0, width: 20, height: 10, rotation: 90, sideGrabbed: ResizeSide.Right);
+
+        // Act - drag the Right handle left by a total of 30 in one tick - 10 further than the Left
+        // anchor (at local X=5, Width=20 means the anchor is exactly at the drag origin's Left edge).
         cursor.X = 70; // > 6px from the push position, satisfies HasMovedEnough
         cursor.XChange = -30;
         cursor.YChange = 0;
-
         sut.HandleDrag();
 
         // Assert - Width flips exactly as in the unrotated case (rotation never touches
@@ -143,7 +154,43 @@ public class ResizeInputHandlerFlipRotationTests
 
         representation.X.ShouldBe(5 + expectedRepositionLocal.X, tolerance: 0.01);
         representation.Y.ShouldBe(0 + expectedRepositionLocal.Y, tolerance: 0.01);
+    }
 
-        context.HasChangedAnythingSinceLastPush.ShouldBeTrue();
+    [Fact]
+    public void OnDrag_ShouldNotDriftAcrossTicks_WhenLeftHandleDraggedOnRotatedObject()
+    {
+        // Regression for the position "shift" the user found manually: a handle that moves BOTH
+        // position and size (Left/Top - unlike Right/Bottom, whose position never moves on a
+        // Left/Top-origin object) must accumulate correctly across MULTIPLE drag ticks on a rotated
+        // object. A single big tick was already covered above and was never broken - the bug only
+        // shows up once representation.X/Y (which get overwritten with a ROTATED, world-space delta
+        // each tick) get read back as if they were still in the LOCAL, pre-rotation frame that
+        // grabStartPositionAxis/trueSizeOffsetSinceGrabAxis are computed in.
+        var (sut, cursor, representation) = CreateGrabbedSut(
+            x: 5, y: 0, width: 20, height: 10, rotation: 90, sideGrabbed: ResizeSide.Left);
+
+        // Two small ticks, same direction, each moving the cursor right by 3 (shrinking the object
+        // from the Left, well short of crossing the anchor at local X=25).
+        cursor.X = 110;
+        cursor.XChange = 3;
+        cursor.YChange = 0;
+        sut.HandleDrag();
+
+        cursor.X = 120;
+        cursor.XChange = 3;
+        cursor.YChange = 0;
+        sut.HandleDrag();
+
+        // Local (pre-rotation) X should move by the full 6px total (Left-origin, Left handle keeps
+        // the Right edge fixed) and Width should shrink by 6, matching one big 6px tick exactly -
+        // this must hold regardless of how the 6px was split across ticks.
+        var expectedRepositionLocal = new System.Numerics.Vector2(6, 0);
+        expectedRepositionLocal.Y *= -1;
+        MathFunctions.RotateVector(ref expectedRepositionLocal, MathHelper.ToRadians(90));
+        expectedRepositionLocal.Y *= -1;
+
+        representation.X.ShouldBe(5 + expectedRepositionLocal.X, tolerance: 0.01);
+        representation.Y.ShouldBe(0 + expectedRepositionLocal.Y, tolerance: 0.01);
+        representation.Width.ShouldBe(14, tolerance: 0.01); // 20 - 6
     }
 }

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
@@ -11,6 +11,11 @@ namespace Gum.Presentation.Tests;
 /// Math.Min/Max of those two edges - rather than assuming the dragged edge is always the min or
 /// always the max, as the pre-#4385 code did - makes crossing the anchor "just work": the
 /// previously-dragged edge becomes the new anchor-side edge with no special-cased branch.
+///
+/// Each call resolves ONE tick's delta from the accumulated true size offset immediately before
+/// and after that tick (not from a "live" position/size) - see ResolveResizeAxis's own doc comment
+/// for why the live representation can't be used as the "before" reference once rotation is
+/// involved (ResizeInputHandlerFlipRotationTests covers that composition end to end).
 /// </summary>
 public class ResizeInputHandlerFlipTests
 {
@@ -18,9 +23,9 @@ public class ResizeInputHandlerFlipTests
     public void ResolveResizeAxis_ShouldReturnZeroDeltas_WhenSizeMultiplierIsZero()
     {
         ResolveResizeAxis(
-            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -999,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25,
+            trueSizeOffsetBeforeAxis: -500, trueSizeOffsetAfterAxis: -999,
             sizeMultiplier: 0, originRatio: 0,
-            livePositionAxis: 5, liveSizeAxis: 25,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(0);
@@ -33,9 +38,9 @@ public class ResizeInputHandlerFlipTests
         // Left-origin box (originRatio 0), Right handle (sizeMultiplier > 0): Left is the anchor
         // and never moves. Shrinking by 10 (20 -> without crossing) should not touch position.
         ResolveResizeAxis(
-            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -10,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -10,
             sizeMultiplier: 1, originRatio: 0,
-            livePositionAxis: 5, liveSizeAxis: 25,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(0);
@@ -48,9 +53,9 @@ public class ResizeInputHandlerFlipTests
         // Shrinking exactly down to the anchor (Width -> 0) is a legitimate stopping point - e.g.
         // an animation that grows a Width from 0 - not something that should trigger a flip.
         ResolveResizeAxis(
-            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -25,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -25,
             sizeMultiplier: 1, originRatio: 0,
-            livePositionAxis: 5, liveSizeAxis: 25,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(0);
@@ -65,9 +70,9 @@ public class ResizeInputHandlerFlipTests
         // which is left of the anchor (5), so the box should flip: new Left=-5 (the overshot
         // dragged edge), new Right=5 (the old anchor), Width=10.
         ResolveResizeAxis(
-            grabStartPositionAxis: 5, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -30,
             sizeMultiplier: 1, originRatio: 0,
-            livePositionAxis: 5, liveSizeAxis: 20,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(-10); // X: 5 -> -5
@@ -82,9 +87,9 @@ public class ResizeInputHandlerFlipTests
         // (Left) edge's raw target is 5+30=35, right of the anchor (25), so the box flips: new
         // Left=25 (the old anchor), new Right=35 (the overshot dragged edge), Width=10.
         ResolveResizeAxis(
-            grabStartPositionAxis: 5, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -30,
             sizeMultiplier: -1, originRatio: 0,
-            livePositionAxis: 5, liveSizeAxis: 20,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(20); // X: 5 -> 25
@@ -99,9 +104,9 @@ public class ResizeInputHandlerFlipTests
         // the Left anchor (5) down to a raw target of 25-30=-5. Flips to Left=-5, Right=5,
         // Width=10, new Center=(−5+5)/2=0.
         ResolveResizeAxis(
-            grabStartPositionAxis: 15, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            grabStartPositionAxis: 15, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -30,
             sizeMultiplier: 1, originRatio: 0.5f,
-            livePositionAxis: 15, liveSizeAxis: 20,
             out float positionDelta, out float sizeDelta);
 
         positionDelta.ShouldBe(-15); // Center: 15 -> 0
@@ -109,34 +114,49 @@ public class ResizeInputHandlerFlipTests
     }
 
     [Fact]
-    public void ResolveResizeAxis_ShouldStayIdempotent_OnceFlippedAndStable_AcrossConsecutiveTicks()
+    public void ResolveResizeAxis_ShouldSumToSameResult_WhenSplitAcrossConsecutiveTicks()
     {
-        // Regression shape for the grid-snap "keep anchor stable across ticks" tests: once a flip
-        // has resolved, feeding the SAME grab-time values and the SAME accumulated true offset (no
-        // further cursor movement) back in as the next tick's live values must produce zero further
-        // delta - proving the flip doesn't jitter/re-trigger every frame.
-        const float grabStartX = 5;
-        const float grabStartWidth = 20;
-        const float trueSizeOffsetSinceGrab = -25; // crosses the anchor by 5
-
+        // The delta for tick N is resolved from grab-time state alone (before/after that tick's own
+        // accumulated offset) rather than by diffing against a live position/size. Two ticks that
+        // together cross the anchor (0 -> -15, then -15 -> -30) must sum to exactly the same
+        // position/size delta as a single tick covering the same total range (0 -> -30) - this is
+        // what keeps per-tick deltas correct once they get rotated and applied to a rotated object's
+        // X/Y (ResizeInputHandlerFlipRotationTests), where the live X/Y can no longer serve as that
+        // reference after the first tick.
         ResolveResizeAxis(
-            grabStartPositionAxis: grabStartX, grabStartSizeAxis: grabStartWidth,
-            trueSizeOffsetSinceGrabAxis: trueSizeOffsetSinceGrab,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -15,
             sizeMultiplier: 1, originRatio: 0,
-            livePositionAxis: grabStartX, liveSizeAxis: grabStartWidth,
             out float positionDelta1, out float sizeDelta1);
 
-        float liveX2 = grabStartX + positionDelta1;
-        float liveWidth2 = grabStartWidth + sizeDelta1;
-
         ResolveResizeAxis(
-            grabStartPositionAxis: grabStartX, grabStartSizeAxis: grabStartWidth,
-            trueSizeOffsetSinceGrabAxis: trueSizeOffsetSinceGrab, // no further cursor movement
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: -15, trueSizeOffsetAfterAxis: -30,
             sizeMultiplier: 1, originRatio: 0,
-            livePositionAxis: liveX2, liveSizeAxis: liveWidth2,
             out float positionDelta2, out float sizeDelta2);
 
-        positionDelta2.ShouldBe(0);
-        sizeDelta2.ShouldBe(0);
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -30,
+            sizeMultiplier: 1, originRatio: 0,
+            out float positionDeltaOneTick, out float sizeDeltaOneTick);
+
+        (positionDelta1 + positionDelta2).ShouldBe(positionDeltaOneTick);
+        (sizeDelta1 + sizeDelta2).ShouldBe(sizeDeltaOneTick);
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldReturnZeroDeltas_WhenOffsetUnchangedSinceLastTick()
+    {
+        // No further cursor movement this tick (before == after) must be a true no-op, even once
+        // already flipped past the anchor.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: -25, trueSizeOffsetAfterAxis: -25,
+            sizeMultiplier: 1, originRatio: 0,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0);
+        sizeDelta.ShouldBe(0);
     }
 }

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
@@ -1,0 +1,142 @@
+using Shouldly;
+using static Gum.Wireframe.Editors.Handlers.ResizeInputHandler;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins ResizeInputHandler.ResolveResizeAxis - the per-axis math backing the "no negative
+/// Width/Height, flip the anchor instead" decision on #4385. Width/Height are resolved from a
+/// grab-time ANCHOR edge (invariant for the whole gesture) and a DRAGGED edge whose raw, never-
+/// clamped position is anchor +/- the true (unclamped) size accumulated since grab. Taking
+/// Math.Min/Max of those two edges - rather than assuming the dragged edge is always the min or
+/// always the max, as the pre-#4385 code did - makes crossing the anchor "just work": the
+/// previously-dragged edge becomes the new anchor-side edge with no special-cased branch.
+/// </summary>
+public class ResizeInputHandlerFlipTests
+{
+    [Fact]
+    public void ResolveResizeAxis_ShouldReturnZeroDeltas_WhenSizeMultiplierIsZero()
+    {
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -999,
+            sizeMultiplier: 0, originRatio: 0,
+            livePositionAxis: 5, liveSizeAxis: 25,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0);
+        sizeDelta.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldShrinkNormally_WhenNotCrossingTheAnchor()
+    {
+        // Left-origin box (originRatio 0), Right handle (sizeMultiplier > 0): Left is the anchor
+        // and never moves. Shrinking by 10 (20 -> without crossing) should not touch position.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -10,
+            sizeMultiplier: 1, originRatio: 0,
+            livePositionAxis: 5, liveSizeAxis: 25,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0);
+        sizeDelta.ShouldBe(-10);
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldAllowExactlyZeroSize_WithoutFlipping()
+    {
+        // Shrinking exactly down to the anchor (Width -> 0) is a legitimate stopping point - e.g.
+        // an animation that grows a Width from 0 - not something that should trigger a flip.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 25, trueSizeOffsetSinceGrabAxis: -25,
+            sizeMultiplier: 1, originRatio: 0,
+            livePositionAxis: 5, liveSizeAxis: 25,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0);
+        sizeDelta.ShouldBe(-25); // new size is exactly 0
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldFlipAnchor_WhenRightHandleDraggedPastLeftOrigin()
+    {
+        // Left-origin box, Left=5, Width=20 (Right=25). Right handle dragged left by a total of 30
+        // - 10 further than the Left anchor. The dragged (Right) edge's raw target is 25-30=-5,
+        // which is left of the anchor (5), so the box should flip: new Left=-5 (the overshot
+        // dragged edge), new Right=5 (the old anchor), Width=10.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            sizeMultiplier: 1, originRatio: 0,
+            livePositionAxis: 5, liveSizeAxis: 20,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(-10); // X: 5 -> -5
+        sizeDelta.ShouldBe(-10); // Width: 20 -> 10
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldFlipAnchor_WhenLeftHandleDraggedPastRightAnchor()
+    {
+        // Mirror of the above: Left-origin box, Left(X)=5, Width=20 (Right anchor=25). Left handle
+        // (sizeMultiplier < 0) dragged right by a total of 30 - past the Right anchor. The dragged
+        // (Left) edge's raw target is 5+30=35, right of the anchor (25), so the box flips: new
+        // Left=25 (the old anchor), new Right=35 (the overshot dragged edge), Width=10.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            sizeMultiplier: -1, originRatio: 0,
+            livePositionAxis: 5, liveSizeAxis: 20,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(20); // X: 5 -> 25
+        sizeDelta.ShouldBe(-10); // Width: 20 -> 10
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldFlipAnchor_ForCenterOrigin()
+    {
+        // Center-origin box (originRatio .5): X tracks the center. Grabbed at Center(X)=15,
+        // Width=20 -> Left=5, Right=25. Right handle dragged left by a total of 30, overshooting
+        // the Left anchor (5) down to a raw target of 25-30=-5. Flips to Left=-5, Right=5,
+        // Width=10, new Center=(−5+5)/2=0.
+        ResolveResizeAxis(
+            grabStartPositionAxis: 15, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            sizeMultiplier: 1, originRatio: 0.5f,
+            livePositionAxis: 15, liveSizeAxis: 20,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(-15); // Center: 15 -> 0
+        sizeDelta.ShouldBe(-10); // Width: 20 -> 10
+    }
+
+    [Fact]
+    public void ResolveResizeAxis_ShouldStayIdempotent_OnceFlippedAndStable_AcrossConsecutiveTicks()
+    {
+        // Regression shape for the grid-snap "keep anchor stable across ticks" tests: once a flip
+        // has resolved, feeding the SAME grab-time values and the SAME accumulated true offset (no
+        // further cursor movement) back in as the next tick's live values must produce zero further
+        // delta - proving the flip doesn't jitter/re-trigger every frame.
+        const float grabStartX = 5;
+        const float grabStartWidth = 20;
+        const float trueSizeOffsetSinceGrab = -25; // crosses the anchor by 5
+
+        ResolveResizeAxis(
+            grabStartPositionAxis: grabStartX, grabStartSizeAxis: grabStartWidth,
+            trueSizeOffsetSinceGrabAxis: trueSizeOffsetSinceGrab,
+            sizeMultiplier: 1, originRatio: 0,
+            livePositionAxis: grabStartX, liveSizeAxis: grabStartWidth,
+            out float positionDelta1, out float sizeDelta1);
+
+        float liveX2 = grabStartX + positionDelta1;
+        float liveWidth2 = grabStartWidth + sizeDelta1;
+
+        ResolveResizeAxis(
+            grabStartPositionAxis: grabStartX, grabStartSizeAxis: grabStartWidth,
+            trueSizeOffsetSinceGrabAxis: trueSizeOffsetSinceGrab, // no further cursor movement
+            sizeMultiplier: 1, originRatio: 0,
+            livePositionAxis: liveX2, liveSizeAxis: liveWidth2,
+            out float positionDelta2, out float sizeDelta2);
+
+        positionDelta2.ShouldBe(0);
+        sizeDelta2.ShouldBe(0);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerGridSnapTests.cs
@@ -171,4 +171,23 @@ public class ResizeInputHandlerGridSnapTests
 
         diffPosition2.ShouldBe(0); // Still never moves
     }
+
+    [Fact]
+    public void GetDifferenceToGridForResizeAxis_ShouldFlipAnchor_WhenDraggedPastAnchor()
+    {
+        // Left-origin box, Left=5, Width=20 (Right=25). Right handle dragged left by a total of
+        // 30 - the dragged (Right) edge's raw target is 25-30=-5, past the Left anchor (5).
+        // Un-snapped this flips to Left=-5, Right=5, Width=10 (see the equivalent unsnapped case in
+        // ResizeInputHandlerFlipTests); snapping the dragged edge (-5) to the 16px grid rounds it to
+        // 0, giving Left=0, Right=5 (anchor), Width=5.
+        GetDifferenceToGridForResizeAxis(gridSize: 16,
+            grabStartPositionAxis: 5, grabStartSizeAxis: 20, trueSizeOffsetSinceGrabAxis: -30,
+            sizeMultiplier: 1, originRatio: 0,
+            positionIsPixelBased: true, sizeIsPixelBased: true,
+            liveAbsoluteMin: 5, livePositionAxis: 5, liveSizeAxis: 20,
+            out float differenceToGridPosition, out float differenceToGridSize);
+
+        differenceToGridPosition.ShouldBe(-5); // X: 5 -> 0
+        differenceToGridSize.ShouldBe(-15); // Width: 20 -> 5
+    }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -350,16 +350,29 @@ public class ResizeInputHandler : InputHandlerBase
     }
 
     /// <summary>
-    /// Resolves the raw (non-grid-snapped) per-axis position/size delta for a resize drag,
-    /// allowing the dragged edge to cross the anchor edge instead of clamping Width/Height at 0.
-    /// See <see cref="GetAnchorAndDraggedLocal"/> and <see cref="ResolveEdgesToPositionAndSize"/> -
+    /// Resolves the raw (non-grid-snapped) per-axis position/size delta for THIS tick of a resize
+    /// drag, allowing the dragged edge to cross the anchor edge instead of clamping Width/Height at
+    /// 0. See <see cref="GetAnchorAndDraggedLocal"/> and <see cref="ResolveEdgesToPositionAndSize"/> -
     /// this is the same anchor/dragged-edge resolution <see cref="GetDifferenceToGridForResizeAxis"/>
     /// uses, minus the grid-snap rounding step, so both paths flip identically (#4385).
+    ///
+    /// The delta is computed ENTIRELY from grab-time state (<paramref name="trueSizeOffsetBeforeAxis"/>
+    /// and <paramref name="trueSizeOffsetAfterAxis"/> - the accumulated true size offset immediately
+    /// before and after this tick) rather than by diffing against the live representation's current
+    /// X/Y. The live X/Y can't be used as the "before" reference for a rotated object: on a rotated
+    /// object the position delta this method returns gets rotated before being applied (see
+    /// ApplySizeChangeForInstance), so the STORED X/Y no longer represents the same local,
+    /// pre-rotation frame that grabStartPositionAxis (and this method's own math) is expressed in
+    /// once even one prior tick has written a rotated delta into it. Resolving "before" and "after"
+    /// from the same grab-time-relative accumulator and diffing those keeps every tick in the local
+    /// frame, so per-tick deltas sum to the same result as one big tick regardless of rotation
+    /// (confirmed by ResizeInputHandlerFlipRotationTests's multi-tick case, which drifted under the
+    /// live-X/Y-diffing approach this replaced).
     /// </summary>
     internal static void ResolveResizeAxis(
-        float grabStartPositionAxis, float grabStartSizeAxis, float trueSizeOffsetSinceGrabAxis,
+        float grabStartPositionAxis, float grabStartSizeAxis,
+        float trueSizeOffsetBeforeAxis, float trueSizeOffsetAfterAxis,
         float sizeMultiplier, float originRatio,
-        float livePositionAxis, float liveSizeAxis,
         out float positionDelta, out float sizeDelta)
     {
         positionDelta = 0;
@@ -370,14 +383,18 @@ public class ResizeInputHandler : InputHandlerBase
             return;
         }
 
-        GetAnchorAndDraggedLocal(grabStartPositionAxis, grabStartSizeAxis, trueSizeOffsetSinceGrabAxis,
-            sizeMultiplier, originRatio, out float anchorLocal, out float draggedLocal);
+        GetAnchorAndDraggedLocal(grabStartPositionAxis, grabStartSizeAxis, trueSizeOffsetBeforeAxis,
+            sizeMultiplier, originRatio, out float anchorLocal, out float oldDraggedLocal);
+        ResolveEdgesToPositionAndSize(anchorLocal, oldDraggedLocal, originRatio,
+            out float oldPositionLocal, out float oldSizeLocal);
 
-        ResolveEdgesToPositionAndSize(anchorLocal, draggedLocal, originRatio,
-            out float newPositionLocal, out float newSize);
+        GetAnchorAndDraggedLocal(grabStartPositionAxis, grabStartSizeAxis, trueSizeOffsetAfterAxis,
+            sizeMultiplier, originRatio, out anchorLocal, out float newDraggedLocal);
+        ResolveEdgesToPositionAndSize(anchorLocal, newDraggedLocal, originRatio,
+            out float newPositionLocal, out float newSizeLocal);
 
-        positionDelta = newPositionLocal - livePositionAxis;
-        sizeDelta = newSize - liveSizeAxis;
+        positionDelta = newPositionLocal - oldPositionLocal;
+        sizeDelta = newSizeLocal - oldSizeLocal;
     }
 
     /// <summary>
@@ -501,8 +518,13 @@ public class ResizeInputHandler : InputHandlerBase
         // Snap To Grid, and toggled unconditionally so no discontinuity appears if the user toggles
         // Snap To Grid mid-drag) - so a resize that overflows past zero can reflect the dragged edge
         // to the opposite side (see ResolveResizeAxis) instead of getting stuck at Width/Height == 0.
+        // Captured before AND after this tick's accumulation - ResolveResizeAxis diffs those two
+        // grab-time-relative snapshots rather than the live representation, since the live X/Y gets
+        // overwritten with a ROTATED delta each tick (see ResolveResizeAxis's own doc comment).
+        Vector2 trueSizeOffsetBefore = Context.GrabbedState.GetTrueSizeOffset(instanceSave);
         Context.GrabbedState.AccumulateTrueSizeOffset(instanceSave,
             cursorXChange * widthMultiplier, cursorYChange * heightMultiplier);
+        Vector2 trueSizeOffsetAfter = Context.GrabbedState.GetTrueSizeOffset(instanceSave);
 
         bool isResizeFromCenter = Context.HotkeyManager.IsPressedInControl(Context.HotkeyManager.ResizeFromCenter);
 
@@ -525,7 +547,7 @@ public class ResizeInputHandler : InputHandlerBase
         {
             // Resize-from-center grows/shrinks symmetrically around a fixed CENTER point rather
             // than a fixed edge, so the anchor-edge/dragged-edge flip above doesn't apply here.
-            // This combination doesn't yet support flip-at-zero (#4386 follow-up) - fall back to a
+            // This combination doesn't yet support flip-at-zero (#4390 follow-up) - fall back to a
             // simple floor clamp so Width can never go negative.
             positionDeltaX = cursorXChange * changeXMultiplier;
             sizeDeltaX = cursorXChange * widthMultiplier;
@@ -537,9 +559,9 @@ public class ResizeInputHandler : InputHandlerBase
         else
         {
             ResolveResizeAxis(
-                grabStartPosition.X, grabStartSize.X, Context.GrabbedState.GetTrueSizeOffset(instanceSave).X,
+                grabStartPosition.X, grabStartSize.X,
+                trueSizeOffsetBefore.X, trueSizeOffsetAfter.X,
                 widthMultiplier, xOriginRatio,
-                representation.X, representation.Width,
                 out positionDeltaX, out sizeDeltaX);
         }
 
@@ -556,9 +578,9 @@ public class ResizeInputHandler : InputHandlerBase
         else
         {
             ResolveResizeAxis(
-                grabStartPosition.Y, grabStartSize.Y, Context.GrabbedState.GetTrueSizeOffset(instanceSave).Y,
+                grabStartPosition.Y, grabStartSize.Y,
+                trueSizeOffsetBefore.Y, trueSizeOffsetAfter.Y,
                 heightMultiplier, yOriginRatio,
-                representation.Y, representation.Height,
                 out positionDeltaY, out sizeDeltaY);
         }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -336,24 +336,87 @@ public class ResizeInputHandler : InputHandlerBase
         // position/size) cancel out exactly, regardless of how they drifted.
         float parentOffset = liveAbsoluteMin - (livePositionAxis - originRatio * liveSizeAxis);
 
-        float grabStartMinLocal = grabStartPositionAxis - originRatio * grabStartSizeAxis;
-        float grabStartMaxLocal = grabStartMinLocal + grabStartSizeAxis;
-        float trueSize = grabStartSizeAxis + trueSizeOffsetSinceGrabAxis;
-
-        bool draggedIsMin = sizeMultiplier < 0;
-        float anchorLocal = draggedIsMin ? grabStartMaxLocal : grabStartMinLocal;
-        float trueDraggedLocal = draggedIsMin ? anchorLocal - trueSize : anchorLocal + trueSize;
+        GetAnchorAndDraggedLocal(grabStartPositionAxis, grabStartSizeAxis, trueSizeOffsetSinceGrabAxis,
+            sizeMultiplier, originRatio, out float anchorLocal, out float trueDraggedLocal);
 
         float snappedDraggedWorld = GridSnapper.SnapRound(parentOffset + trueDraggedLocal, gridSize);
         float snappedDraggedLocal = snappedDraggedWorld - parentOffset;
 
-        float newMinLocal = draggedIsMin ? snappedDraggedLocal : anchorLocal;
-        float newMaxLocal = draggedIsMin ? anchorLocal : snappedDraggedLocal;
-        float newSize = newMaxLocal - newMinLocal;
-        float newPositionLocal = newMinLocal + originRatio * newSize;
+        ResolveEdgesToPositionAndSize(anchorLocal, snappedDraggedLocal, originRatio,
+            out float newPositionLocal, out float newSize);
 
         differenceToGridPosition = newPositionLocal - livePositionAxis;
         differenceToGridSize = newSize - liveSizeAxis;
+    }
+
+    /// <summary>
+    /// Resolves the raw (non-grid-snapped) per-axis position/size delta for a resize drag,
+    /// allowing the dragged edge to cross the anchor edge instead of clamping Width/Height at 0.
+    /// See <see cref="GetAnchorAndDraggedLocal"/> and <see cref="ResolveEdgesToPositionAndSize"/> -
+    /// this is the same anchor/dragged-edge resolution <see cref="GetDifferenceToGridForResizeAxis"/>
+    /// uses, minus the grid-snap rounding step, so both paths flip identically (#4385).
+    /// </summary>
+    internal static void ResolveResizeAxis(
+        float grabStartPositionAxis, float grabStartSizeAxis, float trueSizeOffsetSinceGrabAxis,
+        float sizeMultiplier, float originRatio,
+        float livePositionAxis, float liveSizeAxis,
+        out float positionDelta, out float sizeDelta)
+    {
+        positionDelta = 0;
+        sizeDelta = 0;
+
+        if (sizeMultiplier == 0)
+        {
+            return;
+        }
+
+        GetAnchorAndDraggedLocal(grabStartPositionAxis, grabStartSizeAxis, trueSizeOffsetSinceGrabAxis,
+            sizeMultiplier, originRatio, out float anchorLocal, out float draggedLocal);
+
+        ResolveEdgesToPositionAndSize(anchorLocal, draggedLocal, originRatio,
+            out float newPositionLocal, out float newSize);
+
+        positionDelta = newPositionLocal - livePositionAxis;
+        sizeDelta = newSize - liveSizeAxis;
+    }
+
+    /// <summary>
+    /// Computes the grab-time ANCHOR edge (the edge opposite the one being dragged - invariant for
+    /// the whole gesture) and the DRAGGED edge's raw, never-clamped local position (anchor plus or
+    /// minus the true, unclamped size accumulated since grab). The dragged edge is free to cross
+    /// past the anchor; see <see cref="ResolveEdgesToPositionAndSize"/> for how that's turned into
+    /// a flip instead of a negative size.
+    /// </summary>
+    private static void GetAnchorAndDraggedLocal(
+        float grabStartPositionAxis, float grabStartSizeAxis, float trueSizeOffsetSinceGrabAxis,
+        float sizeMultiplier, float originRatio,
+        out float anchorLocal, out float draggedLocal)
+    {
+        float grabStartMinLocal = grabStartPositionAxis - originRatio * grabStartSizeAxis;
+        float grabStartMaxLocal = grabStartMinLocal + grabStartSizeAxis;
+
+        bool draggedIsMin = sizeMultiplier < 0;
+        anchorLocal = draggedIsMin ? grabStartMaxLocal : grabStartMinLocal;
+
+        float trueSize = grabStartSizeAxis + trueSizeOffsetSinceGrabAxis;
+        draggedLocal = draggedIsMin ? anchorLocal - trueSize : anchorLocal + trueSize;
+    }
+
+    /// <summary>
+    /// Resolves the final local position/size from an anchor edge and a dragged edge. Taking
+    /// Math.Min/Max of the two (rather than assuming the dragged edge is always the min or always
+    /// the max) is what makes crossing the anchor "just work" as a flip: once the dragged edge
+    /// passes the anchor, it naturally becomes the new min (or max) and the anchor becomes the
+    /// other - Width/Height (their difference) can never go negative.
+    /// </summary>
+    private static void ResolveEdgesToPositionAndSize(
+        float anchorLocal, float draggedLocal, float originRatio,
+        out float newPositionLocal, out float newSizeLocal)
+    {
+        float newMinLocal = Math.Min(anchorLocal, draggedLocal);
+        float newMaxLocal = Math.Max(anchorLocal, draggedLocal);
+        newSizeLocal = newMaxLocal - newMinLocal;
+        newPositionLocal = newMinLocal + originRatio * newSizeLocal;
     }
 
     public override void OnSelectionChanged()
@@ -418,13 +481,6 @@ public class ResizeInputHandler : InputHandlerBase
 
         bool hasChange = false;
 
-        // Apply position changes
-        Vector2 reposition = new Vector2(
-            cursorXChange * changeXMultiplier,
-            cursorYChange * changeYMultiplier);
-        // invert Y so up is positive
-        reposition.Y *= -1;
-
         GraphicalUiElement? representation = null;
 
         if (instanceSave != null)
@@ -436,7 +492,82 @@ public class ResizeInputHandler : InputHandlerBase
             representation = Context.WireframeObjectManager.GetRepresentation(elementStack.Last().Element);
         }
 
-        float rotation = MathHelper.ToRadians(representation?.GetAbsoluteRotation() ?? 0);
+        if (representation == null)
+        {
+            return false;
+        }
+
+        // Track the raw, never-clamped size change since grab - unconditionally (not just for
+        // Snap To Grid, and toggled unconditionally so no discontinuity appears if the user toggles
+        // Snap To Grid mid-drag) - so a resize that overflows past zero can reflect the dragged edge
+        // to the opposite side (see ResolveResizeAxis) instead of getting stuck at Width/Height == 0.
+        Context.GrabbedState.AccumulateTrueSizeOffset(instanceSave,
+            cursorXChange * widthMultiplier, cursorYChange * heightMultiplier);
+
+        bool isResizeFromCenter = Context.HotkeyManager.IsPressedInControl(Context.HotkeyManager.ResizeFromCenter);
+
+        float xOriginRatio = GetRatioXOverInSelection(representation, GetCurrentXOrigin(instanceSave));
+        float yOriginRatio = GetRatioYDownInSelection(representation, GetCurrentYOrigin(instanceSave));
+
+        Vector2 grabStartPosition = instanceSave == null
+            ? Context.GrabbedState.ComponentPosition
+            : Context.GrabbedState.InstancePositions.TryGetValue(instanceSave, out var grabbedPosition)
+                ? new Vector2(grabbedPosition.AbsoluteX, grabbedPosition.AbsoluteY)
+                : new Vector2(representation.X, representation.Y);
+        Vector2 grabStartSize = instanceSave == null
+            ? Context.GrabbedState.ComponentSize
+            : Context.GrabbedState.InstanceSizes.TryGetValue(instanceSave, out var grabbedSize)
+                ? grabbedSize
+                : new Vector2(representation.Width, representation.Height);
+
+        float positionDeltaX, sizeDeltaX;
+        if (isResizeFromCenter && widthMultiplier != 0)
+        {
+            // Resize-from-center grows/shrinks symmetrically around a fixed CENTER point rather
+            // than a fixed edge, so the anchor-edge/dragged-edge flip above doesn't apply here.
+            // This combination doesn't yet support flip-at-zero (#4386 follow-up) - fall back to a
+            // simple floor clamp so Width can never go negative.
+            positionDeltaX = cursorXChange * changeXMultiplier;
+            sizeDeltaX = cursorXChange * widthMultiplier;
+            if (representation.Width + sizeDeltaX < 0)
+            {
+                sizeDeltaX = -representation.Width;
+            }
+        }
+        else
+        {
+            ResolveResizeAxis(
+                grabStartPosition.X, grabStartSize.X, Context.GrabbedState.GetTrueSizeOffset(instanceSave).X,
+                widthMultiplier, xOriginRatio,
+                representation.X, representation.Width,
+                out positionDeltaX, out sizeDeltaX);
+        }
+
+        float positionDeltaY, sizeDeltaY;
+        if (isResizeFromCenter && heightMultiplier != 0)
+        {
+            positionDeltaY = cursorYChange * changeYMultiplier;
+            sizeDeltaY = cursorYChange * heightMultiplier;
+            if (representation.Height + sizeDeltaY < 0)
+            {
+                sizeDeltaY = -representation.Height;
+            }
+        }
+        else
+        {
+            ResolveResizeAxis(
+                grabStartPosition.Y, grabStartSize.Y, Context.GrabbedState.GetTrueSizeOffset(instanceSave).Y,
+                heightMultiplier, yOriginRatio,
+                representation.Y, representation.Height,
+                out positionDeltaY, out sizeDeltaY);
+        }
+
+        // Apply position changes
+        Vector2 reposition = new Vector2(positionDeltaX, positionDeltaY);
+        // invert Y so up is positive
+        reposition.Y *= -1;
+
+        float rotation = MathHelper.ToRadians(representation.GetAbsoluteRotation());
         MathFunctions.RotateVector(ref reposition, rotation);
         // flip Y back
         reposition.Y *= -1;
@@ -467,36 +598,34 @@ public class ResizeInputHandler : InputHandlerBase
         }
 
         // Apply size changes
-        if (heightMultiplier != 0 && cursorYChange != 0)
+        if (heightMultiplier != 0 && sizeDeltaY != 0)
         {
             hasChange = true;
             if (instanceSave != null)
             {
-                Context.ElementCommands.ModifyVariable("Height", cursorYChange * heightMultiplier, instanceSave);
+                Context.ElementCommands.ModifyVariable("Height", sizeDeltaY, instanceSave);
             }
             else
             {
-                Context.ElementCommands.ModifyVariable("Height", cursorYChange * heightMultiplier, elementStack.Last().Element);
+                Context.ElementCommands.ModifyVariable("Height", sizeDeltaY, elementStack.Last().Element);
             }
         }
-        if (widthMultiplier != 0 && cursorXChange != 0)
+        if (widthMultiplier != 0 && sizeDeltaX != 0)
         {
             hasChange = true;
             if (instanceSave != null)
             {
-                Context.ElementCommands.ModifyVariable("Width", cursorXChange * widthMultiplier, instanceSave);
+                Context.ElementCommands.ModifyVariable("Width", sizeDeltaX, instanceSave);
             }
             else
             {
-                Context.ElementCommands.ModifyVariable("Width", cursorXChange * widthMultiplier, elementStack.Last().Element);
+                Context.ElementCommands.ModifyVariable("Width", sizeDeltaX, elementStack.Last().Element);
             }
         }
 
         if (Context.SnapToGrid)
         {
             Context.GrabbedState.AccumulateTruePositionOffset(instanceSave, reposition.X, reposition.Y);
-            Context.GrabbedState.AccumulateTrueSizeOffset(instanceSave,
-                cursorXChange * widthMultiplier, cursorYChange * heightMultiplier);
         }
 
         return hasChange;


### PR DESCRIPTION
## Summary
- Dragging a resize handle past the opposite edge now flips which edge is anchored (continuous drag, like Figma/Photoshop) instead of letting Width/Height go negative. 0 remains a valid value.
- `GetDifferenceToGridForResizeAxis` (grid-snap) and the raw (non-snapped) resize path now share the same anchor/dragged-edge resolution (`Math.Min`/`Math.Max` of the two edges), so both flip identically.
- Resize From Center is out of scope here (falls back to a floor clamp, no flip) - tracked in #4390.
- Fixes stale `Tool/EditorTabPlugin_XNA` paths in the `gum-tool-selection` skill for files already relocated to `Tools/Gum.Presentation`.

Closes #4385

## Test plan
- [x] `ResolveResizeAxis` unit tests: normal shrink, exact-zero, flip for Left/Right handle and Center origin, idempotency across ticks
- [x] `GetDifferenceToGridForResizeAxis` flip test (grid-snap path)
- [x] End-to-end test on a rotated `GraphicalUiElement` proving Width flips correctly and the rotated position delta lands where expected
- [x] Full `Gum.Presentation.Tests` suite green (850/850)
- [x] `dotnet build GumFull.sln` clean

Manual test: needed - opening Visual Studio for the resize-handle behavior check.
FRB canary: not needed - `ResizeInputHandler.cs` isn't included via `GumCoreShared.projitems` or `FlatRedBall.Forms.Shared.projitems`.
