### PR TITLE
Copy and paste a whole variable category from the Variables tab context menu

### DIFF
--- a/.claude/skills/gum-tool-variable-grid/SKILL.md
+++ b/.claude/skills/gum-tool-variable-grid/SKILL.md
@@ -107,6 +107,22 @@ Landmine: `CompositeInstanceMember.HandleCustomSet` writes **every** channel on 
 
 ---
 
+## Category Copy/Paste (whole-group values)
+
+Right-clicking a category header offers Copy Values / Paste Values (#4455). The gather/apply logic is headless: `VariableCategoryCopyPasteService` in `Tools/Gum.Presentation/.../VariableGrid/`, fed by `IVariableCategoryRow` rows that `VariableCategoryRowAdapter` (in `Gum/.../VariableGrid/`) wraps around the live WPF `InstanceMember`s. Paste only applies to the category the values were copied from, records as one undo (single `RequestLock` across all writes), and skips rather than fails: absent variables, read-only/reference-assigned rows, type mismatches (numeric mismatches convert), and state names the target doesn't declare.
+
+Category-header menus are `MemberCategory.ContextMenuItems` (`MemberCategoryContextMenuItem` is its own `ICommand`), rendered by the header template in `Frb.Styles.Defaults.xaml`. Landmines:
+
+- **`DataUiGrid.SetMultipleCategoryLists` copies only `Name` and `HeaderColor`** onto the fresh `MemberCategory` objects it creates for multi-select — any other category-level state (`ContextMenuItems`, `HideHeader`, `Width`) is silently dropped. `PropertyGridManager.RefreshCategoryContextMenus` re-populates after every refresh (guarded to only fill empty categories) for exactly this reason.
+- **A `ContextMenu` on a shared template reaches every grid.** The header template serves all `DataUiGrid`s (Code tab, project properties, behaviors), and even a visually-collapsed empty menu still opens and takes mouse capture, eating the next click. Suppress with `ContextMenuService.IsEnabled=False` (via DataTrigger on item count), not `Visibility`.
+- **`Type.IsInstanceOfType` is always false against `Nullable<T>`** for a boxed value — variables declared `int?`/`float?` (`MaxLettersToShow`, `MinWidth`, ...) need `Nullable.GetUnderlyingType` before any reflection type gate.
+- **A state name is just a string** — any automated write to a state row (`State`, `<Category>State`) must validate against the row's `CustomOptions`/available states or it saves a dangling state name that renders as a blank combo.
+- **Write units before values.** Setting `XUnits`/`WidthUnits`/... can convert the target's current `X`/`Width` ("convert variables on unit type change"), so a value written before its unit gets converted away.
+- **`MultiSelectInstanceMember.Value` returns null when the wrapped instances disagree** (indeterminate) — indistinguishable from "unset" by value alone; check `IsIndeterminate` before treating null as absent.
+- Right-clicking inside a value text field pops an empty white box (#4457, cause undetermined — candidates: a displayer's declared-but-never-populated `<ContextMenu />`, or the native text-editing menu unthemed). Pre-existing on main; don't chase it as a regression of grid work.
+
+---
+
 ## Refresh Trigger Flow
 
 ```

--- a/.claude/skills/gum-tool-variable-grid/SKILL.md
+++ b/.claude/skills/gum-tool-variable-grid/SKILL.md
@@ -119,7 +119,7 @@ Category-header menus are `MemberCategory.ContextMenuItems` (`MemberCategoryCont
 - **A state name is just a string** — any automated write to a state row (`State`, `<Category>State`) must validate against the row's `CustomOptions`/available states or it saves a dangling state name that renders as a blank combo.
 - **Write units before values.** Setting `XUnits`/`WidthUnits`/... can convert the target's current `X`/`Width` ("convert variables on unit type change"), so a value written before its unit gets converted away.
 - **`MultiSelectInstanceMember.Value` returns null when the wrapped instances disagree** (indeterminate) — indistinguishable from "unset" by value alone; check `IsIndeterminate` before treating null as absent.
-- Right-clicking inside a value text field pops an empty white box (#4457, cause undetermined — candidates: a displayer's declared-but-never-populated `<ContextMenu />`, or the native text-editing menu unthemed). Pre-existing on main; don't chase it as a regression of grid work.
+- Right-clicking inside a value text field can pop an empty-looking white box (#4457): the native text-editing menu, unthemed — disabled Cut/Copy/Paste entries render invisibly faint, so with no selection and an empty clipboard the menu looks blank. Pre-existing on main; don't chase it as a regression of grid work.
 
 ---
 

--- a/Gum/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRowAdapter.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRowAdapter.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using WpfDataUi.DataTypes;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Adapts the Variables tab's WPF rows to <see cref="IVariableCategoryRow"/> so the headless
+/// <see cref="IVariableCategoryCopyPasteService"/> can read and write them without referencing WPF.
+/// </summary>
+public interface IVariableCategoryRowAdapter
+{
+    /// <summary>Wraps each member of a category as a copy/paste row.</summary>
+    List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members);
+}

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -87,7 +87,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     private CompositeMemberLogic _compositeMemberLogic;
     private StateSaveCategoryDisplayer _stateSaveCategoryDisplayer;
     private BehaviorShowingLogic _behaviorShowingLogic;
-    private IVariableCategoryCopyPasteService _variableCategoryCopyPasteService;
+    private readonly IVariableCategoryCopyPasteService _variableCategoryCopyPasteService;
+    private readonly IVariableCategoryRowAdapter _variableCategoryRowAdapter;
 
     #endregion
 
@@ -155,6 +156,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         _stateEditingIndicatorService = stateEditingIndicatorService;
         _stateSaveCategoryDisplayer = new StateSaveCategoryDisplayer(variableInCategoryPropagationLogic);
         _behaviorShowingLogic = new BehaviorShowingLogic(fileCommands, projectState);
+        _variableCategoryCopyPasteService = new VariableCategoryCopyPasteService(_undoManager);
+        _variableCategoryRowAdapter = new VariableCategoryRowAdapter();
     }
 
     // Normally plugins will initialize through the PluginManager. This needs to happen earlier (see where it's called for info)
@@ -188,8 +191,6 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             _wireframeObjectManager,
             _clipboardService,
             _projectState);
-
-        _variableCategoryCopyPasteService = new VariableCategoryCopyPasteService(_undoManager);
 
         mainControl = new Gum.MainPropertyGrid();
 
@@ -524,44 +525,77 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     #region Category Copy/Paste
 
     /// <summary>
-    /// Rebuilds the copy/paste entries on every category header. This runs after each grid refresh rather
-    /// than when the categories are built, because the multi-select path
+    /// Adds the copy/paste entries to any category header that does not have them yet. This runs after
+    /// each grid refresh rather than when the categories are built, because the multi-select path
     /// (<c>DataUiGrid.SetMultipleCategoryLists</c>) creates its own <see cref="MemberCategory"/> objects
-    /// and copies only their name and header color.
+    /// and copies only their name and header color. Categories the refresh reused keep their existing
+    /// items, so a value-only refresh churns nothing.
     /// </summary>
     private void RefreshCategoryContextMenus()
     {
         foreach (MemberCategory category in mVariablesDataGrid.Categories)
         {
-            MemberCategory categoryForMenu = category;
-
-            category.ContextMenuItems.Clear();
+            if (category.ContextMenuItems.Count > 0)
+            {
+                continue;
+            }
 
             category.ContextMenuItems.Add(new MemberCategoryContextMenuItem(
                 "Copy Values",
-                () => CopyCategoryValues(categoryForMenu)));
+                () => CopyCategoryValues(category)));
 
             category.ContextMenuItems.Add(new MemberCategoryContextMenuItem(
                 "Paste Values",
-                () => PasteCategoryValues(categoryForMenu),
+                () => PasteCategoryValues(category),
                 () => _variableCategoryCopyPasteService.CopiedCategory != null));
         }
     }
 
     private void CopyCategoryValues(MemberCategory category)
     {
-        _variableCategoryCopyPasteService.Copy(category.Name, VariableCategoryRowAdapter.CreateRows(category.Members));
+        CopiedVariableCategory copied;
 
-        int copiedCount = _variableCategoryCopyPasteService.CopiedCategory?.Values.Count ?? 0;
-        _guiCommands.PrintOutput($"Copied {copiedCount} value(s) from {category.Name}");
+        // The rows' effective-value reads walk the inheritance chain per variable; cache element lookups
+        // for the duration, mirroring RefreshDataGrid.
+        _objectFinder.EnableCache();
+        try
+        {
+            copied = _variableCategoryCopyPasteService.Copy(
+                category.Name, _variableCategoryRowAdapter.CreateRows(category.Members));
+        }
+        finally
+        {
+            _objectFinder.DisableCache();
+        }
+
+        string message = $"Copied {copied.Values.Count} value(s) from {copied.CategoryName}";
+        if (copied.IndeterminateVariableNames.Count > 0)
+        {
+            message += $". Not copied (differs across selection): {string.Join(", ", copied.IndeterminateVariableNames)}";
+        }
+        _guiCommands.PrintOutput(message);
     }
 
     private void PasteCategoryValues(MemberCategory category)
     {
-        VariableCategoryPasteResult result =
-            _variableCategoryCopyPasteService.Paste(VariableCategoryRowAdapter.CreateRows(category.Members));
+        VariableCategoryPasteResult result;
 
-        string message = $"Pasted {result.AppliedVariableNames.Count} value(s) into {category.Name}";
+        _objectFinder.EnableCache();
+        try
+        {
+            result = _variableCategoryCopyPasteService.Paste(_variableCategoryRowAdapter.CreateRows(category.Members));
+        }
+        finally
+        {
+            _objectFinder.DisableCache();
+        }
+
+        string sourceName = _variableCategoryCopyPasteService.CopiedCategory?.CategoryName ?? "?";
+        string message = $"Pasted {result.AppliedVariableNames.Count} {sourceName} value(s) into {category.Name}";
+        if (result.AlreadyMatchedVariableNames.Count > 0)
+        {
+            message += $", {result.AlreadyMatchedVariableNames.Count} already matched";
+        }
         if (result.SkippedVariableNames.Count > 0)
         {
             message += $". Skipped {string.Join(", ", result.SkippedVariableNames)}";

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -87,6 +87,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
     private CompositeMemberLogic _compositeMemberLogic;
     private StateSaveCategoryDisplayer _stateSaveCategoryDisplayer;
     private BehaviorShowingLogic _behaviorShowingLogic;
+    private IVariableCategoryCopyPasteService _variableCategoryCopyPasteService;
 
     #endregion
 
@@ -187,6 +188,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             _wireframeObjectManager,
             _clipboardService,
             _projectState);
+
+        _variableCategoryCopyPasteService = new VariableCategoryCopyPasteService(_undoManager);
 
         mainControl = new Gum.MainPropertyGrid();
 
@@ -480,6 +483,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
                 ReconcileCategories(mVariablesDataGrid.Categories, listOfCategories[0], instanceIdentityChanged);
             }
 
+            RefreshCategoryContextMenus();
+
             RefreshErrors(element);
 
             RefreshStateLabel();
@@ -515,6 +520,61 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             category.Members.RemoveAll(item => item.DisplayName == "Name" );
         }
     }
+
+    #region Category Copy/Paste
+
+    /// <summary>
+    /// Rebuilds the copy/paste entries on every category header. This runs after each grid refresh rather
+    /// than when the categories are built, because the multi-select path
+    /// (<c>DataUiGrid.SetMultipleCategoryLists</c>) creates its own <see cref="MemberCategory"/> objects
+    /// and copies only their name and header color.
+    /// </summary>
+    private void RefreshCategoryContextMenus()
+    {
+        foreach (MemberCategory category in mVariablesDataGrid.Categories)
+        {
+            MemberCategory categoryForMenu = category;
+
+            category.ContextMenuItems.Clear();
+
+            category.ContextMenuItems.Add(new MemberCategoryContextMenuItem(
+                "Copy Values",
+                () => CopyCategoryValues(categoryForMenu)));
+
+            category.ContextMenuItems.Add(new MemberCategoryContextMenuItem(
+                "Paste Values",
+                () => PasteCategoryValues(categoryForMenu),
+                () => _variableCategoryCopyPasteService.CopiedCategory != null));
+        }
+    }
+
+    private void CopyCategoryValues(MemberCategory category)
+    {
+        _variableCategoryCopyPasteService.Copy(category.Name, VariableCategoryRowAdapter.CreateRows(category.Members));
+
+        int copiedCount = _variableCategoryCopyPasteService.CopiedCategory?.Values.Count ?? 0;
+        _guiCommands.PrintOutput($"Copied {copiedCount} value(s) from {category.Name}");
+    }
+
+    private void PasteCategoryValues(MemberCategory category)
+    {
+        VariableCategoryPasteResult result =
+            _variableCategoryCopyPasteService.Paste(VariableCategoryRowAdapter.CreateRows(category.Members));
+
+        string message = $"Pasted {result.AppliedVariableNames.Count} value(s) into {category.Name}";
+        if (result.SkippedVariableNames.Count > 0)
+        {
+            message += $". Skipped {string.Join(", ", result.SkippedVariableNames)}";
+        }
+        _guiCommands.PrintOutput(message);
+
+        if (result.AppliedVariableNames.Count > 0)
+        {
+            RefreshEntireGrid(force: true);
+        }
+    }
+
+    #endregion
 
     private void RefreshStateLabel()
     {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -544,10 +544,12 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
                 "Copy Values",
                 () => CopyCategoryValues(category)));
 
