### PR TITLE
Reset ShapeRenderer.Self on GumService.Uninitialize

### DIFF
--- a/MonoGameGum/GumService.XnaLike.cs
+++ b/MonoGameGum/GumService.XnaLike.cs
@@ -242,6 +242,25 @@ public partial class GumService
 
         // (2) Extension-package hook (plural method name) across all loaded assemblies. This is
         // what unblocks Apos shapes on Blazor/WASM.
+        InvokeHookOnAllLoadedAssemblies("RegisterRuntimeTypes");
+    }
+
+    // Mirror of the "RegisterRuntimeTypes" scan above (issue #4416), but for teardown: an optional
+    // package that GumService cannot reference directly — e.g. Gum.Shapes.MonoGame/KNI, which
+    // reference MonoGameGum rather than the other way around — exposes a public static parameterless
+    // "UninitializeRuntimeTypes" method to reset its own static state when Uninitialize runs. A
+    // package with no such hook is simply skipped (see InvokeRuntimeTypeHookIfPresent's guard).
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Scanning for optional self-uninitialize hooks; every call is guarded so a trimmed-away hook degrades to a no-op.")]
+    internal void UninitializeRuntimeTypesThroughReflection()
+    {
+        InvokeHookOnAllLoadedAssemblies("UninitializeRuntimeTypes");
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Scanning for optional self-registration/uninitialize hooks; every call is guarded so a trimmed-away hook degrades to a no-op.")]
+    private void InvokeHookOnAllLoadedAssemblies(string methodName)
+    {
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (assembly.IsDynamic || IsFrameworkAssembly(assembly.GetName()))
@@ -260,7 +279,7 @@ public partial class GumService
                 {
                     continue;
                 }
-                InvokeRuntimeTypeHookIfPresent(type, "RegisterRuntimeTypes");
+                InvokeRuntimeTypeHookIfPresent(type, methodName);
             }
         }
     }
@@ -384,6 +403,11 @@ public partial class GumService
         // back. Packages that register only via [ModuleInitializer] won't, by
         // design — that's a known load-order contract gap tracked in issue #2761.
         RenderableRegistry.Reset();
+
+        // Issue #4416 — reset optional packages' own static state (e.g. ShapeRenderer.Self for
+        // Gum.Shapes.MonoGame/KNI) via the same reflection hook RegisterRuntimeTypesThroughReflection
+        // uses in the opposite direction.
+        UninitializeRuntimeTypesThroughReflection();
 
         Text.Customizations.Clear();
         Text.ContextCustomizations.Clear();

--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -135,6 +135,20 @@ public abstract class AposShapeRuntime : GraphicalUiElement
     }
 
     /// <summary>
+    /// Mirror of <see cref="RegisterRuntimeTypes"/> for teardown (issue #4416). GumService lives in
+    /// MonoGameGum, which this assembly references — not the other way around — so GumService.
+    /// Uninitialize() cannot call <see cref="ShapeRenderer.Uninitialize"/> directly. Instead it
+    /// locates this method by name via reflection (GumService.XnaLike.cs's
+    /// UninitializeRuntimeTypesThroughReflection, the teardown mirror of the RegisterRuntimeTypes
+    /// scan documented above) and invokes it during Uninitialize, resetting ShapeRenderer's Apos.
+    /// Shapes GPU state so Initialize can run again.
+    /// </summary>
+    public static void UninitializeRuntimeTypes()
+    {
+        ShapeRenderer.Self.Uninitialize();
+    }
+
+    /// <summary>
     /// Wires the factory-built Apos shape's <c>OnPreRender</c> hook back at the calling
     /// runtime's <c>PreRender</c>. Each runtime type the shape can back gets its own arm —
     /// the call has to land on the GUE that actually owns the shape so ScreenPixel scaling

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -132,4 +132,29 @@ public class ShapeRenderer
         // covers the path that bypasses GumService. Idempotent via the guard inside.
         Gum.GueDeriving.AposShapeRuntime.RegisterRuntimeTypes();
     }
