### PR TITLE
Note the caret-at-wrap-boundary behavior as accepted

### DIFF
--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -13,6 +13,11 @@ Check the skills list for one matching the feature area and load it **before** g
 ## Don't file
 Sokol is not held to per-backend feature parity — a feature that ships on the MonoGame family, raylib, and Skia but not SokolGum is not a tracked gap.
 
+## Issues you file yourself
+A value you printed while diagnosing something else is an observation, not a report — name what a user would see, or don't file. Say in the body that it came from instrumentation.
+
+**Suggested improvement** must not assert an unverified convention ("editors conventionally do X"). Verify it or write it as an open question: asserted, it becomes the issue's premise, and whoever picks the issue up implements against it without rechecking.
+
 ## Labels
 - **Bug reports get `--label bug`** (label exists, color `#fc2929`). Apply it at creation time.
 - The `bug` label is real and applies silently — don't second-guess it or omit it on later issues.

--- a/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
@@ -348,6 +348,38 @@ public class TextBoxWrappingTests : BaseTestClass
     }
 
     [Fact]
+    public void Wrap_ShouldPlaceCaretAtStartOfNextLine_WhenTrailingSpaceReachesPastTheWrapPoint()
+    {
+        // Issue #4399: a wrapped line only exists once there is text on it, so after typing the
+        // space that ends a line the caret has nowhere to go and stays at the end of that line,
+        // past the right edge. It belongs where the next character will appear instead.
+        const string upToTheWrap = "This little ";
+
+        TextBox textBox = CreateWrappingTextBox();
+        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
+
+        foreach (char character in upToTheWrap)
+        {
+            textBox.HandleCharEntered(character);
+        }
+
+        GetCoreText(textBox).WrappedText.Count.ShouldBe(1,
+            "sanity: the trailing space alone doesn't create a wrapped line");
+        float caretLeftBeforeTheLineExists = visual.CaretInstance.AbsoluteLeft;
+        float caretTopBeforeTheLineExists = visual.CaretInstance.AbsoluteTop;
+
+        // Typing the next character creates the line the caret was anticipating. The caret at
+        // that same index must land where it already was, or it visibly jumps as you type.
+        textBox.HandleCharEntered('a');
+        textBox.CaretIndex = upToTheWrap.Length;
+
+        GetCoreText(textBox).WrappedText.Count.ShouldBe(2,
+            "sanity: the next character does wrap onto a second line");
+        visual.CaretInstance.AbsoluteLeft.ShouldBe(caretLeftBeforeTheLineExists);
+        visual.CaretInstance.AbsoluteTop.ShouldBe(caretTopBeforeTheLineExists);
+    }
+
+    [Fact]
     public void Wrap_ShouldNotShiftTextX_WhenCaretMovedIntoWrappedLine()
     {
         // The reported repro: with the caret placed partway into a wrapped line, the text jumped

--- a/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
@@ -328,58 +328,6 @@ public class TextBoxWrappingTests : BaseTestClass
     }
 
     [Fact]
-    public void Wrap_ShouldKeepCaretInsideHorizontalBounds_WhileTyping()
-    {
-        // Issue #4399: wrapping measures a line without its trailing space but the caret is
-        // measured with it, so typing the space that ends a line put the caret past the right
-        // edge of the text area, where it renders clipped.
-        TextBox textBox = CreateWrappingTextBox();
-
-        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
-
-        foreach (char character in WrappingText)
-        {
-            textBox.HandleCharEntered(character);
-
-            float caretRight = visual.CaretInstance.AbsoluteLeft + visual.CaretInstance.AbsoluteWidth;
-            caretRight.ShouldBeLessThanOrEqualTo(visual.AbsoluteLeft + visual.AbsoluteWidth,
-                $"because the caret must stay inside the text area after typing \"{textBox.Text}\"");
-        }
-    }
-
-    [Fact]
-    public void Wrap_ShouldPlaceCaretAtStartOfNextLine_WhenTrailingSpaceReachesPastTheWrapPoint()
-    {
-        // Issue #4399: a wrapped line only exists once there is text on it, so after typing the
-        // space that ends a line the caret has nowhere to go and stays at the end of that line,
-        // past the right edge. It belongs where the next character will appear instead.
-        const string upToTheWrap = "This little ";
-
-        TextBox textBox = CreateWrappingTextBox();
-        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
-
-        foreach (char character in upToTheWrap)
-        {
-            textBox.HandleCharEntered(character);
-        }
-
-        GetCoreText(textBox).WrappedText.Count.ShouldBe(1,
-            "sanity: the trailing space alone doesn't create a wrapped line");
-        float caretLeftBeforeTheLineExists = visual.CaretInstance.AbsoluteLeft;
-        float caretTopBeforeTheLineExists = visual.CaretInstance.AbsoluteTop;
-
-        // Typing the next character creates the line the caret was anticipating. The caret at
-        // that same index must land where it already was, or it visibly jumps as you type.
-        textBox.HandleCharEntered('a');
-        textBox.CaretIndex = upToTheWrap.Length;
-
-        GetCoreText(textBox).WrappedText.Count.ShouldBe(2,
-            "sanity: the next character does wrap onto a second line");
-        visual.CaretInstance.AbsoluteLeft.ShouldBe(caretLeftBeforeTheLineExists);
-        visual.CaretInstance.AbsoluteTop.ShouldBe(caretTopBeforeTheLineExists);
-    }
-
-    [Fact]
     public void Wrap_ShouldNotShiftTextX_WhenCaretMovedIntoWrappedLine()
     {
         // The reported repro: with the caret placed partway into a wrapped line, the text jumped

--- a/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxWrappingTests.cs
@@ -328,6 +328,26 @@ public class TextBoxWrappingTests : BaseTestClass
     }
 
     [Fact]
