### PR TITLE
Recycle rather than delete user files on rename/delete; move .codsj with the element (Part of #4422)

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -118,7 +118,8 @@ public class MainCodeOutputPlugin : PluginBase
             customCodeGenerator,
             _codeGenerationNameVerifier,
             dialogService,
-            _projectDirectoryProvider);
+            _projectDirectoryProvider,
+            fileCommands);
 
         _messenger = messenger;
         _fileCommands = fileCommands;

--- a/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs
@@ -78,18 +78,13 @@ public class DeleteObjectPlugin : PriorityPlugin
 
             if (deleteXmlCheckBox.IsChecked == true)
             {
-                var fileName = _instanceDeletionHelper.GetFileNameForObject(deletedObject);
+                // The element XML is user data and Gum's undo restores project state, not files on
+                // disk, so it goes to the recycle bin rather than being deleted outright.
+                var response = _instanceDeletionHelper.TryRecycleXmlFileForObject(deletedObject);
 
-                if (fileName?.Exists() == true)
+                if (!response.Succeeded)
                 {
-                    try
-                    {
-                        System.IO.File.Delete(fileName.FullPath);
-                    }
-                    catch
-                    {
-                        _dialogService.ShowMessage("Could not delete the file\n" + fileName);
-                    }
+                    _dialogService.ShowMessage(response.Message);
                 }
             }
         }

