### PR TITLE
Delete: generated + .codsj go unconditionally, custom code becomes a DeleteOptionsWindow choice (part of #4422)

### DIFF
--- a/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
+++ b/Gum/CodeOutputPlugin/MainCodeOutputPlugin.cs
@@ -24,11 +24,14 @@ using ToolsUtilities;
 using CommunityToolkit.Mvvm.Messaging;
 using Gum.Messages;
 using Gum.Localization;
+using Gum.Extensions;
+using Gum.Gui.Windows;
+using System.Windows.Controls;
 
 namespace CodeOutputPlugin;
 
 [Export(typeof(PluginBase))]
-public class MainCodeOutputPlugin : PluginBase
+public class MainCodeOutputPlugin : WpfPluginBase
 {
     #region Fields/Properties
 
@@ -52,6 +55,12 @@ public class MainCodeOutputPlugin : PluginBase
     private readonly ParentSetLogic _parentSetLogic;
     private readonly IFileCommands _fileCommands;
     private CodeOutputProjectSettingsManager _codeOutputProjectSettingsManager;
+    private readonly CodeFileDeleteService _codeFileDeleteService;
+
+    // Lives only between DeleteOptionsWindowShow and DeleteConfirmed; null when the deleted
+    // elements had no user-authored custom code, in which case nothing was asked.
+    private CheckBox? _deleteCustomCodeCheckBox;
+
     private readonly IProjectState _projectState;
     private readonly IProjectDirectoryProvider _projectDirectoryProvider;
     private readonly CodeGenerationNameVerifier _codeGenerationNameVerifier;
@@ -129,6 +138,14 @@ public class MainCodeOutputPlugin : PluginBase
 
         _parentSetLogic = new ParentSetLogic(_codeGenerator, _selectedState, dialogService, _fileCommands);
 
+        _codeFileDeleteService = new CodeFileDeleteService(
+            _codeGenerationFileLocationsService,
+            _elementSettingsManager,
+            _codeGenerator,
+            new CustomCodeStubDetector(),
+            _fileCommands,
+            dialogService);
+
         _messenger.Register<RequestCodeGenerationMessage>(
             this,
             (_, message) => HandleRequestCodeGeneration(message));
@@ -168,6 +185,8 @@ public class MainCodeOutputPlugin : PluginBase
         this.ElementRename += (element, oldName) => _renameService.HandleRename(element, oldName, codeOutputProjectSettings, _codeGenerator.GetVisualApiForElement(element));
         this.ElementAdd += HandleElementAdd;
         this.ElementDelete += HandleElementDeleted;
+        this.DeleteOptionsWindowShow += HandleDeleteOptionsWindowShow;
+        this.DeleteConfirmed += HandleDeleteConfirmed;
         this.BehaviorReferencesChanged += HandleBehaviorReferencesChanged;
 
         this.VariableAdd += HandleVariableAdd;
@@ -194,32 +213,50 @@ public class MainCodeOutputPlugin : PluginBase
 
     #endregion
 
-    private void HandleElementDeleted(ElementSave element)
+    /// <summary>
+    /// Removes the deleted element's derived files (.Generated.cs and .codsj) with no prompt. The
+    /// user-authored custom .cs is handled per-batch by the DeleteOptionsWindow checkbox below.
+    /// </summary>
+    private void HandleElementDeleted(ElementSave element) =>
+        _codeFileDeleteService.ReconcileFilesForDeletedElement(element, codeOutputProjectSettings);
+
+    /// <summary>
+    /// Materializes the code-file option into a real WPF checkbox on the delete dialog. One
+    /// checkbox covers the whole batch, so deleting a folder's worth of elements asks once.
+    /// </summary>
+    private void HandleDeleteOptionsWindowShow(DeleteOptionsWindow deleteWindow, Array objectsToDelete)
     {
-        var elementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
+        // A cancelled delete never fires DeleteConfirmed, so clear the previous dialog's checkbox
+        // here - otherwise a later delete that adds no checkbox would read the stale checked state.
+        _deleteCustomCodeCheckBox = null;
 
-        var visualApi = _codeGenerator.GetVisualApiForElement(element);
+        var checkboxViewModel = _codeFileDeleteService.HandleDeleteOptionsWindowShow(
+            objectsToDelete, codeOutputProjectSettings);
 
-        // If it's deleted, ask the user if they also want to delete generated code files
-        var generatedFile = _codeGenerationFileLocationsService.GetGeneratedFileName(element, elementSettings, codeOutputProjectSettings, visualApi);
-        var customCodeFile = _codeGenerationFileLocationsService.GetCustomCodeFileName(element, elementSettings, codeOutputProjectSettings, visualApi: visualApi);
-
-        if(generatedFile?.Exists() == true || customCodeFile?.Exists() == true)
+        if (checkboxViewModel != null)
         {
-            var message = $"Would you like to delete the generated and custom code files for {element}?";
+            _deleteCustomCodeCheckBox = checkboxViewModel.ToCheckBox();
+            deleteWindow.MainStackPanel.Children.Add(_deleteCustomCodeCheckBox);
+        }
+    }
 
-            if(_dialogService.ShowYesNoMessage(message, "Delete Code?"))
+    /// <summary>
+    /// Reads back the checkbox added by <see cref="HandleDeleteOptionsWindowShow"/> (if any) and
+    /// removes it from the window afterward, mirroring the other DeleteOptionsWindow contributors.
+    /// </summary>
+    private void HandleDeleteConfirmed(DeleteOptionsWindow deleteOptionsWindow, Array deletedObjects)
+    {
+        bool isChecked = _deleteCustomCodeCheckBox?.IsChecked == true;
+
+        _codeFileDeleteService.HandleConfirmDelete(deletedObjects, isChecked, codeOutputProjectSettings);
+
+        if (_deleteCustomCodeCheckBox != null)
+        {
+            if (deleteOptionsWindow.MainStackPanel.Children.Contains(_deleteCustomCodeCheckBox))
             {
-                if(generatedFile?.Exists() == true)
-                {
-                    _fileCommands.MoveToRecycleBin(generatedFile);
-                }
-
-                if(customCodeFile?.Exists() == true)
-                {
-                    _fileCommands.MoveToRecycleBin(customCodeFile);
-                }
+                deleteOptionsWindow.MainStackPanel.Children.Remove(_deleteCustomCodeCheckBox);
             }
+            _deleteCustomCodeCheckBox = null;
         }
     }
 

--- a/Gum/Extensions/DeleteOptionCheckboxExtensions.cs
+++ b/Gum/Extensions/DeleteOptionCheckboxExtensions.cs
@@ -1,4 +1,4 @@
-using StateAnimationPlugin.Managers;
+using Gum.Services.Dialogs;
 using System.Windows.Controls;
 
 namespace Gum.Extensions;

--- a/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
+++ b/Gum/StateAnimationPlugin/MainStateAnimationPlugin.cs
@@ -121,7 +121,7 @@ public class MainStateAnimationPlugin : WpfPluginBase, IAnimationUndoProvider
 
         _animationFilePathService = new AnimationFilePathService(_selectedState, fileCommands, _projectManager);
         _duplicateService = new DuplicateService(_dialogService, _projectManager);
-        _elementDeleteService = new ElementDeleteService(_animationFilePathService, _dialogService);
+        _elementDeleteService = new ElementDeleteService(_animationFilePathService, _dialogService, fileCommands);
         _settingsManager = new SettingsManager();
 
         // The factory closure reads _animationCollectionViewModelManager and _renameManager lazily
@@ -267,6 +267,10 @@ public class MainStateAnimationPlugin : WpfPluginBase, IAnimationUndoProvider
     /// </summary>
     private void HandleDeleteOptionsWindowShow(DeleteOptionsWindow deleteWindow, Array objectsToDelete)
     {
+        // A cancelled delete never fires DeleteConfirmed, so clear the previous dialog's checkbox
+        // here - otherwise a later delete that adds no checkbox would read the stale checked state.
+        _deleteAnimationFileCheckBox = null;
+
         var checkboxViewModel = _elementDeleteService.HandleDeleteOptionsWindowShow(objectsToDelete);
 
         if (checkboxViewModel != null)

--- a/Tests/Gum.Presentation.Tests/CodeFileDeleteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/CodeFileDeleteServiceTests.cs
@@ -1,0 +1,281 @@
+using CodeOutputPlugin.Manager;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Gum.Services.Dialogs;
+using Moq;
+using Newtonsoft.Json;
+using Shouldly;
+using ToolsUtilities;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Tests for CodeFileDeleteService (issue #4422 gap 2/5): the .Generated.cs and .codsj go without a
+/// prompt, the user-authored custom .cs is a separate decision that isn't even asked when the file
+/// is still an untouched stub, and one delete of many elements yields one confirmation.
+/// </summary>
+public class CodeFileDeleteServiceTests : BaseTestClass
+{
+    private const string StubCustomCode = """
+        namespace MyGame.Components
+        {
+            partial class MyComponent
+            {
+                partial void CustomInitialize()
+                {
+
+                }
+            }
+        }
+        """;
+
+    private const string EditedCustomCode = """
+        namespace MyGame.Components
+        {
+            partial class MyComponent
+            {
+                partial void CustomInitialize()
+                {
+                    Text.Text = "Hand written";
+                }
+            }
+        }
+        """;
+
+    private readonly string _projectDirectory;
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly Mock<IDialogService> _dialogService = new();
+    private readonly CodeOutputElementSettingsManager _elementSettingsManager;
+    private readonly CodeFileDeleteService _service;
+
+    public CodeFileDeleteServiceTests()
+    {
+        _projectDirectory = Path.Combine(
+            Path.GetTempPath(), "GumCodeFileDeleteServiceTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_projectDirectory);
+
+        Mock<INameVerifier> nameVerifier = new();
+        string whyNotValid;
+        CommonValidationError error;
+        nameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+
+        CodeGenerationNameVerifier codeGenNameVerifier = new(nameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider =
+            new(_projectDirectory + Path.DirectorySeparatorChar);
+        _elementSettingsManager = new CodeOutputElementSettingsManager(directoryProvider);
+
+        CodeGenerator codeGenerator = new(
+            codeGenNameVerifier,
+            new LocalizationService(),
+            _elementSettingsManager,
+            directoryProvider);
+
+        CodeGenerationFileLocationsService fileLocationsService = new(
+            codeGenerator, codeGenNameVerifier, directoryProvider);
+
+        _service = new CodeFileDeleteService(
+            fileLocationsService,
+            _elementSettingsManager,
+            codeGenerator,
+            new CustomCodeStubDetector(),
+            _fileCommands.Object,
+            _dialogService.Object);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (Directory.Exists(_projectDirectory))
+        {
+            Directory.Delete(_projectDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void HandleConfirmDelete_DoesNotRecycleEditedCustomCode_WhenCheckboxUnchecked()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        FilePath customFile = GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+
+        _service.HandleConfirmDelete(
+            new object[] { component }, deleteEditedCustomCode: false, GivenProjectSettings());
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(customFile), Times.Never);
+    }
+
+    [Fact]
+    public void HandleConfirmDelete_NeverPrompts()
+    {
+        // Reconciliation must never ask a question of its own - the DeleteOptionsWindow checkbox is
+        // the only place the user is consulted, so nothing here can pop a dialog mid-edit.
+        ComponentSave component = GivenComponent("MyComponent");
+        GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+        GivenFile("Code/Components/MyComponent.Generated.cs", "// generated");
+
+        CodeOutputProjectSettings projectSettings = GivenProjectSettings();
+        _service.HandleDeleteOptionsWindowShow(new object[] { component }, projectSettings);
+        _service.HandleConfirmDelete(new object[] { component }, deleteEditedCustomCode: true, projectSettings);
+        _service.ReconcileFilesForDeletedElement(component, projectSettings);
+
+        _dialogService.Verify(
+            x => x.ShowMessage(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.Is<MessageDialogStyle?>(style => style != null)),
+            Times.Never);
+    }
+
+    [Fact]
+    public void HandleConfirmDelete_RecyclesEditedCustomCode_WhenCheckboxChecked()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        FilePath customFile = GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+
+        _service.HandleConfirmDelete(
+            new object[] { component }, deleteEditedCustomCode: true, GivenProjectSettings());
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(customFile), Times.Once);
+    }
+
+    [Fact]
+    public void HandleConfirmDelete_RecyclesUntouchedStub_EvenWhenCheckboxUnchecked()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        FilePath customFile = GivenFile("Code/Components/MyComponent.cs", StubCustomCode);
+
+        _service.HandleConfirmDelete(
+            new object[] { component }, deleteEditedCustomCode: false, GivenProjectSettings());
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(customFile), Times.Once);
+    }
+
+    [Fact]
+    public void HandleDeleteOptionsWindowShow_ReturnsNull_WhenCustomCodeIsUntouchedStub()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        GivenFile("Code/Components/MyComponent.cs", StubCustomCode);
+
+        DeleteOptionCheckboxViewModel? checkbox =
+            _service.HandleDeleteOptionsWindowShow(new object[] { component }, GivenProjectSettings());
+
+        checkbox.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HandleDeleteOptionsWindowShow_ReturnsNull_WhenElementIsNeverGenerate()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+        GivenElementSettingsFile(component, GenerationBehavior.NeverGenerate);
+
+        DeleteOptionCheckboxViewModel? checkbox =
+            _service.HandleDeleteOptionsWindowShow(new object[] { component }, GivenProjectSettings());
+
+        checkbox.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HandleDeleteOptionsWindowShow_ReturnsOneUncheckedCheckbox_WhenCustomCodeIsEdited()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+
+        DeleteOptionCheckboxViewModel? checkbox =
+            _service.HandleDeleteOptionsWindowShow(new object[] { component }, GivenProjectSettings());
+
+        checkbox.ShouldNotBeNull();
+        checkbox.IsChecked.ShouldBeFalse();
+        checkbox.Label.ShouldBe("Delete custom code file (contains your code)");
+    }
+
+    [Fact]
+    public void HandleDeleteOptionsWindowShow_ReturnsSingleCheckbox_ForTwentyElements()
+    {
+        // A folder's worth of elements deleted at once must still be one confirmation, not twenty.
+        object[] components = new object[20];
+        for (int i = 0; i < components.Length; i++)
+        {
+            components[i] = GivenComponent("Component" + i);
+            GivenFile($"Code/Components/Component{i}.cs", EditedCustomCode);
+        }
+
+        DeleteOptionCheckboxViewModel? checkbox =
+            _service.HandleDeleteOptionsWindowShow(components, GivenProjectSettings());
+
+        checkbox.ShouldNotBeNull();
+        checkbox.Label.ShouldBe("Delete 20 custom code files (contain your code)");
+    }
+
+    [Fact]
+    public void ReconcileFilesForDeletedElement_LeavesAllFilesAlone_WhenNeverGenerate()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        GivenFile("Code/Components/MyComponent.Generated.cs", "// generated");
+        GivenElementSettingsFile(component, GenerationBehavior.NeverGenerate);
+
+        _service.ReconcileFilesForDeletedElement(component, GivenProjectSettings());
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(It.IsAny<FilePath>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReconcileFilesForDeletedElement_RecyclesGeneratedAndSettingsFiles_ButNotCustomCode()
+    {
+        ComponentSave component = GivenComponent("MyComponent");
+        FilePath generatedFile = GivenFile("Code/Components/MyComponent.Generated.cs", "// generated");
+        FilePath customFile = GivenFile("Code/Components/MyComponent.cs", EditedCustomCode);
+        FilePath settingsFile = GivenElementSettingsFile(component, GenerationBehavior.GenerateManually);
+
+        _service.ReconcileFilesForDeletedElement(component, GivenProjectSettings());
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(generatedFile), Times.Once);
+        _fileCommands.Verify(x => x.MoveToRecycleBin(settingsFile), Times.Once);
+        _fileCommands.Verify(x => x.MoveToRecycleBin(customFile), Times.Never);
+    }
+
+    private ComponentSave GivenComponent(string name)
+    {
+        ComponentSave component = new ComponentSave { Name = name, BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+        return component;
+    }
+
+    private FilePath GivenElementSettingsFile(ElementSave element, GenerationBehavior behavior)
+    {
+        CodeOutputElementSettings settings = new CodeOutputElementSettings { GenerationBehavior = behavior };
+        return GivenFile(
+            $"Components/{element.Name}.codsj", JsonConvert.SerializeObject(settings));
+    }
+
+    /// <summary>
+    /// Writes a file under the temp project directory. The relative path is given with forward
+    /// slashes and split here - a backslash is a legal file name character on macOS and Linux, so a
+    /// "Code\Components\MyComponent.cs" literal would create one oddly named file in the root.
+    /// </summary>
+    private FilePath GivenFile(string relativePath, string contents)
+    {
+        string fullPath = Path.Combine(
+            new[] { _projectDirectory }.Concat(relativePath.Split('/')).ToArray());
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, contents);
+        return new FilePath(fullPath);
+    }
+
+    private CodeOutputProjectSettings GivenProjectSettings()
+    {
+        return new CodeOutputProjectSettings
+        {
+            CodeProjectRoot = Path.Combine(_projectDirectory, "Code") + Path.DirectorySeparatorChar,
+            RootNamespace = "MyGame",
+            // MonoGameForms names a component's class after the element with no "Runtime" suffix,
+            // so the file names above read the same as the element names.
+            OutputLibrary = OutputLibrary.MonoGameForms
+        };
+    }
+}

--- a/Tests/Gum.Presentation.Tests/ElementDeleteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/ElementDeleteServiceTests.cs
@@ -1,3 +1,4 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Services.Dialogs;
 using Moq;
@@ -18,6 +19,7 @@ public class ElementDeleteServiceTests : IDisposable
     private readonly string _tempDirectory;
     private readonly Mock<IAnimationFilePathService> _animationFilePathService;
     private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IFileCommands> _fileCommands;
     private readonly ElementDeleteService _service;
 
     public ElementDeleteServiceTests()
@@ -28,7 +30,9 @@ public class ElementDeleteServiceTests : IDisposable
 
         _animationFilePathService = new Mock<IAnimationFilePathService>();
         _dialogService = new Mock<IDialogService>();
-        _service = new ElementDeleteService(_animationFilePathService.Object, _dialogService.Object);
+        _fileCommands = new Mock<IFileCommands>();
+        _service = new ElementDeleteService(
+            _animationFilePathService.Object, _dialogService.Object, _fileCommands.Object);
     }
 
     public void Dispose()
@@ -40,19 +44,7 @@ public class ElementDeleteServiceTests : IDisposable
     }
 
     [Fact]
