### PR TITLE
Theme the native TextBox Cut/Copy/Paste context menu

### DIFF
--- a/Gum/Themes/Frb.Styles.Defaults.xaml
+++ b/Gum/Themes/Frb.Styles.Defaults.xaml
@@ -81,6 +81,18 @@
         <Setter Property="FontSize" Value="{Binding Source={StaticResource Scale}, Path=IconButton}" />
     </Style>
 
+    <!--
+        WPF auto-generates the default Cut/Copy/Paste editing menu for a TextBox whose
+        ContextMenu is unset, outside the scope where the app's implicit ContextMenu/MenuItem
+        styles (below) are registered - assigning this explicit menu is what actually themes it
+        (see #4457).
+    -->
+    <ContextMenu x:Key="Frb.ContextMenu.TextEditing" x:Shared="False">
+        <MenuItem Command="{x:Static ApplicationCommands.Cut}" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
+        <MenuItem Command="{x:Static ApplicationCommands.Copy}" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
+        <MenuItem Command="{x:Static ApplicationCommands.Paste}" CommandTarget="{Binding PlacementTarget, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
+    </ContextMenu>
+
     <Style x:Key="SimpleTextBox" TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="{DynamicResource Frb.Brushes.Foreground}" />
         <Setter Property="Background" Value="{DynamicResource Frb.Brushes.Field.Background}" />
@@ -88,6 +100,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="{DynamicResource Frb.Brushes.Border.Secondary}" />
         <Setter Property="CaretBrush" Value="{DynamicResource Frb.Brushes.ThemeContrast}" />
+        <Setter Property="ContextMenu" Value="{StaticResource Frb.ContextMenu.TextEditing}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="TextBox">
@@ -139,6 +152,7 @@
         <Setter Property="md:TextFieldAssist.TextFieldCornerRadius" Value="2" />
         <Setter Property="CaretBrush" Value="{DynamicResource Frb.Brushes.ThemeContrast}" />
         <Setter Property="md:TextFieldAssist.DecorationVisibility" Value="Collapsed" />
+        <Setter Property="ContextMenu" Value="{StaticResource Frb.ContextMenu.TextEditing}" />
         <Style.Triggers>
             <Trigger Property="IsKeyboardFocused" Value="True">
                 <Setter Property="Background" Value="{DynamicResource Frb.Brushes.Background}" />


### PR DESCRIPTION
Closes #4457

## Root cause

WPF's built-in Cut/Copy/Paste text-editing menu only auto-populates when a `TextBox`'s `ContextMenu` is genuinely unset. Gum's implicit `TextBox`/`ContextMenu`/`MenuItem` styles are already registered at `Application.Resources` scope, but they never reach that auto-populated menu - which is why the bug still reproduced on `main` despite the styles existing.

The actual repro path is `PART_EditableTextBox` inside the ComboBox `ControlTemplate` (used by editable combos like Base Type): it never gets a `ContextMenu` assigned, so WPF falls back to its native, unthemed menu. Disabled entries (Cut/Copy with nothing selected, Paste with nothing on the clipboard) render with the default light-theme foreground and become unreadably faint or fully invisible.

`WpfDataUi`'s `TextBoxDisplay` (and sibling Display controls) already assign their own explicit, already-themed `ContextMenu` ("Make Default" + plugin events), so those aren't part of this bug.

## Fix

Assign an explicit, themed Cut/Copy/Paste `ContextMenu` (bound to `ApplicationCommands`) to both places that register an implicit `TextBox` style in `Frb.Styles.Defaults.xaml`:
- the app-wide implicit `TextBox` style
- `SimpleTextBox`, which the Variables grid (`DataUiGrid.VariableGrid`) locally substitutes in place of the app-wide one - this is the style actually in effect for the reported Base Type combo

Since the ComboBox template doesn't set `ContextMenu` locally on `PART_EditableTextBox`, it now inherits this explicit menu, which resolves through normal implicit style lookup and picks up the theme's dark `ContextMenu`/`MenuItem` styling (including a properly readable disabled foreground).

## Manual test: needed

Opening VS for you.

1. Build/run the Gum tool, select any element, go to the Variables tab.
2. Right-click inside the **Base Type** combo's editable text with nothing selected and nothing on the clipboard - the menu should show a themed dark popup with Cut/Copy/Paste all present (Paste greyed out, readable, not invisible).
3. Select some text in that field and right-click - Cut/Copy should be enabled and Paste's enabled state should reflect clipboard content.
4. Right-click in an ordinary Variables-tab text field (e.g. a Width/X value) - same themed menu.

## FRB canary: not needed

Change is Gum tool WPF theme XAML (`Gum/Themes/Frb.Styles.Defaults.xaml`), not FRB1-shared runtime source.