--- a/Tests/Gum.Presentation.Tests/InstanceDeletionHelperTests.cs
+++ b/Tests/Gum.Presentation.Tests/InstanceDeletionHelperTests.cs
@@ -1,0 +1,87 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.Gui.Plugins;
+using Gum.Managers;
+using Moq;
+using Shouldly;
+using ToolsUtilities;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Tests for the file-reconciliation half of InstanceDeletionHelper. An element's XML file is user
+/// data that Gum's undo cannot restore, so deleting an element must not destroy it outright.
+/// </summary>
+public class InstanceDeletionHelperTests : BaseTestClass
+{
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly InstanceDeletionHelper _instanceDeletionHelper;
+    private readonly string _projectDirectory;
+
+    public InstanceDeletionHelperTests()
+    {
+        _projectDirectory = Path.Combine(Path.GetTempPath(), "GumInstanceDeletionHelperTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_projectDirectory);
+
+        _instanceDeletionHelper = new InstanceDeletionHelper(
+            Mock.Of<IDeleteLogic>(),
+            Mock.Of<IGuiCommands>(),
+            Mock.Of<IWireframeCommands>(),
+            _fileCommands.Object);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (Directory.Exists(_projectDirectory))
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Creates the element's XML file on disk and points IFileCommands at it, the way the tool does
+    /// for a saved element.
+    /// </summary>
+    private ComponentSave GivenComponentWithXmlFileOnDisk(string name)
+    {
+        ComponentSave component = new ComponentSave { Name = name };
+
+        string xmlPath = Path.Combine(_projectDirectory, name + ".gucx");
+        File.WriteAllText(xmlPath, "<ComponentSave />");
+
+        _fileCommands
+            .Setup(x => x.GetFullPathXmlFile(component, name))
+            .Returns(new FilePath(xmlPath));
+
+        return component;
+    }
+
+    [Fact]
+    public void TryRecycleXmlFileForObject_WhenTheFileCannotBeRemoved_ReturnsAnExplanatoryMessage()
+    {
+        ComponentSave component = GivenComponentWithXmlFileOnDisk("LockedComponent");
+        _fileCommands
+            .Setup(x => x.MoveToRecycleBin(It.IsAny<FilePath>()))
+            .Throws(new IOException("The process cannot access the file because it is being used by another process."));
+
+        GeneralResponse response = _instanceDeletionHelper.TryRecycleXmlFileForObject(component);
+
+        response.Succeeded.ShouldBeFalse();
+        response.Message.ShouldContain("LockedComponent.gucx");
+        response.Message.ShouldContain("read-only");
+    }
+
+    [Fact]
+    public void TryRecycleXmlFileForObject_WhenTheFileExists_MovesItToTheRecycleBin()
+    {
+        ComponentSave component = GivenComponentWithXmlFileOnDisk("MyComponent");
+
+        GeneralResponse response = _instanceDeletionHelper.TryRecycleXmlFileForObject(component);
+
+        response.Succeeded.ShouldBeTrue();
+        _fileCommands.Verify(
+            x => x.MoveToRecycleBin(new FilePath(Path.Combine(_projectDirectory, "MyComponent.gucx"))),
+            Times.Once);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/RenameServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/RenameServiceTests.cs
@@ -9,6 +9,7 @@ using Gum.Services;
 using Gum.Services.Dialogs;
 using Moq;
 using Shouldly;
+using ToolsUtilities;
 
 namespace Gum.Presentation.Tests;
 
@@ -21,6 +22,7 @@ namespace Gum.Presentation.Tests;
 public class RenameServiceTests : BaseTestClass
 {
     private readonly Mock<IDialogService> _dialogService = new();
+    private readonly Mock<IFileCommands> _fileCommands = new();
     private readonly Mock<IGuiCommands> _guiCommands = new();
     private readonly RenameService _renameService;
     private readonly string _codeProjectRoot;
@@ -29,6 +31,12 @@ public class RenameServiceTests : BaseTestClass
     {
         _codeProjectRoot = Path.Combine(Path.GetTempPath(), "GumRenameServiceTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_codeProjectRoot);
+
+        // The real recycle bin removes the file, so the fake does too - otherwise a move onto the
+        // recycled path would fail with "file already exists".
+        _fileCommands
+            .Setup(x => x.MoveToRecycleBin(It.IsAny<FilePath>()))
+            .Callback<FilePath>(filePath => File.Delete(filePath.FullPath));
 
         Mock<INameVerifier> nameVerifier = new();
         string whyNotValid;
@@ -43,7 +51,9 @@ public class RenameServiceTests : BaseTestClass
             .Callback<Action, int>((action, _) => action());
 
         CodeGenerationNameVerifier codeGenNameVerifier = new(nameVerifier.Object);
-        FixedProjectDirectoryProvider directoryProvider = new(_codeProjectRoot);
+        // Production's project directory always carries a trailing separator (it comes from
+        // FileManager.GetDirectory), and element XML paths are built by string concatenation.
+        FixedProjectDirectoryProvider directoryProvider = new(_codeProjectRoot + Path.DirectorySeparatorChar);
         CodeOutputElementSettingsManager elementSettingsManager = new(directoryProvider);
         LocalizationService localizationService = new();
 
@@ -70,7 +80,8 @@ public class RenameServiceTests : BaseTestClass
             customCodeGenerator,
             codeGenNameVerifier,
             _dialogService.Object,
-            directoryProvider);
+            directoryProvider,
+            _fileCommands.Object);
     }
 
     public override void Dispose()
@@ -117,7 +128,7 @@ public class RenameServiceTests : BaseTestClass
     /// "Components\MyComponent.cs" literal would create one oddly named file in the root rather than
     /// the nested file the test means.
     /// </summary>
-    private void GivenCustomCodeFile(string relativePath, string contents)
+    private void GivenFile(string relativePath, string contents)
     {
         string fullPath = Path.Combine(_codeProjectRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
         Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
@@ -125,23 +136,67 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void HandleRename_WithEmptyCodeProjectRoot_DoesNothing()
+    public void HandleRename_WhenCollidingFileCannotBeRecycled_ShowsAnExplanatoryMessage()
     {
+        GivenFile("Components/OldName.cs", "partial class OldName\r\n{\r\n}\r\n");
+        GivenFile("Components/NewName.cs", "//already at the rename target, and locked");
+
+        ComponentSave element = GivenComponentInProject("NewName");
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+
+        string? errorMessage = null;
+        _dialogService
+            .Setup(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageDialogStyle?>()))
+            .Callback<string, string, MessageDialogStyle?>((message, _, style) =>
+            {
+                // A null style is the plain error popup; the overwrite prompt uses YesNo.
+                if (style == null)
+                {
+                    errorMessage = message;
+                }
+            })
+            .Returns(MessageDialogResult.Affirmative);
+
+        _fileCommands
+            .Setup(x => x.MoveToRecycleBin(It.IsAny<FilePath>()))
+            .Throws(new UnauthorizedAccessException("Access to the path is denied."));
+
+        _renameService.HandleRename(element, oldName: "OldName", projectSettings, VisualApi.Gum);
+
+        errorMessage.ShouldNotBeNull();
+        errorMessage.ShouldContain("NewName.cs");
+        errorMessage.ShouldContain("read-only");
+        // A raw exception dump names the exception type and its stack; the user gets a sentence.
+        errorMessage.ShouldNotContain(nameof(UnauthorizedAccessException));
+    }
+
+    [Fact]
+    public void HandleRename_WhenElementMovedOutOfFolderToRoot_UpdatesNamespace()
+    {
+        GivenFile("Components/Widgets/MyComponent.cs",
+            "namespace MyGame.Components.Widgets\r\n" +
+            "{\r\n" +
+            "    partial class MyComponent\r\n" +
+            "    {\r\n" +
+            "    }\r\n" +
+            "}\r\n");
+
         ComponentSave element = GivenComponentInProject("MyComponent");
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
 
-        _renameService.HandleRename(
-            element,
-            oldName: "OldName",
-            codeOutputProjectSettings: new CodeOutputProjectSettings(), // CodeProjectRoot defaults to empty
-            visualApi: VisualApi.Gum);
+        _renameService.HandleRename(element, oldName: "Widgets/MyComponent", projectSettings, VisualApi.Gum);
 
-        _dialogService.VerifyNoOtherCalls();
+        File.Exists(Path.Combine(_codeProjectRoot, "Components", "Widgets", "MyComponent.cs")).ShouldBeFalse();
+
+        string movedCustomCode = File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "MyComponent.cs"));
+        movedCustomCode.ShouldContain("namespace MyGame.Components\r");
+        movedCustomCode.ShouldNotContain("Widgets");
     }
 
     [Fact]
     public void HandleRename_WhenElementMovedToFolder_MovesCustomFileAndUpdatesNamespaceToMatchGeneratedFile()
     {
-        GivenCustomCodeFile("Components/MyComponent.cs",
+        GivenFile("Components/MyComponent.cs",
             "namespace MyGame.Components\r\n" +
             "{\r\n" +
             "    partial class MyComponent\r\n" +
@@ -152,7 +207,7 @@ public class RenameServiceTests : BaseTestClass
             "        }\r\n" +
             "    }\r\n" +
             "}\r\n");
-        GivenCustomCodeFile("Components/MyComponent.Generated.cs", "//stale generated file");
+        GivenFile("Components/MyComponent.Generated.cs", "//stale generated file");
 
         // The tool renames the element (folder moves arrive as a rename to "Folder/Name") before
         // notifying the rename service, so the element already carries its new identity here.
@@ -179,9 +234,41 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleRename_WhenElementMovedToFolder_MovesElementSettingsFile()
+    {
+        // The .codsj holding per-element code settings sits next to the element XML, so it has to
+        // follow the element into its new folder or the settings silently revert to defaults.
+        GivenFile("Components/MyComponent.codsj", "{\"UsingStatements\":\"using MovedSettingsMarker;\"}");
+
+        ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+
+        _renameService.HandleRename(element, oldName: "MyComponent", projectSettings, VisualApi.Gum);
+
+        File.Exists(Path.Combine(_codeProjectRoot, "Components", "MyComponent.codsj")).ShouldBeFalse();
+        File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "Widgets", "MyComponent.codsj"))
+            .ShouldContain("MovedSettingsMarker");
+    }
+
+    [Fact]
+    public void HandleRename_WhenElementRenamedInPlace_MovesElementSettingsFile()
+    {
+        GivenFile("Components/OldName.codsj", "{\"UsingStatements\":\"using RenamedSettingsMarker;\"}");
+
+        ComponentSave element = GivenComponentInProject("NewName");
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+
+        _renameService.HandleRename(element, oldName: "OldName", projectSettings, VisualApi.Gum);
+
+        File.Exists(Path.Combine(_codeProjectRoot, "Components", "OldName.codsj")).ShouldBeFalse();
+        File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "NewName.codsj"))
+            .ShouldContain("RenamedSettingsMarker");
+    }
+
+    [Fact]
     public void HandleRename_WhenElementRenamedInPlace_RenamesClassAndKeepsNamespace()
     {
-        GivenCustomCodeFile("Components/OldName.cs",
+        GivenFile("Components/OldName.cs",
             "namespace MyGame.Components\r\n" +
             "{\r\n" +
             "    partial class OldName\r\n" +
@@ -208,32 +295,74 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void HandleRename_WhenElementMovedOutOfFolderToRoot_UpdatesNamespace()
+    public void HandleRename_WhenOnlyCasingChanges_KeepsCustomCodeAndCorrectsFileNameCasing()
     {
-        GivenCustomCodeFile("Components/Widgets/MyComponent.cs",
-            "namespace MyGame.Components.Widgets\r\n" +
+        GivenFile("Components/MyComponent.cs",
+            "namespace MyGame.Components\r\n" +
             "{\r\n" +
             "    partial class MyComponent\r\n" +
             "    {\r\n" +
+            "        partial void CustomInitialize()\r\n" +
+            "        {\r\n" +
+            "            HandWrittenMarker();\r\n" +
+            "        }\r\n" +
             "    }\r\n" +
             "}\r\n");
 
-        ComponentSave element = GivenComponentInProject("MyComponent");
+        ComponentSave element = GivenComponentInProject("mycomponent");
         CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
 
-        _renameService.HandleRename(element, oldName: "Widgets/MyComponent", projectSettings, VisualApi.Gum);
+        _renameService.HandleRename(element, oldName: "MyComponent", projectSettings, VisualApi.Gum);
 
-        File.Exists(Path.Combine(_codeProjectRoot, "Components", "Widgets", "MyComponent.cs")).ShouldBeFalse();
+        // Old and new point at the same physical file on a case-insensitive filesystem, so there is
+        // nothing to overwrite - no prompt, and above all no delete of the user's code.
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
 
-        string movedCustomCode = File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "MyComponent.cs"));
-        movedCustomCode.ShouldContain("namespace MyGame.Components\r");
-        movedCustomCode.ShouldNotContain("Widgets");
+        string customCodeDirectory = Path.Combine(_codeProjectRoot, "Components");
+        File.ReadAllText(Path.Combine(customCodeDirectory, "mycomponent.cs")).ShouldContain("HandWrittenMarker();");
+        Directory.GetFiles(customCodeDirectory, "*.cs").Select(Path.GetFileName).ShouldContain("mycomponent.cs");
+    }
+
+    [Fact]
+    public void HandleRename_WhenTargetCustomFileExists_MovesItToTheRecycleBinRatherThanDeletingIt()
+    {
+        GivenFile("Components/OldName.cs",
+            "namespace MyGame.Components\r\n" +
+            "{\r\n" +
+            "    partial class OldName\r\n" +
+            "    {\r\n" +
+            "        partial void CustomInitialize()\r\n" +
+            "        {\r\n" +
+            "            HandWrittenMarker();\r\n" +
+            "        }\r\n" +
+            "    }\r\n" +
+            "}\r\n");
+        GivenFile("Components/NewName.cs", "//already at the rename target");
+
+        ComponentSave element = GivenComponentInProject("NewName");
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+
+        // MessageDialogStyle.YesNo hands back a new instance per call, so it cannot be matched by
+        // value - match the overwrite prompt on its title instead.
+        _dialogService
+            .Setup(x => x.ShowMessage(It.IsAny<string>(), "Overwrite?", It.IsAny<MessageDialogStyle?>()))
+            .Returns(MessageDialogResult.Affirmative);
+
+        _renameService.HandleRename(element, oldName: "OldName", projectSettings, VisualApi.Gum);
+
+        // Custom code is user-authored and Gum's undo does not restore files, so the overwritten
+        // file has to be recoverable from the recycle bin.
+        FilePath overwrittenFile = new FilePath(Path.Combine(_codeProjectRoot, "Components", "NewName.cs"));
+        _fileCommands.Verify(x => x.MoveToRecycleBin(overwrittenFile), Times.Once);
+
+        File.Exists(Path.Combine(_codeProjectRoot, "Components", "OldName.cs")).ShouldBeFalse();
+        File.ReadAllText(overwrittenFile.FullPath).ShouldContain("HandWrittenMarker();");
     }
 
     [Fact]
     public void HandleRename_WithAppendFolderToNamespaceOff_LeavesNamespaceUnchangedAcrossFolderMove()
     {
-        GivenCustomCodeFile("Components/MyComponent.cs",
+        GivenFile("Components/MyComponent.cs",
             "namespace MyGame.Components\r\n" +
             "{\r\n" +
             "    partial class MyComponent\r\n" +
@@ -252,40 +381,44 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void UpdateHeadersInCustomCode_WithFileScopedNamespace_UpdatesNamespaceAndKeepsSemicolon()
+    public void HandleRename_WithEmptyCodeProjectRoot_DoesNothing()
     {
-        ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
-        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
-        string contents =
-            "namespace MyGame.Components;\r\n" +
-            "\r\n" +
-            "partial class MyComponent\r\n" +
-            "{\r\n" +
-            "}\r\n";
+        ComponentSave element = GivenComponentInProject("MyComponent");
 
-        string updated = _renameService.UpdateHeadersInCustomCode(contents, element, elementSettings: null, projectSettings);
+        _renameService.HandleRename(
+            element,
+            oldName: "OldName",
+            codeOutputProjectSettings: new CodeOutputProjectSettings(), // CodeProjectRoot defaults to empty
+            visualApi: VisualApi.Gum);
 
-        updated.ShouldContain("namespace MyGame.Components.Widgets;");
+        _dialogService.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public void UpdateHeadersInCustomCode_WithNoRootNamespace_LeavesExistingNamespaceAlone()
+    public void HandleVariableSet_WhenBaseTypeChangedWithInheritanceInCustomCode_RewritesTheBaseType()
     {
-        ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
-        // Without a RootNamespace codegen emits no namespace at all, so there is nothing to rename the
-        // user's hand-written namespace to. Blanking it would produce uncompilable code.
-        CodeOutputProjectSettings projectSettings = GivenProjectSettings(rootNamespace: string.Empty, appendFolderToNamespace: true);
-        string contents =
-            "namespace MyHandWrittenNamespace\r\n" +
+        GivenFile("Components/MyComponent.cs",
+            "namespace MyGame.Components\r\n" +
             "{\r\n" +
-            "    partial class MyComponent\r\n" +
+            "    partial class MyComponent : Container\r\n" +
             "    {\r\n" +
+            "        partial void CustomInitialize()\r\n" +
+            "        {\r\n" +
+            "            HandWrittenMarker();\r\n" +
+            "        }\r\n" +
             "    }\r\n" +
-            "}\r\n";
+            "}\r\n");
 
-        string updated = _renameService.UpdateHeadersInCustomCode(contents, element, elementSettings: null, projectSettings);
+        ComponentSave element = GivenComponentInProject("MyComponent");
+        element.BaseType = "Rectangle";
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+        projectSettings.InheritanceLocation = InheritanceLocation.InCustomCode;
 
-        updated.ShouldContain("namespace MyHandWrittenNamespace");
+        _renameService.HandleVariableSet(element, instance: null, "BaseType", oldValue: "Container", projectSettings);
+
+        string customCode = File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "MyComponent.cs"));
+        customCode.ShouldContain("HandWrittenMarker();");
+        customCode.ShouldNotContain(": Container");
     }
 
     [Fact]
@@ -308,23 +441,20 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void UpdateHeadersInCustomCode_WithInheritanceInGeneratedCode_KeepsUserAddedBaseType()
+    public void UpdateHeadersInCustomCode_WithFileScopedNamespace_UpdatesNamespaceAndKeepsSemicolon()
     {
         ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
-        // InheritanceLocation defaults to InGeneratedCode, so the generated partial owns the base list
-        // and anything the user added to the custom partial (an interface, say) has to survive.
         CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
         string contents =
-            "namespace MyGame.Components\r\n" +
+            "namespace MyGame.Components;\r\n" +
+            "\r\n" +
+            "partial class MyComponent\r\n" +
             "{\r\n" +
-            "    partial class MyComponent : IDisposable\r\n" +
-            "    {\r\n" +
-            "    }\r\n" +
             "}\r\n";
 
         string updated = _renameService.UpdateHeadersInCustomCode(contents, element, elementSettings: null, projectSettings);
 
-        updated.ShouldContain("partial class MyComponent : IDisposable");
+        updated.ShouldContain("namespace MyGame.Components.Widgets;");
     }
 
     [Fact]
@@ -350,6 +480,46 @@ public class RenameServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void UpdateHeadersInCustomCode_WithInheritanceInGeneratedCode_KeepsUserAddedBaseType()
+    {
+        ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
+        // InheritanceLocation defaults to InGeneratedCode, so the generated partial owns the base list
+        // and anything the user added to the custom partial (an interface, say) has to survive.
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
+        string contents =
+            "namespace MyGame.Components\r\n" +
+            "{\r\n" +
+            "    partial class MyComponent : IDisposable\r\n" +
+            "    {\r\n" +
+            "    }\r\n" +
+            "}\r\n";
+
+        string updated = _renameService.UpdateHeadersInCustomCode(contents, element, elementSettings: null, projectSettings);
+
+        updated.ShouldContain("partial class MyComponent : IDisposable");
+    }
+
+    [Fact]
+    public void UpdateHeadersInCustomCode_WithNoRootNamespace_LeavesExistingNamespaceAlone()
+    {
+        ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
+        // Without a RootNamespace codegen emits no namespace at all, so there is nothing to rename the
+        // user's hand-written namespace to. Blanking it would produce uncompilable code.
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings(rootNamespace: string.Empty, appendFolderToNamespace: true);
+        string contents =
+            "namespace MyHandWrittenNamespace\r\n" +
+            "{\r\n" +
+            "    partial class MyComponent\r\n" +
+            "    {\r\n" +
+            "    }\r\n" +
+            "}\r\n";
+
+        string updated = _renameService.UpdateHeadersInCustomCode(contents, element, elementSettings: null, projectSettings);
+
+        updated.ShouldContain("namespace MyHandWrittenNamespace");
+    }
+
+    [Fact]
     public void UpdateHeadersInCustomCode_WithWindowsLineEndings_DoesNotStripTheCarriageReturn()
     {
         ComponentSave element = GivenComponentInProject("Widgets/MyComponent");
@@ -367,30 +537,4 @@ public class RenameServiceTests : BaseTestClass
         updated.ShouldContain("partial class MyComponent\r\n");
     }
 
-    [Fact]
-    public void HandleVariableSet_WhenBaseTypeChangedWithInheritanceInCustomCode_RewritesTheBaseType()
-    {
-        GivenCustomCodeFile("Components/MyComponent.cs",
-            "namespace MyGame.Components\r\n" +
-            "{\r\n" +
-            "    partial class MyComponent : Container\r\n" +
-            "    {\r\n" +
-            "        partial void CustomInitialize()\r\n" +
-            "        {\r\n" +
-            "            HandWrittenMarker();\r\n" +
-            "        }\r\n" +
-            "    }\r\n" +
-            "}\r\n");
-
-        ComponentSave element = GivenComponentInProject("MyComponent");
-        element.BaseType = "Rectangle";
-        CodeOutputProjectSettings projectSettings = GivenProjectSettings("MyGame", appendFolderToNamespace: true);
-        projectSettings.InheritanceLocation = InheritanceLocation.InCustomCode;
-
-        _renameService.HandleVariableSet(element, instance: null, "BaseType", oldValue: "Container", projectSettings);
-
-        string customCode = File.ReadAllText(Path.Combine(_codeProjectRoot, "Components", "MyComponent.cs"));
-        customCode.ShouldContain("HandWrittenMarker();");
-        customCode.ShouldNotContain(": Container");
-    }
 }

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/RenameService.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/RenameService.cs
@@ -1,4 +1,5 @@
 using Gum.ProjectServices.CodeGeneration;
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
 using System;
@@ -17,13 +18,15 @@ public class RenameService
     private readonly CustomCodeGenerator _customCodeGenerator;
     private readonly CodeOutputElementSettingsManager _elementSettingsManager;
     private readonly IDialogService _dialogService;
+    private readonly IFileCommands _fileCommands;
 
     public RenameService(CodeGenerationService codeGenerationService,
         CodeGenerator codeGenerator,
         CustomCodeGenerator customCodeGenerator,
         CodeGenerationNameVerifier nameVerifier,
         IDialogService dialogService,
-        IProjectDirectoryProvider projectDirectoryProvider)
+        IProjectDirectoryProvider projectDirectoryProvider,
+        IFileCommands fileCommands)
     {
         _codeGenerationFileLocationsService = new CodeGenerationFileLocationsService(codeGenerator, nameVerifier, projectDirectoryProvider);
         _elementSettingsManager = new CodeOutputElementSettingsManager(projectDirectoryProvider);
@@ -31,16 +34,22 @@ public class RenameService
         _codeGenerator = codeGenerator;
         _customCodeGenerator = customCodeGenerator;
         _dialogService = dialogService;
+        _fileCommands = fileCommands;
     }
 
     public void HandleRename(ElementSave element, string oldName, CodeOutputProjectSettings codeOutputProjectSettings, VisualApi visualApi)
     {
-        if (codeOutputProjectSettings.CodeProjectRoot == string.Empty)
-        {
-            return;
-        }
         try
         {
+            // The .codsj sits next to the element's XML rather than in the code project, so it
+            // follows the element even when no code output folder is configured.
+            MoveElementSettingsFile(element, oldName);
+
+            if (codeOutputProjectSettings.CodeProjectRoot == string.Empty)
+            {
+                return;
+            }
+
             var elementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
 
             var oldGeneratedFileName = _codeGenerationFileLocationsService.GetGeneratedFileName(element, elementSettings, codeOutputProjectSettings, visualApi, oldName);
@@ -48,10 +57,42 @@ public class RenameService
             var newCustomFileName = _codeGenerationFileLocationsService.GetCustomCodeFileName(element, elementSettings, codeOutputProjectSettings, visualApi);
             RegenerateAndMoveCode(element, elementSettings, codeOutputProjectSettings, oldGeneratedFileName, oldCustomFileName, newCustomFileName);
         }
+        catch (FileOperationException e)
+        {
+            _dialogService.ShowMessage(e.Message, $"Error moving code for {element}");
+        }
         catch (Exception e)
         {
             _dialogService.ShowMessage(e.ToString(), $"Error moving code for {element}");
         }
+    }
+
+    /// <summary>
+    /// Moves the element's .codsj settings file from its old name/folder to the current one. Without
+    /// this a renamed or relocated element silently reverts to default per-element code settings.
+    /// </summary>
+    private void MoveElementSettingsFile(ElementSave element, string oldName)
+    {
+        FilePath? oldSettingsFile = _elementSettingsManager.GetCodeSettingsFilePath(element, oldName);
+        FilePath? newSettingsFile = _elementSettingsManager.GetCodeSettingsFilePath(element);
+
+        ////////////////Early Out/////////////////
+        if (oldSettingsFile == null || newSettingsFile == null ||
+            oldSettingsFile.FullPath == newSettingsFile.FullPath ||
+            !oldSettingsFile.Exists())
+        {
+            return;
+        }
+
+        // A file already at the destination belongs to some other element, so leave both alone
+        // rather than overwriting settings that cannot be recovered.
+        if (newSettingsFile.Exists() && !IsSameFileWithDifferentCase(oldSettingsFile, newSettingsFile))
+        {
+            return;
+        }
+        //////////////End Early Out///////////////
+
+        MoveFile(oldSettingsFile, newSettingsFile);
     }
 
     private void RegenerateAndMoveCode(ElementSave element,
@@ -59,40 +100,52 @@ public class RenameService
         CodeOutputProjectSettings codeOutputProjectSettings, FilePath? oldGeneratedFileName,
         FilePath? oldCustomFileName, FilePath? newCustomFileName)
     {
-        // 1. Delete the old generated file
+        // 1. Delete the old generated file. Generated code is derived data - step 5 recreates it
+        // byte-identical at the new name - so deleting it outright is lossless.
         if (oldGeneratedFileName?.Exists() == true)
         {
-            System.IO.File.Delete(oldGeneratedFileName.FullPath);
+            try
+            {
+                System.IO.File.Delete(oldGeneratedFileName.FullPath);
+            }
+            catch (Exception e) when (FileOperationFailure.IsAccessFailure(e))
+            {
+                throw new FileOperationException(
+                    FileOperationFailure.BuildMessage(
+                        $"Could not delete this generated code file:\n{oldGeneratedFileName.FullPath}", e),
+                    e);
+            }
         }
 
         // 2. Rename the existing custom code file
-        if (oldCustomFileName?.Exists() == true)
+        if (oldCustomFileName?.Exists() == true && newCustomFileName != null)
         {
             bool shouldMove = true;
-            if (newCustomFileName?.Exists() == true)
+
+            // A rename that only changes casing points both names at the same physical file on a
+            // case-insensitive filesystem, so there is nothing to overwrite - MoveFile corrects the
+            // casing instead.
+            bool isOverwritingAnotherFile = newCustomFileName.Exists() &&
+                !IsSameFileWithDifferentCase(oldCustomFileName, newCustomFileName);
+
+            if (isOverwritingAnotherFile)
             {
                 var message = $"Would you like to rename the custom code file to:\n" +
                     $"{newCustomFileName.FullPath}\n" +
-                    $"This would delete the existing file that is already there";
+                    $"The file already there will be moved to the recycle bin.";
                 shouldMove = _dialogService.ShowYesNoMessage(message, "Overwrite?");
 
                 if (shouldMove)
                 {
-                    System.IO.File.Delete(newCustomFileName.FullPath);
+                    // Custom code is user-authored and unrecoverable through Gum's undo, so it goes
+                    // to the recycle bin rather than being deleted outright.
+                    RecycleFile(newCustomFileName);
                 }
             }
 
             if (shouldMove)
             {
-                // Moving into a folder for the first time means the destination directory may not
-                // exist yet - without this the move throws and the custom file orphans at its old path.
-                var newDirectory = newCustomFileName!.GetDirectoryContainingThis();
-                if (newDirectory != null && !System.IO.Directory.Exists(newDirectory.FullPath))
-                {
-                    System.IO.Directory.CreateDirectory(newDirectory.FullPath);
-                }
-
-                System.IO.File.Move(oldCustomFileName.FullPath, newCustomFileName.FullPath);
+                MoveFile(oldCustomFileName, newCustomFileName);
             }
         }
 
@@ -119,6 +172,74 @@ public class RenameService
 
         // 5. Regenerate this
         _codeGenerationService.GenerateCodeForElement(element, thisElementOutputSettings, codeOutputProjectSettings, showPopups: false);
+    }
+
+    /// <summary>
+    /// True when the two paths differ only by casing, which means they are the same physical file on
+    /// a case-insensitive filesystem (Windows, macOS).
+    /// </summary>
+    private static bool IsSameFileWithDifferentCase(FilePath first, FilePath second) =>
+        first.FullPath != second.FullPath &&
+        string.Equals(first.FullPath, second.FullPath, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Moves a file, creating the destination directory if needed and translating file-access
+    /// failures into a message the user can act on.
+    /// </summary>
+    private static void MoveFile(FilePath source, FilePath destination)
+    {
+        try
+        {
+            // Moving into a folder for the first time means the destination directory may not exist
+            // yet - without this the move throws and the file orphans at its old path.
+            var destinationDirectory = destination.GetDirectoryContainingThis();
+            if (destinationDirectory != null && !System.IO.Directory.Exists(destinationDirectory.FullPath))
+            {
+                System.IO.Directory.CreateDirectory(destinationDirectory.FullPath);
+            }
+
+            if (IsSameFileWithDifferentCase(source, destination))
+            {
+                // Source and destination are the same physical file, so move through a temporary
+                // name. Windows corrects the casing with a direct move, but File.Move pre-checks the
+                // destination on Unix and throws "already exists" on a case-insensitive macOS
+                // volume. The casing on disk does have to change: git is case-sensitive even where
+                // the filesystem is not.
+                var temporaryPath = destination.FullPath + ".gumrename";
+                System.IO.File.Move(source.FullPath, temporaryPath);
+                System.IO.File.Move(temporaryPath, destination.FullPath);
+            }
+            else
+            {
+                System.IO.File.Move(source.FullPath, destination.FullPath);
+            }
+        }
+        catch (Exception e) when (FileOperationFailure.IsAccessFailure(e))
+        {
+            throw new FileOperationException(
+                FileOperationFailure.BuildMessage(
+                    $"Could not move this file:\n{source.FullPath}\nto:\n{destination.FullPath}", e),
+                e);
+        }
+    }
+
+    /// <summary>
+    /// Sends a file to the recycle bin, translating file-access failures into a message the user
+    /// can act on.
+    /// </summary>
+    private void RecycleFile(FilePath filePath)
+    {
+        try
+        {
+            _fileCommands.MoveToRecycleBin(filePath);
+        }
+        catch (Exception e) when (FileOperationFailure.IsAccessFailure(e))
+        {
+            throw new FileOperationException(
+                FileOperationFailure.BuildMessage(
+                    $"Could not move this file to the recycle bin:\n{filePath.FullPath}", e),
+                e);
+        }
     }
 
     public void HandleVariableSet(ElementSave element, InstanceSave? instance, string variableName, object? oldValue, CodeOutputProjectSettings codeOutputProjectSettings)
@@ -165,17 +286,24 @@ public class RenameService
 
         if (newCustomFileName != null)
         {
-            if (newCustomFileName != oldCustomFileName)
+            try
             {
-                RegenerateAndMoveCode(element, elementSettings, codeOutputProjectSettings, oldGeneratedFileName, oldCustomFileName, newCustomFileName);
+                if (newCustomFileName != oldCustomFileName)
+                {
+                    RegenerateAndMoveCode(element, elementSettings, codeOutputProjectSettings, oldGeneratedFileName, oldCustomFileName, newCustomFileName);
+                }
+                else
+                {
+                    string fileContents = FileManager.FromFileText(newCustomFileName.FullPath);
+
+                    fileContents = UpdateHeadersInCustomCode(fileContents, element, elementSettings, codeOutputProjectSettings);
+
+                    FileManager.SaveText(fileContents, newCustomFileName.FullPath);
+                }
             }
-            else
+            catch (FileOperationException e)
             {
-                string fileContents = FileManager.FromFileText(newCustomFileName.FullPath);
-
-                fileContents = UpdateHeadersInCustomCode(fileContents, element, elementSettings, codeOutputProjectSettings);
-
-                FileManager.SaveText(fileContents, newCustomFileName.FullPath);
+                _dialogService.ShowMessage(e.Message, $"Error moving code for {element}");
             }
         }
     }

--- a/Tools/Gum.Presentation/Managers/FileOperationException.cs
+++ b/Tools/Gum.Presentation/Managers/FileOperationException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Thrown when a file operation fails for a reason the user can act on. Callers show
+/// <see cref="Exception.Message"/> directly - it is already written for the user, so it must not be
+/// wrapped in a stack trace dump. Build the message with <see cref="FileOperationFailure"/>.
+/// </summary>
+public class FileOperationException : Exception
+{
+    public FileOperationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Tools/Gum.Presentation/Managers/FileOperationFailure.cs
+++ b/Tools/Gum.Presentation/Managers/FileOperationFailure.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Builds user-facing messages for failed file operations. Read-only files, files open in another
+/// program, and source-control locks are all ordinary situations for a Gum user, so they get an
+/// explanation of what to do rather than a raw exception dump.
+/// </summary>
+public static class FileOperationFailure
+{
+    /// <summary>
+    /// True when the exception indicates the file could not be accessed rather than a
+    /// programming error.
+    /// </summary>
+    public static bool IsAccessFailure(Exception exception) =>
+        exception is IOException or UnauthorizedAccessException;
+
+    /// <summary>
+    /// Builds a message explaining a failed file operation. <paramref name="attemptedAction"/> is a
+    /// full sentence naming the file, such as "Could not move this file to the recycle bin:\n[path]".
+    /// </summary>
+    public static string BuildMessage(string attemptedAction, Exception exception)
+    {
+        string guidance = IsAccessFailure(exception)
+            ? "The file may be read-only, open in another program, or locked by source control. " +
+              "Make the file writable and try again."
+            : "The operation failed unexpectedly.";
+
+        return $"{attemptedAction}\n\n{guidance}\n\nDetails: {exception.Message}";
+    }
+}

--- a/Tools/Gum.Presentation/Managers/InstanceDeletionHelper.cs
+++ b/Tools/Gum.Presentation/Managers/InstanceDeletionHelper.cs
@@ -222,6 +222,35 @@ public class InstanceDeletionHelper
     }
 
     /// <summary>
+    /// Sends the XML file backing the given deleted object to the recycle bin, or does nothing when
+    /// the object has no file (an <see cref="InstanceSave"/>) or the file is already gone. The file
+    /// is user data that Gum's undo cannot restore, so it is never permanently deleted here.
+    /// </summary>
+    /// <returns>
+    /// An unsuccessful response carrying a user-facing message when the file could not be removed.
+    /// </returns>
+    public GeneralResponse TryRecycleXmlFileForObject(object deletedObject)
+    {
+        FilePath? fileName = GetFileNameForObject(deletedObject);
+
+        if (fileName?.Exists() != true)
+        {
+            return GeneralResponse.SuccessfulResponse;
+        }
+
+        try
+        {
+            _fileCommands.MoveToRecycleBin(fileName);
+            return GeneralResponse.SuccessfulResponse;
+        }
+        catch (Exception e)
+        {
+            return GeneralResponse.UnsuccessfulWith(FileOperationFailure.BuildMessage(
+                $"Could not move this file to the recycle bin:\n{fileName.FullPath}", e));
+        }
+    }
+
+    /// <summary>
     /// Decides whether the "Delete XML file?" option should be offered for the given object being
     /// deleted. Instances have no XML file of their own. An element only offers this option when
     /// its name is not shared by another element in the project (e.g. duplicates added directly to

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputElementSettingsManager.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputElementSettingsManager.cs
@@ -30,9 +30,15 @@ public class CodeOutputElementSettingsManager
         System.IO.File.WriteAllText(fileName.FullPath, serialized);
     }
 
-    internal FilePath? GetCodeSettingsFilePath(ElementSave element)
+    /// <summary>
+    /// Gets the path to the element's .codsj settings file, which sits alongside the element's XML.
+    /// Pass <paramref name="forcedElementName"/> to resolve the path the file had under a different
+    /// element name, which rename uses to find the file still sitting at the old name.
+    /// </summary>
+    public FilePath? GetCodeSettingsFilePath(ElementSave element, string? forcedElementName = null)
     {
-        FilePath? fileName = ElementFilePathHelper.GetFullPathXmlFile(element, _projectDirectoryProvider.ProjectDirectory);
+        FilePath? fileName = ElementFilePathHelper.GetFullPathXmlFile(element,
+            _projectDirectoryProvider.ProjectDirectory, forcedElementName);
         if (fileName == null)
         {
             return null;

--- a/Tools/Gum.ProjectServices/CodeGeneration/ElementFilePathHelper.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/ElementFilePathHelper.cs
@@ -10,15 +10,20 @@ namespace Gum.ProjectServices.CodeGeneration;
 public static class ElementFilePathHelper
 {
     /// <summary>
-    /// Gets the full path to an element's XML file given the project directory.
+    /// Gets the full path to an element's XML file given the project directory. Pass
+    /// <paramref name="forcedElementName"/> to resolve the path the element had under a different
+    /// name, which rename uses to locate files still sitting at the old name.
     /// </summary>
-    public static FilePath? GetFullPathXmlFile(ElementSave? element, string? projectDirectory)
+    public static FilePath? GetFullPathXmlFile(ElementSave? element, string? projectDirectory,
+        string? forcedElementName = null)
     {
         if (element == null || string.IsNullOrEmpty(projectDirectory))
         {
             return null;
         }
 
-        return projectDirectory + element.Subfolder + "\\" + element.Name + "." + element.FileExtension;
+        string elementName = string.IsNullOrEmpty(forcedElementName) ? element.Name : forcedElementName!;
+
+        return projectDirectory + element.Subfolder + "\\" + elementName + "." + element.FileExtension;
     }
 }


### PR DESCRIPTION
Part of #4422 — gap 3, the rename half of gap 5, the `File.Delete` noted at the end of gap 5, and two of the open questions.

## The bug that destroyed user code

`RenameService.RegenerateAndMoveCode` called `System.IO.File.Delete` on an existing custom code file when the rename target was already occupied. Custom code is user-authored and Gum's undo restores project state, not files on disk, so that was unrecoverable. It now goes to the recycle bin via `IFileCommands.MoveToRecycleBin`, matching what the delete path already did.

The old `.Generated.cs` is still hard-deleted — deliberate, and now commented as such. It is derived data that the regeneration step recreates byte-identical, so deleting it is lossless.

## Case-only rename was the same bug, silently

`Foo` -> `foo` points old and new at the same physical file on Windows/macOS, so the collision check fired and the tool offered to "delete the existing file that is already there" — i.e. the file it was about to move. Now detected and skipped, and the move goes through a temp name so the casing actually changes on disk (git is case-sensitive even where the filesystem is not; a direct `File.Move` also throws "already exists" on macOS).

## `.codsj` follows the element

Per-element code settings (`GenerationBehavior`, namespace override, custom output path) live in `ElementName.codsj` next to the element XML and were never moved, so a rename or folder move silently reverted the element to defaults. `RenameService` now moves the file alongside the element — including when `CodeProjectRoot` is empty, since the `.codsj` isn't in the code project.

## Element XML delete

`DeleteObjectPlugin.HandleDeleteConfirmed`'s "Delete XML file" option hard-deleted the element XML. It now recycles it, through a new `InstanceDeletionHelper.TryRecycleXmlFileForObject` seam (the plugin method itself is WPF-bound and untestable).

## Locked / read-only files

`File.Move`/`File.Delete`/recycle failures surfaced as `e.ToString()` in a popup. `FileOperationFailure` builds a message naming the file and pointing at read-only / open-in-another-program / source-control-lock; `FileOperationException` carries it so callers show `.Message` rather than a stack dump. `HandleVariableSet` (the BaseType-change path into the same code) got the same handling — it previously had none at all.

## Tests

`RenameServiceTests` (extends the existing real-temp-directory harness): collision recycles rather than deletes, `.codsj` follows a rename, `.codsj` follows a folder move, case-only rename keeps the file and corrects its casing, unrecyclable collision produces an explanatory message. New `InstanceDeletionHelperTests` covers the XML recycle and its failure message. All red first.

Also: alphabetized `RenameServiceTests`' methods per the repo convention, and gave the test's `FixedProjectDirectoryProvider` the trailing separator production always has (element XML paths are built by string concatenation, so without it the `.codsj` path was malformed).

`dotnet build GumFull.sln` clean, no new warnings. `Gum.Presentation.Tests` 893, `Gum.ProjectServices.Tests` 495, `GumToolUnitTests` 1261 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