-    public void HandleConfirmDelete_DeletesAnimationFile_WhenIsCheckedTrue()
-    {
-        ComponentSave component = new ComponentSave { Name = "Foo" };
-        FilePath ganxPath = CreateAnimationFile("Foo");
-        _animationFilePathService.Setup(x => x.GetAbsoluteAnimationFileNameFor(component)).Returns(ganxPath);
-
-        _service.HandleConfirmDelete(new object[] { component }, isChecked: true);
-
-        File.Exists(ganxPath.FullPath).ShouldBeFalse();
-    }
-
-    [Fact]
-    public void HandleConfirmDelete_DoesNotDeleteAnimationFile_WhenIsCheckedFalse()
+    public void HandleConfirmDelete_DoesNotRecycleAnimationFile_WhenIsCheckedFalse()
     {
         ComponentSave component = new ComponentSave { Name = "Foo" };
         FilePath ganxPath = CreateAnimationFile("Foo");
@@ -60,7 +52,21 @@ public class ElementDeleteServiceTests : IDisposable
 
         _service.HandleConfirmDelete(new object[] { component }, isChecked: false);
 
-        File.Exists(ganxPath.FullPath).ShouldBeTrue();
+        _fileCommands.Verify(x => x.MoveToRecycleBin(ganxPath), Times.Never);
+    }
+
+    [Fact]
+    public void HandleConfirmDelete_RecyclesAnimationFile_WhenIsCheckedTrue()
+    {
+        // Recycle bin rather than File.Delete: a .ganx holds user-authored animation data, and
+        // Gum's undo covers project state, not files on disk (issue #4422).
+        ComponentSave component = new ComponentSave { Name = "Foo" };
+        FilePath ganxPath = CreateAnimationFile("Foo");
+        _animationFilePathService.Setup(x => x.GetAbsoluteAnimationFileNameFor(component)).Returns(ganxPath);
+
+        _service.HandleConfirmDelete(new object[] { component }, isChecked: true);
+
+        _fileCommands.Verify(x => x.MoveToRecycleBin(ganxPath), Times.Once);
     }
 
     [Fact]