+            // Enabled only on the category the values came from - Font values only paste onto Font, even
+            // where variable names happen to overlap with another category.
             category.ContextMenuItems.Add(new MemberCategoryContextMenuItem(
                 "Paste Values",
                 () => PasteCategoryValues(category),
-                () => _variableCategoryCopyPasteService.CopiedCategory != null));
+                () => _variableCategoryCopyPasteService.CopiedCategory?.CategoryName == category.Name));
         }
     }
 
@@ -583,7 +585,8 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         _objectFinder.EnableCache();
         try
         {
-            result = _variableCategoryCopyPasteService.Paste(_variableCategoryRowAdapter.CreateRows(category.Members));
+            result = _variableCategoryCopyPasteService.Paste(
+                category.Name, _variableCategoryRowAdapter.CreateRows(category.Members));
         }
         finally
         {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -131,6 +131,9 @@ public class StateReferencingInstanceMember : InstanceMember
     /// <inheritdoc cref="VariableGridEntry.IsAssignedByReference"/>
     public bool IsAssignedByReference => _entry.IsAssignedByReference;
 
+    /// <inheritdoc cref="VariableGridEntry.IsStateSelection"/>
+    public bool IsStateSelection => _entry.IsStateSelection;
+
     public int SortValue
     {
         get => _entry.SortValue;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -128,6 +128,9 @@ public class StateReferencingInstanceMember : InstanceMember
 
     public string RootVariableName => _entry.RootVariableName;
 
+    /// <inheritdoc cref="VariableGridEntry.IsAssignedByReference"/>
+    public bool IsAssignedByReference => _entry.IsAssignedByReference;
+
     public int SortValue
     {
         get => _entry.SortValue;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gum.PropertyGridHelpers;
@@ -13,27 +14,18 @@ namespace Gum.Plugins.InternalPlugins.VariableGrid;
 public static class VariableCategoryRowAdapter
 {
     /// <summary>
-    /// Wraps each member of a category, expanding composite rows (such as the single color row backed by
-    /// Red/Green/Blue) into their underlying channels so copy/paste operates on real variables.
+    /// Wraps each member of a category as a copy/paste row.
     /// </summary>
-    public static List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members)
-    {
-        List<IVariableCategoryRow> rows = new List<IVariableCategoryRow>();
-
-        foreach (InstanceMember member in members)
-        {
-            if (member is CompositeInstanceMember composite)
-            {
-                rows.AddRange(CreateRows(composite.ChannelMembers));
-            }
-            else
-            {
-                rows.Add(new InstanceMemberRow(member));
-            }
-        }
-
-        return rows;
-    }
+    /// <remarks>
+    /// Rows are taken exactly as the grid presents them, including composite rows (the color swatch backed
+    /// by Red/Green/Blue) and multi-select wrappers. Expanding a composite into its channels here would
+    /// name it differently depending on whether one or several objects are selected - the multi-select
+    /// wrapper sits above the composite, not below it - so a copy in one mode would not match a paste in
+    /// the other. Writing through the row as-is also keeps each wrapper's own behavior: the composite skips
+    /// unchanged channels, and the multi-select wrapper fans the value out and refreshes afterwards.
+    /// </remarks>
+    public static List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members) =>
+        members.Select(member => (IVariableCategoryRow)new InstanceMemberRow(member)).ToList();
 
     private class InstanceMemberRow : IVariableCategoryRow
     {
@@ -52,7 +44,21 @@ public static class VariableCategoryRowAdapter
 
         public object? Value => _member.Value;
 
-        public bool TrySetValue(object? value)
+        public Type? ValueType
+        {
+            get
+            {
+                // PropertyType throws when the member has neither an instance to reflect over nor a custom
+                // type event. IsDefined is true only when one of those two is available.
+                if (!_member.IsDefined)
+                {
+                    return null;
+                }
+                return _member.PropertyType;
+            }
+        }
+
+        public bool TrySetValue(object value)
         {
             ApplyValueResult result = _member.SetValue(value, SetPropertyCommitType.Full);
 
@@ -66,8 +72,8 @@ public static class VariableCategoryRowAdapter
         }
 
         /// <summary>
-        /// The unqualified variable name. A multi-select row is a wrapper with no variable of its own, so
-        /// it reports the name of the rows it fans out to (they all share one).
+        /// The name a copied value is matched by. A multi-select row is a wrapper with no variable of its
+        /// own, so it reports the name of the rows it fans out to (they all share one).
         /// </summary>
         private static string GetRootVariableName(InstanceMember member)
         {
@@ -81,6 +87,8 @@ public static class VariableCategoryRowAdapter
                 return GetRootVariableName(multiSelectMember.InstanceMembers[0]);
             }
 
+            // Composite rows fall through to here. Their name is the composite's own (for example "Color"),
+            // which is stable across single- and multi-select because both build it the same way.
             return member.Name;
         }
 
@@ -94,6 +102,11 @@ public static class VariableCategoryRowAdapter
             if (member is MultiSelectInstanceMember multiSelectMember)
             {
                 return multiSelectMember.InstanceMembers.Any(GetIsAssignedByReference);
+            }
+
+            if (member is CompositeInstanceMember compositeMember)
+            {
+                return compositeMember.ChannelMembers.Any(GetIsAssignedByReference);
             }
 
             return false;

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
@@ -7,24 +7,19 @@ using WpfDataUi.DataTypes;
 
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
-/// <summary>
-/// Adapts the Variables tab's WPF rows to <see cref="IVariableCategoryRow"/> so the headless
-/// <see cref="VariableCategoryCopyPasteService"/> can read and write them without referencing WPF.
-/// </summary>
-public static class VariableCategoryRowAdapter
+/// <inheritdoc cref="IVariableCategoryRowAdapter"/>
+public class VariableCategoryRowAdapter : IVariableCategoryRowAdapter
 {
-    /// <summary>
-    /// Wraps each member of a category as a copy/paste row.
-    /// </summary>
+    /// <inheritdoc/>
     /// <remarks>
     /// Rows are taken exactly as the grid presents them, including composite rows (the color swatch backed
     /// by Red/Green/Blue) and multi-select wrappers. Expanding a composite into its channels here would
     /// name it differently depending on whether one or several objects are selected - the multi-select
     /// wrapper sits above the composite, not below it - so a copy in one mode would not match a paste in
     /// the other. Writing through the row as-is also keeps each wrapper's own behavior: the composite skips
-    /// unchanged channels, and the multi-select wrapper fans the value out and refreshes afterwards.
+    /// unchanged channels, and the multi-select wrapper fans the value out to every selected instance.
     /// </remarks>
-    public static List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members) =>
+    public List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members) =>
         members.Select(member => (IVariableCategoryRow)new InstanceMemberRow(member)).ToList();
 
     private class InstanceMemberRow : IVariableCategoryRow
@@ -38,9 +33,13 @@ public static class VariableCategoryRowAdapter
 
         public string RootVariableName => GetRootVariableName(_member);
 
+        // No recursion needed: DataUiGrid.TryCreateMultiGroup forces IsReadOnly onto multi-select wrappers
+        // (Any of the wrapped rows), and CompositeInstanceMember overrides it over its channels.
         public bool IsReadOnly => _member.IsReadOnly;
 
         public bool IsAssignedByReference => GetIsAssignedByReference(_member);
+
+        public bool IsIndeterminate => _member.IsIndeterminate;
 
         public object? Value => _member.Value;
 
@@ -60,15 +59,18 @@ public static class VariableCategoryRowAdapter
 
         public bool TrySetValue(object value)
         {
-            ApplyValueResult result = _member.SetValue(value, SetPropertyCommitType.Full);
-
-            if (result != ApplyValueResult.Success)
+            // A state name is only meaningful on the element that declares it. Writing one the target does
+            // not have would pass the CLR type gate (it is just a string) and save a dangling state name
+            // into the project, so validate against the row's available states.
+            if (GetIsStateSelection(_member) && _member.CustomOptions?.Contains(value) != true)
             {
                 return false;
             }
 
-            _member.CallAfterSetByUi();
-            return true;
+            // No CallAfterSetByUi here: nothing subscribes AfterSetByUi, and the category-level handler it
+            // reaches (DataUiGrid.HandleInstanceMemberSetByUi) re-reads every row in the whole grid - per
+            // pasted value - only for the caller's final full refresh to redo that work anyway.
+            return _member.SetValue(value, SetPropertyCommitType.Full) == ApplyValueResult.Success;
         }
 
         /// <summary>
@@ -90,6 +92,21 @@ public static class VariableCategoryRowAdapter
             // Composite rows fall through to here. Their name is the composite's own (for example "Color"),
             // which is stable across single- and multi-select because both build it the same way.
             return member.Name;
+        }
+
+        private static bool GetIsStateSelection(InstanceMember member)
+        {
+            if (member is StateReferencingInstanceMember stateReferencingMember)
+            {
+                return stateReferencingMember.IsStateSelection;
+            }
+
+            if (member is MultiSelectInstanceMember multiSelectMember && multiSelectMember.InstanceMembers.Count > 0)
+            {
+                return GetIsStateSelection(multiSelectMember.InstanceMembers[0]);
+            }
+
+            return false;
         }
 
         private static bool GetIsAssignedByReference(InstanceMember member)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/VariableCategoryRowAdapter.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using Gum.PropertyGridHelpers;
+using WpfDataUi;
+using WpfDataUi.DataTypes;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Adapts the Variables tab's WPF rows to <see cref="IVariableCategoryRow"/> so the headless
+/// <see cref="VariableCategoryCopyPasteService"/> can read and write them without referencing WPF.
+/// </summary>
+public static class VariableCategoryRowAdapter
+{
+    /// <summary>
+    /// Wraps each member of a category, expanding composite rows (such as the single color row backed by
+    /// Red/Green/Blue) into their underlying channels so copy/paste operates on real variables.
+    /// </summary>
+    public static List<IVariableCategoryRow> CreateRows(IEnumerable<InstanceMember> members)
+    {
+        List<IVariableCategoryRow> rows = new List<IVariableCategoryRow>();
+
+        foreach (InstanceMember member in members)
+        {
+            if (member is CompositeInstanceMember composite)
+            {
+                rows.AddRange(CreateRows(composite.ChannelMembers));
+            }
+            else
+            {
+                rows.Add(new InstanceMemberRow(member));
+            }
+        }
+
+        return rows;
+    }
+
+    private class InstanceMemberRow : IVariableCategoryRow
+    {
+        private readonly InstanceMember _member;
+
+        public InstanceMemberRow(InstanceMember member)
+        {
+            _member = member;
+        }
+
+        public string RootVariableName => GetRootVariableName(_member);
+
+        public bool IsReadOnly => _member.IsReadOnly;
+
+        public bool IsAssignedByReference => GetIsAssignedByReference(_member);
+
+        public object? Value => _member.Value;
+
+        public bool TrySetValue(object? value)
+        {
+            ApplyValueResult result = _member.SetValue(value, SetPropertyCommitType.Full);
+
+            if (result != ApplyValueResult.Success)
+            {
+                return false;
+            }
+
+            _member.CallAfterSetByUi();
+            return true;
+        }
+
+        /// <summary>
+        /// The unqualified variable name. A multi-select row is a wrapper with no variable of its own, so
+        /// it reports the name of the rows it fans out to (they all share one).
+        /// </summary>
+        private static string GetRootVariableName(InstanceMember member)
+        {
+            if (member is StateReferencingInstanceMember stateReferencingMember)
+            {
+                return stateReferencingMember.RootVariableName;
+            }
+
+            if (member is MultiSelectInstanceMember multiSelectMember && multiSelectMember.InstanceMembers.Count > 0)
+            {
+                return GetRootVariableName(multiSelectMember.InstanceMembers[0]);
+            }
+
+            return member.Name;
+        }
+
+        private static bool GetIsAssignedByReference(InstanceMember member)
+        {
+            if (member is StateReferencingInstanceMember stateReferencingMember)
+            {
+                return stateReferencingMember.IsAssignedByReference;
+            }
+
+            if (member is MultiSelectInstanceMember multiSelectMember)
+            {
+                return multiSelectMember.InstanceMembers.Any(GetIsAssignedByReference);
+            }
+
+            return false;
+        }
+    }
+}

