### PR TITLE
Bump Apos.Shapes to 0.7.10 to fix Mesa llvmpipe shader compile failure

### DIFF
--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -41,8 +41,15 @@
 			no content pipeline, no buildTransitive content, no PrivateAssets blocking needed
 			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
 			ship is gone; consumers just reference the package.
+
+			0.7.10, not the latest (0.8.1): upstream's own changelog says the OpenGL shader
+			"still failed to load ... with Shader Compilation Failed" on macOS/WebGL through
+			0.7.9, fixed in 0.7.10 (#4410 - same exception this repo hit on Mesa llvmpipe).
+			0.7.11 changes DrawRing's second-radius semantics (rings render 2x thicker) with
+			no compensating change in Arc.cs, so staying at 0.7.10 avoids that behavior change
+			until Arc.cs and its tests are updated deliberately.
 		-->
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.7.8" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.7.10" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -41,8 +41,15 @@
 			no content pipeline, no buildTransitive content, no PrivateAssets blocking needed
 			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
 			ship is gone; consumers just reference the package.
+
+			0.7.10, not the latest (0.8.1): upstream's own changelog says the OpenGL shader
+			"still failed to load ... with Shader Compilation Failed" on macOS/WebGL through
+			0.7.9, fixed in 0.7.10 (#4410 - same exception this repo hit on Mesa llvmpipe).
+			0.7.11 changes DrawRing's second-radius semantics (rings render 2x thicker) with
+			no compensating change in Arc.cs, so staying at 0.7.10 avoids that behavior change
+			until Arc.cs and its tests are updated deliberately.
 		-->
-		<PackageReference Include="Apos.Shapes" Version="0.7.8" />
+		<PackageReference Include="Apos.Shapes" Version="0.7.10" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/Tests/Gum.ProjectServices.MonoGame.Tests/MonoGameScreenshotServiceTests.cs
+++ b/Tests/Gum.ProjectServices.MonoGame.Tests/MonoGameScreenshotServiceTests.cs
@@ -34,16 +34,6 @@ public class MonoGameScreenshotServiceTests : IDisposable
     [Fact]
     public void TakeScreenshot_FilledCircleScreen_WritesPngWithFillColorInExpectedRegion()
     {
-        // Self-gated like ScreenshotCommandTests' raylib tests: Apos.Shapes' embedded shader
-        // throws "Shader Compilation Failed" under the Windows CI runner's Mesa llvmpipe software
-        // GL (this step's own GALLIUM_DRIVER=llvmpipe), even with GraphicsProfile.HiDef set. Real
-        // Windows GPU drivers render this correctly (verified locally) - see #4410, tracking the
-        // Mesa incompatibility separately from this test.
-        if (Environment.GetEnvironmentVariable("GALLIUM_DRIVER") == "llvmpipe")
-        {
-            return;
-        }
-
         string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
 
         ProjectCreator creator = new ProjectCreator();


### PR DESCRIPTION
#4410 root cause: this repo is pinned to Apos.Shapes 0.7.8, whose OpenGL shader still had a known "Shader Compilation Failed" bug — upstream's own changelog says it was only fully fixed in 0.7.10 (0.7.8's fix was for a different, incomplete case; 0.7.10 says the shader "still failed to load ... on macOS/WebGL" and fixes it further). That's the exact exception #4409's new test hit on the Windows CI runner's Mesa llvmpipe software GL.

Fix: bump `Apos.Shapes` / `Apos.Shapes.KNI` 0.7.8 -> 0.7.10, and remove the `GALLIUM_DRIVER` self-gate #4409 added so `MonoGameScreenshotServiceTests` actually exercises the fix in CI instead of no-op'ing there.

**Why 0.7.10, not latest (0.8.1):** 0.7.11 changes `DrawRing`'s second-radius semantics (rings render 2x thicker) with no compensating change in Gum's `Arc.cs` — a separate, deliberate upgrade this PR doesn't take. 0.8.0/0.8.1 add text/SVG rendering and remove FontStashSharp, unrelated API surface. 0.7.10 gets the shader fix with zero behavior change to any Apos.Shapes API Gum calls (`DrawCircle`/`DrawRectangle`/`DrawLine`/`DrawArc`/`DrawRing`, none of which changed shape between 0.7.8 and 0.7.10).

**Verification (local, real GPU)**
- `MonoGameGum.Shapes.Tests` — 222 passed
- `Gum.ProjectServices.MonoGame.Tests` — 1 passed (the self-gate now removed)
- `Gum.Cli.Tests` — 67 passed

CI is the actual test of the fix here (Mesa llvmpipe isn't reproducible locally) — watching the Windows job.

Closes #4410
