### PR TITLE
Sync skills-writer with de-drifted version

### DIFF
--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -52,11 +52,11 @@ Before writing anything, identify where the ground truth already lives:
 
 ## Skill File Rules
 
-- **Length**: aim under 100 lines. Hard ceiling 500. Bloat costs agent context on every load.
+- **Length**: not a target — a byproduct. The damped-response process above is what keeps a skill short: most edits are ~20% pulls (a signpost, not a walkthrough), so length only grows where demand genuinely, repeatedly pulls. Don't pad toward a line count, and don't treat headroom under a number as license to add more than the current pull warrants. Hard ceiling 500 lines as a bloat backstop, not a goal.
 - **Naming**: kebab-case noun phrases (e.g., `gum-tool-undo`).
 - **Frontmatter**: `name` and `description`. **The description is loaded into every session's skill listing** — it pays for itself in context tokens forever. Keep it brutally short. See "Writing the description" below.
 - **Structure**: `##` sections. Tables for file maps. Prose for relationships and gotchas.
-- **Progressive disclosure**: keep SKILL.md to high-level architecture; spill advanced content into sibling files (e.g., `[xnafiddle.md](xnafiddle.md)`) only when it's bulky enough to justify a second file.
+- **Progressive disclosure**: keep SKILL.md to high-level architecture; spill advanced content into sibling files (e.g., `detail.md`) only when it's bulky enough to justify a second file.
 
 ## Writing the description
 


### PR DESCRIPTION
## Summary
- Consolidates with the newer skill-creator lineage used in FRB2/KidDefense/CrankyChibiCthulhu, now all renamed to skills-writer for consistency ("writer" covers both creating and updating skills).
- Drops the fixed 500-line ceiling in favor of "length is whatever the topic warrants."
- Adds a mandatory approval gate: show the full draft and wait for explicit approval before writing any skill file.
- Adds the Converging-pull exception alongside Landmines/Bimodal-pull.

Repo-specific `docs/` pointers are unchanged.