+
+    /// <summary>
+    /// Releases the ShapeBatch's GPU resources and resets <see cref="IsInitialized"/> so
+    /// <see cref="Initialize(GraphicsDevice, ContentManager)"/> can be called again. Safe to call
+    /// when never initialized (e.g. invoked from GumService.Uninitialize for an app that never set
+    /// up shapes) — a no-op in that case, since this is called via GumService's reflection-based
+    /// UninitializeRuntimeTypes hook (see AposShapeRuntime.UninitializeRuntimeTypes) regardless of
+    /// whether this app actually uses shapes.
+    /// </summary>
+    public void Uninitialize()
+    {
+        if (!IsInitialized)
+        {
+            return;
+        }
+
+        _sb?.Dispose();
+        _sb = default!;
+
+        IsInitialized = false;
+        _isBatchBegun = false;
+        _currentView = null;
+        _currentRasterizerState = null;
+        _statistics = null;
+    }
 }

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum.IntegrationTests.csproj
@@ -26,6 +26,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
+		<ProjectReference Include="..\..\Runtimes\GumShapes\MonoGameGumShapes.csproj" />
 		<ProjectReference Include="..\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
 		<!-- Referenced so the in-memory font creator can be exercised end-to-end (KernSmith atlas
 		     generation -> MonoGame Texture2D upload -> BitmapFont), mirroring RaylibGum.Tests. -->

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs
@@ -3,6 +3,7 @@ using Gum.GueDeriving;
 using Gum.Wireframe;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameAndGum.Renderables;
 using RenderingLibrary;
 using RenderingLibrary.Content;
 using Shouldly;
@@ -146,6 +147,24 @@ public class UninitializeTests : BaseTestClass
     }
 
     // -------------------------------------------------------------------------
+    // ShapeRenderer (Apos.Shapes) — issue #4416
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Uninitialize_AllowsShapeRendererReinitialize()
+    {
+        // Repro from #4416: a host (e.g. FlatRedBall2) that calls ShapeRenderer.Self.Initialize
+        // during its own startup, then GumService.Uninitialize(), then re-initializes both. Before
+        // the fix, ShapeRenderer.Self.IsInitialized stayed true across Uninitialize, so the second
+        // ShapeRenderer.Self.Initialize() threw "ShapeRenderer is already initialized".
+        using var reinitGame = new GameForShapeRendererReinitializeTest();
+
+        Should.NotThrow(() => reinitGame.RunOneFrame());
+
+        ShapeRenderer.Self.IsInitialized.ShouldBeTrue();
+    }
+
+    // -------------------------------------------------------------------------
     // Nested Game classes
     // -------------------------------------------------------------------------
 
@@ -210,6 +229,54 @@ public class UninitializeTests : BaseTestClass
 
         protected override void Dispose(bool disposing)
         {
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Calls ShapeRenderer.Self.Initialize alongside GumService, then Uninitialize, then
+    /// re-initializes both — used to verify that GumService.Uninitialize() resets ShapeRenderer.Self
+    /// so a host-driven second Initialize (#4416) does not throw.
+    /// </summary>
+    private class GameForShapeRendererReinitializeTest : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+        public GumService GumService { get; }
+
+        public GameForShapeRendererReinitializeTest()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this)
+            {
+                // Apos.Shapes uses an SM4 effect that the default Reach profile can't load - #4403.
+                GraphicsProfile = GraphicsProfile.HiDef,
+            };
+            GumService = new GumService();
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            GumService.Initialize(this, DefaultVisualsVersion.V2);
+            ShapeRenderer.Self.Initialize(GraphicsDevice, Content);
+
+            GumService.Uninitialize();
+
+            // Second initialization on a fresh instance.
+            GumService.Initialize(this, DefaultVisualsVersion.V2);
+            ShapeRenderer.Self.Initialize(GraphicsDevice, Content);
+        }
+
+        protected override void Draw(GameTime gameTime) =>
+            GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (GumService.IsInitialized)
+            {
+                GumService.Uninitialize();
+            }
             LoaderManager.Self?.DisposeAndClear();
             base.Dispose(disposing);
         }