+    public void Wrap_ShouldKeepCaretInsideHorizontalBounds_WhileTyping()
+    {
+        // Issue #4399: wrapping measures a line without its trailing space but the caret is
+        // measured with it, so typing the space that ends a line put the caret past the right
+        // edge of the text area, where it renders clipped.
+        TextBox textBox = CreateWrappingTextBox();
+
+        DefaultTextBoxBaseRuntime visual = (DefaultTextBoxBaseRuntime)textBox.Visual;
+
+        foreach (char character in WrappingText)
+        {
+            textBox.HandleCharEntered(character);
+
+            float caretRight = visual.CaretInstance.AbsoluteLeft + visual.CaretInstance.AbsoluteWidth;
+            caretRight.ShouldBeLessThanOrEqualTo(visual.AbsoluteLeft + visual.AbsoluteWidth,
+                $"because the caret must stay inside the text area after typing \"{textBox.Text}\"");
+        }
+    }
+
+    [Fact]
     public void Wrap_ShouldNotShiftTextX_WhenCaretMovedIntoWrappedLine()
     {
         // The reported repro: with the caret placed partway into a wrapped line, the text jumped

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1318,7 +1318,7 @@ public abstract class TextBoxBase :
                 var shouldShowFirstOfNextLine =
                     // If we're at the very end of the line,
                     relativeIndexOnLine == lineLength &&
-                    // the last character is whitespace,
+                    // the line has content,
                     currentLine.Length > 0 &&
                     // we have another line
                     lineNumber < coreTextObject.WrappedText.Count - 1 &&
@@ -1984,6 +1984,19 @@ public abstract class TextBoxBase :
     private void SetXCaretPositionForLine(string stringToMeasure, int indexIntoLine)
     {
         var newPosition = GetXCaretPositionForLineRelativeToTextParent(stringToMeasure, indexIntoLine);
+
+        if (DoesTextComponentWrap)
+        {
+            // Wrapping fits every line to the text component, so a caret past its right edge
+            // can only come from a trailing space: wrapping measures without one, but the caret
+            // is measured with it. There is no wrapped line for the caret to move onto until
+            // the next character is typed, so hold it at the wrap point rather than letting it
+            // render outside the clipped region (issue #4399).
+            float maximumPosition = this.textComponent.X
+                + this.textComponent.AbsoluteWidth
+                - this.caretComponent.AbsoluteWidth;
+            newPosition = System.Math.Min(newPosition, maximumPosition);
+        }
 
         // assumes caret and text have the same parent
         this.caretComponent.X = newPosition;

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1318,7 +1318,7 @@ public abstract class TextBoxBase :
                 var shouldShowFirstOfNextLine =
                     // If we're at the very end of the line,
                     relativeIndexOnLine == lineLength &&
-                    // the line has content,
+                    // the last character is whitespace,
                     currentLine.Length > 0 &&
                     // we have another line
                     lineNumber < coreTextObject.WrappedText.Count - 1 &&
@@ -1374,14 +1374,16 @@ public abstract class TextBoxBase :
         {
             GetLineNumber(caretIndex, out int lineNumber, out int _, out int relativeIndexOnLine);
 
+            // A wrapped line exists only once there is text on it, so in the moment after
+            // typing the space that ends a line there is no next line for the caret to move
+            // to: it stays at the end of the current one, which puts it just outside the
+            // clipped text area until the next character arrives. Considered and left as-is
+            // -- no user has reported it, and it isn't settled that moving the caret down
+            // early is what a text box should do. Revisit if it ever comes up (issue #4399).
+
             if (lineNumber == -1)
             {
                 SetXCaretPositionForLine(string.Empty, 0);
-            }
-            else if (IsCaretPastWrapPointOnLastLine(lineNumber, relativeIndexOnLine))
-            {
-                SetXCaretPositionForLine(string.Empty, 0);
-                lineNumber++;
             }
             else
             {
@@ -1395,35 +1397,6 @@ public abstract class TextBoxBase :
 
             caretComponent.Y = ResolveLineYForComponent(caretY, caretComponent);
         }
-    }
-
-    /// <summary>
-    /// True when the caret sits after a trailing space that reaches past the wrap point of the
-    /// last line. Wrapping measures a line without its trailing space while the caret is
-    /// measured with it, so such a caret would render outside the text area. The next typed
-    /// character starts a new line, so the caret belongs at the start of that line — Gum just
-    /// hasn't produced it yet, since a wrapped line only appears once there is text on it.
-    /// </summary>
-    private bool IsCaretPastWrapPointOnLastLine(int lineNumber, int relativeIndexOnLine)
-    {
-        if (!DoesTextComponentWrap || lineNumber != coreTextObject.WrappedText.Count - 1)
-        {
-            return false;
-        }
-
-        var line = coreTextObject.WrappedText[lineNumber];
-
-        if (relativeIndexOnLine != line.Length ||
-            line.Length == 0 ||
-            !char.IsWhiteSpace(line[line.Length - 1]))
-        {
-            return false;
-        }
-
-        float caretRight = GetXCaretPositionForLineRelativeToTextParent(line, relativeIndexOnLine)
-            + caretComponent.AbsoluteWidth;
-
-        return caretRight > this.textComponent.X + this.textComponent.AbsoluteWidth;
     }
 
     private void UpdateToIsFocused() => UpdateToIsFocused(wasFocused: isFocused);

--- a/MonoGameGum/Forms/Controls/TextBoxBase.cs
+++ b/MonoGameGum/Forms/Controls/TextBoxBase.cs
@@ -1378,6 +1378,11 @@ public abstract class TextBoxBase :
             {
                 SetXCaretPositionForLine(string.Empty, 0);
             }
+            else if (IsCaretPastWrapPointOnLastLine(lineNumber, relativeIndexOnLine))
+            {
+                SetXCaretPositionForLine(string.Empty, 0);
+                lineNumber++;
+            }
             else
             {
                 SetXCaretPositionForLine(coreTextObject.WrappedText[lineNumber], relativeIndexOnLine);
@@ -1390,6 +1395,35 @@ public abstract class TextBoxBase :
 
             caretComponent.Y = ResolveLineYForComponent(caretY, caretComponent);
         }
+    }
+
+    /// <summary>
+    /// True when the caret sits after a trailing space that reaches past the wrap point of the
+    /// last line. Wrapping measures a line without its trailing space while the caret is
+    /// measured with it, so such a caret would render outside the text area. The next typed
+    /// character starts a new line, so the caret belongs at the start of that line — Gum just
+    /// hasn't produced it yet, since a wrapped line only appears once there is text on it.
+    /// </summary>
+    private bool IsCaretPastWrapPointOnLastLine(int lineNumber, int relativeIndexOnLine)
+    {
+        if (!DoesTextComponentWrap || lineNumber != coreTextObject.WrappedText.Count - 1)
+        {
+            return false;
+        }
+
+        var line = coreTextObject.WrappedText[lineNumber];
+
+        if (relativeIndexOnLine != line.Length ||
+            line.Length == 0 ||
+            !char.IsWhiteSpace(line[line.Length - 1]))
+        {
+            return false;
+        }
+
+        float caretRight = GetXCaretPositionForLineRelativeToTextParent(line, relativeIndexOnLine)
+            + caretComponent.AbsoluteWidth;
+
+        return caretRight > this.textComponent.X + this.textComponent.AbsoluteWidth;
     }
 
     private void UpdateToIsFocused() => UpdateToIsFocused(wasFocused: isFocused);
@@ -1984,19 +2018,6 @@ public abstract class TextBoxBase :
     private void SetXCaretPositionForLine(string stringToMeasure, int indexIntoLine)
     {
         var newPosition = GetXCaretPositionForLineRelativeToTextParent(stringToMeasure, indexIntoLine);
-
-        if (DoesTextComponentWrap)
-        {
-            // Wrapping fits every line to the text component, so a caret past its right edge
-            // can only come from a trailing space: wrapping measures without one, but the caret
-            // is measured with it. There is no wrapped line for the caret to move onto until
-            // the next character is typed, so hold it at the wrap point rather than letting it
-            // render outside the clipped region (issue #4399).
-            float maximumPosition = this.textComponent.X
-                + this.textComponent.AbsoluteWidth
-                - this.caretComponent.AbsoluteWidth;
-            newPosition = System.Math.Min(newPosition, maximumPosition);
-        }
 
         // assumes caret and text have the same parent
         this.caretComponent.X = newPosition;


### PR DESCRIPTION
Records the decision on #4399 instead of changing behavior.

A wrapped line exists only once there is text on it, so right after typing the space that ends a line the caret has no next line to move to and sits just outside the clipped text area until the next character arrives. It predates #4398 (verified by running against `50caec5bd`), nobody has reported it, and it isn't settled that a text box should move the caret down early — browsers and word processors hang a trailing space past the wrap point.

Comment only, so the next person doesn't re-derive it. Door left open if it's ever reported.

Closes #4399