--- a/Gum/Themes/Frb.Styles.Defaults.xaml
+++ b/Gum/Themes/Frb.Styles.Defaults.xaml
@@ -1665,18 +1665,20 @@
     <DataTemplate x:Key="DataUi.CategoryHeaderTemplate" DataType="{x:Type wpfdatauiTypes:MemberCategory}">
         <!--  Transparent border so the header area, not just the text glyphs, is a right-click target.  -->
         <Border HorizontalAlignment="Stretch" Background="Transparent">
+            <Border.Style>
+                <!--  Categories with no items (grids other than the Variables tab) must not open the menu at
+                      all: a collapsed-but-open popup would still take mouse capture and swallow the next
+                      click, where before this template the header had no menu and right-click was a no-op.  -->
+                <Style TargetType="{x:Type Border}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ContextMenuItems.Count}" Value="0">
+                            <Setter Property="ContextMenuService.IsEnabled" Value="False" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
             <Border.ContextMenu>
                 <ContextMenu ItemsSource="{Binding ContextMenuItems}">
-                    <ContextMenu.Style>
-                        <!--  Categories that add no items (grids other than the Variables tab) show nothing at all.  -->
-                        <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type ContextMenu}">
-                            <Style.Triggers>
-                                <Trigger Property="HasItems" Value="False">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ContextMenu.Style>
                     <ContextMenu.ItemContainerStyle>
                         <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
                             <Setter Property="Header" Value="{Binding Header}" />

--- a/Gum/Themes/Frb.Styles.Defaults.xaml
+++ b/Gum/Themes/Frb.Styles.Defaults.xaml
@@ -1663,12 +1663,36 @@
     </DataTemplate>
 
     <DataTemplate x:Key="DataUi.CategoryHeaderTemplate" DataType="{x:Type wpfdatauiTypes:MemberCategory}">
-        <TextBlock
-            Margin="0,4,0,4"
-            VerticalAlignment="Center"
-            FontWeight="Medium"
-            Foreground="{DynamicResource Frb.Brushes.ThemeContrast}"
-            Text="{Binding Name}" />
+        <!--  Transparent border so the header area, not just the text glyphs, is a right-click target.  -->
+        <Border HorizontalAlignment="Stretch" Background="Transparent">
+            <Border.ContextMenu>
+                <ContextMenu ItemsSource="{Binding ContextMenuItems}">
+                    <ContextMenu.Style>
+                        <!--  Categories that add no items (grids other than the Variables tab) show nothing at all.  -->
+                        <Style BasedOn="{StaticResource {x:Type ContextMenu}}" TargetType="{x:Type ContextMenu}">
+                            <Style.Triggers>
+                                <Trigger Property="HasItems" Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ContextMenu.Style>
+                    <ContextMenu.ItemContainerStyle>
+                        <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type MenuItem}">
+                            <Setter Property="Header" Value="{Binding Header}" />
+                            <!--  MemberCategoryContextMenuItem is its own ICommand.  -->
+                            <Setter Property="Command" Value="{Binding}" />
+                        </Style>
+                    </ContextMenu.ItemContainerStyle>
+                </ContextMenu>
+            </Border.ContextMenu>
+            <TextBlock
+                Margin="0,4,0,4"
+                VerticalAlignment="Center"
+                FontWeight="Medium"
+                Foreground="{DynamicResource Frb.Brushes.ThemeContrast}"
+                Text="{Binding Name}" />
+        </Border>
     </DataTemplate>
 
     <Style BasedOn="{StaticResource {x:Type wpfdataui:DataUiGrid}}" TargetType="{x:Type wpfdataui:DataUiGrid}">

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
@@ -87,7 +87,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceIsBold });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+        VariableCategoryPasteResult result = service.Paste("Font", new IVariableCategoryRow[] { targetFontSize });
 
         targetFontSize.Value.ShouldBe(36);
         result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
@@ -106,7 +106,7 @@ public class VariableCategoryCopyPasteServiceTests
         VariableCategoryCopyPasteService service = CreateService();
         // Category order is X then XUnits; writing X first would let the unit change convert it away.
         service.Copy("Position", new IVariableCategoryRow[] { sourceX, sourceXUnits });
-        service.Paste(new IVariableCategoryRow[] { targetX, targetXUnits });
+        service.Paste("Position", new IVariableCategoryRow[] { targetX, targetXUnits });
 
         writeLog.ShouldBe(new[] { "XUnits", "X" });
     }
@@ -119,10 +119,29 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+        VariableCategoryPasteResult result = service.Paste("Font", new IVariableCategoryRow[] { targetFontSize });
 
         targetFontSize.Value.ShouldBe(36f);
         result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
+    }
+
+    /// <summary>
+    /// Values only paste onto the category they were copied from - Font values must not land on
+    /// Rendering, even where variable names happen to overlap.
+    /// </summary>
+    [Fact]
+    public void Paste_ShouldNotApplyToADifferentCategoryThanTheValuesWereCopiedFrom()
+    {
+        FakeRow sourceAlpha = new FakeRow { RootVariableName = "Alpha", Value = 255 };
+        FakeRow targetAlpha = new FakeRow { RootVariableName = "Alpha", Value = 128 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Text", new IVariableCategoryRow[] { sourceAlpha });
+        VariableCategoryPasteResult result = service.Paste("Rendering", new IVariableCategoryRow[] { targetAlpha });
+
+        targetAlpha.SetCount.ShouldBe(0);
+        result.AppliedVariableNames.ShouldBeEmpty();
+        result.SkippedVariableNames.ShouldBeEmpty();
     }
 
     /// <summary>
@@ -137,7 +156,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Text", new IVariableCategoryRow[] { sourceMaxLetters });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetMaxLetters });
+        VariableCategoryPasteResult result = service.Paste("Text", new IVariableCategoryRow[] { targetMaxLetters });
 
         targetMaxLetters.Value.ShouldBe(20);
         result.AppliedVariableNames.ShouldBe(new[] { "MaxLettersToShow" });
@@ -152,7 +171,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+        VariableCategoryPasteResult result = service.Paste("Font", new IVariableCategoryRow[] { targetFontSize });
 
         targetFontSize.SetCount.ShouldBe(0);
         result.AppliedVariableNames.ShouldBeEmpty();
@@ -169,7 +188,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceFont });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { lockedFontSize, referencedFont });
+        VariableCategoryPasteResult result = service.Paste("Font", new IVariableCategoryRow[] { lockedFontSize, referencedFont });
 
         lockedFontSize.SetCount.ShouldBe(0);
         referencedFont.SetCount.ShouldBe(0);
@@ -186,7 +205,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFont });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFont });
+        VariableCategoryPasteResult result = service.Paste("Font", new IVariableCategoryRow[] { targetFont });
 
         targetFont.SetCount.ShouldBe(0);
         result.SkippedVariableNames.ShouldBe(new[] { "Font" });
@@ -208,7 +227,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceIsBold });
-        service.Paste(new IVariableCategoryRow[] { targetFontSize, targetIsBold });
+        service.Paste("Font", new IVariableCategoryRow[] { targetFontSize, targetIsBold });
 
         _undoManager.Verify(item => item.RequestLock(), Times.Once);
         writesWhenLockReleased.ShouldBe(2, "the lock must still be held while every value is written");
@@ -229,7 +248,7 @@ public class VariableCategoryCopyPasteServiceTests
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("States and Visibility", new IVariableCategoryRow[] { sourceVisible });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { indeterminateVisible });
+        VariableCategoryPasteResult result = service.Paste("States and Visibility", new IVariableCategoryRow[] { indeterminateVisible });
 
         indeterminateVisible.SetCount.ShouldBe(1);
         indeterminateVisible.Value.ShouldBe(true);

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
@@ -1,0 +1,119 @@
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+public class VariableCategoryCopyPasteServiceTests
+{
+    private class FakeRow : IVariableCategoryRow
+    {
+        public string RootVariableName { get; set; } = "";
+        public bool IsReadOnly { get; set; }
+        public bool IsAssignedByReference { get; set; }
+        public object? Value { get; set; }
+        public int SetCount { get; private set; }
+
+        public bool TrySetValue(object? value)
+        {
+            Value = value;
+            SetCount++;
+            return true;
+        }
+    }
+
+    private readonly Mock<IUndoManager> _undoManager = new();
+
+    private VariableCategoryCopyPasteService CreateService() => new(_undoManager.Object);
+
+    [Fact]
+    public void Paste_ShouldApplyMatchingVariables_AndSkipOnesTheTargetDoesNotHave()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        FakeRow sourceIsBold = new FakeRow { RootVariableName = "IsBold", Value = true };
+        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 12 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceIsBold });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+
+        targetFontSize.Value.ShouldBe(36);
+        result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
+        result.SkippedVariableNames.ShouldBe(new[] { "IsBold" });
+    }
+
+    [Fact]
+    public void Paste_ShouldSkipReadOnlyAndReferenceAssignedRows()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        FakeRow sourceFont = new FakeRow { RootVariableName = "Font", Value = "Luckiest Guy" };
+        FakeRow lockedFontSize = new FakeRow { RootVariableName = "FontSize", Value = 12, IsReadOnly = true };
+        FakeRow referencedFont = new FakeRow { RootVariableName = "Font", Value = "Arial", IsAssignedByReference = true };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceFont });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { lockedFontSize, referencedFont });
+
+        lockedFontSize.SetCount.ShouldBe(0);
+        referencedFont.SetCount.ShouldBe(0);
+        result.AppliedVariableNames.ShouldBeEmpty();
+        result.SkippedVariableNames.ShouldBe(new[] { "FontSize", "Font" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Paste_ShouldSkipValuesWhoseTypeDoesNotMatchTheTargetsCurrentValue()
+    {
+        FakeRow sourceFont = new FakeRow { RootVariableName = "Font", Value = "Luckiest Guy" };
+        FakeRow targetFont = new FakeRow { RootVariableName = "Font", Value = 3 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFont });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFont });
+
+        targetFont.Value.ShouldBe(3);
+        result.SkippedVariableNames.ShouldBe(new[] { "Font" });
+    }
+
+    [Fact]
+    public void Copy_ShouldExcludeIdentityVariablesAndNullValues()
+    {
+        FakeRow name = new FakeRow { RootVariableName = "Name", Value = "TitleText" };
+        FakeRow baseType = new FakeRow { RootVariableName = "BaseType", Value = "Text" };
+        FakeRow locked = new FakeRow { RootVariableName = "Locked", Value = true };
+        FakeRow references = new FakeRow { RootVariableName = "VariableReferences", Value = new List<string>() };
+        FakeRow unset = new FakeRow { RootVariableName = "MaxLettersToShow", Value = null };
+        FakeRow fontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("General", new IVariableCategoryRow[] { name, baseType, locked, references, unset, fontSize });
+
+        service.CopiedCategory.ShouldNotBeNull();
+        service.CopiedCategory!.CategoryName.ShouldBe("General");
+        service.CopiedCategory.Values.Select(item => item.RootVariableName).ShouldBe(new[] { "FontSize" });
+    }
+
+    [Fact]
+    public void Paste_ShouldTakeASingleUndoLockHeldAcrossEveryWrite()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        FakeRow sourceIsBold = new FakeRow { RootVariableName = "IsBold", Value = true };
+        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 12 };
+        FakeRow targetIsBold = new FakeRow { RootVariableName = "IsBold", Value = false };
+
+        int writesWhenLockReleased = -1;
+        _undoManager
+            .Setup(item => item.RequestLock())
+            .Returns(() => new UndoLock(() =>
+                writesWhenLockReleased = targetFontSize.SetCount + targetIsBold.SetCount));
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize, sourceIsBold });
+        service.Paste(new IVariableCategoryRow[] { targetFontSize, targetIsBold });
+
+        _undoManager.Verify(item => item.RequestLock(), Times.Once);
+        writesWhenLockReleased.ShouldBe(2, "the lock must still be held while every value is written");
+        targetFontSize.Value.ShouldBe(36);
+        targetIsBold.Value.ShouldBe(true);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
@@ -15,7 +15,12 @@ public class VariableCategoryCopyPasteServiceTests
         public object? Value { get; set; }
         public int SetCount { get; private set; }
 
