### PR TITLE
Reset AposShapeRuntime._registered on UninitializeRuntimeTypes

### DIFF
--- a/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/AposShapeRuntime.cs
@@ -142,9 +142,16 @@ public abstract class AposShapeRuntime : GraphicalUiElement
     /// UninitializeRuntimeTypesThroughReflection, the teardown mirror of the RegisterRuntimeTypes
     /// scan documented above) and invokes it during Uninitialize, resetting ShapeRenderer's Apos.
     /// Shapes GPU state so Initialize can run again.
+    ///
+    /// Also resets <see cref="_registered"/> (issue #4417) — GumService.Uninitialize() clears
+    /// ElementSaveExtensions' registrations via ClearRegistrations(), but without this reset
+    /// RegisterRuntimeTypes' _registered guard would skip re-applying its RegisterGueInstantiation
+    /// calls on the next Initialize, permanently losing the Arc/ColoredCircle/Line/RoundedRectangle
+    /// registrations after a single Uninitialize -> Initialize cycle.
     /// </summary>
     public static void UninitializeRuntimeTypes()
     {
+        _registered = false;
         ShapeRenderer.Self.Uninitialize();
     }
 

--- a/Tests/MonoGameGum.Shapes.Tests/AposShapeRuntimeReregistrationTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/AposShapeRuntimeReregistrationTests.cs
@@ -1,0 +1,31 @@
+using Gum.DataTypes;
+using Gum.GueDeriving;
+using GumRuntime;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #4417 — AposShapeRuntime.RegisterRuntimeTypes latches its ElementSaveExtensions
+// registrations behind a static _registered flag that is set once and never reset. GumService.
+// Uninitialize() clears those registrations via ElementSaveExtensions.ClearRegistrations(), but
+// AposShapeRuntime.UninitializeRuntimeTypes() (the reflection teardown hook added in #4416) never
+// resets _registered, so a subsequent Initialize's re-scan silently no-ops and Arc/ColoredCircle/
+// Line/RoundedRectangle never come back.
+public class AposShapeRuntimeReregistrationTests
+{
+    [Fact]
+    public void RegisterRuntimeTypes_AfterUninitializeRuntimeTypes_ReregistersGueInstantiation()
+    {
+        AposShapeRuntime.RegisterRuntimeTypes();
+
+        ElementSaveExtensions.ClearRegistrations();
+        AposShapeRuntime.UninitializeRuntimeTypes();
+
+        AposShapeRuntime.RegisterRuntimeTypes();
+
+        ComponentSave elementSave = new ComponentSave { Name = "Arc" };
+        var gue = ElementSaveExtensions.CreateGueForElement(elementSave);
+
+        gue.ShouldBeOfType<global::MonoGameGum.GueDeriving.ArcRuntime>();
+    }
+}


### PR DESCRIPTION
Closes #4417

`AposShapeRuntime.UninitializeRuntimeTypes()` (added in #4416) reset `ShapeRenderer.Self` but never reset the `_registered` guard in `RegisterRuntimeTypes()`. Since `GumService.Uninitialize()` clears `ElementSaveExtensions`' registrations via `ClearRegistrations()`, a second `Initialize()` would skip re-registering Arc/ColoredCircle/Line/RoundedRectangle because `_registered` was still `true` from the first cycle.

Fix: reset `_registered = false` in `UninitializeRuntimeTypes()`.

Added a red-then-green test (`AposShapeRuntimeReregistrationTests`) that reproduces the full Register -> ClearRegistrations -> Uninitialize -> Register cycle and asserts `CreateGueForElement("Arc")` resolves to `ArcRuntime` afterward.
