### PR TITLE
Only revert CustomCursor to Arrow when leaving an element that set one

### DIFF
--- a/MonoGameGum.Tests/Forms/FormsUtilitiesCustomCursorTests.cs
+++ b/MonoGameGum.Tests/Forms/FormsUtilitiesCustomCursorTests.cs
@@ -1,0 +1,90 @@
+using Gum.DataTypes;
+using Gum.Forms;
+using Gum.Forms.Controls;
+using Gum.GueDeriving;
+using Gum.Input;
+using Gum.Wireframe;
+using Microsoft.Xna.Framework;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+// Covers issue #4442: a cursor set directly via ICursor.CustomCursor (e.g. a game calling
+// Mouse.SetCursor / GumUI.Cursor.CustomCursor outside of any FrameworkElement.CustomCursor)
+// was being reset to Cursors.Arrow every time the hovered FrameworkElement changed, even when
+// neither the old nor the new element had a CustomCursor of its own -- e.g. simply hovering
+// onto or off of a plain Button.
+public class FormsUtilitiesCustomCursorTests : BaseTestClass
+{
+    [Fact]
+    public void Update_ShouldNotResetCustomCursor_WhenHoveringOntoElementWithNoCustomCursorOfItsOwn()
+    {
+        Mock<ICursor> cursor = CreateMockCursorWithPosition(x: 500, y: 500);
+
+        Button button = new();
+        button.AddToRoot();
+        button.X = 0;
+        button.Y = 0;
+        button.Width = 100;
+        button.Height = 100;
+        button.Visual.WidthUnits = DimensionUnitType.Absolute;
+        button.Visual.HeightUnits = DimensionUnitType.Absolute;
+
+        GumService.Default.Update(new GameTime());
+
+        // Simulates a game setting the cursor directly (e.g. Mouse.SetCursor), independent of
+        // any FrameworkElement.CustomCursor.
+        cursor.Object.CustomCursor = Cursors.SizeWE;
+
+        cursor.Setup(c => c.X).Returns(10);
+        cursor.Setup(c => c.Y).Returns(10);
+
+        GumService.Default.Update(new GameTime());
+
+        cursor.Object.CustomCursor.ShouldBe(Cursors.SizeWE);
+    }
+
+    [Fact]
+    public void Update_ShouldRevertToArrow_WhenLeavingElementThatHadCustomCursor()
+    {
+        Mock<ICursor> cursor = CreateMockCursorWithPosition(x: 500, y: 500);
+
+        FrameworkElement withCustomCursor = new(new ContainerRuntime());
+        withCustomCursor.Visual.AddToRoot();
+        withCustomCursor.Visual.Click += (_, _) => { };
+        withCustomCursor.X = 0;
+        withCustomCursor.Y = 0;
+        withCustomCursor.Width = 100;
+        withCustomCursor.Height = 100;
+        withCustomCursor.Visual.WidthUnits = DimensionUnitType.Absolute;
+        withCustomCursor.Visual.HeightUnits = DimensionUnitType.Absolute;
+        withCustomCursor.CustomCursor = Cursors.SizeWE;
+
+        cursor.Setup(c => c.X).Returns(10);
+        cursor.Setup(c => c.Y).Returns(10);
+        GumService.Default.Update(new GameTime());
+
+        cursor.Object.CustomCursor.ShouldBe(Cursors.SizeWE);
+
+        cursor.Setup(c => c.X).Returns(500);
+        cursor.Setup(c => c.Y).Returns(500);
+        GumService.Default.Update(new GameTime());
+
+        cursor.Object.CustomCursor.ShouldBe(Cursors.Arrow);
+    }
+
+    private static Mock<ICursor> CreateMockCursorWithPosition(int x, int y)
+    {
+        Mock<ICursor> cursor = new();
+        FormsUtilities.SetCursor(cursor.Object);
+        cursor.SetupProperty(c => c.WindowPushed);
+        cursor.SetupProperty(c => c.VisualOver);
+        cursor.SetupProperty(c => c.CustomCursor);
+        cursor.Setup(c => c.X).Returns(x);
+        cursor.Setup(c => c.Y).Returns(y);
+        cursor.Setup(c => c.LastInputDevice).Returns(InputDevice.Mouse);
+        return cursor;
+    }
+}

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -555,13 +555,18 @@ public class FormsUtilities
 
         ToolTipService.Update(cursor, gameTimeSeconds);
 
-        var didChangeFrameworkElement = frameworkElementOver != frameworkElementOverBefore;
+        // Only reset to Arrow when leaving an element whose CustomCursor Gum itself was applying --
+        // not on every FrameworkElement change. Otherwise hovering onto/off of any plain element
+        // (which has no CustomCursor of its own) stomps a cursor a game set directly (e.g. via
+        // Mouse.SetCursor or ICursor.CustomCursor), independent of FrameworkElement.CustomCursor
+        // (issue #4442).
+        var wasApplyingCustomCursor = frameworkElementOverBefore?.IsEnabled == true && frameworkElementOverBefore.CustomCursor != null;
 
         if (frameworkElementOver?.IsEnabled == true && frameworkElementOver.CustomCursor != null)
         {
             cursor.CustomCursor = frameworkElementOver?.CustomCursor;
         }
-        else if (didChangeFrameworkElement)
+        else if (wasApplyingCustomCursor)
         {
             cursor.CustomCursor = Cursors.Arrow;
         }


### PR DESCRIPTION
Closes #4442

## Bug

`FormsUtilities.Update` reset `ICursor.CustomCursor` to `Cursors.Arrow` on **every** hovered-`FrameworkElement` change, not just when leaving an element that had actually set one. Hovering onto/off any plain `Button` (no `CustomCursor` of its own) was enough to trigger the reset — clobbering a cursor a game set directly (`Mouse.SetCursor`, or `GumUI.Cursor.CustomCursor`), independent of `FrameworkElement.CustomCursor`.

## Fix

Only revert to `Arrow` when the *previous* hovered element was one Gum had actually applied a `CustomCursor` for (e.g. a `Window` resize border), not on every hover-target change.

## Tests

`FormsUtilitiesCustomCursorTests`:
- `Update_ShouldNotResetCustomCursor_WhenHoveringOntoElementWithNoCustomCursorOfItsOwn` — red before the fix (asserted `Arrow`, got `SizeWE`... i.e. asserted `SizeWE`, got `Arrow`), green after.
- `Update_ShouldRevertToArrow_WhenLeavingElementThatHadCustomCursor` — pins the existing Window-border-resize behavior.

Full `MonoGameGum.Tests` suite: 2178/2178 passing. `RaylibGum`, `SkiaGum`, `SilkNetGum` (which share `FormsUtilities.cs`) build clean.

Manual test: not needed — the tests assert the exact `ICursor.CustomCursor` value that `Cursor.CustomCursor`'s setter (`MonoGameGum/Input/Cursor.cs`) forwards 1:1 into `Mouse.SetCursor`, not an approximation.

FRB canary: not needed — `FormsUtilities.cs` is excluded from FRB1's `FlatRedBall.Forms.Shared.projitems` per the file's own header comment; never compiled by FRB1.