-        public bool TrySetValue(object? value)
+        /// <summary>Defaults to the declared type of whatever the row currently holds, as a real row would.</summary>
+        public Type? DeclaredType { get; set; }
+
+        public Type? ValueType => DeclaredType ?? Value?.GetType();
+
+        public bool TrySetValue(object value)
         {
             Value = value;
             SetCount++;
@@ -62,31 +67,52 @@ public class VariableCategoryCopyPasteServiceTests
     }
 
     [Fact]
-    public void Paste_ShouldSkipValuesWhoseTypeDoesNotMatchTheTargetsCurrentValue()
+    public void Paste_ShouldSkipValuesWhoseTypeTheTargetRowDoesNotAccept()
     {
         FakeRow sourceFont = new FakeRow { RootVariableName = "Font", Value = "Luckiest Guy" };
-        FakeRow targetFont = new FakeRow { RootVariableName = "Font", Value = 3 };
+        // The target holds no value yet, so only its declared type can reject the paste.
+        FakeRow targetFont = new FakeRow { RootVariableName = "Font", Value = null, DeclaredType = typeof(int) };
 
         VariableCategoryCopyPasteService service = CreateService();
         service.Copy("Font", new IVariableCategoryRow[] { sourceFont });
         VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFont });
 
-        targetFont.Value.ShouldBe(3);
+        targetFont.SetCount.ShouldBe(0);
         result.SkippedVariableNames.ShouldBe(new[] { "Font" });
     }
 
     [Fact]
-    public void Copy_ShouldExcludeIdentityVariablesAndNullValues()
+    public void Paste_ShouldNotRewriteAValueTheTargetAlreadyShows()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        // Matches already, but only by inheriting it - rewriting would author it explicitly for no gain.
+        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+
+        targetFontSize.SetCount.ShouldBe(0);
+        result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
+    }
+
+    [Fact]
+    public void Copy_ShouldExcludeIdentityVariablesNullValuesAndLists()
     {
         FakeRow name = new FakeRow { RootVariableName = "Name", Value = "TitleText" };
         FakeRow baseType = new FakeRow { RootVariableName = "BaseType", Value = "Text" };
         FakeRow locked = new FakeRow { RootVariableName = "Locked", Value = true };
+        FakeRow parent = new FakeRow { RootVariableName = "Parent", Value = "SomeContainer" };
         FakeRow references = new FakeRow { RootVariableName = "VariableReferences", Value = new List<string>() };
+        FakeRow someList = new FakeRow { RootVariableName = "SomeListVariable", Value = new List<string> { "a" } };
         FakeRow unset = new FakeRow { RootVariableName = "MaxLettersToShow", Value = null };
         FakeRow fontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
 
         VariableCategoryCopyPasteService service = CreateService();
-        service.Copy("General", new IVariableCategoryRow[] { name, baseType, locked, references, unset, fontSize });
+        service.Copy("General", new IVariableCategoryRow[]
+        {
+            name, baseType, locked, parent, references, someList, unset, fontSize
+        });
 
         service.CopiedCategory.ShouldNotBeNull();
         service.CopiedCategory!.CategoryName.ShouldBe("General");

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs
@@ -12,11 +12,15 @@ public class VariableCategoryCopyPasteServiceTests
         public string RootVariableName { get; set; } = "";
         public bool IsReadOnly { get; set; }
         public bool IsAssignedByReference { get; set; }
+        public bool IsIndeterminate { get; set; }
         public object? Value { get; set; }
         public int SetCount { get; private set; }
 
         /// <summary>Defaults to the declared type of whatever the row currently holds, as a real row would.</summary>
         public Type? DeclaredType { get; set; }
+
+        /// <summary>Optional shared log recording write order across several rows.</summary>
+        public List<string>? WriteLog { get; set; }
 
         public Type? ValueType => DeclaredType ?? Value?.GetType();
 
@@ -24,6 +28,7 @@ public class VariableCategoryCopyPasteServiceTests
         {
             Value = value;
             SetCount++;
+            WriteLog?.Add(RootVariableName);
             return true;
         }
     }
@@ -31,6 +36,47 @@ public class VariableCategoryCopyPasteServiceTests
     private readonly Mock<IUndoManager> _undoManager = new();
 
     private VariableCategoryCopyPasteService CreateService() => new(_undoManager.Object);
+
+    [Fact]
+    public void Copy_ShouldExcludeIdentityVariablesNullValuesAndLists()
+    {
+        FakeRow name = new FakeRow { RootVariableName = "Name", Value = "TitleText" };
+        FakeRow baseType = new FakeRow { RootVariableName = "BaseType", Value = "Text" };
+        FakeRow defaultChild = new FakeRow { RootVariableName = "DefaultChildContainer", Value = "Inner" };
+        FakeRow locked = new FakeRow { RootVariableName = "Locked", Value = true };
+        FakeRow parent = new FakeRow { RootVariableName = "Parent", Value = "SomeContainer" };
+        FakeRow references = new FakeRow { RootVariableName = "VariableReferences", Value = new List<string>() };
+        FakeRow someList = new FakeRow { RootVariableName = "SomeListVariable", Value = new List<string> { "a" } };
+        FakeRow unset = new FakeRow { RootVariableName = "MaxLettersToShow", Value = null };
+        FakeRow fontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("General", new IVariableCategoryRow[]
+        {
+            name, baseType, defaultChild, locked, parent, references, someList, unset, fontSize
+        });
+
+        service.CopiedCategory.ShouldNotBeNull();
+        service.CopiedCategory!.CategoryName.ShouldBe("General");
+        service.CopiedCategory.Values.Select(item => item.RootVariableName).ShouldBe(new[] { "FontSize" });
+    }
+
+    /// <summary>
+    /// A multi-select row whose instances disagree reports null, which is indistinguishable from an unset
+    /// variable by value alone. Copy must report it so the user knows the capture is incomplete.
+    /// </summary>
+    [Fact]
+    public void Copy_ShouldReportIndeterminateRowsInsteadOfSilentlyDroppingThem()
+    {
+        FakeRow fontSize = new FakeRow { RootVariableName = "FontSize", Value = null, IsIndeterminate = true };
+        FakeRow isBold = new FakeRow { RootVariableName = "IsBold", Value = true };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        CopiedVariableCategory copied = service.Copy("Font", new IVariableCategoryRow[] { fontSize, isBold });
+
+        copied.Values.Select(item => item.RootVariableName).ShouldBe(new[] { "IsBold" });
+        copied.IndeterminateVariableNames.ShouldBe(new[] { "FontSize" });
+    }
 
     [Fact]
     public void Paste_ShouldApplyMatchingVariables_AndSkipOnesTheTargetDoesNotHave()
@@ -46,6 +92,71 @@ public class VariableCategoryCopyPasteServiceTests
         targetFontSize.Value.ShouldBe(36);
         result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
         result.SkippedVariableNames.ShouldBe(new[] { "IsBold" });
+    }
+
+    [Fact]
+    public void Paste_ShouldApplyUnitVariablesBeforeTheirValues()
+    {
+        List<string> writeLog = new List<string>();
+        FakeRow sourceX = new FakeRow { RootVariableName = "X", Value = 100f };
+        FakeRow sourceXUnits = new FakeRow { RootVariableName = "XUnits", Value = "PixelsFromLeft" };
+        FakeRow targetX = new FakeRow { RootVariableName = "X", Value = 5f, WriteLog = writeLog };
+        FakeRow targetXUnits = new FakeRow { RootVariableName = "XUnits", Value = "PercentageOfParent", WriteLog = writeLog };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        // Category order is X then XUnits; writing X first would let the unit change convert it away.
+        service.Copy("Position", new IVariableCategoryRow[] { sourceX, sourceXUnits });
+        service.Paste(new IVariableCategoryRow[] { targetX, targetXUnits });
+
+        writeLog.ShouldBe(new[] { "XUnits", "X" });
+    }
+
+    [Fact]
+    public void Paste_ShouldConvertNumericValuesToTheTargetRowsNumericType()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 12f, DeclaredType = typeof(float) };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+
+        targetFontSize.Value.ShouldBe(36f);
+        result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
+    }
+
+    /// <summary>
+    /// Nullable-declared variables (int? MaxLettersToShow, float? MinWidth) are common, and reflection's
+    /// IsInstanceOfType is always false for a boxed value against a Nullable&lt;T&gt; type.
+    /// </summary>
+    [Fact]
+    public void Paste_ShouldNotRejectANullableTargetWhoseUnderlyingTypeMatches()
+    {
+        FakeRow sourceMaxLetters = new FakeRow { RootVariableName = "MaxLettersToShow", Value = 20 };
+        FakeRow targetMaxLetters = new FakeRow { RootVariableName = "MaxLettersToShow", Value = null, DeclaredType = typeof(int?) };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Text", new IVariableCategoryRow[] { sourceMaxLetters });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetMaxLetters });
+
+        targetMaxLetters.Value.ShouldBe(20);
+        result.AppliedVariableNames.ShouldBe(new[] { "MaxLettersToShow" });
+    }
+
+    [Fact]
+    public void Paste_ShouldNotRewriteAValueTheTargetAlreadyShows()
+    {
+        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+        // Matches already, but only by inheriting it - rewriting would author it explicitly for no gain.
+        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
+
+        targetFontSize.SetCount.ShouldBe(0);
+        result.AppliedVariableNames.ShouldBeEmpty();
+        result.AlreadyMatchedVariableNames.ShouldBe(new[] { "FontSize" });
     }
 
     [Fact]
@@ -82,44 +193,6 @@ public class VariableCategoryCopyPasteServiceTests
     }
 
     [Fact]
