### PR TITLE
Let themed CheckBox labels wrap by stretching the content column

### DIFF
--- a/Gum/Extensions/DeleteOptionCheckboxExtensions.cs
+++ b/Gum/Extensions/DeleteOptionCheckboxExtensions.cs
@@ -16,15 +16,12 @@ public static class DeleteOptionCheckboxExtensions
         return new CheckBox
         {
             // A TextBlock rather than the raw string so a long label wraps instead of being clipped
-            // mid-word. MaxWidth is what makes the wrap engage: the themed CheckBox template lays
-            // the content out in an Auto column, which measures at the label's desired width and so
-            // never supplies a constraint of its own. Sized to the delete dialog's fixed width less
-            // its padding and the check box glyph.
+            // mid-word; the themed CheckBox template's content column now stretches to the dialog's
+            // width, giving the wrap something to wrap against.
             Content = new TextBlock
             {
                 Text = viewModel.Label,
-                TextWrapping = TextWrapping.Wrap,
-                MaxWidth = 290
+                TextWrapping = TextWrapping.Wrap
             },
             HorizontalAlignment = HorizontalAlignment.Left,
             IsChecked = viewModel.IsChecked

--- a/Gum/Themes/Frb.Styles.Defaults.xaml
+++ b/Gum/Themes/Frb.Styles.Defaults.xaml
@@ -278,7 +278,7 @@
                     <Grid x:Name="root">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Border
                             x:Name="Border"

--- a/Tool/Tests/GumToolUnitTests/Extensions/DeleteOptionCheckboxExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Extensions/DeleteOptionCheckboxExtensionsTests.cs
@@ -51,15 +51,15 @@ public class DeleteOptionCheckboxExtensionsTests
     }
 
     /// <summary>
-    /// The themed CheckBox template measures its content in an Auto column, so TextWrapping alone
-    /// never engages - an explicit constraint on the TextBlock is what makes the label wrap.
+    /// The themed CheckBox template's content column now stretches to the available width, so the
+    /// TextBlock itself no longer needs its own width constraint for wrapping to engage.
     /// </summary>
     [StaFact]
-    public void ToCheckBox_ShouldConstrainLabelWidth_SoWrappingActuallyEngages()
+    public void ToCheckBox_ShouldNotConstrainLabelWidth_TemplateColumnHandlesWrapping()
     {
         CheckBox checkBox = new DeleteOptionCheckboxViewModel { Label = "Anything" }.ToCheckBox();
 
         TextBlock content = checkBox.Content.ShouldBeOfType<TextBlock>();
-        double.IsPositiveInfinity(content.MaxWidth).ShouldBeFalse();
+        double.IsPositiveInfinity(content.MaxWidth).ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- The `CheckBox` `ControlTemplate` in `Gum/Themes/Frb.Styles.Defaults.xaml` laid the glyph and content out in two `Auto` columns. An `Auto` column measures at the child's desired width, so the content column never supplied a width constraint and `TextWrapping="Wrap"` never engaged.
- Changed the content column to `*` so it stretches to available width instead.
- Dropped the `MaxWidth=290` per-site workaround in `DeleteOptionCheckboxExtensions.cs` that this forced on the delete dialog's checkbox.
- Updated `DeleteOptionCheckboxExtensionsTests` (was asserting the now-removed `MaxWidth`; now asserts the TextBlock relies on the template instead).

Closes #4433

## Test plan
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj --filter DeleteOptionCheckboxExtensionsTests` — 5/5 green
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] Manual verification in the running tool (delete dialog, New Project dialog, Import-from-.gumx tree checkboxes, Add Forms window, Plugins dialog, texture-coordinate snap-to-grid checkbox) — confirmed by user
