### PR TITLE
Fix NotImplementedException resizing objects with certain dimension units

### DIFF
--- a/GumDataTypes/UnitConverter.cs
+++ b/GumDataTypes/UnitConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Gum.DataTypes;
 using Gum.Managers;
 
@@ -258,8 +259,17 @@ namespace Gum.Converters
             }
             else if(generalX == GeneralUnitType.MaintainFileAspectRatio)
             {
-                // This requires possibly doing Y beforeX, so we'll just keep it for now:
-                relativeX = pixelXToConvert;
+                // pixelWidth = ownerHeightInPixels * (fileWidth/fileHeight) * (mWidth/100), so a raw
+                // 1:1 pixel delta is wrong - mWidth is a percentage of the aspect-ratio-correct size,
+                // not a pixel value (see GraphicalUiElement.UpdateDimensions's MaintainFileAspectRatio case).
+                if (fileWidth == 0 || fileHeight == 0 || ownerHeightInPixels == 0)
+                {
+                    relativeX = pixelXToConvert;
+                }
+                else
+                {
+                    relativeX = pixelXToConvert * 100f * fileHeight / (ownerHeightInPixels * fileWidth);
+                }
             }
             else if(generalX == GeneralUnitType.PercentageOfOtherDimension)
             {
@@ -292,8 +302,16 @@ namespace Gum.Converters
             }
             else if(generalY == GeneralUnitType.MaintainFileAspectRatio)
             {
-                // This won't convert properly - maybe eventually?
-                relativeY = pixelYToConvert;
+                // pixelHeight = ownerWidthInPixels * (fileHeight/fileWidth) * (mHeight/100) - see the
+                // generalX branch above for why a raw 1:1 pixel delta is wrong here too.
+                if (fileWidth == 0 || fileHeight == 0 || ownerWidthInPixels == 0)
+                {
+                    relativeY = pixelYToConvert;
+                }
+                else
+                {
+                    relativeY = pixelYToConvert * 100f * fileWidth / (ownerWidthInPixels * fileHeight);
+                }
             }
             else if (generalY == GeneralUnitType.PercentageOfFile)
             {
@@ -435,6 +453,75 @@ namespace Gum.Converters
                 case GeneralUnitType.PixelsFromSmall:
                 default:
                     return isXAxis ? PositionUnitType.PixelsFromLeft : PositionUnitType.PixelsFromTop;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Math for resizing a <see cref="DimensionUnitType.Ratio"/>-typed Width/Height by a pixel-space
+    /// amount. A Ratio value's rendered pixel size is <c>availableSpace * ratioValue / sumOfRatioSiblings</c>
+    /// (siblings meaning other same-axis, same-parent instances also using Ratio), so a raw 1:1
+    /// pixel-to-ratio-number change (as used for pixel-based unit types) is wrong: it doesn't account
+    /// for the siblings sharing that same pool of space.
+    /// </summary>
+    public static class RatioResizeCalculator
+    {
+        /// <summary>
+        /// The change to a Ratio value that reproduces <paramref name="pixelDelta"/> of rendered pixel
+        /// change, assuming the sum of all Ratio siblings' values (including this one) stays constant.
+        /// Rendered pixel size is linear in the ratio value under that assumption, so scaling the ratio
+        /// value by the same fraction as the desired pixel change reproduces that pixel change exactly.
+        /// </summary>
+        public static float GetRatioDeltaForPixelDelta(float currentRatioValue, float currentPixelSize, float pixelDelta)
+        {
+            if (currentPixelSize == 0)
+            {
+                return 0;
+            }
+
+            return pixelDelta / currentPixelSize * currentRatioValue;
+        }
+
+        /// <summary>
+        /// Computes new Ratio values for a dragged Ratio-typed instance and its Ratio-typed siblings
+        /// (same parent, same axis) after a pixel-space resize of the dragged instance. The dragged
+        /// instance's ratio changes by <see cref="GetRatioDeltaForPixelDelta"/>; the complementary
+        /// change is taken from the siblings in proportion to their current ratio values, which keeps
+        /// the sum of all ratio values constant (so the total pixel space they occupy together doesn't
+        /// change) and preserves the siblings' proportions relative to each other. With no siblings to
+        /// redistribute to, the dragged ratio is left unchanged - changing it wouldn't produce a visible
+        /// size change anyway, since a sole Ratio-typed child always fills all available space.
+        /// </summary>
+        public static void ApplyResize(
+            float draggedCurrentRatio, float draggedCurrentPixelSize, float pixelDelta,
+            IReadOnlyList<float> siblingRatios,
+            out float draggedNewRatio, out float[] siblingNewRatios)
+        {
+            siblingNewRatios = new float[siblingRatios.Count];
+
+            float siblingRatioSum = 0f;
+            for (int i = 0; i < siblingRatios.Count; i++)
+            {
+                siblingRatioSum += siblingRatios[i];
+            }
+
+            if (siblingRatioSum == 0)
+            {
+                draggedNewRatio = draggedCurrentRatio;
+                for (int i = 0; i < siblingRatios.Count; i++)
+                {
+                    siblingNewRatios[i] = siblingRatios[i];
+                }
+                return;
+            }
+
+            float ratioDelta = GetRatioDeltaForPixelDelta(draggedCurrentRatio, draggedCurrentPixelSize, pixelDelta);
+            draggedNewRatio = draggedCurrentRatio + ratioDelta;
+
+            for (int i = 0; i < siblingRatios.Count; i++)
+            {
+                float share = siblingRatios[i] / siblingRatioSum;
+                siblingNewRatios[i] = siblingRatios[i] - ratioDelta * share;
             }
         }
     }

--- a/GumDataTypes/UnitConverter.cs
+++ b/GumDataTypes/UnitConverter.cs
@@ -397,6 +397,11 @@ namespace Gum.Converters
                     return GeneralUnitType.PercentageOfOtherDimension;
                 case DimensionUnitType.MaintainFileAspectRatio:
                     return GeneralUnitType.MaintainFileAspectRatio;
+                case DimensionUnitType.Ratio:
+                case DimensionUnitType.ScreenPixel:
+                    return GeneralUnitType.PixelsFromSmall;
+                case DimensionUnitType.RelativeToMaxParentOrChildren:
+                    return GeneralUnitType.PixelsFromLarge;
                 default:
                     throw new NotImplementedException();
             }