--- a/Tests/Gum.ProjectServices.Tests/CustomCodeStubDetectorTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CustomCodeStubDetectorTests.cs
@@ -1,0 +1,166 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Localization;
+using Gum.Managers;
+using Gum.ProjectServices.CodeGeneration;
+using Moq;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// Tests for <see cref="CustomCodeStubDetector"/>, which decides whether an element's custom
+/// code file still holds nothing but the generated stub. A false negative only costs an extra
+/// prompt; a false positive would silently recycle user-authored code, so the interesting cases
+/// here are the ones that must come back false.
+/// </summary>
+public class CustomCodeStubDetectorTests : BaseTestClass
+{
+    private readonly CustomCodeStubDetector _detector = new();
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsFalse_WhenCustomInitializeHasBody()
+    {
+        string contents = """
+            namespace MyGame.Components
+            {
+                partial class MyComponent
+                {
+                    partial void CustomInitialize()
+                    {
+                        DoSomething();
+                    }
+                }
+            }
+            """;
+
+        _detector.IsUntouchedStub(contents).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsFalse_WhenExtraFieldExists()
+    {
+        string contents = """
+            namespace MyGame.Components
+            {
+                partial class MyComponent
+                {
+                    private int _score;
+
+                    partial void CustomInitialize()
+                    {
+
+                    }
+                }
+            }
+            """;
+
+        _detector.IsUntouchedStub(contents).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsFalse_WhenExtraMethodExists()
+    {
+        string contents = """
+            namespace MyGame.Components
+            {
+                partial class MyComponent
+                {
+                    partial void CustomInitialize()
+                    {
+
+                    }
+
+                    public void Reset()
+                    {
+                    }
+                }
+            }
+            """;
+
+        _detector.IsUntouchedStub(contents).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsTrue_ForCustomCodeGeneratorOutput()
+    {
+        // Pins the detector against the live template rather than a hand-written copy of it, so a
+        // change to CustomCodeGenerator that stops matching shows up here instead of silently
+        // turning every freshly-created stub into a prompt.
+        ComponentSave component = new ComponentSave { Name = "MyComponent", BaseType = "Container" };
+        component.States.Add(new StateSave { Name = "Default", ParentContainer = component });
+
+        Mock<INameVerifier> nameVerifier = new();
+        string whyNotValid;
+        CommonValidationError error;
+        nameVerifier
+            .Setup(v => v.IsValidCSharpName(It.IsAny<string>(), out whyNotValid, out error))
+            .Returns(true);
+
+        CodeGenerationNameVerifier codeGenNameVerifier = new(nameVerifier.Object);
+        FixedProjectDirectoryProvider directoryProvider = new(projectDirectory: null);
+        CodeOutputElementSettingsManager elementSettingsManager = new(directoryProvider);
+        CodeGenerator codeGenerator = new(
+            codeGenNameVerifier,
+            new LocalizationService(),
+            elementSettingsManager,
+            directoryProvider);
+        CustomCodeGenerator customCodeGenerator = new(codeGenerator, codeGenNameVerifier);
+
+        CodeOutputProjectSettings projectSettings = new CodeOutputProjectSettings
+        {
+            RootNamespace = "MyGame",
+            OutputLibrary = OutputLibrary.MonoGameForms
+        };
+
+        string contents = customCodeGenerator.GetCustomCodeForElement(
+            component, new CodeOutputElementSettings(), projectSettings);
+
+        _detector.IsUntouchedStub(contents).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsTrue_ForEmptyFile()
+    {
+        _detector.IsUntouchedStub("   \r\n  ").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsTrue_ForFileScopedNamespaceWithBaseListAndComments()
+    {
+        string contents = """
+            using System;
+            using MonoGameGum.Forms.Controls;
+
+            namespace MyGame.Components;
+
+            // A comment the user added but no actual code
+            public partial class MyComponent : Button
+            {
+                /* still empty */
+                partial void CustomInitialize()
+                {
+                }
+            }
+            """;
+
+        _detector.IsUntouchedStub(contents).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsUntouchedStub_ReturnsTrue_ForStubWithNoNamespace()
+    {
+        // RootNamespace empty means codegen emits no namespace at all.
+        string contents = """
+            partial class MyComponent
+            {
+                partial void CustomInitialize()
+                {
+
+                }
+            }
+            """;
+
+        _detector.IsUntouchedStub(contents).ShouldBeTrue();
+    }
+}

--- a/Tools/Gum.Presentation/CodeOutputPlugin/Manager/CodeFileDeleteService.cs
+++ b/Tools/Gum.Presentation/CodeOutputPlugin/Manager/CodeFileDeleteService.cs
@@ -1,0 +1,233 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.ProjectServices.CodeGeneration;
+using Gum.Services.Dialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ToolsUtilities;
+
+namespace CodeOutputPlugin.Manager;
+
+/// <summary>
+/// Reconciles an element's code files on disk when the element is deleted (issue #4422).
+/// <para>
+/// Three files are involved and they are not equally precious. The <c>.Generated.cs</c> is derived
+/// data - a pure function of the element - and the <c>.codsj</c> holds regenerable settings for an
+/// element that no longer exists, so both go unconditionally with no prompt
+/// (<see cref="ReconcileFilesForDeletedElement"/>). The custom <c>.cs</c> is user-authored and
+/// unrecoverable through Gum, so it is a separate, explicit decision surfaced as a checkbox in the
+/// existing DeleteOptionsWindow (<see cref="HandleDeleteOptionsWindowShow"/> /
+/// <see cref="HandleConfirmDelete"/>). Because that checkbox is computed once for the whole batch,
+/// deleting twenty elements still produces exactly one confirmation.
+/// </para>
+/// <para>
+/// A custom file that is still an untouched stub carries no user code, so it is removed without
+/// asking. Elements set to <see cref="GenerationBehavior.NeverGenerate"/> are left completely
+/// alone - the user is hand-managing those files.
+/// </para>
+/// </summary>
+public class CodeFileDeleteService
+{
+    private readonly CodeGenerationFileLocationsService _fileLocationsService;
+    private readonly CodeOutputElementSettingsManager _elementSettingsManager;
+    private readonly CodeGenerator _codeGenerator;
+    private readonly ICustomCodeStubDetector _stubDetector;
+    private readonly IFileCommands _fileCommands;
+    private readonly IDialogService _dialogService;
+
+    public CodeFileDeleteService(
+        CodeGenerationFileLocationsService fileLocationsService,
+        CodeOutputElementSettingsManager elementSettingsManager,
+        CodeGenerator codeGenerator,
+        ICustomCodeStubDetector stubDetector,
+        IFileCommands fileCommands,
+        IDialogService dialogService)
+    {
+        _fileLocationsService = fileLocationsService;
+        _elementSettingsManager = elementSettingsManager;
+        _codeGenerator = codeGenerator;
+        _stubDetector = stubDetector;
+        _fileCommands = fileCommands;
+        _dialogService = dialogService;
+    }
+
+    /// <summary>
+    /// Returns a single checkbox view model covering every element in <paramref name="objectsToDelete"/>
+    /// whose custom code file holds user-authored code, or null when none do (so nothing is asked
+    /// for untouched stubs). Defaults to unchecked: losing user code needs a deliberate click.
+    /// </summary>
+    public DeleteOptionCheckboxViewModel? HandleDeleteOptionsWindowShow(
+        Array objectsToDelete, CodeOutputProjectSettings projectSettings)
+    {
+        List<FilePath> editedFiles = GetEditedCustomCodeFiles(objectsToDelete, projectSettings);
+
+        if (editedFiles.Count == 0)
+        {
+            return null;
+        }
+
+        string label = editedFiles.Count == 1
+            ? "Delete custom code file (contains your code)"
+            : $"Delete {editedFiles.Count} custom code files (contain your code)";
+
+        return new DeleteOptionCheckboxViewModel
+        {
+            Label = label,
+            IsChecked = false
+        };
+    }
+
+    /// <summary>
+    /// Removes the custom code files for the deleted elements: untouched stubs always, and files
+    /// containing user-authored code only when <paramref name="deleteEditedCustomCode"/> is true
+    /// (the checkbox from <see cref="HandleDeleteOptionsWindowShow"/> was ticked). Always uses the
+    /// recycle bin, never a hard delete.
+    /// </summary>
+    public void HandleConfirmDelete(
+        Array deletedObjects, bool deleteEditedCustomCode, CodeOutputProjectSettings projectSettings)
+    {
+        List<FilePath> failures = new List<FilePath>();
+
+        foreach (ElementSave element in GetGeneratedElements(deletedObjects))
+        {
+            CodeOutputElementSettings elementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
+            FilePath? customCodeFile = GetCustomCodeFile(element, elementSettings, projectSettings);
+
+            if (customCodeFile?.Exists() != true)
+            {
+                continue;
+            }
+
+            bool isStub = IsUntouchedStub(customCodeFile);
+            if (isStub || deleteEditedCustomCode)
+            {
+                TryRecycle(customCodeFile, failures);
+            }
+        }
+
+        ReportFailures(failures);
+    }
+
+    /// <summary>
+    /// Removes the derived files for a deleted element - the <c>.Generated.cs</c> and the
+    /// per-element <c>.codsj</c> settings file - with no prompt. The custom code file is never
+    /// touched here; that decision belongs to <see cref="HandleConfirmDelete"/>.
+    /// </summary>
+    public void ReconcileFilesForDeletedElement(ElementSave element, CodeOutputProjectSettings projectSettings)
+    {
+        if (!IsGeneratedElement(element))
+        {
+            return;
+        }
+
+        CodeOutputElementSettings elementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
+        if (elementSettings.GenerationBehavior == GenerationBehavior.NeverGenerate)
+        {
+            return;
+        }
+
+        List<FilePath> failures = new List<FilePath>();
+
+        VisualApi visualApi = _codeGenerator.GetVisualApiForElement(element);
+        FilePath? generatedFile = _fileLocationsService.GetGeneratedFileName(
+            element, elementSettings, projectSettings, visualApi);
+
+        if (generatedFile?.Exists() == true)
+        {
+            TryRecycle(generatedFile, failures);
+        }
+
+        FilePath? settingsFile = _elementSettingsManager.GetCodeSettingsFilePath(element);
+        if (settingsFile?.Exists() == true)
+        {
+            TryRecycle(settingsFile, failures);
+        }
+
+        ReportFailures(failures);
+    }
+
+    private List<FilePath> GetEditedCustomCodeFiles(Array objectsToDelete, CodeOutputProjectSettings projectSettings)
+    {
+        List<FilePath> toReturn = new List<FilePath>();
+
+        foreach (ElementSave element in GetGeneratedElements(objectsToDelete))
+        {
+            CodeOutputElementSettings elementSettings = _elementSettingsManager.LoadOrCreateSettingsFor(element);
+            FilePath? customCodeFile = GetCustomCodeFile(element, elementSettings, projectSettings);
+
+            if (customCodeFile?.Exists() == true && !IsUntouchedStub(customCodeFile))
+            {
+                toReturn.Add(customCodeFile);
+            }
+        }
+
+        return toReturn;
+    }
+
+    private FilePath? GetCustomCodeFile(
+        ElementSave element, CodeOutputElementSettings elementSettings, CodeOutputProjectSettings projectSettings)
+    {
+        VisualApi visualApi = _codeGenerator.GetVisualApiForElement(element);
+        return _fileLocationsService.GetCustomCodeFileName(element, elementSettings, projectSettings, visualApi);
+    }
+
+    /// <summary>
+    /// Elements whose code files Gum owns: Screens and Components that aren't hand-managed. A file
+    /// that can't be read is treated as edited, so the user is asked rather than losing it silently.
+    /// </summary>
+    private IEnumerable<ElementSave> GetGeneratedElements(Array objects)
+    {
+        return objects.OfType<ElementSave>()
+            .Where(IsGeneratedElement)
+            .Where(item => _elementSettingsManager.LoadOrCreateSettingsFor(item).GenerationBehavior
+                != GenerationBehavior.NeverGenerate);
+    }
+
+    private static bool IsGeneratedElement(ElementSave element) => element is ComponentSave or ScreenSave;
+
+    private bool IsUntouchedStub(FilePath customCodeFile)
+    {
+        try
+        {
+            return _stubDetector.IsUntouchedStub(System.IO.File.ReadAllText(customCodeFile.FullPath));
+        }
+        catch (System.IO.IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private void TryRecycle(FilePath filePath, List<FilePath> failures)
+    {
+        try
+        {
+            _fileCommands.MoveToRecycleBin(filePath);
+        }
+        catch
+        {
+            failures.Add(filePath);
+        }
+    }
+
+    /// <summary>
+    /// Reports every file that could not be removed in one informational popup - never a prompt,
+    /// and never one popup per file, so a batch delete can't produce a wall of dialogs.
+    /// </summary>
+    private void ReportFailures(List<FilePath> failures)
+    {
+        if (failures.Count == 0)
+        {
+            return;
+        }
+
+        string message = "Could not delete the following code file(s):\n"
+            + string.Join("\n", failures.Select(item => "  • " + item.FullPath));
+
+        _dialogService.ShowMessage(message);
+    }
+}

--- a/Tools/Gum.Presentation/Dialogs/DeleteOptionCheckboxViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/DeleteOptionCheckboxViewModel.cs
@@ -1,10 +1,10 @@
-namespace StateAnimationPlugin.Managers;
+namespace Gum.Services.Dialogs;
 
 /// <summary>
 /// Framework-neutral request to show a checkbox option in the DeleteOptionsWindow's
 /// plugin-extension area (see <c>DeleteDialogService</c>/<c>DeleteOptionsWindow.MainStackPanel</c>).
 /// The WPF host materializes this into a real checkbox and, once the user confirms delete, reads
-/// its final <see cref="IsChecked"/> state back into <see cref="ElementDeleteService"/> (ADR-0005).
+/// its final <see cref="IsChecked"/> state back into the contributing service (ADR-0005).
 /// </summary>
 public class DeleteOptionCheckboxViewModel
 {

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/ElementDeleteService.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/ElementDeleteService.cs
@@ -1,3 +1,4 @@
+using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Services.Dialogs;
 using System;
@@ -16,11 +17,16 @@ public class ElementDeleteService
 {
     private readonly IAnimationFilePathService _animationFilePathService;
     private readonly IDialogService _dialogService;
+    private readonly IFileCommands _fileCommands;
 
-    public ElementDeleteService(IAnimationFilePathService animationFilePathService, IDialogService dialogService)
+    public ElementDeleteService(
+        IAnimationFilePathService animationFilePathService,
+        IDialogService dialogService,
+        IFileCommands fileCommands)
     {
         _animationFilePathService = animationFilePathService;
         _dialogService = dialogService;
+        _fileCommands = fileCommands;
     }
 
     /// <summary>
@@ -47,8 +53,11 @@ public class ElementDeleteService
     }
 
     /// <summary>
-    /// Deletes the animation (.ganx) file for each deleted element when <paramref name="isChecked"/>
-    /// is true (the checkbox added by <see cref="HandleDeleteOptionsWindowShow"/> was left checked).
+    /// Moves the animation (.ganx) file for each deleted element to the recycle bin when
+    /// <paramref name="isChecked"/> is true (the checkbox added by
+    /// <see cref="HandleDeleteOptionsWindowShow"/> was left checked). A .ganx holds user-authored
+    /// animation data and Gum's undo covers project state rather than files on disk, so this is
+    /// never a hard delete (issue #4422).
     /// </summary>
     public void HandleConfirmDelete(Array deletedObjects, bool isChecked)
     {
@@ -67,7 +76,7 @@ public class ElementDeleteService
                 {
                     try
                     {
-                        System.IO.File.Delete(fileName.FullPath);
+                        _fileCommands.MoveToRecycleBin(fileName);
                     }
                     catch
                     {

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputElementSettingsManager.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeOutputElementSettingsManager.cs
@@ -30,7 +30,12 @@ public class CodeOutputElementSettingsManager
         System.IO.File.WriteAllText(fileName.FullPath, serialized);
     }
 
-    internal FilePath? GetCodeSettingsFilePath(ElementSave element)
+    /// <summary>
+    /// Gets the path of the element's .codsj settings file (alongside its XML), or null when the
+    /// element has no resolvable XML path. Public so delete/rename reconciliation outside this
+    /// assembly can move or remove the file along with the element.
+    /// </summary>
+    public FilePath? GetCodeSettingsFilePath(ElementSave element)
     {
         FilePath? fileName = ElementFilePathHelper.GetFullPathXmlFile(element, _projectDirectoryProvider.ProjectDirectory);
         if (fileName == null)

--- a/Tools/Gum.ProjectServices/CodeGeneration/CustomCodeStubDetector.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CustomCodeStubDetector.cs
@@ -1,0 +1,108 @@
+using System.Text.RegularExpressions;
+
+namespace Gum.ProjectServices.CodeGeneration;
+
+/// <summary>
+/// Decides whether an element's custom code file still contains nothing but the generated stub.
+/// </summary>
+public interface ICustomCodeStubDetector
+{
+    /// <summary>
+    /// Returns true when <paramref name="customCodeFileContents"/> holds no user-authored code -
+    /// only usings, a namespace, a class header and an empty-bodied <c>CustomInitialize</c>.
+    /// </summary>
+    bool IsUntouchedStub(string customCodeFileContents);
+}
+
+/// <summary>
+/// Structural implementation of <see cref="ICustomCodeStubDetector"/>: strips comments, usings, the
+/// namespace and the class header, then requires what remains to be an empty-bodied
+/// <c>CustomInitialize</c> and nothing else. Deliberately not a comparison against
+/// <see cref="CustomCodeGenerator"/>'s current output, which changes across Gum versions and would
+/// misjudge files written by an older one. Anything it can't account for reads as "not a stub", so
+/// the failure direction is an unnecessary prompt rather than recycling user code.
+/// </summary>
+public class CustomCodeStubDetector : ICustomCodeStubDetector
+{
+    private static readonly Regex BlockCommentRegex = new(@"/\*.*?\*/", RegexOptions.Singleline);
+    private static readonly Regex LineCommentRegex = new(@"//[^\r\n]*");
+    private static readonly Regex WhitespaceRegex = new(@"\s+");
+
+    // Anchored at the start of the remaining text so a `using var x = ...;` inside a method body
+    // can never be mistaken for a using directive.
+    private static readonly Regex UsingDirectiveRegex = new(@"^using\s+[^;{}]*;\s*");
+    private static readonly Regex FileScopedNamespaceRegex = new(@"^namespace\s+[\w\.@]+\s*;\s*");
+    private static readonly Regex BlockScopedNamespaceRegex = new(@"^namespace\s+[\w\.@]+\s*\{\s*");
+
+    private const string ClassModifiers = @"(?:(?:public|internal|private|protected|sealed|abstract|static|partial)\s+)*";
+    private static readonly Regex ClassHeaderRegex = new(
+        $@"^{ClassModifiers}class\s+@?\w+\s*(?::\s*[^{{}}]+)?\{{\s*");
+
+    private const string MethodModifiers = @"(?:(?:public|internal|private|protected|partial)\s+)*";
+    private static readonly Regex EmptyCustomInitializeRegex = new(
+        $@"^{MethodModifiers}void\s+CustomInitialize\s*\(\s*\)\s*\{{\s*\}}\s*$");
+
+    /// <inheritdoc/>
+    public bool IsUntouchedStub(string customCodeFileContents)
+    {
+        string remaining = Normalize(customCodeFileContents);
+
+        // Nothing at all is nothing to lose, so it counts as untouched.
+        if (remaining.Length == 0)
+        {
+            return true;
+        }
+
+        remaining = StripRepeatedly(UsingDirectiveRegex, remaining);
+
+        bool hasNamespaceClosingBrace = false;
+        if (FileScopedNamespaceRegex.Match(remaining) is { Success: true } fileScoped)
+        {
+            remaining = remaining.Substring(fileScoped.Length);
+        }
+        else if (BlockScopedNamespaceRegex.Match(remaining) is { Success: true } blockScoped)
+        {
+            remaining = remaining.Substring(blockScoped.Length);
+            hasNamespaceClosingBrace = true;
+        }
+
+        Match classHeader = ClassHeaderRegex.Match(remaining);
+        if (!classHeader.Success)
+        {
+            return false;
+        }
+        remaining = remaining.Substring(classHeader.Length);
+
+        // The class body's closing brace, plus the namespace's if it was block-scoped.
+        string expectedClosing = hasNamespaceClosingBrace ? "} }" : "}";
+        if (!remaining.EndsWith(expectedClosing))
+        {
+            return false;
+        }
+        remaining = remaining.Substring(0, remaining.Length - expectedClosing.Length).TrimEnd();
+
+        return EmptyCustomInitializeRegex.IsMatch(remaining);
+    }
+
+    /// <summary>
+    /// Removes comments and collapses every whitespace run to a single space, so the remaining
+    /// checks can be written against one predictable spacing rather than the file's formatting.
+    /// </summary>
+    private static string Normalize(string contents)
+    {
+        string withoutComments = BlockCommentRegex.Replace(contents, " ");
+        withoutComments = LineCommentRegex.Replace(withoutComments, " ");
+        return WhitespaceRegex.Replace(withoutComments, " ").Trim();
+    }
+
+    private static string StripRepeatedly(Regex regex, string text)
+    {
+        Match match = regex.Match(text);
+        while (match.Success)
+        {
+            text = text.Substring(match.Length);
+            match = regex.Match(text);
+        }
+        return text;
+    }
+}


### PR DESCRIPTION
Part of #4422 (gap 2, plus the delete half of gap 5). Gap 1 already landed in #4423.

## What changed

`MainCodeOutputPlugin.HandleElementDeleted` asked one Yes/No covering both code files. "Yes" recycled the user's hand-written custom `.cs` when they may have only wanted the generated file gone; "No" left an orphaned `.Generated.cs` compiling forever. The per-element `.codsj` was never cleaned up at all.

Now, per the invariant in the issue:

- **`.Generated.cs`** — derived data, removed unconditionally, no prompt.
- **`.codsj`** — regenerable settings for a deleted element, removed unconditionally, no prompt.
- **Custom `.cs`** — a separate, explicit decision, and not asked at all when the file is still an untouched stub. Never a plain `File.Delete`; always the recycle bin.

The custom-code decision is a checkbox contributed to the existing `DeleteOptionsWindow` (the `DeleteOptionsWindowShow`/`DeleteConfirmed` plugin events), not a second dialog. It is computed once for the whole batch, so deleting a folder's worth of elements produces one confirmation rather than twenty. It defaults to **unchecked** — losing user code needs a deliberate click.

Elements with `GenerationBehavior.NeverGenerate` are left completely alone (generated, custom and `.codsj`) — the user is hand-managing those.

Nothing in this path prompts, so automatic regeneration can't pop a dialog; a test pins that.

## Stub detection

`CustomCodeStubDetector` (`Tools/Gum.ProjectServices/CodeGeneration/`) decides structurally: strip comments, usings, the namespace and the class header, then require what remains to be an empty-bodied `CustomInitialize` and nothing else. Handles block- and file-scoped namespaces, no namespace at all (empty `RootNamespace`), an inheritance list, and added access modifiers. Deliberately not a diff against `CustomCodeGenerator`'s current output, which changes across Gum versions and would misjudge files written by an older one. Anything it can't account for reads as "not a stub", so the failure direction is an unnecessary prompt, never lost code. One test pins it against the live `CustomCodeGenerator` output so template drift shows up here.

## Bundled fixes

- `ElementDeleteService` (the `.ganx` sidecar contributor to the same dialog) hard-`File.Delete`d user-authored animation data. Switched to `IFileCommands.MoveToRecycleBin` — same invariant, since Gum's undo covers project state, not files on disk.
- Both `DeleteOptionsWindow` contributors cached their WPF checkbox in a field and only cleared it in `DeleteConfirmed`. A cancelled delete never fires that, so the next delete could read a stale checked state and recycle a file without asking. Cleared on show instead.
- `DeleteOptionCheckboxViewModel` moved from `StateAnimationPlugin.Managers` to `Gum.Services.Dialogs` now that two plugins contribute one.
- `MainCodeOutputPlugin` moved from `PluginBase` to `WpfPluginBase` — the delete-dialog events live there.

## Tests

`CodeFileDeleteServiceTests` (10) and `CustomCodeStubDetectorTests` (7), both headless with a mocked `IFileCommands`/`IDialogService` and real temp files. Covered: untouched stub never prompted for, edited custom file is, generated + `.codsj` go without a prompt, declining still removes the generated file, 20 elements produce one checkbox, no prompt is ever issued, `NeverGenerate` is untouched.

`GumFull.sln` builds clean with no new warnings; `Gum.Presentation.Tests` (896), `Gum.ProjectServices.Tests` (502) and `GumToolUnitTests` (1261, incl. `AllPluginsCompositionTests`) all green.

`CodeOutputElementSettingsManager.GetCodeSettingsFilePath` widened `internal` → `public` so reconciliation outside `Gum.ProjectServices` can reach it. The rename-side PR makes the same one-line change; it merges trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