--- a/Tests/MonoGameGum.Shapes.Tests/ShapeRendererUninitializeTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/ShapeRendererUninitializeTests.cs
@@ -1,0 +1,30 @@
+using MonoGameAndGum.Renderables;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #4416 — GumService.Uninitialize() didn't reset ShapeRenderer.Self, so a second
+// Initialize() threw "ShapeRenderer is already initialized" (e.g. FlatRedBall2's startup path).
+// These tests exercise ShapeRenderer.Uninitialize() headlessly via the test-only IsInitialized
+// seam; the real GraphicsDevice-backed round trip is covered by
+// MonoGameGum.IntegrationTests.MonoGameGum.UninitializeTests.
+public class ShapeRendererUninitializeTests
+{
+    [Fact]
+    public void Uninitialize_WhenInitialized_ResetsIsInitializedToFalse()
+    {
+        ShapeRenderer.Self.SetIsInitializedForTesting(true);
+
+        ShapeRenderer.Self.Uninitialize();
+
+        ShapeRenderer.Self.IsInitialized.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Uninitialize_WhenNeverInitialized_DoesNotThrow()
+    {
+        ShapeRenderer.Self.SetIsInitializedForTesting(false);
+
+        Should.NotThrow(() => ShapeRenderer.Self.Uninitialize());
+    }
+}


### PR DESCRIPTION
## Summary

`GumService.Uninitialize()` reset everything else a second `Initialize` needs, but not `ShapeRenderer.Self` — its `IsInitialized` flag stayed `true`, so a host that re-initializes (e.g. FlatRedBall2, which calls `ShapeRenderer.Self.Initialize` during its own startup) hit `InvalidOperationException: ShapeRenderer is already initialized` on the second call.

`MonoGameGum` can't reference the shapes package directly (`MonoGameGumShapes`/`KniGumShapes` reference `MonoGameGum`, not the reverse), so `GumService.Uninitialize()` can't call `ShapeRenderer.Self.Uninitialize()` by type. Fixed via the same reflection hook `RegisterRuntimeTypesThroughReflection` already uses in the opposite direction: `GumService.UninitializePlatform()` now scans loaded assemblies for a public static `UninitializeRuntimeTypes()` method and invokes it if present. `AposShapeRuntime.UninitializeRuntimeTypes()` implements that hook and resets `ShapeRenderer.Self`.

- Added `ShapeRenderer.Uninitialize()` — disposes the `ShapeBatch`, resets `IsInitialized` and batch state. No-op if never initialized (it's invoked unconditionally by the reflection scan, even for apps that never use shapes).
- Extracted the register scan's assembly-walking loop into a shared `InvokeHookOnAllLoadedAssemblies(methodName)`, reused by the new uninitialize scan.

Closes #4416

## Follow-up filed

While tracing this, found that `AposShapeRuntime`'s `Arc`/`ColoredCircle`/`Line`/`RoundedRectangle` GUE-instantiation registrations don't come back after a second `Initialize` either (a `static bool _registered` guard, combined with `ElementSaveExtensions.ClearRegistrations()` wiping the dictionary on `Uninitialize`). This was unreachable before this fix since no app could complete a second init cycle with shapes at all. Filed as #4417.

## Test plan
- [x] `Tests/MonoGameGum.Shapes.Tests/ShapeRendererUninitializeTests.cs` — headless unit tests for `ShapeRenderer.Uninitialize()` (resets flag; no-op when never initialized).
- [x] `Tests/MonoGameGum.IntegrationTests/MonoGameGum/UninitializeTests.cs` — real-GraphicsDevice regression test reproducing the issue's exact repro (Initialize → ShapeRenderer.Initialize → Uninitialize → Initialize → ShapeRenderer.Initialize, must not throw).
- [x] Full `MonoGameGum.Shapes.Tests` (224), `MonoGameGum.IntegrationTests` (85), `MonoGameGum.Tests` (2174), `MonoGameGum.Tests.V2` (154), `Gum.ProjectServices.MonoGame.Tests` (1) — all green, no regressions.
- FRB canary: not needed — FlatRedBall sibling repo absent, and none of the changed files (`GumService.XnaLike.cs`, `Runtimes/GumShapes/*`) appear in `GumCoreShared.projitems`.
- Manual test: not needed — covered by the real-GraphicsDevice integration test above, which exercises the exact repro end-to-end.