-    public void Paste_ShouldNotRewriteAValueTheTargetAlreadyShows()
-    {
-        FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
-        // Matches already, but only by inheriting it - rewriting would author it explicitly for no gain.
-        FakeRow targetFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
-
-        VariableCategoryCopyPasteService service = CreateService();
-        service.Copy("Font", new IVariableCategoryRow[] { sourceFontSize });
-        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { targetFontSize });
-
-        targetFontSize.SetCount.ShouldBe(0);
-        result.AppliedVariableNames.ShouldBe(new[] { "FontSize" });
-    }
-
-    [Fact]
-    public void Copy_ShouldExcludeIdentityVariablesNullValuesAndLists()
-    {
-        FakeRow name = new FakeRow { RootVariableName = "Name", Value = "TitleText" };
-        FakeRow baseType = new FakeRow { RootVariableName = "BaseType", Value = "Text" };
-        FakeRow locked = new FakeRow { RootVariableName = "Locked", Value = true };
-        FakeRow parent = new FakeRow { RootVariableName = "Parent", Value = "SomeContainer" };
-        FakeRow references = new FakeRow { RootVariableName = "VariableReferences", Value = new List<string>() };
-        FakeRow someList = new FakeRow { RootVariableName = "SomeListVariable", Value = new List<string> { "a" } };
-        FakeRow unset = new FakeRow { RootVariableName = "MaxLettersToShow", Value = null };
-        FakeRow fontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
-
-        VariableCategoryCopyPasteService service = CreateService();
-        service.Copy("General", new IVariableCategoryRow[]
-        {
-            name, baseType, locked, parent, references, someList, unset, fontSize
-        });
-
-        service.CopiedCategory.ShouldNotBeNull();
-        service.CopiedCategory!.CategoryName.ShouldBe("General");
-        service.CopiedCategory.Values.Select(item => item.RootVariableName).ShouldBe(new[] { "FontSize" });
-    }
-
-    [Fact]
     public void Paste_ShouldTakeASingleUndoLockHeldAcrossEveryWrite()
     {
         FakeRow sourceFontSize = new FakeRow { RootVariableName = "FontSize", Value = 36 };
@@ -141,5 +214,25 @@ public class VariableCategoryCopyPasteServiceTests
         writesWhenLockReleased.ShouldBe(2, "the lock must still be held while every value is written");
         targetFontSize.Value.ShouldBe(36);
         targetIsBold.Value.ShouldBe(true);
+    }
+
+    /// <summary>
+    /// A multi-select row whose instances disagree reports a null value (indeterminate). Pasting onto it
+    /// must write, unifying the selection - the skip-if-equal guard must not treat "no single value" as
+    /// "already matches".
+    /// </summary>
+    [Fact]
+    public void Paste_ShouldWriteToAnIndeterminateTargetRow()
+    {
+        FakeRow sourceVisible = new FakeRow { RootVariableName = "Visible", Value = true };
+        FakeRow indeterminateVisible = new FakeRow { RootVariableName = "Visible", Value = null };
+
+        VariableCategoryCopyPasteService service = CreateService();
+        service.Copy("States and Visibility", new IVariableCategoryRow[] { sourceVisible });
+        VariableCategoryPasteResult result = service.Paste(new IVariableCategoryRow[] { indeterminateVisible });
+
+        indeterminateVisible.SetCount.ShouldBe(1);
+        indeterminateVisible.Value.ShouldBe(true);
+        result.AppliedVariableNames.ShouldBe(new[] { "Visible" });
     }
 }

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
@@ -1,0 +1,125 @@
+using System;
+using CommunityToolkit.Mvvm.Messaging;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Logic;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.StateAnimation.SaveClasses;
+using Gum.ToolStates;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pastes against the real <see cref="UndoManager"/> rather than a mock, because the whole point of the
+/// single lock the service takes is how it interacts with undo recording. A mock cannot show that.
+/// </summary>
+public class VariableCategoryCopyPasteUndoTests : BaseTestClass
+{
+    private readonly ComponentSave _component;
+    private readonly UndoManager _undoManager;
+
+    /// <summary>A row backed by a real <see cref="StateSave"/>, so an undo snapshot actually sees the write.</summary>
+    private class StateBackedRow : IVariableCategoryRow
+    {
+        private readonly StateSave _state;
+
+        public StateBackedRow(StateSave state, string rootVariableName)
+        {
+            _state = state;
+            RootVariableName = rootVariableName;
+        }
+
+        public string RootVariableName { get; }
+
+        public bool IsReadOnly => false;
+
+        public bool IsAssignedByReference => false;
+
+        public object? Value => _state.GetValue(RootVariableName);
+
+        public Type? ValueType => Value?.GetType();
+
+        public bool TrySetValue(object value)
+        {
+            _state.SetValue(RootVariableName, value);
+            return true;
+        }
+    }
+
+    private sealed class NoAnimationUndoProvider : IAnimationUndoProvider
+    {
+        public ElementAnimationsSave? GetCurrentAnimations(ElementSave element) => null;
+
+        public void ApplyAnimations(ElementSave element, ElementAnimationsSave animations)
+        {
+        }
+    }
+
+    public VariableCategoryCopyPasteUndoTests()
+    {
+        _component = new ComponentSave();
+        _component.States.Add(new StateSave { Name = "Default" });
+
+        Mock<ISelectedState> selectedState = new Mock<ISelectedState>();
+        selectedState.Setup(item => item.SelectedElement).Returns(_component);
+        selectedState.Setup(item => item.SelectedComponent).Returns(_component);
+        selectedState.Setup(item => item.SelectedStateSave).Returns(_component.DefaultState);
+
+        _undoManager = new UndoManager(
+            selectedState.Object,
+            new Mock<IUndoRenameLogic>().Object,
+            new Mock<IGuiCommands>().Object,
+            new Mock<IFileCommands>().Object,
+            new Mock<IMessenger>().Object,
+            new Mock<IUndoPluginNotifier>().Object,
+            new NoAnimationUndoProvider());
+    }
+
+    /// <summary>
+    /// A pasted group must undo as one action. If each write recorded its own undo, a single
+    /// <see cref="UndoManager.PerformUndo"/> would roll back only the last variable and leave the rest
+    /// of the group applied.
+    /// </summary>
+    [Fact]
+    public void PerformUndo_AfterAPaste_ShouldRestoreEveryVariableInTheGroupAtOnce()
+    {
+        StateSave sourceState = new StateSave { Name = "Source" };
+        sourceState.SetValue("FontSize", 36);
+        sourceState.SetValue("IsBold", true);
+        sourceState.SetValue("OutlineThickness", 4);
+
+        _component.DefaultState.SetValue("FontSize", 12);
+        _component.DefaultState.SetValue("IsBold", false);
+        _component.DefaultState.SetValue("OutlineThickness", 0);
+
+        _undoManager.RecordState();
+
+        VariableCategoryCopyPasteService service = new VariableCategoryCopyPasteService(_undoManager);
+        service.Copy("Font", new IVariableCategoryRow[]
+        {
+            new StateBackedRow(sourceState, "FontSize"),
+            new StateBackedRow(sourceState, "IsBold"),
+            new StateBackedRow(sourceState, "OutlineThickness")
+        });
+        service.Paste(new IVariableCategoryRow[]
+        {
+            new StateBackedRow(_component.DefaultState, "FontSize"),
+            new StateBackedRow(_component.DefaultState, "IsBold"),
+            new StateBackedRow(_component.DefaultState, "OutlineThickness")
+        });
+
+        _component.DefaultState.GetValueOrDefault<int>("FontSize").ShouldBe(36);
+        _component.DefaultState.GetValueOrDefault<bool>("IsBold").ShouldBe(true);
+        _component.DefaultState.GetValueOrDefault<int>("OutlineThickness").ShouldBe(4);
+
+        _undoManager.PerformUndo();
+
+        _component.DefaultState.GetValueOrDefault<int>("FontSize").ShouldBe(12);
+        _component.DefaultState.GetValueOrDefault<bool>("IsBold").ShouldBe(false);
+        _component.DefaultState.GetValueOrDefault<int>("OutlineThickness").ShouldBe(0);
+    }
+}

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
@@ -39,6 +39,8 @@ public class VariableCategoryCopyPasteUndoTests : BaseTestClass
 
         public bool IsAssignedByReference => false;
 
+        public bool IsIndeterminate => false;
+
         public object? Value => _state.GetValue(RootVariableName);
 
         public Type? ValueType => Value?.GetType();

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
@@ -107,7 +107,7 @@ public class VariableCategoryCopyPasteUndoTests : BaseTestClass
             new StateBackedRow(sourceState, "IsBold"),
             new StateBackedRow(sourceState, "OutlineThickness")
         });
-        service.Paste(new IVariableCategoryRow[]
+        service.Paste("Font", new IVariableCategoryRow[]
         {
             new StateBackedRow(_component.DefaultState, "FontSize"),
             new StateBackedRow(_component.DefaultState, "IsBold"),

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
@@ -23,24 +23,56 @@ public class VariableCategoryRowAdapterTests : BaseTestClass
         return member;
     }
 
-    [Fact]
-    public void CreateRows_ShouldExpandACompositeRowIntoItsChannels()
+    private static CompositeInstanceMember CreateColorComposite(int initialValue)
     {
-        InstanceMember red = CreateMember("Red", 10);
-        InstanceMember green = CreateMember("Green", 20);
-        CompositeInstanceMember composite = new CompositeInstanceMember(
+        InstanceMember red = CreateMember("Red", initialValue);
+        InstanceMember green = CreateMember("Green", initialValue);
+        return new CompositeInstanceMember(
             "Color",
             new List<InstanceMember> { red, green },
             typeof(int),
             channelValues => (int)channelValues[0]!,
             compositeValue => new object?[] { compositeValue, compositeValue });
-        InstanceMember fontSize = CreateMember("FontSize", 36);
+    }
+
+    /// <summary>
+    /// A composite must be matched by the same name whether one object or several are selected. The
+    /// multi-select wrapper sits above the composite, so expanding composites into their channels would
+    /// name them Red/Green with one object selected but Color with two, and a copy made in one mode would
+    /// silently not apply in the other.
+    /// </summary>
+    [Fact]
+    public void CreateRows_ShouldNameACompositeRowTheSameInSingleAndMultiSelect()
+    {
+        CompositeInstanceMember singleSelectComposite = CreateColorComposite(10);
+        MultiSelectInstanceMember multiSelectComposite = new MultiSelectInstanceMember
+        {
+            Name = "Color",
+            InstanceMembers = new List<InstanceMember> { CreateColorComposite(10), CreateColorComposite(20) }
+        };
+
+        List<IVariableCategoryRow> singleSelectRows =
+            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { singleSelectComposite });
+        List<IVariableCategoryRow> multiSelectRows =
+            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { multiSelectComposite });
+
+        singleSelectRows.Single().RootVariableName.ShouldBe("Color");
+        multiSelectRows.Single().RootVariableName.ShouldBe("Color");
+    }
+
+    [Fact]
+    public void TrySetValue_ShouldWriteThroughACompositeRowToEveryChannel()
+    {
+        CompositeInstanceMember composite = CreateColorComposite(10);
 
         List<IVariableCategoryRow> rows =
-            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { composite, fontSize });
+            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { composite });
 
-        rows.Select(row => row.RootVariableName).ShouldBe(new[] { "Red", "Green", "FontSize" });
-        rows[0].Value.ShouldBe(10);
+        rows.Single().Value.ShouldBe(10);
+        rows.Single().TrySetValue(30).ShouldBeTrue();
+
+        composite.ChannelMembers[0].Value.ShouldBe(30);
+        composite.ChannelMembers[1].Value.ShouldBe(30);
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Shouldly;
+using WpfDataUi.DataTypes;
+using Xunit;
+
+namespace GumToolUnitTests.VariableGrid;
+
+public class VariableCategoryRowAdapterTests : BaseTestClass
+{
+    /// <summary>
+    /// Builds a grid row backed by a local value rather than by reflection over an instance, so a test can
+    /// read and write it without standing up a real <c>StateReferencingInstanceMember</c>.
+    /// </summary>
+    private static InstanceMember CreateMember(string name, object? initialValue)
+    {
+        object? backingValue = initialValue;
+        InstanceMember member = new InstanceMember(name, null!);
+        member.CustomGetEvent += (_) => backingValue;
+        member.CustomGetTypeEvent += (_) => typeof(object);
+        member.CustomSetPropertyEvent += (_, args) => backingValue = args.Value;
+        return member;
+    }
+
+    [Fact]
+    public void CreateRows_ShouldExpandACompositeRowIntoItsChannels()
+    {
+        InstanceMember red = CreateMember("Red", 10);
+        InstanceMember green = CreateMember("Green", 20);
+        CompositeInstanceMember composite = new CompositeInstanceMember(
+            "Color",
+            new List<InstanceMember> { red, green },
+            typeof(int),
+            channelValues => (int)channelValues[0]!,
+            compositeValue => new object?[] { compositeValue, compositeValue });
+        InstanceMember fontSize = CreateMember("FontSize", 36);
+
+        List<IVariableCategoryRow> rows =
+            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { composite, fontSize });
+
+        rows.Select(row => row.RootVariableName).ShouldBe(new[] { "Red", "Green", "FontSize" });
+        rows[0].Value.ShouldBe(10);
+    }
+
+    [Fact]
+    public void TrySetValue_ShouldWriteThroughAMultiSelectRowToEveryWrappedMember()
+    {
+        InstanceMember firstInstanceFontSize = CreateMember("FontSize", 12);
+        InstanceMember secondInstanceFontSize = CreateMember("FontSize", 14);
+        MultiSelectInstanceMember multiSelect = new MultiSelectInstanceMember
+        {
+            Name = "FontSize",
+            InstanceMembers = new List<InstanceMember> { firstInstanceFontSize, secondInstanceFontSize }
+        };
+
+        List<IVariableCategoryRow> rows =
+            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { multiSelect });
+
+        rows.Single().RootVariableName.ShouldBe("FontSize");
+        rows.Single().TrySetValue(36).ShouldBeTrue();
+
+        firstInstanceFontSize.Value.ShouldBe(36);
+        secondInstanceFontSize.Value.ShouldBe(36);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs
@@ -1,6 +1,20 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Managers;
+using Gum.Plugins;
 using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.PropertyGridHelpers;
+using Gum.PropertyGridHelpers.Converters;
+using Gum.Reflection;
+using Gum.Services;
+using Gum.ToolStates;
+using Gum.Undo;
+using Gum.Wireframe;
+using Moq.AutoMock;
 using Shouldly;
 using WpfDataUi.DataTypes;
 using Xunit;
@@ -9,6 +23,9 @@ namespace GumToolUnitTests.VariableGrid;
 
 public class VariableCategoryRowAdapterTests : BaseTestClass
 {
+    private readonly VariableCategoryRowAdapter _adapter = new();
+    private readonly AutoMocker _mocker = new();
+
     /// <summary>
     /// Builds a grid row backed by a local value rather than by reflection over an instance, so a test can
     /// read and write it without standing up a real <c>StateReferencingInstanceMember</c>.
@@ -35,6 +52,41 @@ public class VariableCategoryRowAdapterTests : BaseTestClass
             compositeValue => new object?[] { compositeValue, compositeValue });
     }
 
