### PR TITLE
Rename gum-user-question-triage skill to user-asks

### DIFF
--- a/.claude/skills/user-asks/SKILL.md
+++ b/.claude/skills/user-asks/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: gum-user-question-triage
-description: Answering Discord/GitHub user questions — search skills→docs→code, cite the docs URL, suggest doc/API fixes with confidence, or file an issue. Triggers: pasted user question, "how do I", GitHub issue triage, "answer this person".
+name: user-asks
+description: Answering Discord/GitHub user questions — search skills→docs→code, cite the docs URL, suggest doc/API fixes with confidence, or file an issue. Triggers: pasted user question, "how do I", GitHub issue triage, "answer this person", "user asks".
 ---
 
 # Answering User Questions


### PR DESCRIPTION
## Summary
- Renamed `.claude/skills/gum-user-question-triage/` to `.claude/skills/user-asks/` so the manual slash-command invocation (`/user-asks`) is easier to remember than the old name.
- Content unchanged aside from adding "user asks" as an explicit trigger phrase in the frontmatter description.

## Test plan
- [x] Docs-only change, no build/runtime surface — manual test not needed.