--- a/MonoGameGum/Forms/Controls/Splitter.cs
+++ b/MonoGameGum/Forms/Controls/Splitter.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes;
+﻿using Gum.Converters;
+using Gum.DataTypes;
 using Gum.Wireframe;
 using System;
 using System.Collections.Generic;
@@ -263,17 +264,15 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
         {
             if (resizeBehavior == Controls.ResizeBehavior.Rows)
             {
-                var firstHeightInPixels = firstVisual.AbsoluteHeight;
-
-                var ratioToAdd = (changeInPixels / firstHeightInPixels) * firstVisual.Height;
+                var ratioToAdd = RatioResizeCalculator.GetRatioDeltaForPixelDelta(
+                    firstVisual.Height, firstVisual.AbsoluteHeight, changeInPixels);
                 firstVisual.Height += ratioToAdd;
                 secondVisual.Height -= ratioToAdd;
             }
             else
             {
-                var firstWidthInPixels = firstVisual.AbsoluteWidth;
-
-                var ratioToAdd = (changeInPixels / firstWidthInPixels) * firstVisual.Width;
+                var ratioToAdd = RatioResizeCalculator.GetRatioDeltaForPixelDelta(
+                    firstVisual.Width, firstVisual.AbsoluteWidth, changeInPixels);
                 firstVisual.Width += ratioToAdd;
                 secondVisual.Width -= ratioToAdd;
             }
@@ -315,9 +314,8 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else if(firstUnits == DimensionUnitType.Ratio)
             {
-                var firstHeightInPixels = firstVisual.AbsoluteHeight;
-
-                var ratioToAdd = (changeInPixels / firstHeightInPixels) * firstVisual.Height;
+                var ratioToAdd = RatioResizeCalculator.GetRatioDeltaForPixelDelta(
+                    firstVisual.Height, firstVisual.AbsoluteHeight, changeInPixels);
                 firstVisual.Height += ratioToAdd;
             }
 
@@ -354,9 +352,8 @@ public class Splitter : Gum.Forms.Controls.FrameworkElement
             }
             else if(secondUnits == DimensionUnitType.Ratio)
             {
-                var secondHeightInPixels = secondVisual.AbsoluteHeight;
-
-                var ratioToAdd = (changeInPixels / secondHeightInPixels) * secondVisual.Height;
+                var ratioToAdd = RatioResizeCalculator.GetRatioDeltaForPixelDelta(
+                    secondVisual.Height, secondVisual.AbsoluteHeight, changeInPixels);
                 secondVisual.Height -= ratioToAdd;
             }
         }

--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -205,6 +205,59 @@ public class ElementCommandsTests : BaseTestClass
     }
 
     [Fact]
+    public void ModifyVariable_WidthUnitsAbsoluteMultipliedByFontScale_ShouldDividePixelDeltaByGlobalFontScale()
+    {
+        // Rendered pixel width = raw Width * GlobalFontScale (GraphicalUiElement.UpdateDimensions's
+        // AbsoluteMultipliedByFontScale case), so a raw 1:1 pixel-delta-to-Width mapping (correct for
+        // plain Absolute) over-scales the drag by GlobalFontScale - reported as resize "multiplying
+        // the cursor movement" when Font Scale != 1.
+        float originalFontScale = GraphicalUiElement.GlobalFontScale;
+        try
+        {
+            GraphicalUiElement.GlobalFontScale = 4f;
+
+            ScreenSave screen = new ScreenSave { Name = "FontScaleScreen" };
+            StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+            screen.States.Add(defaultState);
+
+            InstanceSave instance = new InstanceSave { Name = "RectangleInstance", BaseType = "Container", ParentContainer = screen };
+            screen.Instances.Add(instance);
+
+            StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+            containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+            GumProjectSave project = new GumProjectSave();
+            project.StandardElements.Add(containerStandard);
+            project.Screens.Add(screen);
+            ObjectFinder.GumProjectSave = project;
+
+            defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Value = 50f, Type = "float", SetsValue = true });
+            defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.WidthUnits", Value = DimensionUnitType.AbsoluteMultipliedByFontScale, Type = "DimensionUnitType", SetsValue = true });
+
+            GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+            GraphicalUiElement gue = new GraphicalUiElement(new InvisibleRenderable())
+                { Name = "RectangleInstance", Width = 50f, WidthUnits = DimensionUnitType.AbsoluteMultipliedByFontScale, Tag = instance };
+            gue.Parent = rootGue;
+
+            _selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+            _selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+            _selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+
+            _wireframeObjectManager.Setup(x => x.GetRepresentation(instance, null)).Returns(gue);
+            _wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+            // Dragging by 20 real pixels should change the raw stored Width by 20/4=5 (not 20).
+            float result = _sut.ModifyVariable("Width", 20f, instance);
+
+            result.ShouldBe(55f, tolerance: 0.0001f);
+        }
+        finally
+        {
+            GraphicalUiElement.GlobalFontScale = originalFontScale;
+        }
+    }
+
+    [Fact]
     public void ModifyVariable_DragThenReleaseOnRectScreenScenario_TracksCorrectlyThroughoutWithNoReversion()
     {
         // Reproduces the real RectScreen.gusx repro reported by the user: RectangleInstance1 has

--- a/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementCommandsTests.cs
@@ -14,6 +14,7 @@ using Gum.ToolCommands;
 using Gum.ToolStates;
 using Gum.Wireframe;
 using Moq;
+using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
 
@@ -311,6 +312,108 @@ public class ElementCommandsTests : BaseTestClass
             // Release must never revert the drag's resolved value.
             defaultState.GetValue("RectangleInstance1.X").ShouldBe(649f, $"after release commit of {possiblyChangedVariable.Name}");
         }
