### PR TITLE
Gate MoveToLayer parented-element guard behind #if !FRB

### DIFF
--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6195,14 +6195,24 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         bool hasContainedObject = mContainedObjectAsIpso != null;
         if (hasContainedObject)
         {
+#if !FRB
+            // FRB1's PositionedObjectGueWrapper (GumCoreShared\FlatRedBall\Embedded\PositionedObjectGueWrapper.cs)
+            // deliberately parents every FRB-attached Gum object to a synthetic, never-added-to-managers
+            // GraphicalUiElement whose sole job is translating FRB world position into Gum coordinates. That
+            // proxy is never itself drawn, so there is no double-render risk - this guard only makes sense
+            // for standalone Gum, where a real structural parent is the thing walking Children during Draw.
             if (Parent != null)
             {
+                var parentDescription = string.IsNullOrEmpty(Parent.Name)
+                    ? $"an unnamed {Parent.GetType().Name}"
+                    : Parent.Name;
                 throw new InvalidOperationException(
-                    $"Cannot move {this} to a different layer because it is parented to {Parent}. " +
+                    $"Cannot move {this} to a different layer because it is parented to {parentDescription}. " +
                     "MoveToLayer only re-homes top-level layer members; a parented element is already " +
                     "drawn through its parent's render tree, so also adding it to a layer would double-render it. " +
                     "Remove it from its parent first, or use AddToManagers instead.");
             }
+#endif
             if(layerToAddTo == null)
             {
                 throw new InvalidOperationException($"Cannot move {this} to a different layer because it is not currently on a layer and no layer was provided");

--- a/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
+++ b/MonoGameGum.Tests/Runtimes/GraphicalUiElementTests.cs
@@ -2132,6 +2132,34 @@ public class GraphicalUiElementTests : BaseTestClass
         Should.Throw<InvalidOperationException>(() => child.MoveToLayer(targetLayer));
     }
 
+    [Fact]
+    public void MoveToLayer_ParentedElement_UnnamedParent_ShouldMentionUnnamedInMessage()
+    {
+        ContainerRuntime root = new();
+        ContainerRuntime child = new();
+        root.Children.Add(child);
+
+        Layer targetLayer = new();
+
+        var exception = Should.Throw<InvalidOperationException>(() => child.MoveToLayer(targetLayer));
+
+        exception.Message.ShouldContain("unnamed");
+    }
+
+    [Fact]
+    public void MoveToLayer_ParentedElement_NamedParent_ShouldIncludeParentNameInMessage()
+    {
+        ContainerRuntime root = new() { Name = "RootContainer" };
+        ContainerRuntime child = new();
+        root.Children.Add(child);
+
+        Layer targetLayer = new();
+
+        var exception = Should.Throw<InvalidOperationException>(() => child.MoveToLayer(targetLayer));
+
+        exception.Message.ShouldContain("RootContainer");
+    }
+
     #endregion
 
     #region Try Get Property


### PR DESCRIPTION
## Summary

- The #4343 `MoveToLayer` "parented element" guard fires for FRB1's `PositionedObjectGueWrapper` position-proxy pattern, breaking `MoveToFrbLayer` for every FRB1 entity with an attached Gum visual (e.g. health bars). Confirmed root cause: `PositionedObjectGueWrapper.cs:69` parents Gum objects to a synthetic, never-added-to-managers `GraphicalUiElement` used purely to translate FRB world position into Gum coordinates - it's never drawn, so the double-render risk doesn't apply.
- Fix: gate the throw with `#if !FRB`, matching this file's existing precedent (e.g. lines 30, 5850, 6477, 7285) for FRB1-only behavior divergence.
- Also improves the exception message to say `"an unnamed {Type}"` when the parent has no name, instead of printing the ambiguous bare type name.

Closes #4414

## Test plan
- [x] `dotnet test MonoGameGum.Tests` - `MoveToLayer` suite green (6/6), including two new tests for the unnamed/named parent message.
- [x] FRB canary build (`GumCore.DesktopGlNet6.csproj`) - 0 errors.

Manual test: not needed - the standalone-Gum throw path is unchanged and covered by unit tests; the FRB-side fix is proven by the canary build plus the reported stack trace's exact code path.

FRB canary: pass
