### PR TITLE
Flip Resize From Center at zero Width/Height instead of floor-clamping

### DIFF
--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerFlipTests.cs
@@ -160,3 +160,117 @@ public class ResizeInputHandlerFlipTests
         sizeDelta.ShouldBe(0);
     }
 }
+
+/// <summary>
+/// Pins ResizeInputHandler.ResolveResizeAxisFromCenter - the Resize From Center counterpart to
+/// <see cref="ResizeInputHandlerFlipTests"/> (#4390). Resize From Center grows/shrinks
+/// symmetrically around a fixed CENTER point rather than a fixed edge, so there is no "other" edge
+/// to flip against the way the plain edge-anchored resize does. Instead: Width/Height is always the
+/// absolute value of the true (signed, never-clamped) size accumulated since grab, and position is
+/// re-derived each tick from the grab-time center - which itself never moves - and the new size.
+/// </summary>
+public class ResizeInputHandlerFlipFromCenterTests
+{
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldGrowSymmetrically_WhenNotCrossingZero()
+    {
+        // Left-origin box (originRatio 0): Left(X)=10, Width=20 -> Center=20. A single tick that
+        // grows the true size offset by 10 (Width: 20 -> 30) should keep Center fixed at 20, moving
+        // Left from 10 to 5 (half the growth on each side).
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: 10,
+            originRatio: 0,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(-5); // X: 10 -> 5
+        sizeDelta.ShouldBe(10); // Width: 20 -> 30
+    }
+
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldAllowExactlyZeroSize_WithoutFlipping()
+    {
+        // Shrinking exactly down to the center (Width -> 0) is a legitimate stopping point, not a
+        // flip trigger.
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -20,
+            originRatio: 0,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(10); // X: 10 -> 20 (Center stays at 20, Width is 0)
+        sizeDelta.ShouldBe(-20); // Width: 20 -> 0
+    }
+
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldFlip_WhenShrinkingPastZero()
+    {
+        // Left-origin box: Left(X)=10, Width=20 -> Center=20. Shrinking the true size offset past
+        // -20 (the point Width hits 0) continues symmetric growth in the "flipped" sense - Width is
+        // the magnitude of the true (signed) size - while Center stays fixed at 20.
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -60,
+            originRatio: 0,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(-10); // X: 10 -> 0 (Left=0, Right=40, Center=20)
+        sizeDelta.ShouldBe(20); // Width: 20 -> 40
+    }
+
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldKeepCenterFixed_ForCenterOrigin()
+    {
+        // Center-origin box (originRatio .5): X already tracks the center directly, so it must
+        // never move regardless of how far the size offset crosses zero.
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 20, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -60,
+            originRatio: 0.5f,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0); // Center-origin X is already the center - stays at 20
+        sizeDelta.ShouldBe(20); // Width: 20 -> 40
+    }
+
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldSumToSameResult_WhenSplitAcrossConsecutiveTicks()
+    {
+        // Same per-tick-from-grab-state invariant as ResolveResizeAxis: two ticks that together
+        // cross zero (0 -> -30, then -30 -> -60) must sum to the same delta as one tick covering the
+        // same total range (0 -> -60).
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -30,
+            originRatio: 0,
+            out float positionDelta1, out float sizeDelta1);
+
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: -30, trueSizeOffsetAfterAxis: -60,
+            originRatio: 0,
+            out float positionDelta2, out float sizeDelta2);
+
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: 0, trueSizeOffsetAfterAxis: -60,
+            originRatio: 0,
+            out float positionDeltaOneTick, out float sizeDeltaOneTick);
+
+        (positionDelta1 + positionDelta2).ShouldBe(positionDeltaOneTick);
+        (sizeDelta1 + sizeDelta2).ShouldBe(sizeDeltaOneTick);
+    }
+
+    [Fact]
+    public void ResolveResizeAxisFromCenter_ShouldReturnZeroDeltas_WhenOffsetUnchangedSinceLastTick()
+    {
+        ResolveResizeAxisFromCenter(
+            grabStartPositionAxis: 10, grabStartSizeAxis: 20,
+            trueSizeOffsetBeforeAxis: -60, trueSizeOffsetAfterAxis: -60,
+            originRatio: 0,
+            out float positionDelta, out float sizeDelta);
+
+        positionDelta.ShouldBe(0);
+        sizeDelta.ShouldBe(0);
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -398,6 +398,33 @@ public class ResizeInputHandler : InputHandlerBase
     }
 
     /// <summary>