+    }
+
+    [Fact]
+    public void ModifyVariable_WidthUnitsRatio_ShouldRedistributeComplementaryChangeToRatioSibling()
+    {
+        // #4395 follow-up: dragging a Ratio-typed Width/Height handle used to apply the raw pixel
+        // delta 1:1 to the Ratio number, which (since a Ratio value's rendered pixel size depends on
+        // every Ratio sibling's value, not just its own) made the drag snap to extreme sizes instead
+        // of tracking the cursor. 100px-wide container, two Ratio=1 children (50px each) - shrinking
+        // FirstItem by 1px should grow SecondItem by 1px in response.
+        ScreenSave screen = new ScreenSave { Name = "RatioScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave firstInstance = new InstanceSave { Name = "FirstItem", BaseType = "Container", ParentContainer = screen };
+        InstanceSave secondInstance = new InstanceSave { Name = "SecondItem", BaseType = "Container", ParentContainer = screen };
+        screen.Instances.Add(firstInstance);
+        screen.Instances.Add(secondInstance);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Screens.Add(screen);
+        ObjectFinder.GumProjectSave = project;
+
+        defaultState.Variables.Add(new VariableSave { Name = "FirstItem.Width", Value = 1f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "FirstItem.WidthUnits", Value = DimensionUnitType.Ratio, Type = "DimensionUnitType", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "SecondItem.Width", Value = 1f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "SecondItem.WidthUnits", Value = DimensionUnitType.Ratio, Type = "DimensionUnitType", SetsValue = true });
+
+        GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+        GraphicalUiElement firstGue = new GraphicalUiElement(new InvisibleRenderable())
+            { Name = "FirstItem", Width = 1f, WidthUnits = DimensionUnitType.Ratio, Tag = firstInstance };
+        GraphicalUiElement secondGue = new GraphicalUiElement(new InvisibleRenderable())
+            { Name = "SecondItem", Width = 1f, WidthUnits = DimensionUnitType.Ratio, Tag = secondInstance };
+        firstGue.Parent = rootGue;
+        secondGue.Parent = rootGue;
+        // Sets the rendered pixel size directly, bypassing the real Ratio layout pass (which would
+        // need a full parent-driven children-layout run) - both start at 50px in a 100px container.
+        ((IPositionedSizedObject)firstGue).Width = 50f;
+        ((IPositionedSizedObject)secondGue).Width = 50f;
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+        _selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+
+        _wireframeObjectManager.Setup(x => x.GetRepresentation(firstInstance, null)).Returns(firstGue);
+        _wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+        float result = _sut.ModifyVariable("Width", -1f, firstInstance);
+
+        result.ShouldBe(0.98f, tolerance: 0.0001f);
+        ((float)defaultState.GetValue("FirstItem.Width")).ShouldBe(0.98f, tolerance: 0.0001f);
+        ((float)defaultState.GetValue("SecondItem.Width")).ShouldBe(1.02f, tolerance: 0.0001f);
+        firstGue.Width.ShouldBe(0.98f, tolerance: 0.0001f);
+        secondGue.Width.ShouldBe(1.02f, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ModifyVariable_WidthUnitsRatio_WithNoRatioSiblings_ShouldLeaveRatioValueUnchanged()
+    {
+        // A sole Ratio-typed child always fills all available space regardless of its Ratio value,
+        // so there's nothing to redistribute to - the drag can't produce a visible size change, and
+        // the stored Ratio value is left as-is rather than growing unboundedly with every drag tick.
+        ScreenSave screen = new ScreenSave { Name = "RatioScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave firstInstance = new InstanceSave { Name = "FirstItem", BaseType = "Container", ParentContainer = screen };
+        screen.Instances.Add(firstInstance);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Screens.Add(screen);
+        ObjectFinder.GumProjectSave = project;
+
+        defaultState.Variables.Add(new VariableSave { Name = "FirstItem.Width", Value = 1f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "FirstItem.WidthUnits", Value = DimensionUnitType.Ratio, Type = "DimensionUnitType", SetsValue = true });
+
+        GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+        GraphicalUiElement firstGue = new GraphicalUiElement(new InvisibleRenderable())
+            { Name = "FirstItem", Width = 1f, WidthUnits = DimensionUnitType.Ratio, Tag = firstInstance };
+        firstGue.Parent = rootGue;
+        ((IPositionedSizedObject)firstGue).Width = 100f;
+
+        _selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+        _selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+        _selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+
+        _wireframeObjectManager.Setup(x => x.GetRepresentation(firstInstance, null)).Returns(firstGue);
+        _wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+        float result = _sut.ModifyVariable("Width", -1f, firstInstance);
+
+        result.ShouldBe(1f);
+        ((float)defaultState.GetValue("FirstItem.Width")).ShouldBe(1f);
+        firstGue.Width.ShouldBe(1f);
     }
 
     #endregion

--- a/Tests/Gum.Presentation.Tests/ResizeInputHandlerNonPixelUnitTests.cs
+++ b/Tests/Gum.Presentation.Tests/ResizeInputHandlerNonPixelUnitTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Input;
+using Gum.Managers;
+using Gum.Plugins;
+using Gum.PropertyGridHelpers;
+using Gum.ToolCommands;
+using Gum.ToolStates;
+using Gum.Wireframe;
+using Gum.Wireframe.Editors;
+using Gum.Wireframe.Editors.Handlers;
+using Gum.Wireframe.Editors.Visuals;
+using Moq;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// End-to-end regression for #4395's follow-up: GrabbedState used to capture an instance's grab-time
+/// size from GraphicalUiElement.Width/Height, which is the RAW unit-specific stored value (e.g. a
+/// Ratio weight like 1), not its rendered pixel size. ResizeInputHandler.ResolveResizeAxis mixes that
+/// grab-time size directly against real cursor pixel deltas to decide when the dragged edge crosses
+/// the anchor and should flip (see ResizeInputHandlerFlipTests) - so once the raw stored number was
+/// smaller than the pixel distance dragged, it flipped immediately, even though the object's actual
+/// rendered size was nowhere near zero. Reported as: shrinking a Ratio-Width rectangle below a raw
+/// Width of ~1 made it "increase" and the object jump left, out of its container.
+/// </summary>
+public class ResizeInputHandlerNonPixelUnitTests
+{
+    private class FakeCursorState : IGumCursorState
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float XChange { get; set; }
+        public float YChange { get; set; }
+        public bool PrimaryDown { get; set; }
+        public bool PrimaryPush { get; set; }
+        public bool PrimaryClick { get; set; }
+        public bool IsInWindow { get; set; } = true;
+        public bool PrimaryDoubleClick { get; set; }
+        public bool SecondaryPush { get; set; }
+        public bool PrimaryDownIgnoringIsInWindow { get; set; }
+        public void SetCursor(GumCursorKind kind) { }
+    }
+
+    [Fact]
+    public void OnDrag_ShrinkingRatioWidthRectangleFarBelowItsRawRatioValue_ShouldNotFlip()
+    {
+        // Container 400px wide, two Ratio=1 children (200px each) - matches the RectScreen-style
+        // repro. RectangleInstance's raw Width (1) is far smaller than the real cursor distance
+        // being dragged (190px), which is exactly the scenario that used to falsely trigger a flip.
+        ScreenSave screen = new ScreenSave { Name = "RatioScreen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave firstInstance = new InstanceSave { Name = "RectangleInstance", BaseType = "Container", ParentContainer = screen };
+        InstanceSave secondInstance = new InstanceSave { Name = "RectangleInstance1", BaseType = "Container", ParentContainer = screen };
+        screen.Instances.Add(firstInstance);
+        screen.Instances.Add(secondInstance);
+
+        StandardElementSave containerStandard = new StandardElementSave { Name = "Container" };
+        containerStandard.States.Add(new StateSave { Name = "Default", ParentContainer = containerStandard });
+
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(containerStandard);
+        project.Screens.Add(screen);
+        ObjectFinder.Self.GumProjectSave = project;
+
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Value = 1f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.WidthUnits", Value = DimensionUnitType.Ratio, Type = "DimensionUnitType", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.Width", Value = 1f, Type = "float", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance1.WidthUnits", Value = DimensionUnitType.Ratio, Type = "DimensionUnitType", SetsValue = true });
+
+        GraphicalUiElement rootGue = new GraphicalUiElement(new InvisibleRenderable());
+        GraphicalUiElement firstGue = new GraphicalUiElement(new InvisibleRenderable())
+            { Name = "RectangleInstance", Width = 1f, WidthUnits = DimensionUnitType.Ratio, Tag = firstInstance };
+        GraphicalUiElement secondGue = new GraphicalUiElement(new InvisibleRenderable())
+            { Name = "RectangleInstance1", Width = 1f, WidthUnits = DimensionUnitType.Ratio, Tag = secondInstance };
+        firstGue.Parent = rootGue;
+        secondGue.Parent = rootGue;
+        // Sets the rendered pixel size directly, bypassing the real Ratio layout pass - the same
+        // controlled setup ElementCommandsTests uses for its Ratio-resize tests.
+        ((IPositionedSizedObject)firstGue).Width = 200f;
+        ((IPositionedSizedObject)secondGue).Width = 200f;
+
+        Mock<ISelectedState> selectedState = new();
+        selectedState.SetupGet(x => x.SelectedElement).Returns(screen);
+        selectedState.SetupGet(x => x.SelectedStateSave).Returns(defaultState);
+        selectedState.SetupGet(x => x.CustomCurrentStateSave).Returns((StateSave)null);
+        selectedState.SetupGet(x => x.SelectedInstances).Returns(new[] { firstInstance });
+        selectedState.SetupGet(x => x.SelectedInstance).Returns(firstInstance);
+        selectedState.Setup(x => x.GetTopLevelElementStack())
+            .Returns(new List<ElementWithState> { new ElementWithState(screen) });
+
+        Mock<IWireframeObjectManager> wireframeObjectManager = new();
+        wireframeObjectManager.Setup(x => x.GetRepresentation(firstInstance, It.IsAny<List<ElementWithState>>())).Returns(firstGue);
+        wireframeObjectManager.SetupGet(x => x.RootGue).Returns(rootGue);
+
+        ElementCommands elementCommands = new ElementCommands(
+            selectedState.Object,
+            Mock.Of<IGuiCommands>(),
+            Mock.Of<IFileCommands>(),
+            Mock.Of<IVariableInCategoryPropagationLogic>(),
+            wireframeObjectManager.Object,
+            Mock.Of<IPluginManager>(),
+            Mock.Of<IProjectManager>(),
+            Mock.Of<IProjectState>());
+
+        Mock<IResizeHandlesVisual> handlesVisual = new();
+        handlesVisual.SetupGet(x => x.Visible).Returns(true);
+        handlesVisual.Setup(x => x.GetSideOver(It.IsAny<float>(), It.IsAny<float>())).Returns(ResizeSide.Right);
+
+        Mock<ISelectionManager> selectionManager = new();
+        selectionManager.SetupGet(x => x.HasSelection).Returns(true);
+        selectionManager.SetupGet(x => x.SelectedGues).Returns(new List<GraphicalUiElement>());
+
+        FakeCursorState cursor = new() { X = 100, Y = 100, PrimaryPush = true };
+
+        EditorContext context = EditorContextTestHelper.Create(
+            selectedState: selectedState.Object,
+            selectionManager: selectionManager.Object,
+            wireframeObjectManager: wireframeObjectManager.Object,
+            cursor: cursor,
+            elementCommands: elementCommands);
+
+        ResizeInputHandler sut = new ResizeInputHandler(context, handlesVisual.Object);
+
+        sut.UpdateHover(0f, 0f);
+        context.GrabbedState.HandlePush(); // captures grab-time InstanceSizes - must use AbsoluteWidth
+        sut.HandlePush(0f, 0f);
+
+        cursor.PrimaryDown = true;
+        cursor.PrimaryPush = false;
+
+        // Drag the Right handle left by 190px in one tick - far more than the raw Ratio value (1),
+        // but well short of the real 200px pixel width reaching zero.
+        cursor.X = 70;
+        cursor.XChange = -190;
+        cursor.YChange = 0;
+        sut.HandleDrag();
+
+        // No flip: a Right-handle drag on a Left-origin object never moves X. Under the bug, the
+        // confused grab-time size (1, the raw ratio) was exceeded almost immediately by the real
+        // pixel drag distance, triggering a flip that shifted X left even though X should be static
+        // for a Right-handle drag - exactly the reported "object moves left, out of its container."
+        firstGue.X.ShouldBe(0f, tolerance: 0.01f);
+
+        // The raw Ratio value shrank towards (200px - 190px = 10px of) the original 200px, i.e. it
+        // decreased proportionally - not increased, which was the other half of the reported symptom
+        // ("instead of the ratio continuing to go down... it seems to increase").
+        float newRatioValue = (float)defaultState.GetValue("RectangleInstance.Width");
+        newRatioValue.ShouldBeLessThan(1f);
+        newRatioValue.ShouldBeGreaterThan(0f);
+        newRatioValue.ShouldBe(1f * (10f / 200f), tolerance: 0.01f);
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/Editors/Visuals/DimensionDisplayVisual.cs
+++ b/Tool/EditorTabPlugin_XNA/Editors/Visuals/DimensionDisplayVisual.cs
@@ -280,7 +280,7 @@ public class DimensionDisplayVisual : EditorVisualBase
         _endCap2.RelativePoint = rotatedRightDirection * endCapLength;
     }
 
-    private string GetDimensionSuffix(DimensionUnitType unitType, bool isWidth)
+    internal static string GetDimensionSuffix(DimensionUnitType unitType, bool isWidth)
     {
         return unitType switch
         {
@@ -291,6 +291,8 @@ public class DimensionDisplayVisual : EditorVisualBase
             DimensionUnitType.Ratio => " Ratio of Parent",
             DimensionUnitType.RelativeToChildren => " Relative to Children",
             DimensionUnitType.RelativeToParent => " Relative to Parent",
+            DimensionUnitType.AbsoluteMultipliedByFontScale => " x Font Scale",
+            DimensionUnitType.RelativeToMaxParentOrChildren => " Relative to Max of Parent or Children",
             _ => null
         };
     }

--- a/Tool/Tests/GumToolUnitTests/Converters/RatioResizeCalculatorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Converters/RatioResizeCalculatorTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Gum.Converters;
+using Shouldly;
+
+namespace GumToolUnitTests.Converters;
+
+/// <summary>
+/// Pins <see cref="RatioResizeCalculator.ApplyResize"/>, the math for dragging a
+/// <c>DimensionUnitType.Ratio</c>-typed Width/Height (#4395).
+/// </summary>
+public class RatioResizeCalculatorTests
+{
+    [Fact]
+    public void ApplyResize_WithOneSibling_ShouldRedistributeComplementaryChangeToSibling()
+    {
+        // 100px-wide container, two Ratio=1 children -> 50px each. Shrink the dragged one by 1px.
+        float draggedCurrentRatio = 1f;
+        float draggedCurrentPixelSize = 50f;
+        float pixelDelta = -1f;
+        List<float> siblingRatios = new() { 1f };
+
+        RatioResizeCalculator.ApplyResize(draggedCurrentRatio, draggedCurrentPixelSize, pixelDelta, siblingRatios,
+            out float draggedNewRatio, out float[] siblingNewRatios);
+
+        draggedNewRatio.ShouldBe(0.98f, tolerance: 0.0001f);
+        siblingNewRatios.ShouldBe(new[] { 1.02f }, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ApplyResize_WithNoSiblings_ShouldLeaveDraggedRatioUnchanged()
+    {
+        float draggedCurrentRatio = 1f;
+        float draggedCurrentPixelSize = 100f;
+        float pixelDelta = -1f;
+        List<float> siblingRatios = new();
+
+        RatioResizeCalculator.ApplyResize(draggedCurrentRatio, draggedCurrentPixelSize, pixelDelta, siblingRatios,
+            out float draggedNewRatio, out float[] siblingNewRatios);
+
+        draggedNewRatio.ShouldBe(1f);
+        siblingNewRatios.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ApplyResize_WithMultipleSiblings_ShouldRedistributeProportionally()
+    {
+        // 120px-wide container, ratios 2/1/3 (sum 6) -> pixel sizes 40/20/60. Grow the dragged one by 12px.
+        float draggedCurrentRatio = 2f;
+        float draggedCurrentPixelSize = 40f;
+        float pixelDelta = 12f;
+        List<float> siblingRatios = new() { 1f, 3f };
+
+        RatioResizeCalculator.ApplyResize(draggedCurrentRatio, draggedCurrentPixelSize, pixelDelta, siblingRatios,
+            out float draggedNewRatio, out float[] siblingNewRatios);
+
+        draggedNewRatio.ShouldBe(2.6f, tolerance: 0.0001f);
+        siblingNewRatios.ShouldBe(new[] { 0.85f, 2.55f }, tolerance: 0.0001f);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Converters/UnitConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Converters/UnitConverterTests.cs
@@ -1,0 +1,24 @@
+using Gum.Converters;
+using Gum.DataTypes;
+using Shouldly;
+
+namespace GumToolUnitTests.Converters;
+
+/// <summary>
+/// Pins <see cref="UnitConverter.ConvertToGeneralUnit(DimensionUnitType)"/> against every
+/// <see cref="DimensionUnitType"/> value, including ones added after the switch was last updated
+/// (#4395 - resizing an object using one of these threw NotImplementedException).
+/// </summary>
+public class UnitConverterTests
+{
+    [Theory]
+    [InlineData(DimensionUnitType.Ratio, GeneralUnitType.PixelsFromSmall)]
+    [InlineData(DimensionUnitType.ScreenPixel, GeneralUnitType.PixelsFromSmall)]
+    [InlineData(DimensionUnitType.RelativeToMaxParentOrChildren, GeneralUnitType.PixelsFromLarge)]
+    public void ConvertToGeneralUnit_ShouldMapEveryDimensionUnitTypeWithoutThrowing(DimensionUnitType unitType, GeneralUnitType expected)
+    {
+        GeneralUnitType result = UnitConverter.ConvertToGeneralUnit(unitType);
+
+        result.ShouldBe(expected);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Converters/UnitConverterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Converters/UnitConverterTests.cs
@@ -11,14 +11,117 @@ namespace GumToolUnitTests.Converters;
 /// </summary>
 public class UnitConverterTests
 {
+    // Covers every DimensionUnitType selectable as a Width/Height unit in the tool (see
+    // WidthUnitsControl/HeightUnitsControl's option lists) - PixelsFromSmall/PixelsFromLarge both
+    // mean "resize 1:1 with the cursor" (ElementCommands.ConvertAmountToPixelAccordingToUnitType
+    // returns the raw pixel delta unchanged for both buckets).
     [Theory]
+    [InlineData(DimensionUnitType.Absolute, GeneralUnitType.PixelsFromSmall)]
+    [InlineData(DimensionUnitType.RelativeToParent, GeneralUnitType.PixelsFromLarge)]
+    [InlineData(DimensionUnitType.PercentageOfParent, GeneralUnitType.Percentage)]
     [InlineData(DimensionUnitType.Ratio, GeneralUnitType.PixelsFromSmall)]
-    [InlineData(DimensionUnitType.ScreenPixel, GeneralUnitType.PixelsFromSmall)]
+    [InlineData(DimensionUnitType.RelativeToChildren, GeneralUnitType.PixelsFromSmall)]
+    [InlineData(DimensionUnitType.PercentageOfOtherDimension, GeneralUnitType.PercentageOfOtherDimension)]
+    [InlineData(DimensionUnitType.PercentageOfSourceFile, GeneralUnitType.PercentageOfFile)]
+    [InlineData(DimensionUnitType.MaintainFileAspectRatio, GeneralUnitType.MaintainFileAspectRatio)]
+    [InlineData(DimensionUnitType.AbsoluteMultipliedByFontScale, GeneralUnitType.PixelsFromSmall)]
     [InlineData(DimensionUnitType.RelativeToMaxParentOrChildren, GeneralUnitType.PixelsFromLarge)]
+    [InlineData(DimensionUnitType.ScreenPixel, GeneralUnitType.PixelsFromSmall)]
     public void ConvertToGeneralUnit_ShouldMapEveryDimensionUnitTypeWithoutThrowing(DimensionUnitType unitType, GeneralUnitType expected)
     {
         GeneralUnitType result = UnitConverter.ConvertToGeneralUnit(unitType);
 
         result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ConvertToUnitTypeCoordinates_WithPercentageOfParentX_ShouldScaleByParentWidth()
+    {
+        float parentWidth = 200f;
+        float pixelDeltaX = 10f;
+
+        UnitConverter.Self.ConvertToUnitTypeCoordinates(pixelDeltaX, 0f,
+            GeneralUnitType.Percentage, GeneralUnitType.Percentage,
+            ownerWidthInPixels: 0f, ownerHeightInPixels: 0f,
+            parentWidth: parentWidth, parentHeight: 0f,
+            fileWidth: 0f, fileHeight: 0f,
+            out float relativeX, out float relativeY);
+
+        relativeX.ShouldBe(5f, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ConvertToUnitTypeCoordinates_WithPercentageOfSourceFileX_ShouldScaleByFileWidth()
+    {
+        // Covers the EntireTexture case only; ElementCommands.ConvertAmountToPixelAccordingToUnitType
+        // applies an additional texture-visible-ratio adjustment for non-EntireTexture sprites.
+        float fileWidth = 300f;
+        float pixelDeltaX = 10f;
+
+        UnitConverter.Self.ConvertToUnitTypeCoordinates(pixelDeltaX, 0f,
+            GeneralUnitType.PercentageOfFile, GeneralUnitType.PercentageOfFile,
+            ownerWidthInPixels: 0f, ownerHeightInPixels: 0f,
+            parentWidth: 0f, parentHeight: 0f,
+            fileWidth: fileWidth, fileHeight: 0f,
+            out float relativeX, out float relativeY);
+
+        relativeX.ShouldBe(10f / 3f, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ConvertToUnitTypeCoordinates_WithPercentageOfOtherDimensionX_ShouldScaleByOwnerHeight()
+    {
+        float ownerHeightInPixels = 40f;
+        float pixelDeltaX = 10f;
+
+        UnitConverter.Self.ConvertToUnitTypeCoordinates(pixelDeltaX, 0f,
+            GeneralUnitType.PercentageOfOtherDimension, GeneralUnitType.PercentageOfOtherDimension,
+            ownerWidthInPixels: 0f, ownerHeightInPixels: ownerHeightInPixels,
+            parentWidth: 0f, parentHeight: 0f,
+            fileWidth: 0f, fileHeight: 0f,
+            out float relativeX, out float relativeY);
+
+        relativeX.ShouldBe(25f, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ConvertToUnitTypeCoordinates_WithMaintainFileAspectRatioX_ShouldScaleByFileAndOwnerSize()
+    {
+        // Sprite where pixelWidth = ownerHeightInPixels * (fileWidth/fileHeight) * (mWidth/100):
+        // 40 * (300/100) * (100/100) = 120. Growing by 12px should scale mWidth by 10 (not 12) -
+        // #4395 follow-up: this branch was a stub that returned the raw pixel delta unchanged.
+        float ownerHeightInPixels = 40f;
+        float fileWidth = 300f;
+        float fileHeight = 100f;
+        float pixelDeltaX = 12f;
+
+        UnitConverter.Self.ConvertToUnitTypeCoordinates(pixelDeltaX, 0f,
+            GeneralUnitType.MaintainFileAspectRatio, GeneralUnitType.MaintainFileAspectRatio,
+            ownerWidthInPixels: 0f, ownerHeightInPixels: ownerHeightInPixels,
+            parentWidth: 0f, parentHeight: 0f,
+            fileWidth: fileWidth, fileHeight: fileHeight,
+            out float relativeX, out float relativeY);
+
+        relativeX.ShouldBe(10f, tolerance: 0.0001f);
+    }
+
+    [Fact]
+    public void ConvertToUnitTypeCoordinates_WithMaintainFileAspectRatioY_ShouldScaleByFileAndOwnerSize()
+    {
+        // pixelHeight = ownerWidthInPixels * (fileHeight/fileWidth) * (mHeight/100):
+        // 40 * (100/300) * (100/100) = 13.333. Growing by 4px should scale mHeight by 30 (not 4).
+        float ownerWidthInPixels = 40f;
+        float fileWidth = 300f;
+        float fileHeight = 100f;
+        float pixelDeltaY = 4f;
+
+        UnitConverter.Self.ConvertToUnitTypeCoordinates(0f, pixelDeltaY,
+            GeneralUnitType.MaintainFileAspectRatio, GeneralUnitType.MaintainFileAspectRatio,
+            ownerWidthInPixels: ownerWidthInPixels, ownerHeightInPixels: 0f,
+            parentWidth: 0f, parentHeight: 0f,
+            fileWidth: fileWidth, fileHeight: fileHeight,
+            out float relativeX, out float relativeY);
+
+        relativeY.ShouldBe(30f, tolerance: 0.0001f);
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Wireframe/DimensionDisplayVisualTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Wireframe/DimensionDisplayVisualTests.cs
@@ -1,0 +1,41 @@
+using Gum.DataTypes;
+using Gum.Wireframe.Editors.Visuals;
+using Shouldly;
+
+namespace GumToolUnitTests.Wireframe;
+
+/// <summary>
+/// Pins <see cref="DimensionDisplayVisual.GetDimensionSuffix"/> against every DimensionUnitType
+/// selectable as a Width/Height unit in the tool. AbsoluteMultipliedByFontScale and
+/// RelativeToMaxParentOrChildren were missing, so the resize handle's dimension display showed only
+/// the raw absolute pixel size for those two - unlike Ratio/Percentage/etc., which show both the raw
+/// stored value and the resulting pixel size (#4395 follow-up).
+/// </summary>
+public class DimensionDisplayVisualTests
+{
+    [Theory]
+    [InlineData(DimensionUnitType.Absolute, false)]
+    [InlineData(DimensionUnitType.RelativeToParent, true)]
+    [InlineData(DimensionUnitType.PercentageOfParent, true)]
+    [InlineData(DimensionUnitType.Ratio, true)]
+    [InlineData(DimensionUnitType.RelativeToChildren, true)]
+    [InlineData(DimensionUnitType.PercentageOfOtherDimension, true)]
+    [InlineData(DimensionUnitType.PercentageOfSourceFile, true)]
+    [InlineData(DimensionUnitType.MaintainFileAspectRatio, true)]
+    [InlineData(DimensionUnitType.AbsoluteMultipliedByFontScale, true)]
+    [InlineData(DimensionUnitType.RelativeToMaxParentOrChildren, true)]
+    public void GetDimensionSuffix_ShouldReturnNonNullSuffix_ForEveryUnitTypeExceptAbsolute(
+        DimensionUnitType unitType, bool shouldHaveSuffix)
+    {
+        string suffix = DimensionDisplayVisual.GetDimensionSuffix(unitType, isWidth: true);
+
+        if (shouldHaveSuffix)
+        {
+            suffix.ShouldNotBeNull();
+        }
+        else
+        {
+            suffix.ShouldBeNull();
+        }
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/EditorTab/Editors/Handlers/ResizeInputHandler.cs
@@ -221,7 +221,7 @@ public class ResizeInputHandler : InputHandlerBase
                 : new Vector2(gue.X, gue.Y);
             Vector2 grabStartSize = Context.GrabbedState.InstanceSizes.TryGetValue(save, out var grabbedSize)
                 ? grabbedSize
-                : new Vector2(gue.Width, gue.Height);
+                : new Vector2(gue.AbsoluteWidth, gue.AbsoluteHeight);
 
             SnapInstanceToGrid(gue, save, gridSize,
                 grabStartPosition, grabStartSize,
@@ -567,7 +567,7 @@ public class ResizeInputHandler : InputHandlerBase
             ? Context.GrabbedState.ComponentSize
             : Context.GrabbedState.InstanceSizes.TryGetValue(instanceSave, out var grabbedSize)
                 ? grabbedSize
-                : new Vector2(representation.Width, representation.Height);
+                : new Vector2(representation.AbsoluteWidth, representation.AbsoluteHeight);
 
         float positionDeltaX, sizeDeltaX;
         if (isResizeFromCenter && widthMultiplier != 0)

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -550,6 +550,14 @@ public class ElementCommands : IElementCommands
 
     private float ConvertAmountToPixelAccordingToUnitType(string baseVariableName, float amount, object unitsVariableAsObject)
     {
+        if (unitsVariableAsObject is DimensionUnitType.AbsoluteMultipliedByFontScale)
+        {
+            // Rendered pixel size = raw Width/Height * GlobalFontScale (see
+            // GraphicalUiElement.UpdateDimensions's AbsoluteMultipliedByFontScale case), so a raw 1:1
+            // pixel-to-value mapping (correct for plain Absolute) over-scales the drag by GlobalFontScale.
+            return GraphicalUiElement.GlobalFontScale == 0 ? 0 : amount / GraphicalUiElement.GlobalFontScale;
+        }
+
         GeneralUnitType generalUnitType = UnitConverter.ConvertToGeneralUnit(unitsVariableAsObject);
 
         float xAmount;

--- a/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
+++ b/Tools/Gum.Presentation/ToolCommands/ElementCommands.cs
@@ -382,6 +382,14 @@ public class ElementCommands : IElementCommands
                 throw new InvalidOperationException("Cannot be infinite");
             }
 
+            if ((baseVariableName == "Width" || baseVariableName == "Height") &&
+                unitsVariableAsObject is DimensionUnitType.Ratio &&
+                graphicalUiElement != null)
+            {
+                return ModifyRatioVariable(baseVariableName, modificationAmount, instanceSave,
+                    graphicalUiElement, currentValue, nameWithInstance);
+            }
+
             modificationAmount = ConvertAmountToPixelAccordingToUnitType(baseVariableName, modificationAmount, unitsVariableAsObject);
 
             if (float.IsPositiveInfinity(modificationAmount))
@@ -418,6 +426,59 @@ public class ElementCommands : IElementCommands
         {
             return 0;
         }
+    }
+
+    /// <summary>
+    /// Handles <see cref="ModifyVariable(string, float, InstanceSave)"/> for a Width/Height whose
+    /// units is <see cref="DimensionUnitType.Ratio"/>. A Ratio value's rendered pixel size depends on
+    /// every Ratio-typed sibling's value (see <see cref="RatioResizeCalculator"/>), so the dragged
+    /// instance's Ratio siblings - other instances sharing its layout parent, with the same axis also
+    /// set to Ratio - are adjusted alongside it to keep the drag tracking the cursor.
+    /// </summary>
+    private float ModifyRatioVariable(string baseVariableName, float modificationAmount, InstanceSave instanceSave,
+        GraphicalUiElement graphicalUiElement, float currentValue, string nameWithInstance)
+    {
+        var ratioSiblings = (graphicalUiElement.Parent?.Children ?? Enumerable.Empty<GraphicalUiElement>())
+            .Where(child => child != graphicalUiElement && child.Tag is InstanceSave)
+            .Where(child => (baseVariableName == "Width" ? child.WidthUnits : child.HeightUnits) == DimensionUnitType.Ratio)
+            .ToList();
+
+        float currentPixelSize = baseVariableName == "Width" ? graphicalUiElement.AbsoluteWidth : graphicalUiElement.AbsoluteHeight;
+        List<float> siblingCurrentRatios = ratioSiblings
+            .Select(sibling => baseVariableName == "Width" ? sibling.Width : sibling.Height)
+            .ToList();
+
+        RatioResizeCalculator.ApplyResize(currentValue, currentPixelSize, modificationAmount, siblingCurrentRatios,
+            out float newValue, out float[] siblingNewRatios);
+
+        _selectedState.SelectedStateSave.SetValue(nameWithInstance, newValue, instanceSave, "float");
+        graphicalUiElement.SetProperty(baseVariableName, newValue);
+
+        for (int i = 0; i < ratioSiblings.Count; i++)
+        {
+            InstanceSave siblingInstance = (InstanceSave)ratioSiblings[i].Tag!;
+            string siblingNameWithInstance = siblingInstance.Name + "." + baseVariableName;
+
+            _selectedState.SelectedStateSave.SetValue(siblingNameWithInstance, siblingNewRatios[i], siblingInstance, "float");
+            ratioSiblings[i].SetProperty(baseVariableName, siblingNewRatios[i]);
+        }
+
+        var rootGue = _wireframeObjectManager.RootGue;
+        ElementSaveExtensions.ApplyVariableReferences(_selectedState.SelectedElement, _selectedState.SelectedStateSave, rootGue);
+
+        rootGue?.ApplyVariableReferences(_selectedState.SelectedStateSave);
+
+        _variableInCategoryPropagationLogic.PropagateVariablesInCategory(nameWithInstance,
+            _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
+
+        for (int i = 0; i < ratioSiblings.Count; i++)
+        {
+            InstanceSave siblingInstance = (InstanceSave)ratioSiblings[i].Tag!;
+            _variableInCategoryPropagationLogic.PropagateVariablesInCategory(siblingInstance.Name + "." + baseVariableName,
+                _selectedState.SelectedElement, _selectedState.SelectedStateCategorySave);
+        }
+
+        return newValue;
     }
 
     public float ModifyVariable(string baseVariableName, float modificationAmount, ElementSave elementSave)

--- a/Tools/Gum.Presentation/Wireframe/GrabbedState.cs
+++ b/Tools/Gum.Presentation/Wireframe/GrabbedState.cs
@@ -219,7 +219,13 @@ public class GrabbedState
             var graphicalUiElement = _wireframeObjectManager.GetRepresentation(_selectedState.SelectedElement);
 
             ComponentPosition = new Vector2(graphicalUiElement.X, graphicalUiElement.Y);
-            ComponentSize = new Vector2(graphicalUiElement.Width, graphicalUiElement.Height);
+            // AbsoluteWidth/Height (not Width/Height) - the resize math below mixes this against
+            // cursor pixel deltas, so it must be in the same (pixel) space. Width/Height is the raw
+            // unit-specific stored value (e.g. a Ratio weight like 1, or a percentage), which is not
+            // pixels for most unit types - using it made the resize "flip" (see ResolveResizeAxis)
+            // trigger as soon as that small raw number was exceeded by real cursor pixel movement,
+            // long before the object's actual rendered size reached zero (#4395 follow-up).
+            ComponentSize = new Vector2(graphicalUiElement.AbsoluteWidth, graphicalUiElement.AbsoluteHeight);
         }
         else if(_selectedState.SelectedInstances.Count() != 0)
         {
@@ -241,8 +247,9 @@ public class GrabbedState
                         StateY = instanceStateY
                     };
                     InstancePositions.Add(instance, stateAndAbsolutePositions);
+                    // AbsoluteWidth/Height, not Width/Height - see the ComponentSize comment above.
                     InstanceSizes.Add(instance,
-                        new Vector2(instanceGue.Width, instanceGue.Height));
+                        new Vector2(instanceGue.AbsoluteWidth, instanceGue.AbsoluteHeight));
                 }
 
             }


### PR DESCRIPTION
`UnitConverter.ConvertToGeneralUnit(DimensionUnitType)` never handled `Ratio`, `ScreenPixel`, or `RelativeToMaxParentOrChildren` (all added after the switch was written), so resizing an instance using any of these unit types threw `NotImplementedException` in `ResizeInputHandler`.

Fixing the crash surfaced several deeper bugs, all variants of the same root cause: several unit types' *stored* value isn't 1:1 with pixels, but the resize code assumed it was.

1. **Wrong resize math.** `Ratio`, `MaintainFileAspectRatio`, and `AbsoluteMultipliedByFontScale` don't hold pixel values, so applying the raw drag pixel delta 1:1 (correct for pixel-based units) made resize snap to extreme sizes or scale too fast.
2. **False "flip" trigger.** `GrabbedState` captured grab-time size from `GraphicalUiElement.Width/Height` - the raw unit-specific stored value (e.g. a Ratio weight like `1`) - not the rendered pixel size. `ResizeInputHandler.ResolveResizeAxis` mixes that against real cursor pixel deltas to detect when the dragged edge crosses the anchor and should flip, so a small raw number got exceeded by ordinary cursor movement almost immediately, flipping the resize (value jumping the wrong way, object sliding out of its container) long before the object's actual size was near zero.
3. **Missing dimension-display info.** The resize-handle tooltip showed only the raw pixel size for `AbsoluteMultipliedByFontScale`/`RelativeToMaxParentOrChildren`, unlike every other non-Absolute unit (which show the raw stored value *and* the resulting pixel size).

Fixes:
- `RatioResizeCalculator` computes the correct sibling-aware delta for `Ratio` (keeps the sum of all Ratio values constant) and `ElementCommands.ModifyVariable` uses it for Width/Height, redistributing the complementary change across Ratio siblings proportionally.
- `UnitConverter.ConvertToUnitTypeCoordinates`'s `MaintainFileAspectRatio` branches were stubs that passed the raw pixel delta through unchanged; now scale correctly using file and owner size.
- `ElementCommands.ConvertAmountToPixelAccordingToUnitType` now divides the pixel delta by `GraphicalUiElement.GlobalFontScale` for `AbsoluteMultipliedByFontScale`.
- `GrabbedState` now captures `AbsoluteWidth`/`AbsoluteHeight` (true pixel size) instead of the raw stored value, for both the whole-component and per-instance grab paths.
- `DimensionDisplayVisual.GetDimensionSuffix` now covers `AbsoluteMultipliedByFontScale` and `RelativeToMaxParentOrChildren`.
- `Splitter.cs`'s duplicated ratio-delta formula now calls the shared `RatioResizeCalculator.GetRatioDeltaForPixelDelta` helper.
- Extended `UnitConverterTests` to cover every Width/Height unit type selectable in the tool, and added end-to-end regression tests reproducing the reported flip and font-scale bugs.

Closes #4395