+    private StateReferencingInstanceMember CreateStateSelectionRow(string variableName)
+    {
+        ComponentSave component = new ComponentSave { Name = "AdapterTestComponent" };
+        component.States.Add(new StateSave());
+        component.DefaultState.ParentContainer = component;
+        ObjectFinder.Self.GumProjectSave ??= new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave.Components.Add(component);
+
+        return new StateReferencingInstanceMember(
+            Array.Empty<Attribute>(),
+            new AvailableStatesConverter(category: "", _mocker.Get<ISelectedState>()),
+            typeof(string),
+            false,
+            false,
+            true,
+            component.DefaultState,
+            null,
+            variableName,
+            null,
+            component,
+            _mocker.Get<ISelectedState>(),
+            _mocker.Get<IUndoManager>(),
+            _mocker.Get<IGuiCommands>(),
+            _mocker.Get<IFileCommands>(),
+            _mocker.Get<ISetVariableLogic>(),
+            _mocker.Get<IWireframeObjectManager>(),
+            _mocker.Get<IPluginManager>(),
+            _mocker.Get<IHotkeyManager>(),
+            _mocker.Get<IDeleteVariableService>(),
+            _mocker.Get<IExposeVariableService>(),
+            _mocker.Get<IEditVariableService>(),
+            _mocker.Get<ITypeManager>(),
+            _mocker.Get<IClipboardService>());
+    }
+
     /// <summary>
     /// A composite must be matched by the same name whether one object or several are selected. The
     /// multi-select wrapper sits above the composite, so expanding composites into their channels would
@@ -52,12 +104,26 @@ public class VariableCategoryRowAdapterTests : BaseTestClass
         };
 
         List<IVariableCategoryRow> singleSelectRows =
-            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { singleSelectComposite });
+            _adapter.CreateRows(new List<InstanceMember> { singleSelectComposite });
         List<IVariableCategoryRow> multiSelectRows =
-            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { multiSelectComposite });
+            _adapter.CreateRows(new List<InstanceMember> { multiSelectComposite });
 
         singleSelectRows.Single().RootVariableName.ShouldBe("Color");
         multiSelectRows.Single().RootVariableName.ShouldBe("Color");
+    }
+
+    /// <summary>
+    /// State names are only meaningful on the element that declares them. A pasted state name the target
+    /// does not offer must be rejected, or a dangling state name gets saved into the project.
+    /// </summary>
+    [Fact]
+    public void TrySetValue_ShouldRejectAStateNameTheTargetDoesNotHave()
+    {
+        StateReferencingInstanceMember stateRow = CreateStateSelectionRow("StyleCategoryState");
+
+        List<IVariableCategoryRow> rows = _adapter.CreateRows(new List<InstanceMember> { stateRow });
+
+        rows.Single().TrySetValue("StateTheTargetDoesNotHave").ShouldBeFalse();
     }
 
     [Fact]
@@ -65,8 +131,7 @@ public class VariableCategoryRowAdapterTests : BaseTestClass
     {
         CompositeInstanceMember composite = CreateColorComposite(10);
 
-        List<IVariableCategoryRow> rows =
-            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { composite });
+        List<IVariableCategoryRow> rows = _adapter.CreateRows(new List<InstanceMember> { composite });
 
         rows.Single().Value.ShouldBe(10);
         rows.Single().TrySetValue(30).ShouldBeTrue();
@@ -86,8 +151,7 @@ public class VariableCategoryRowAdapterTests : BaseTestClass
             InstanceMembers = new List<InstanceMember> { firstInstanceFontSize, secondInstanceFontSize }
         };
 
-        List<IVariableCategoryRow> rows =
-            VariableCategoryRowAdapter.CreateRows(new List<InstanceMember> { multiSelect });
+        List<IVariableCategoryRow> rows = _adapter.CreateRows(new List<InstanceMember> { multiSelect });
 
         rows.Single().RootVariableName.ShouldBe("FontSize");
         rows.Single().TrySetValue(36).ShouldBeTrue();

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/CopiedVariableCategory.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/CopiedVariableCategory.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// The values captured by a Variables tab category copy, held in memory by
+/// <see cref="VariableCategoryCopyPasteService"/> rather than on the system clipboard (mirroring
+/// <c>CopyPasteLogic.CopiedData</c>).
+/// </summary>
+public class CopiedVariableCategory
+{
+    /// <summary>The name of the category the values came from, used to label the paste menu item.</summary>
+    public string CategoryName { get; }
+
+    /// <summary>The captured values, in the order they appeared in the source category.</summary>
+    public IReadOnlyList<CopiedVariableValue> Values { get; }
+
+    public CopiedVariableCategory(string categoryName, IReadOnlyList<CopiedVariableValue> values)
+    {
+        CategoryName = categoryName;
+        Values = values;
+    }
+}
+
+/// <summary>A single variable name/value pair captured by a category copy.</summary>
+public class CopiedVariableValue
+{
+    public string RootVariableName { get; }
+
+    public object Value { get; }
+
+    public CopiedVariableValue(string rootVariableName, object value)
+    {
+        RootVariableName = rootVariableName;
+        Value = value;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/CopiedVariableCategory.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/CopiedVariableCategory.cs
@@ -7,31 +7,18 @@ namespace Gum.Plugins.InternalPlugins.VariableGrid;
 /// <see cref="VariableCategoryCopyPasteService"/> rather than on the system clipboard (mirroring
 /// <c>CopyPasteLogic.CopiedData</c>).
 /// </summary>
-public class CopiedVariableCategory
-{
-    /// <summary>The name of the category the values came from, used to label the paste menu item.</summary>
-    public string CategoryName { get; }
-
-    /// <summary>The captured values, in the order they appeared in the source category.</summary>
-    public IReadOnlyList<CopiedVariableValue> Values { get; }
-
-    public CopiedVariableCategory(string categoryName, IReadOnlyList<CopiedVariableValue> values)
-    {
-        CategoryName = categoryName;
-        Values = values;
-    }
-}
+/// <param name="CategoryName">The name of the category the values came from, reported back when pasting.</param>
+/// <param name="Values">The captured values, in the order they appeared in the source category.</param>
+/// <param name="IndeterminateVariableNames">
+/// Variables that could not be captured because the source was a multi-selection whose instances
+/// disagree on the value. Reported so the user knows the copy is incomplete.
+/// </param>
+public record CopiedVariableCategory(
+    string CategoryName,
+    IReadOnlyList<CopiedVariableValue> Values,
+    IReadOnlyList<string> IndeterminateVariableNames);
 
 /// <summary>A single variable name/value pair captured by a category copy.</summary>
-public class CopiedVariableValue
-{
-    public string RootVariableName { get; }
-
-    public object Value { get; }
-
-    public CopiedVariableValue(string rootVariableName, object value)
-    {
-        RootVariableName = rootVariableName;
-        Value = value;
-    }
-}
+/// <param name="RootVariableName">The unqualified variable name, used to match a row on the paste target.</param>
+/// <param name="Value">The effective value at copy time.</param>
+public record CopiedVariableValue(string RootVariableName, object Value);

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
@@ -19,7 +19,9 @@ public interface IVariableCategoryCopyPasteService
 
     /// <summary>
     /// Writes the copied values onto the supplied rows, matching by variable name and recording the whole
-    /// group as a single undo. Returns an empty result if nothing has been copied.
+    /// group as a single undo. Returns an empty result if nothing has been copied, or if
+    /// <paramref name="targetCategoryName"/> is not the category the values were copied from - Font values
+    /// only paste onto Font, even where variable names happen to overlap.
     /// </summary>
-    VariableCategoryPasteResult Paste(IEnumerable<IVariableCategoryRow> targetRows);
+    VariableCategoryPasteResult Paste(string targetCategoryName, IEnumerable<IVariableCategoryRow> targetRows);
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// Copies the values of a whole Variables tab category (Font, Text, Position, ...) and pastes them onto
+/// another object, so matching one object to another does not require retyping each variable.
+/// </summary>
+public interface IVariableCategoryCopyPasteService
+{
+    /// <summary>The most recently copied category, or null if nothing has been copied this session.</summary>
+    CopiedVariableCategory? CopiedCategory { get; }
+
+    /// <summary>Captures the effective values of the supplied rows, replacing anything previously copied.</summary>
+    void Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows);
+
+    /// <summary>
+    /// Writes the copied values onto the supplied rows, matching by variable name and recording the whole
+    /// group as a single undo. Returns an empty result if nothing has been copied.
+    /// </summary>
+    VariableCategoryPasteResult Paste(IEnumerable<IVariableCategoryRow> targetRows);
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryCopyPasteService.cs
@@ -11,8 +11,11 @@ public interface IVariableCategoryCopyPasteService
     /// <summary>The most recently copied category, or null if nothing has been copied this session.</summary>
     CopiedVariableCategory? CopiedCategory { get; }
 
-    /// <summary>Captures the effective values of the supplied rows, replacing anything previously copied.</summary>
-    void Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows);
+    /// <summary>
+    /// Captures the effective values of the supplied rows, replacing anything previously copied, and
+    /// returns the captured payload.
+    /// </summary>
+    CopiedVariableCategory Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows);
 
     /// <summary>
     /// Writes the copied values onto the supplied rows, matching by variable name and recording the whole

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
@@ -1,0 +1,24 @@
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// A single variable row as seen by <see cref="VariableCategoryCopyPasteService"/>. The Variables tab
+/// rows are WPF <c>InstanceMember</c>s (and multi-select/composite wrappers over them), which cannot be
+/// referenced from this headless assembly, so the view side adapts each row to this interface.
+/// </summary>
+public interface IVariableCategoryRow
+{
+    /// <summary>The unqualified variable name, used to match a copied value to a row on the paste target.</summary>
+    string RootVariableName { get; }
+
+    /// <summary>Whether the row rejects edits (for example a variable on a locked instance).</summary>
+    bool IsReadOnly { get; }
+
+    /// <summary>Whether the row's value comes from a <c>VariableReferences</c> assignment, which a paste must not shadow.</summary>
+    bool IsAssignedByReference { get; }
+
+    /// <summary>The row's effective value, whether authored on the selected state or inherited.</summary>
+    object? Value { get; }
+
+    /// <summary>Writes a value to the row, returning whether the assignment was accepted.</summary>
+    bool TrySetValue(object? value);
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
@@ -18,6 +18,12 @@ public interface IVariableCategoryRow
     /// <summary>Whether the row's value comes from a <c>VariableReferences</c> assignment, which a paste must not shadow.</summary>
     bool IsAssignedByReference { get; }
 
+    /// <summary>
+    /// Whether the row has no single value because a multi-selection's instances disagree. Such a row's
+    /// <see cref="Value"/> is null, and a copy must report it rather than silently treating it as unset.
+    /// </summary>
+    bool IsIndeterminate { get; }
+
     /// <summary>The row's effective value, whether authored on the selected state or inherited.</summary>
     object? Value { get; }
 

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/IVariableCategoryRow.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Gum.Plugins.InternalPlugins.VariableGrid;
 
 /// <summary>
@@ -19,6 +21,17 @@ public interface IVariableCategoryRow
     /// <summary>The row's effective value, whether authored on the selected state or inherited.</summary>
     object? Value { get; }
 
-    /// <summary>Writes a value to the row, returning whether the assignment was accepted.</summary>
-    bool TrySetValue(object? value);
+    /// <summary>
+    /// The type the row accepts, or null when it cannot be determined. Used to reject a paste between
+    /// same-named variables of different types; the current <see cref="Value"/> is not a reliable stand-in
+    /// for this, since a row showing no value at all is exactly where a mistyped paste would land.
+    /// </summary>
+    Type? ValueType { get; }
+
+    /// <summary>
+    /// Writes a value to the row, returning whether the assignment was accepted. Never null: a copy skips
+    /// rows that have no value, since writing null would author an explicit null rather than restore
+    /// inheritance.
+    /// </summary>
+    bool TrySetValue(object value);
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Gum.Undo;
 
@@ -10,19 +11,35 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
 {
     /// <summary>
     /// Variables that identify or gate an object rather than describe its appearance. Copying a whole
-    /// category must never rename the target, retype it, lock it, or overwrite its reference list.
+    /// category must never rename the target, retype it, lock it, reparent it, or overwrite its
+    /// reference list.
     /// </summary>
     private static readonly HashSet<string> NeverCopiedVariableNames = new()
     {
         "Name",
         "BaseType",
+        "DefaultChildContainer",
         "Locked",
         "Parent",
         "VariableReferences"
     };
 
+    private static readonly HashSet<Type> NumericTypes = new()
+    {
+        typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
+        typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal)
+    };
+
+    private enum PasteOutcome
+    {
+        Skipped,
+        AlreadyMatched,
+        Written
+    }
+
     private readonly IUndoManager _undoManager;
 
+    /// <inheritdoc/>
     public CopiedVariableCategory? CopiedCategory { get; private set; }
 
     public VariableCategoryCopyPasteService(IUndoManager undoManager)
@@ -30,9 +47,11 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
         _undoManager = undoManager;
     }
 
