### PR TITLE
Fix Bubblegum focus-ring geometry and missing Window border

### DIFF
--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ItemsControl.gucx
@@ -161,10 +161,10 @@
       <Value xsi:type="xsd:string">InnerPanelInstance</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.CornerRadius" SetsValue="true">
-      <Value xsi:type="xsd:float">8</Value>
+      <Value xsi:type="xsd:float">10</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">4</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="FocusedIndicator.HeightUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
@@ -189,7 +189,7 @@
       <Value xsi:type="xsd:boolean">false</Value>
     </Variable>
     <Variable Type="float" Name="FocusedIndicator.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">4</Value>
     </Variable>
     <Variable Type="DimensionUnitType" Name="FocusedIndicator.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Window.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Window.gucx
@@ -5,7 +5,7 @@
   <State>
     <Name>Default</Name>
     <Variable Type="float" Name="Background.CornerRadius" SetsValue="true">
-      <Value xsi:type="xsd:float">0</Value>
+      <Value xsi:type="xsd:float">14</Value>
     </Variable>
     <Variable Type="int" Name="Background.DropshadowAlpha" SetsValue="true">
       <Value xsi:type="xsd:int">80</Value>
@@ -78,6 +78,54 @@
       <Value xsi:type="xsd:int">1</Value>
     </Variable>
     <Variable Type="PositionUnitType" Name="Background.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">14</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="BorderInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="BorderInstance.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="int" Name="BorderInstance.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">204</Value>
+    </Variable>
+    <Variable Type="int" Name="BorderInstance.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">170</Value>
+    </Variable>
+    <Variable Type="int" Name="BorderInstance.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">240</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">2</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="BorderInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="BorderInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="BorderInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="BorderInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="BorderInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="BorderInstance.YUnits" SetsValue="true">
       <Value xsi:type="xsd:int">7</Value>
     </Variable>
     <Variable Type="float" Name="BorderBottomInstance.Height" SetsValue="true">
@@ -490,6 +538,16 @@
     </VariableList>
     <VariableList xsi:type="VariableListSaveOfString">
       <Type>string</Type>
+      <Name>BorderInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>StrokeColor = Components/Bubblegum/Styles.Border.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
       <Name>TitleBarFill.VariableReferences</Name>
       <Category>References</Category>
       <IsFile>false</IsFile>
@@ -510,6 +568,7 @@
     </VariableList>
   </State>
   <Instance Name="Background" BaseType="Rectangle" />
+  <Instance Name="BorderInstance" BaseType="Rectangle" />
   <Instance Name="InnerPanelInstance" BaseType="Bubblegum/Controls/Panel" />
   <Instance Name="TitleBarInstance" BaseType="Bubblegum/Controls/Panel" />
   <Instance Name="TitleBarFill" BaseType="Rectangle" />


### PR DESCRIPTION
Part of #4424 — audited Bubblegum's Add Forms tool content against its C# theme source (`Themes/Gum.Themes.Bubblegum.MonoGame/`) for the three bug classes found while porting Neon.

## Found and fixed

- **Focus-ring geometry (bug class 1):** `ItemsControl.gucx`'s `FocusedIndicator` was undersized — `CornerRadius=8`, `Width`/`Height` delta `=0` — instead of matching `ScrollViewerVisual`'s `CornerRadius=8` + `FocusRingInset=2` (ItemsControl has no own C# visual; it inherits ScrollViewerVisual's shell). Fixed to `CornerRadius=10`, delta `=4`, matching `ScrollViewer.gucx`'s already-correct ring.
- **Dropshadow/stroke wiring (bug class 2):** `Window.gucx` was missing its border entirely — `Background.CornerRadius` was `0` (should be `14`, per `WindowVisual.cs`) and the 2px accent border (`BubblegumShapes.Border`, `"BubblegumWindowBorder"` in code) had no tool-content equivalent at all. Added a `BorderInstance` following the same pattern ComboBox's own border uses.

## Checked clean, no fix needed

- Every other control's focus ring, dropshadow/stroke wiring — checked control-by-control against every `*Visual.cs`.
- **Alpha-drop on composite color refs (bug class 3):** doesn't apply to Bubblegum — the theme hardcodes alpha as a literal `<Variable>` next to composite `*Color =` references rather than routing translucent swatches through the composite form, so there's no channel to drop.

## Out of scope, filed separately

`ToggleButtonVisual.cs` exists in Bubblegum's C# theme (and DarkPro's) but has no matching `ToggleButton.gucx` in either theme's tool content — filed as #4425, unrelated to the three #4424 bug classes.

## Verification

- `gumcli check` / `check-references` / `diff-standards` on `Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx` — clean before and after.
- `BubblegumTemplateTests` (11 tests) and full `Gum.ProjectServices.Tests` suite (485 passed, 3 pre-existing skips) — all green.
- Full `GumFull.sln` rebuild + diffed staged `Content/FormsThemes/Bubblegum/` output against source — identical, confirms the postbuild copy picked up both fixes.
- `gumcli screenshot` of `Window` (default state) and `ItemsControl` (Focused category state temporarily forced visible, then reverted) — both fixes visually confirmed: Window now has rounded corners + visible pink border; ItemsControl's focus ring renders as a symmetric outward halo instead of flush/undersized.

Manual test: screenshots covered it — both fixes are static geometry/stroke changes with no interactive-state logic, and the rendered PNGs confirm the exact visual result. Manual re-verification in the running tool is optional.