+    /// Center-anchored counterpart to <see cref="ResolveResizeAxis"/> (#4390). Resize From Center
+    /// grows/shrinks symmetrically around a fixed CENTER point rather than a fixed edge, so the
+    /// anchor-edge/dragged-edge Math.Min/Max approach doesn't apply - there is no "other" edge to
+    /// flip against. Flip here is simpler: Width/Height is the absolute value of the true (signed,
+    /// never-clamped) size accumulated since grab, and position is re-derived each tick from the
+    /// grab-time CENTER (itself invariant - it never moves) and the new size, so the center never
+    /// drifts even as the size crosses zero and grows again in the "flipped" direction.
+    /// </summary>
+    internal static void ResolveResizeAxisFromCenter(
+        float grabStartPositionAxis, float grabStartSizeAxis,
+        float trueSizeOffsetBeforeAxis, float trueSizeOffsetAfterAxis,
+        float originRatio,
+        out float positionDelta, out float sizeDelta)
+    {
+        float oldSizeLocal = Math.Abs(grabStartSizeAxis + trueSizeOffsetBeforeAxis);
+        float newSizeLocal = Math.Abs(grabStartSizeAxis + trueSizeOffsetAfterAxis);
+
+        float centerAxis = grabStartPositionAxis + (0.5f - originRatio) * grabStartSizeAxis;
+
+        float oldPositionLocal = centerAxis - (0.5f - originRatio) * oldSizeLocal;
+        float newPositionLocal = centerAxis - (0.5f - originRatio) * newSizeLocal;
+
+        positionDelta = newPositionLocal - oldPositionLocal;
+        sizeDelta = newSizeLocal - oldSizeLocal;
+    }
+
+    /// <summary>
     /// Computes the grab-time ANCHOR edge (the edge opposite the one being dragged - invariant for
     /// the whole gesture) and the DRAGGED edge's raw, never-clamped local position (anchor plus or
     /// minus the true, unclamped size accumulated since grab). The dragged edge is free to cross
@@ -545,16 +572,11 @@ public class ResizeInputHandler : InputHandlerBase
         float positionDeltaX, sizeDeltaX;
         if (isResizeFromCenter && widthMultiplier != 0)
         {
-            // Resize-from-center grows/shrinks symmetrically around a fixed CENTER point rather
-            // than a fixed edge, so the anchor-edge/dragged-edge flip above doesn't apply here.
-            // This combination doesn't yet support flip-at-zero (#4390 follow-up) - fall back to a
-            // simple floor clamp so Width can never go negative.
-            positionDeltaX = cursorXChange * changeXMultiplier;
-            sizeDeltaX = cursorXChange * widthMultiplier;
-            if (representation.Width + sizeDeltaX < 0)
-            {
-                sizeDeltaX = -representation.Width;
-            }
+            ResolveResizeAxisFromCenter(
+                grabStartPosition.X, grabStartSize.X,
+                trueSizeOffsetBefore.X, trueSizeOffsetAfter.X,
+                xOriginRatio,
+                out positionDeltaX, out sizeDeltaX);
         }
         else
         {
@@ -568,12 +590,11 @@ public class ResizeInputHandler : InputHandlerBase
         float positionDeltaY, sizeDeltaY;
         if (isResizeFromCenter && heightMultiplier != 0)
         {
-            positionDeltaY = cursorYChange * changeYMultiplier;
-            sizeDeltaY = cursorYChange * heightMultiplier;
-            if (representation.Height + sizeDeltaY < 0)
-            {
-                sizeDeltaY = -representation.Height;
-            }
+            ResolveResizeAxisFromCenter(
+                grabStartPosition.Y, grabStartSize.Y,
+                trueSizeOffsetBefore.Y, trueSizeOffsetAfter.Y,
+                yOriginRatio,
+                out positionDeltaY, out sizeDeltaY);
         }
         else
         {


### PR DESCRIPTION
## Summary
Resize From Center now flips at zero Width/Height instead of floor-clamping, matching the flip behavior #4385/#4391 already gave ordinary edge-anchored resizes.

Width/Height becomes `abs(signed size since grab)`; position is re-derived each tick from the grab-time center (invariant) and the new size, so the center never drifts even as size crosses zero.

## Test plan
- Added `ResizeInputHandlerFlipFromCenterTests` (6 cases: symmetric growth, exact-zero stop, flip past zero, center-origin invariance, multi-tick sum, no-op tick) pinning the new `ResolveResizeAxisFromCenter` math.
- `dotnet test Tests/Gum.Presentation.Tests` - 858/858 passed.

Closes #4390