-    public void Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows)
+    /// <inheritdoc/>
+    public CopiedVariableCategory Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows)
     {
         List<CopiedVariableValue> values = new List<CopiedVariableValue>();
+        List<string> indeterminate = new List<string>();
 
         foreach (IVariableCategoryRow row in rows)
         {
@@ -41,34 +60,47 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
                 continue;
             }
 
+            // A multi-selection whose instances disagree has no single value to capture. Report it rather
+            // than letting it look like the copy silently covered the whole category.
+            if (row.IsIndeterminate)
+            {
+                indeterminate.Add(row.RootVariableName);
+                continue;
+            }
+
+            object? value = row.Value;
+
             // A null row has no value to stamp onto the target. Writing null would author an explicit
             // null rather than restoring inheritance (which is what "Make Default" does), so skip it.
-            if (row.Value == null)
+            if (value == null)
             {
                 continue;
             }
 
             // Copying holds the value by reference, so handing a list to a second element would leave both
             // sharing one instance and editing one would silently change the other.
-            if (row.Value is System.Collections.IList)
+            if (value is System.Collections.IList)
             {
                 continue;
             }
 
-            values.Add(new CopiedVariableValue(row.RootVariableName, row.Value));
+            values.Add(new CopiedVariableValue(row.RootVariableName, value));
         }
 
-        CopiedCategory = new CopiedVariableCategory(categoryName, values);
+        CopiedCategory = new CopiedVariableCategory(categoryName, values, indeterminate);
+        return CopiedCategory;
     }
 
+    /// <inheritdoc/>
     public VariableCategoryPasteResult Paste(IEnumerable<IVariableCategoryRow> targetRows)
     {
         List<string> applied = new List<string>();
+        List<string> alreadyMatched = new List<string>();
         List<string> skipped = new List<string>();
 
         if (CopiedCategory == null)
         {
-            return new VariableCategoryPasteResult(applied, skipped);
+            return new VariableCategoryPasteResult(applied, alreadyMatched, skipped);
         }
 
         Dictionary<string, IVariableCategoryRow> rowsByName = new Dictionary<string, IVariableCategoryRow>();
@@ -82,65 +114,106 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
             }
         }
 
+        // Units before values: setting XUnits/WidthUnits/... can convert the target's current X/Width to
+        // preserve on-screen position ("convert variables on unit type change"), so a value written before
+        // its unit gets converted away from what was copied. Applying units first makes the conversion act
+        // on the target's old value, and the copied value then lands verbatim. OrderBy is stable, so the
+        // original category order is kept within each group.
+        IEnumerable<CopiedVariableValue> orderedValues = CopiedCategory.Values
+            .OrderBy(item => item.RootVariableName.EndsWith("Units", StringComparison.Ordinal) ? 0 : 1);
+
         // One lock across every write, so the whole group is a single undo. Nested locks taken by the
         // multi-select rows underneath are harmless: recording only resumes once the last lock is gone.
         using (_undoManager.RequestLock())
         {
-            foreach (CopiedVariableValue copiedValue in CopiedCategory.Values)
+            foreach (CopiedVariableValue copiedValue in orderedValues)
             {
-                if (TryApply(copiedValue, rowsByName))
+                switch (TryApply(copiedValue, rowsByName))
                 {
-                    applied.Add(copiedValue.RootVariableName);
-                }
-                else
-                {
-                    skipped.Add(copiedValue.RootVariableName);
+                    case PasteOutcome.Written:
+                        applied.Add(copiedValue.RootVariableName);
+                        break;
+                    case PasteOutcome.AlreadyMatched:
+                        alreadyMatched.Add(copiedValue.RootVariableName);
+                        break;
+                    default:
+                        skipped.Add(copiedValue.RootVariableName);
+                        break;
                 }
             }
         }
 
-        return new VariableCategoryPasteResult(applied, skipped);
+        return new VariableCategoryPasteResult(applied, alreadyMatched, skipped);
     }
 
-    private static bool TryApply(CopiedVariableValue copiedValue, Dictionary<string, IVariableCategoryRow> rowsByName)
+    private static PasteOutcome TryApply(CopiedVariableValue copiedValue, Dictionary<string, IVariableCategoryRow> rowsByName)
     {
         if (!rowsByName.TryGetValue(copiedValue.RootVariableName, out IVariableCategoryRow? row))
         {
-            return false;
+            return PasteOutcome.Skipped;
         }
 
         if (row.IsReadOnly || row.IsAssignedByReference)
         {
-            return false;
+            return PasteOutcome.Skipped;
         }
 
-        if (!IsTypeCompatible(copiedValue.Value, row.ValueType))
+        if (!TryResolveValueForTarget(copiedValue.Value, row.ValueType, out object valueToWrite))
         {
-            return false;
+            return PasteOutcome.Skipped;
         }
 
         // The target already shows this value. Writing it anyway would author an inherited value explicitly
-        // onto the target for no gain, so leave it alone and report it as matched.
-        if (Equals(row.Value, copiedValue.Value))
+        // onto the target for no gain, so leave it alone. A multi-select row whose instances disagree
+        // reports null (indeterminate), which never matches, so a paste onto it still unifies the selection.
+        if (Equals(row.Value, valueToWrite))
         {
-            return true;
+            return PasteOutcome.AlreadyMatched;
         }
 
-        return row.TrySetValue(copiedValue.Value);
+        return row.TrySetValue(valueToWrite) ? PasteOutcome.Written : PasteOutcome.Skipped;
     }
 
     /// <summary>
-    /// Whether a copied value can stand in for the target row. Same-named variables can still differ in
-    /// type between elements (for example a Font that is a system font name on one object and a file on
-    /// another). A row that cannot report its type is allowed through and left to reject the value itself.
+    /// Decides what to write to the target row, if anything. Same-named variables can still differ in type
+    /// between elements (for example a Font that is a system font name on one object and a file on
+    /// another); the write path stores the value raw, so a mistyped box would fail later casts. Numeric
+    /// mismatches (an int 36 pasted onto a float row) are converted rather than skipped; any other
+    /// mismatch is rejected. A row that cannot report its type is written as-is and left to reject the
+    /// value itself.
     /// </summary>
-    private static bool IsTypeCompatible(object copiedValue, Type? targetValueType)
+    private static bool TryResolveValueForTarget(object copiedValue, Type? targetType, out object valueToWrite)
     {
-        if (targetValueType == null)
+        valueToWrite = copiedValue;
+
+        if (targetType == null)
         {
             return true;
         }
 
-        return targetValueType.IsInstanceOfType(copiedValue);
+        // Nullable targets are common (int? MaxLettersToShow, float? MinWidth) and a copied value is never
+        // null here, so compare against the underlying type - IsInstanceOfType on Nullable<T> is always
+        // false for a boxed T.
+        Type effectiveTargetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        if (effectiveTargetType.IsInstanceOfType(copiedValue))
+        {
+            return true;
+        }
+
+        if (NumericTypes.Contains(effectiveTargetType) && NumericTypes.Contains(copiedValue.GetType()))
+        {
+            try
+            {
+                valueToWrite = Convert.ChangeType(copiedValue, effectiveTargetType, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (OverflowException)
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
@@ -17,6 +17,7 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
         "Name",
         "BaseType",
         "Locked",
+        "Parent",
         "VariableReferences"
     };
 
@@ -43,6 +44,13 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
             // A null row has no value to stamp onto the target. Writing null would author an explicit
             // null rather than restoring inheritance (which is what "Make Default" does), so skip it.
             if (row.Value == null)
+            {
+                continue;
+            }
+
+            // Copying holds the value by reference, so handing a list to a second element would leave both
+            // sharing one instance and editing one would silently change the other.
+            if (row.Value is System.Collections.IList)
             {
                 continue;
             }
@@ -106,26 +114,33 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
             return false;
         }
 
-        if (!IsTypeCompatible(copiedValue.Value, row.Value))
+        if (!IsTypeCompatible(copiedValue.Value, row.ValueType))
         {
             return false;
+        }
+
+        // The target already shows this value. Writing it anyway would author an inherited value explicitly
+        // onto the target for no gain, so leave it alone and report it as matched.
+        if (Equals(row.Value, copiedValue.Value))
+        {
+            return true;
         }
 
         return row.TrySetValue(copiedValue.Value);
     }
 
     /// <summary>
-    /// Whether a copied value can stand in for the target row's current value. Same-named variables can
-    /// still differ in type between elements (for example a Font that is a system font name on one object
-    /// and a file on another), and there is nothing to compare against when the target has no value yet.
+    /// Whether a copied value can stand in for the target row. Same-named variables can still differ in
+    /// type between elements (for example a Font that is a system font name on one object and a file on
+    /// another). A row that cannot report its type is allowed through and left to reject the value itself.
     /// </summary>
-    private static bool IsTypeCompatible(object copiedValue, object? currentTargetValue)
+    private static bool IsTypeCompatible(object copiedValue, Type? targetValueType)
     {
-        if (currentTargetValue == null)
+        if (targetValueType == null)
         {
             return true;
         }
 
-        return currentTargetValue.GetType() == copiedValue.GetType();
+        return targetValueType.IsInstanceOfType(copiedValue);
     }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
@@ -92,13 +92,13 @@ public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteServic
     }
 
     /// <inheritdoc/>
