### PR TITLE
Clarify theme delivery paths and require guidance-file edits in the worktree

### DIFF
--- a/.claude/skills/gum-forms-theme-import/SKILL.md
+++ b/.claude/skills/gum-forms-theme-import/SKILL.md
@@ -6,7 +6,12 @@ description: Add Forms dialog's tool-content theme system (Templates/FormsThemes
 # Add Forms Theme Import
 
 Distinct from code-only themes (`gum-theming` skill — C# `*Visual` subclasses, NuGet
-packages). This is the **tool-content** side: a theme is a self-contained Gum project under
+packages). The two are **alternative delivery paths, not layers**: a theme imported here renders
+from the user's own `.gumx`, so a `Gum.Themes.*` package is never needed for the styled look.
+KernSmith and the runtime's shapes package are still recommended (fonts, shape-backed visuals) but
+bypassable — the tool never edits the user's game project.
+
+This is the **tool-content** side: a theme is a self-contained Gum project under
 `Tools/Gum.ProjectServices/Templates/FormsThemes/<Name>/` (its own `GumProject.gumx`,
 `Components/`, `Behaviors/`, `Screens/`, `Standards/`) that Add Forms copies into the user's
 project. `Bubblegum`, `Hazard`, and `DarkPro` have parity today (#3527 tracks porting the rest:

--- a/.claude/skills/gum-theming/SKILL.md
+++ b/.claude/skills/gum-theming/SKILL.md
@@ -5,7 +5,7 @@ description: Building or modifying a Gum theme package (Themes/Gum.Themes.*) —
 
 # Gum Theming
 
-A theme restyles Forms controls by subclassing each V3 default visual, swapping the children that define the look, and re-wiring the state callbacks. See `Themes/Gum.Themes.Editor.MonoGame/` (NineSlice-only) and `Themes/Gum.Themes.DarkPro.MonoGame/` (NineSlice + Apos.Shapes) for two working examples on opposite ends of the visual-primitive spectrum.
+A theme restyles Forms controls by subclassing each V3 default visual, swapping the children that define the look, and re-wiring the state callbacks. **This packaged-C# path serves games with no Gum project** — a project that imports the same theme's tool content via Add Forms (`gum-forms-theme-import`) gets the styled look from its own `.gumx` and needs no `Gum.Themes.*` package at all. See `Themes/Gum.Themes.Editor.MonoGame/` (NineSlice-only) and `Themes/Gum.Themes.DarkPro.MonoGame/` (NineSlice + Apos.Shapes) for two working examples on opposite ends of the visual-primitive spectrum.
 
 This skill is about *authoring* a theme. For how a theme is *consumed* — installing the NuGet package, calling `Apply`, and the catalog of shipped themes — see the user guide: https://docs.flatredball.com/gum/code/styling/themes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ Select the agent that best matches the task at hand. For tasks that span multipl
 
 When a task surfaces an improvement to a checked-in guidance file — a skill (`.claude/skills/`), an agent (`.claude/agents/`), `CLAUDE.md`, or `code-style.md` — include that change in the **same PR** as the work that motivated it. Do not ask whether it is okay, and do not split it into a separate PR. These files are shared repo artifacts, and bundling keeps the improvement next to the change that prompted it (and its rationale). The most common case: you hit a confusing pattern or recurring mistake, fix it, and add a rule to the relevant skill so it does not recur — both belong in one PR.
 
+Edit these files **in the worktree**, never the primary checkout — an edit in the primary checkout never reaches the branch, and the PR ships without it.
+
 ## Building and Testing
 
 Pick the right build target based on what you're working on:


### PR DESCRIPTION
Guidance files only.

- `gum-forms-theme-import` / `gum-theming`: each skill implied the other's path was a required layer. Both now state they are alternative delivery paths — a theme imported as tool content renders from the user's own `.gumx` and needs no `Gum.Themes.*` package.
- `CLAUDE.md`: guidance files must be edited in the worktree, not the primary checkout, where the edit never reaches the branch.

Manual test: not needed — markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
