### PR TITLE
Fix ScrollViewer applying spurious scroll delta on new touch

### DIFF
--- a/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
+++ b/MonoGameGum.Tests/Forms/ScrollViewerTests.cs
@@ -200,6 +200,75 @@ public class ScrollViewerTests : BaseTestClass
         scrollViewer.Visual.Children.ShouldNotContain(button1.Visual);
     }
 
+    #region Touch Scrolling
+
+    [Fact]
+    public void HandleRollOver_ShouldIgnoreCursorDelta_OnTouchPushFrame()
+    {
+        ScrollViewer scrollViewer = BuildTallScrollViewerForTouch();
+
+        Mock<ICursor> cursor = BuildTouchCursorMock(isPush: true, yChange: -500);
+
+        Mock<IInputReceiverKeyboardMonoGame> keyboard = new();
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(scrollViewer.Visual, cursor.Object, keyboard.Object, 0);
+
+        scrollViewer.VerticalScrollBarValue.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HandleRollOver_ShouldApplyCursorDelta_OnSubsequentTouchFrame()
+    {
+        ScrollViewer scrollViewer = BuildTallScrollViewerForTouch();
+
+        Mock<ICursor> cursor = BuildTouchCursorMock(isPush: false, yChange: -500);
+
+        Mock<IInputReceiverKeyboardMonoGame> keyboard = new();
+        GueInteractiveExtensionMethods.DoUiActivityRecursively(scrollViewer.Visual, cursor.Object, keyboard.Object, 0);
+
+        scrollViewer.VerticalScrollBarValue.ShouldBe(500, tolerance: 0.01);
+    }
+
+    private static ScrollViewer BuildTallScrollViewerForTouch()
+    {
+        ScrollViewer scrollViewer = new();
+        scrollViewer.Visual.Width = 200;
+        scrollViewer.Visual.Height = 200;
+        GumService.Default.Root.Children.Add(scrollViewer.Visual);
+
+        ContainerRuntime tallContent = new();
+        tallContent.Width = 0;
+        tallContent.WidthUnits = global::Gum.DataTypes.DimensionUnitType.RelativeToParent;
+        tallContent.Height = 1000;
+        tallContent.HeightUnits = global::Gum.DataTypes.DimensionUnitType.Absolute;
+        scrollViewer.AddChild(tallContent);
+
+        GumService.Default.Root.UpdateLayout();
+
+        return scrollViewer;
+    }
+
+    private static Mock<ICursor> BuildTouchCursorMock(bool isPush, int yChange)
+    {
+        Mock<ICursor> cursor = new();
+        cursor.SetupProperty(x => x.VisualOver);
+        cursor.SetupProperty(x => x.WindowPushed);
+        cursor.Setup(x => x.LastInputDevice).Returns(InputDevice.TouchScreen);
+        cursor.Setup(x => x.PrimaryDown).Returns(true);
+        cursor.Setup(x => x.PrimaryPush).Returns(isPush);
+        cursor.Setup(x => x.X).Returns(100);
+        cursor.Setup(x => x.Y).Returns(100);
+        cursor.Setup(x => x.XChange).Returns(0);
+        cursor.Setup(x => x.YChange).Returns(yChange);
+
+        // ScrollViewer.HandleRollOver reads the static FrameworkElement.MainCursor, not the
+        // cursor instance passed to DoUiActivityRecursively -- both must point at the same mock.
+        FrameworkElement.MainCursor = cursor.Object;
+
+        return cursor;
+    }
+
+    #endregion
+
     [Fact]
     public void OnFocusUpdate_ShouldScrollByRightStickDeflection_WhenTopLevelFocused()
     {

--- a/MonoGameGum/Forms/Controls/ScrollViewer.cs
+++ b/MonoGameGum/Forms/Controls/ScrollViewer.cs
@@ -511,7 +511,12 @@ public class ScrollViewer :
 
     private void HandleRollOver(object sender, RoutedEventArgs args)
     {
-        if (MainCursor.PrimaryDown && MainCursor.LastInputDevice == InputDevice.TouchScreen)
+        // On the frame a touch first makes contact, XChange/YChange reflect the jump from
+        // wherever the cursor last was (a prior tap, or 0,0) to the new touch position, not
+        // real finger movement. Applying that as a scroll delta causes a random-looking jump
+        // on every tap and can shift content out from under the finger, eating the tap (#4394).
+        if (MainCursor.PrimaryDown && MainCursor.LastInputDevice == InputDevice.TouchScreen &&
+            !MainCursor.PrimaryPush)
         {
             verticalScrollBar.Value -= MainCursor.YChange /
                 global::RenderingLibrary.ISystemManagers.Default.Renderer.Camera.Zoom;

--- a/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
+++ b/docs/code/events-and-interactivity/mouse-and-touch-screen-cursor.md
@@ -12,9 +12,15 @@ Touch support varies by runtime. Where a runtime has no real touch API, touch is
 |---|---|---|
 | raylib | Partial | Single tap may not register as a click; a longer tap or a second tap works. Selection-style interactions (e.g. list items) work fine. |
 | Silk.NET | Full | ✅ |
-| MonoGame (DesktopGL) | Full | ✅ |
+| MonoGame / KNI (DesktopGL) | Mouse-emulated | No real touch API on Windows; see note below. |
 
 raylib's default desktop backend (GLFW) has no real touch input. See raylib's own [source comment acknowledging this](https://github.com/raysan5/raylib/blob/4640c849208079d758d8f0dbb4b5b7816db5ed0c/src/platforms/rcore_desktop_glfw.c#L1305-L1310). raylib's SDL backend does support real touch, but isn't what Gum's raylib runtime currently uses.
+
+{% hint style="warning" %}
+**A Windows touchscreen cannot be used to test `InputDevice.TouchScreen`-specific behavior on MonoGame or KNI's DesktopGL backend.** Tapping the screen still moves the cursor and registers clicks and drags, because Windows silently promotes untranslated touch input into synthetic mouse messages for apps that haven't opted into raw touch handling; DesktopGL's underlying SDL2 layer never wires up real touch events at all. That promoted input arrives as ordinary mouse input, so `Cursor.LastInputDevice` reports `InputDevice.Mouse`, never `InputDevice.TouchScreen`. MonoGame's WindowsDX backend does populate `TouchPanel`, but from a single mouse-derived point, not independent hardware touch tracking, so it has the same limitation.
+
+Code that only reacts when `LastInputDevice == InputDevice.TouchScreen` will look correct in a Windows test (since the mouse-emulated input still drives clicks and drags) while remaining untested for real touch. Verifying that code path requires a platform whose windowing layer genuinely captures touch, such as Android or iOS.
+{% endhint %}
 
 ## Code Example: Accessing the Cursor
 


### PR DESCRIPTION
## Summary
- On the frame a touch first makes contact, `Cursor.XChange`/`YChange` reflect the jump from wherever the cursor last was (a prior tap, or 0,0) to the new touch position — not real finger movement.
- `ScrollViewer.HandleRollOver` applied that delta as a scroll on every touch-down frame, producing a random-looking scroll jump on every tap that could shift content out from under the finger, eating the tap entirely (matches the reported "registers every touch as a scroll, no more taps").
- Fix: ignore the cursor delta on the touch's push frame; only scroll on subsequent frames where the delta reflects actual movement.

Closes #4394

## Test plan
- [x] `MonoGameGum.Tests/Forms/ScrollViewerTests.cs`: new tests pin that a push-frame delta is ignored and a subsequent-frame delta is applied.
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 2155 passed.
- [x] RaylibGum / KniGum builds (ScrollViewer.cs is file-linked into both) — clean.
- [x] FRB canary (`FlatRedBall.Forms.DesktopGlNet6.csproj`) — pass.

Manual test: not needed — the reported behavior only manifests on real touch hardware timing (spurious delta from stale cursor position), which the unit tests reproduce directly via a mocked `ICursor`; there's no way to make a desktop mouse/simulator repro the actual bug.