-    public VariableCategoryPasteResult Paste(IEnumerable<IVariableCategoryRow> targetRows)
+    public VariableCategoryPasteResult Paste(string targetCategoryName, IEnumerable<IVariableCategoryRow> targetRows)
     {
         List<string> applied = new List<string>();
         List<string> alreadyMatched = new List<string>();
         List<string> skipped = new List<string>();
 
-        if (CopiedCategory == null)
+        if (CopiedCategory == null || CopiedCategory.CategoryName != targetCategoryName)
         {
             return new VariableCategoryPasteResult(applied, alreadyMatched, skipped);
         }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryCopyPasteService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gum.Undo;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <inheritdoc cref="IVariableCategoryCopyPasteService"/>
+public class VariableCategoryCopyPasteService : IVariableCategoryCopyPasteService
+{
+    /// <summary>
+    /// Variables that identify or gate an object rather than describe its appearance. Copying a whole
+    /// category must never rename the target, retype it, lock it, or overwrite its reference list.
+    /// </summary>
+    private static readonly HashSet<string> NeverCopiedVariableNames = new()
+    {
+        "Name",
+        "BaseType",
+        "Locked",
+        "VariableReferences"
+    };
+
+    private readonly IUndoManager _undoManager;
+
+    public CopiedVariableCategory? CopiedCategory { get; private set; }
+
+    public VariableCategoryCopyPasteService(IUndoManager undoManager)
+    {
+        _undoManager = undoManager;
+    }
+
+    public void Copy(string categoryName, IEnumerable<IVariableCategoryRow> rows)
+    {
+        List<CopiedVariableValue> values = new List<CopiedVariableValue>();
+
+        foreach (IVariableCategoryRow row in rows)
+        {
+            if (NeverCopiedVariableNames.Contains(row.RootVariableName))
+            {
+                continue;
+            }
+
+            // A null row has no value to stamp onto the target. Writing null would author an explicit
+            // null rather than restoring inheritance (which is what "Make Default" does), so skip it.
+            if (row.Value == null)
+            {
+                continue;
+            }
+
+            values.Add(new CopiedVariableValue(row.RootVariableName, row.Value));
+        }
+
+        CopiedCategory = new CopiedVariableCategory(categoryName, values);
+    }
+
+    public VariableCategoryPasteResult Paste(IEnumerable<IVariableCategoryRow> targetRows)
+    {
+        List<string> applied = new List<string>();
+        List<string> skipped = new List<string>();
+
+        if (CopiedCategory == null)
+        {
+            return new VariableCategoryPasteResult(applied, skipped);
+        }
+
+        Dictionary<string, IVariableCategoryRow> rowsByName = new Dictionary<string, IVariableCategoryRow>();
+        foreach (IVariableCategoryRow row in targetRows)
+        {
+            // A category should not contain the same variable twice, but if it does the first row wins
+            // rather than throwing mid-paste.
+            if (!rowsByName.ContainsKey(row.RootVariableName))
+            {
+                rowsByName.Add(row.RootVariableName, row);
+            }
+        }
+
+        // One lock across every write, so the whole group is a single undo. Nested locks taken by the
+        // multi-select rows underneath are harmless: recording only resumes once the last lock is gone.
+        using (_undoManager.RequestLock())
+        {
+            foreach (CopiedVariableValue copiedValue in CopiedCategory.Values)
+            {
+                if (TryApply(copiedValue, rowsByName))
+                {
+                    applied.Add(copiedValue.RootVariableName);
+                }
+                else
+                {
+                    skipped.Add(copiedValue.RootVariableName);
+                }
+            }
+        }
+
+        return new VariableCategoryPasteResult(applied, skipped);
+    }
+
+    private static bool TryApply(CopiedVariableValue copiedValue, Dictionary<string, IVariableCategoryRow> rowsByName)
+    {
+        if (!rowsByName.TryGetValue(copiedValue.RootVariableName, out IVariableCategoryRow? row))
+        {
+            return false;
+        }
+
+        if (row.IsReadOnly || row.IsAssignedByReference)
+        {
+            return false;
+        }
+
+        if (!IsTypeCompatible(copiedValue.Value, row.Value))
+        {
+            return false;
+        }
+
+        return row.TrySetValue(copiedValue.Value);
+    }
+
+    /// <summary>
+    /// Whether a copied value can stand in for the target row's current value. Same-named variables can
+    /// still differ in type between elements (for example a Font that is a system font name on one object
+    /// and a file on another), and there is nothing to compare against when the target has no value yet.
+    /// </summary>
+    private static bool IsTypeCompatible(object copiedValue, object? currentTargetValue)
+    {
+        if (currentTargetValue == null)
+        {
+            return true;
+        }
+
+        return currentTargetValue.GetType() == copiedValue.GetType();
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryPasteResult.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryPasteResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Gum.Plugins.InternalPlugins.VariableGrid;
+
+/// <summary>
+/// What a category paste actually did. Paste is deliberately lenient - a variable the target does not
+/// have, cannot take, or would shadow a reference on is skipped rather than failing the whole paste -
+/// so the caller needs this to report the outcome.
+/// </summary>
+public class VariableCategoryPasteResult
+{
+    /// <summary>Names of the variables whose values were written to the target.</summary>
+    public IReadOnlyList<string> AppliedVariableNames { get; }
+
+    /// <summary>Names of the copied variables that were not written.</summary>
+    public IReadOnlyList<string> SkippedVariableNames { get; }
+
+    public VariableCategoryPasteResult(IReadOnlyList<string> appliedVariableNames, IReadOnlyList<string> skippedVariableNames)
+    {
+        AppliedVariableNames = appliedVariableNames;
+        SkippedVariableNames = skippedVariableNames;
+    }
+}

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryPasteResult.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableCategoryPasteResult.cs
@@ -7,17 +7,10 @@ namespace Gum.Plugins.InternalPlugins.VariableGrid;
 /// have, cannot take, or would shadow a reference on is skipped rather than failing the whole paste -
 /// so the caller needs this to report the outcome.
 /// </summary>
-public class VariableCategoryPasteResult
-{
-    /// <summary>Names of the variables whose values were written to the target.</summary>
-    public IReadOnlyList<string> AppliedVariableNames { get; }
-
-    /// <summary>Names of the copied variables that were not written.</summary>
-    public IReadOnlyList<string> SkippedVariableNames { get; }
-
-    public VariableCategoryPasteResult(IReadOnlyList<string> appliedVariableNames, IReadOnlyList<string> skippedVariableNames)
-    {
-        AppliedVariableNames = appliedVariableNames;
-        SkippedVariableNames = skippedVariableNames;
-    }
-}
+/// <param name="AppliedVariableNames">Variables whose values were written to the target.</param>
+/// <param name="AlreadyMatchedVariableNames">Variables the target already showed with the copied value, left untouched.</param>
+/// <param name="SkippedVariableNames">Copied variables that were neither written nor matched.</param>
+public record VariableCategoryPasteResult(
+    IReadOnlyList<string> AppliedVariableNames,
+    IReadOnlyList<string> AlreadyMatchedVariableNames,
+    IReadOnlyList<string> SkippedVariableNames);

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
@@ -105,6 +105,9 @@ public class VariableGridEntry
     /// <summary>Whether the row's context menu should offer "Make Default" (false for the Name variable and reference-assigned rows).</summary>
     public bool SupportsMakeDefault { get; }
 
+    /// <summary>Whether this row's value comes from a <c>VariableReferences</c> assignment rather than being authored directly.</summary>
+    public bool IsAssignedByReference { get; }
+
     // Prior to April 10 2023 this was always true. Now that we have multi-select, we don't want to
     // call it here if editing multiple objects. Instead, we want to have the multi-select call it and
     // pass the list of variables so that a single undo can be performed.
@@ -321,7 +324,9 @@ public class VariableGridEntry
 
         Instance = instanceSave != null ? instanceSave : stateListCategoryContainer;
 
-        SupportsMakeDefault = variableName != "Name" && !isAssignedByReference;
+        IsAssignedByReference = isAssignedByReference;
+
+        SupportsMakeDefault = variableName != "Name" && !IsAssignedByReference;
 
         var alreadyHasSpaces = RootVariableName.Contains(' ');
         DisplayName = alreadyHasSpaces

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
@@ -108,6 +108,13 @@ public class VariableGridEntry
     /// <summary>Whether this row's value comes from a <c>VariableReferences</c> assignment rather than being authored directly.</summary>
     public bool IsAssignedByReference { get; }
 
+    /// <summary>
+    /// Whether this row selects a state (the uncategorized "State" row or a <c>&lt;Category&gt;State</c>
+    /// row). State names are only meaningful on the element that declares them, so automated writes
+    /// (category paste) must validate the value against the row's available states first.
+    /// </summary>
+    public bool IsStateSelection => _converter is AvailableStatesConverter;
+
     // Prior to April 10 2023 this was always true. Now that we have multi-select, we don't want to
     // call it here if editing multiple objects. Instead, we want to have the multi-select call it and
     // pass the list of variables so that a single undo can be performed.

--- a/WpfDataUi/DataTypes/MemberCategory.cs
+++ b/WpfDataUi/DataTypes/MemberCategory.cs
@@ -63,6 +63,16 @@ public class MemberCategory : INotifyPropertyChanged
         private set;
     }
 
+    /// <summary>
+    /// Right-click menu entries for the category header. Empty by default; a consumer adds items to
+    /// offer category-wide actions such as copying every value in the category.
+    /// </summary>
+    public ObservableCollection<MemberCategoryContextMenuItem> ContextMenuItems
+    {
+        get;
+        private set;
+    }
+
     double? width;
     public double? Width
     {
@@ -99,50 +109,46 @@ public class MemberCategory : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public event Action<InstanceMember> MemberValueChangedByUi;
+    public event Action<InstanceMember>? MemberValueChangedByUi;
 
     #endregion
 
     #region Methods
 
-    public MemberCategory() 
+    public MemberCategory()
     {
-        InstantiateAll();
-    }
+        Name = "";
 
-    public MemberCategory(string name) 
-    {
-        InstantiateAll();
-        Name = name; 
-    }
-
-    void InstantiateAll()
-    {
         HideHeader = false;
 
         Members = new ObservableCollection<InstanceMember>();
 
+        ContextMenuItems = new ObservableCollection<MemberCategoryContextMenuItem>();
+
         Members.CollectionChanged += HandleMembersChanged;
+    }
+
+    public MemberCategory(string name) : this()
+    {
+        Name = name;
     }
 
     void HandleMembersChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
         NotifyPropertyChanged("Visibility");
 
-        switch(e.Action)
+        bool isAddOrReplace =
+            e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add ||
+            e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Replace;
+
+        if (!isAddOrReplace || e.NewItems == null)
         {
-            case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
-                foreach(InstanceMember newItem in e.NewItems)
-                {
-                    newItem.Category = this;
-                }
-                break;
-            case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
-                foreach(InstanceMember newItem in e.NewItems)
-                {
-                    newItem.Category = this;
-                }
-                break;
+            return;
+        }
+
+        foreach (InstanceMember newItem in e.NewItems)
+        {
+            newItem.Category = this;
         }
     }
 

--- a/WpfDataUi/DataTypes/MemberCategoryContextMenuItem.cs
+++ b/WpfDataUi/DataTypes/MemberCategoryContextMenuItem.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Windows.Input;
+
+namespace WpfDataUi.DataTypes;
+
+/// <summary>
+/// One entry in a <see cref="MemberCategory"/>'s right-click menu. The item is its own
+/// <see cref="ICommand"/> so the menu can be built purely by binding (unlike
+/// <see cref="InstanceMember.ContextMenuEvents"/>, whose menu each displayer assembles in code).
+/// </summary>
+public class MemberCategoryContextMenuItem : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    /// <summary>The text shown in the menu.</summary>
+    public string Header { get; }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Forwarded to <see cref="CommandManager.RequerySuggested"/> so WPF re-evaluates
+    /// <see cref="CanExecute"/> when the menu opens, rather than only when the category is rebuilt.
+    /// </remarks>
+    public event EventHandler? CanExecuteChanged
+    {
+        add => CommandManager.RequerySuggested += value;
+        remove => CommandManager.RequerySuggested -= value;
+    }
+
+    public MemberCategoryContextMenuItem(string header, Action execute, Func<bool>? canExecute = null)
+    {
+        Header = header;
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    /// <inheritdoc/>
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    /// <inheritdoc/>
+    public void Execute(object? parameter) => _execute();
+}


### PR DESCRIPTION
Closes #4455.

Right-click a category header in the Variables tab (Font, Text, Position, ...) and you get **Copy Values** and **Paste Values**. Matching one object to another no longer means reading a value off one object, selecting the other, typing it, and going back for the next one.

Copy captures the effective value of every row in the category (what is displayed, whether authored on the selected state or inherited). Paste writes them onto the current selection, matching by variable name, recorded as a single undo. Because the grid already routes a multi-selection through `MultiSelectInstanceMember`, selecting several objects and pasting once applies to all of them, so the loop is: copy once from the mockup, select every target, paste once.

Paste is deliberately lenient. It skips rather than fails on a variable the target does not have (pasting Font onto a Sprite), read-only rows (locked instances), rows driven by a `VariableReferences` assignment, values whose type the target row does not accept, and values the target already shows. The outcome is reported to the output window: `Pasted 6 value(s) into Font. Skipped FontScale, OutlineThickness`.

Never copied, regardless of category: `Name`, `BaseType`, `Locked`, `Parent`, `VariableReferences`. These identify or gate an object rather than describe it, and a pasted parent name is dangling on another element. List-valued variables are skipped too, since the value is held by reference and source and target would otherwise share one instance.

## Shape

The gather/apply logic is headless in `Gum.Presentation` (`VariableCategoryCopyPasteService`) and unit tested there without WPF. The Variables tab's WPF rows are adapted to it through `IVariableCategoryRow`.

Rows are taken exactly as the grid presents them, including composite rows (the color swatch) and multi-select wrappers. An earlier revision expanded composites into their Red/Green/Blue channels; that was wrong, because the multi-select wrapper sits *above* the composite, so the same row was named Red/Green with one object selected and Color with several, and a copy made in one mode silently did not apply in the other. Writing through the row as-is also preserves each wrapper's own behavior: the composite skips unchanged channels, and the multi-select wrapper fans the value out and refreshes afterwards.

`MemberCategory` gained a `ContextMenuItems` collection (`MemberCategoryContextMenuItem` is its own `ICommand`, so the menu is built purely by binding). The category header template in `Frb.Styles.Defaults.xaml` hosts the menu; categories that add no items show nothing at all, so other `DataUiGrid` consumers are unaffected.

## Design notes on the variants not built

- **Copy To...** (stay on the source, pick the destination from a dialog) does not fit the existing write path. `VariableGridEntry.SetValue` writes to `_selectedState.SelectedStateSave`, so writing into an element that is not selected means bypassing the grid write path and hand-rolling refresh and undo.
- **Copy From...** (sit on the target, pull from a source picked in a dialog) does fit, since reading from a non-selected element is safe and the write still lands on the selected element. It reuses this PR's payload and applier and only adds a source picker, so it is a natural follow-up if the two-gesture flow feels like one step too many.

## Testing

- `Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteServiceTests.cs` covers apply/skip matching, read-only and reference-assigned rows, the type guard, the never-copied set, the already-matches case, and that one undo lock is held across every write.
- `Tool/Tests/GumToolUnitTests/VariableGrid/VariableCategoryRowAdapterTests.cs` pins the composite naming being identical in single- and multi-select, and write-through for composite and multi-select rows.
- `Gum.Presentation.Tests` 915 passed, `GumToolUnitTests` 1269 passed, `GumFull.sln` builds with no new warnings.
- Not unit tested: the `PropertyGridManager` glue that hangs the menu items on the live grid, and the XAML. Those need a manual pass in the running tool.

## Manual test steps

1. Open a project, select a Text object with fonts set, right-click the **Font** header, Copy Values.
2. Select a different Text object, right-click **Font**, Paste Values. The font settings should match and one Ctrl+Z should undo the whole group.
3. Select several Text objects at once and paste. All of them should update, again as one undo.
4. Right-click **Font** on a Sprite and paste. Nothing should change, and the output window should say everything was skipped.
5. Right-click a category header on a locked instance and paste. Values should be skipped rather than written.

## Boyscout

`MemberCategory`'s two constructors were chained and `HandleMembersChanged`'s duplicated switch arms merged with a null guard, clearing four pre-existing nullable warnings in the file.
