### PR TITLE
Fix DialogBox.Dismiss raising FinishedShowing before cleanup

### DIFF
--- a/MonoGameGum.Tests/Forms/DialogBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/DialogBoxTests.cs
@@ -259,4 +259,51 @@ public class DialogBoxTests : BaseTestClass
         // Three short entries -> three pages, first popped -> two remaining.
         dialogBox.PagesRemaining.ShouldBe(2);
     }
+
+    [Fact]
+    public void Dismiss_ShouldClearPagesAndDropFocus_BeforeFinishedShowingFires()
+    {
+        var (dialogBox, visual) = CreateDialogBox();
+        dialogBox.LettersPerSecond = 0;
+        dialogBox.IsFocused = true;
+
+        dialogBox.Show(new[] { "one", "two", "three" });
+        dialogBox.PagesRemaining.ShouldBeGreaterThan(0); // sanity: pages queued
+
+        bool sawFinishedShowing = false;
+        dialogBox.FinishedShowing += (_, _) =>
+        {
+            sawFinishedShowing = true;
+            dialogBox.PagesRemaining.ShouldBe(0,
+                "Dismiss must clear pages before raising FinishedShowing");
+            dialogBox.IsFocused.ShouldBeFalse(
+                "Dismiss must drop focus before raising FinishedShowing");
+        };
+
+        dialogBox.Dismiss();
+
+        sawFinishedShowing.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FinishedShowingHandler_ReShow_ShouldSurviveDismissCleanup()
+    {
+        var (dialogBox, visual) = CreateDialogBox();
+        dialogBox.LettersPerSecond = 0;
+
+        dialogBox.Show("first");
+        dialogBox.FinishedShowing += (_, _) =>
+        {
+            // Typical chained-dialog usage: show the next dialog from the handler.
+            dialogBox.IsFocused = true;
+            dialogBox.Show(new[] { "second A", "second B" });
+        };
+
+        dialogBox.Dismiss();
+
+        // The re-shown dialog must not be wiped by Dismiss()'s post-event cleanup.
+        dialogBox.IsVisible.ShouldBeTrue();
+        dialogBox.IsFocused.ShouldBeTrue();
+        dialogBox.PagesRemaining.ShouldBe(1); // two pages, first popped, rest must survive
+    }
 }

--- a/MonoGameGum/Forms/Controls/Games/DialogBox.cs
+++ b/MonoGameGum/Forms/Controls/Games/DialogBox.cs
@@ -677,9 +677,12 @@ public class DialogBox : FrameworkElement, IInputReceiver
         LastTimeDismissed = global::RenderingLibrary.IGumService.Default?.GameTime ?? 0;
 #endif
         PageAdvanced?.Invoke(this, null);
-        FinishedShowing?.Invoke(this, null);
+        // Finish cleanup BEFORE raising FinishedShowing so a handler that re-shows the
+        // dialog (e.g. a chained sequence of dialogs) is not undone by the state reset
+        // below. Matches the async path, which fires the event only after the show loop ends.
         this.Pages.Clear();
         IsFocused = false;
+        FinishedShowing?.Invoke(this, null);
     }
 
     public void OnFocusUpdatePreview(RoutedEventArgs args)


### PR DESCRIPTION
## Summary

\DialogBox.Dismiss()\ cleared the dialog's \Pages\ and dropped keyboard focus **after** raising \FinishedShowing\:

\\\csharp
public void Dismiss()
{
    this.IsVisible = false;
    ...
    PageAdvanced?.Invoke(this, null);
    FinishedShowing?.Invoke(this, null);  // fired BEFORE cleanup
    this.Pages.Clear();
    IsFocused = false;
}
\\\

A handler that re-shows the dialog from \FinishedShowing\ (the natural implementation of chained/sequential dialogs) had its freshly-shown pages and focus wiped by the tail of \Dismiss()\. Result: the next dialog box is visible but stuck — no pages, no input focus.

## Fix

Move \Pages.Clear()\ and \IsFocused = false\ before \FinishedShowing\ fires, so the dialog is fully dismissed by the time the event is raised. This also matches the \ShowAsync\ path, which only fires the event after the show loop has fully ended (its cleanup happens before the event too).

## Tests

Two new tests in \MonoGameGum.Tests/Forms/DialogBoxTests.cs\:
- \Dismiss_ShouldClearPagesAndDropFocus_BeforeFinishedShowingFires\ — pins the ordering contract.
- \FinishedShowingHandler_ReShow_ShouldSurviveDismissCleanup\ — the real-world chained-dialog scenario: re-showing a 2-page dialog from the handler must keep its remaining page and focus.

Both fail on the previous ordering and pass with the fix. Full \MonoGameGum.Tests\ suite passes (2174).