### PR TITLE
Rebuild Silk.NET's GumService as a GumServiceSkiaBase subclass (#4452 phase 2)

### DIFF
--- a/GumCommon/HostServices/Async/SingleThreadSynchronizationContext.cs
+++ b/GumCommon/HostServices/Async/SingleThreadSynchronizationContext.cs
@@ -5,15 +5,14 @@ using System.Threading;
 namespace Gum.Async;
 
 /// <summary>
-/// A <see cref="SynchronizationContext"/> that funnels async continuations onto
-/// the game's primary thread by queuing them and draining the queue once per
-/// frame from <see cref="GumService.Update(Microsoft.Xna.Framework.GameTime)"/>.
+/// A <see cref="SynchronizationContext"/> that funnels async continuations onto the host's primary
+/// thread by queuing them and draining the queue once per frame from the owning service's
+/// <c>Update</c>.
 /// </summary>
 /// <remarks>
-/// Install via <c>GumService.UseSingleThreadedAsync()</c>. After install,
-/// <c>await</c> continuations in handlers (including
-/// <c>await dialogBox.ShowAsync(...)</c>) resume on the primary thread, so it is
-/// safe to mutate UI state after the await without thread-affinity surprises.
+/// Install via <c>GumService.UseSingleThreadedAsync()</c>. After install, <c>await</c> continuations
+/// in handlers (including <c>await dialogBox.ShowAsync(...)</c>) resume on the primary thread, so it
+/// is safe to mutate UI state after the await without thread-affinity surprises.
 /// </remarks>
 public class SingleThreadSynchronizationContext : SynchronizationContext
 {

--- a/GumCommon/HostServices/GumHotReloadManager.cs
+++ b/GumCommon/HostServices/GumHotReloadManager.cs
@@ -30,7 +30,8 @@ public interface IGumHotReloadManager
 
     /// <summary>
     /// Starts watching the directory containing the specified .gumx project file for changes.
-    /// This is not typically called directly — use <see cref="GumService.EnableHotReload"/> instead.
+    /// This is not typically called directly — use <see cref="GumServiceSkiaBase.EnableHotReload"/>
+    /// or the MonoGame/Raylib GumService's equivalent instead.
     /// </summary>
     /// <param name="absoluteGumxSourcePath">The absolute path to the .gumx project file.</param>
     void Start(string absoluteGumxSourcePath);
@@ -42,10 +43,10 @@ public interface IGumHotReloadManager
 
     /// <summary>
     /// Checks for a pending reload and, if enough time has elapsed since the last file change, performs the reload.
-    /// This is not typically called directly — <see cref="GumService"/> calls this automatically each frame.
+    /// This is not typically called directly — the owning service calls this automatically each frame.
     /// </summary>
     /// <param name="roots">The roots whose direct children will be rebuilt from the reloaded project.
-    /// Typically the same collection passed to <see cref="GumService.Update(GameTime, IEnumerable{GraphicalUiElement})"/>.</param>
+    /// Typically the same collection passed to the owning service's per-frame Update.</param>
     void Update(IEnumerable<GraphicalUiElement> roots);
 }
 
@@ -53,8 +54,19 @@ public interface IGumHotReloadManager
 /// Default implementation of <see cref="IGumHotReloadManager"/>. Watches Gum project files on disk
 /// and hot-reloads the element tree when changes are detected.
 /// </summary>
+/// <remarks>
+/// Lives in GumCommon (not a MonoGame/Raylib-specific project) so any host — including Skia-family
+/// hosts via <c>GumServiceSkiaBase</c> — can reuse it (issue #4452). The two platform-specific
+/// operations a reload needs to re-run (applying the project's texture filter, and loading
+/// *Animations.ganx/.ganj files) are supplied by the owning service via the constructor instead of
+/// being hardcoded to a specific concrete GumService type.
+/// </remarks>
 public class GumHotReloadManager : IGumHotReloadManager
 {
+    private readonly Action<GumProjectSave> _applyProjectTextureFilter;
+    private readonly Func<GumProjectSave, Gum.Bundle.IGumFileProvider, int> _loadAnimationsFromProvider;
+    private readonly Action<string> _disposeCachedAsset;
+
     private string _projectSourcePath = "";
     private string _binGumDirectory = "";
     private FileSystemWatcher? _watcher;
@@ -62,6 +74,32 @@ public class GumHotReloadManager : IGumHotReloadManager
     private DateTime _lastChangeTime;
     private readonly List<string> _changedFontFiles = new List<string>();
     private readonly object _fontFileLock = new object();
+
+    /// <param name="applyProjectTextureFilter">
+    /// Applies the reloaded project's <see cref="GumProjectSave.TextureFilter"/> to the host's
+    /// renderer — the same operation the host's own Initialize runs on first load. Each host's
+    /// GumService already implements this (e.g. <c>GumService.ApplyProjectTextureFilter</c>).
+    /// </param>
+    /// <param name="loadAnimationsFromProvider">
+    /// Loads *Animations.ganx/.ganj files from the given file provider into the reloaded project.
+    /// Each host's GumService already implements this (e.g. <c>GumService.LoadAnimationsFromProvider</c>).
+    /// </param>
+    /// <param name="disposeCachedAsset">
+    /// Evicts a standardized (absolute, case-preserved) file path from the host's content cache, so a
+    /// changed font/texture reloads from disk instead of returning the stale cached version. The
+    /// concrete cache (<c>RenderingLibrary.Content.LoaderManager</c>) is an engine-specific type not
+    /// available in GumCommon, so the host supplies this hook (e.g.
+    /// <c>path => RenderingLibrary.Content.LoaderManager.Self.Dispose(path)</c>).
+    /// </param>
+    public GumHotReloadManager(
+        Action<GumProjectSave> applyProjectTextureFilter,
+        Func<GumProjectSave, Gum.Bundle.IGumFileProvider, int> loadAnimationsFromProvider,
+        Action<string> disposeCachedAsset)
+    {
+        _applyProjectTextureFilter = applyProjectTextureFilter;
+        _loadAnimationsFromProvider = loadAnimationsFromProvider;
+        _disposeCachedAsset = disposeCachedAsset;
+    }
 
     /// <inheritdoc/>
     public event Action? ReloadCompleted;
@@ -150,7 +188,7 @@ public class GumHotReloadManager : IGumHotReloadManager
     /// type that should trigger a hot reload - both the XML and JSON forms of the project, element,
     /// animation, and behavior formats, plus bitmap fonts. Internal (not private) so tests can pin
     /// the watched set directly; the actual reload dispatch (<c>GumProjectSave.Load</c>,
-    /// <c>GumService.LoadAnimationsFromProvider</c>) already handles both XML and JSON content, so
+    /// the injected animation loader) already handles both XML and JSON content, so
     /// this gate is the only place that needed the JSON siblings added (issue #4182).
     /// </summary>
     internal static bool IsWatchedExtension(string extension) =>
@@ -191,10 +229,6 @@ public class GumHotReloadManager : IGumHotReloadManager
         var destinationFontCache = Path.Combine(_binGumDirectory, "FontCache");
         Directory.CreateDirectory(destinationFontCache);
 
-        // global:: needed now that this file is in namespace Gum — a bare
-        // "RenderingLibrary.Content" would resolve against Gum.RenderingLibrary.
-        var loaderManager = global::RenderingLibrary.Content.LoaderManager.Self;
-
         foreach (var sourceFntPath in changedFonts)
         {
             var fileName = Path.GetFileName(sourceFntPath);
@@ -216,13 +250,13 @@ public class GumHotReloadManager : IGumHotReloadManager
             // Unload the cached font so it gets reloaded from the new file
             var absoluteFontPath = Path.Combine(destinationFontCache, fileName);
             var standardizedFont = ToolsUtilities.FileManager.Standardize(absoluteFontPath, preserveCase: true, makeAbsolute: true);
-            loaderManager.Dispose(standardizedFont);
+            _disposeCachedAsset(standardizedFont);
 
             // Unload the cached texture pages so they get reloaded too
             foreach (var pngPath in copiedPngs)
             {
                 var standardizedPng = ToolsUtilities.FileManager.Standardize(pngPath, preserveCase: true, makeAbsolute: true);
-                loaderManager.Dispose(standardizedPng);
+                _disposeCachedAsset(standardizedPng);
             }
         }
     }
@@ -252,7 +286,7 @@ public class GumHotReloadManager : IGumHotReloadManager
         // Re-apply the project's texture filter so editing it in the tool carries over on reload
         // (issue #3199). On XNALIKE this takes effect on the next Draw; on raylib it affects
         // textures loaded after this point (already-cached textures keep their prior filter).
-        GumService.ApplyProjectTextureFilter(newProject);
+        _applyProjectTextureFilter(newProject);
 
         foreach (var element in newProject.AllElements)
         {
@@ -275,12 +309,12 @@ public class GumHotReloadManager : IGumHotReloadManager
         string? sourceDirectory = Path.GetDirectoryName(_projectSourcePath);
         Gum.Bundle.LooseFileGumFileProvider animationProvider = new Gum.Bundle.LooseFileGumFileProvider(
             string.IsNullOrEmpty(sourceDirectory) ? "." : sourceDirectory);
-        GumService.LoadAnimationsFromProvider(newProject, animationProvider);
+        _loadAnimationsFromProvider(newProject, animationProvider);
 
         System.Diagnostics.Debug.WriteLine(
             $"[HotReload] rootList.Count = {rootList.Count}");
 
-        ApplyDiff(rootList, newProject, SystemManagers.Default);
+        ApplyDiff(rootList, newProject, ISystemManagers.Default!);
 
         System.Diagnostics.Debug.WriteLine("[HotReload] DONE");
 

--- a/GumCommon/HostServices/WindowFitController.cs
+++ b/GumCommon/HostServices/WindowFitController.cs
@@ -1,0 +1,170 @@
+using System;
+
+namespace Gum;
+
+/// <summary>
+/// Tracks a window-fit policy (zoom-to-window or expand-to-window) and recomputes canvas size and
+/// camera zoom when the window resizes. Composed by <c>GumService</c> (issue #3608) and
+/// <c>GumServiceSkiaBase</c> (issue #4452) instead of each owning its own inline copy of this state.
+/// </summary>
+/// <remarks>
+/// The owning service supplies how to read the current window size and how to apply a computed fit
+/// (camera zoom + canvas size) back onto its own <c>SystemManagers</c>/<c>Root</c> — this class holds
+/// only the policy state and the pure math delegation, so it has no dependency on any specific host.
+/// </remarks>
+public class WindowFitController
+{
+    private enum FitPolicy
+    {
+        None,
+        Zoom,
+        Expand,
+    }
+
+    private readonly Func<(int width, int height)> _getWindowSize;
+    // Applies a computed (zoom, canvasWidth, canvasHeight) fit to the host.
+    private readonly Action<float, float, float> _applyFit;
+
+    private FitPolicy _fitPolicy;
+    private WindowZoomMode _fitZoomMode;
+    private float _fitDefaultZoom;
+    private int? _zoomReferenceWidth;
+    private int? _zoomReferenceHeight;
+
+    // Update() polls these against the current window size each frame so resize
+    // detection is platform-agnostic — no resize-event subscription on either backend.
+    private int _lastSeenWindowWidth;
+    private int _lastSeenWindowHeight;
+
+    /// <param name="getWindowSize">Returns the current window (or canvas, for windowless hosts) size.</param>
+    /// <param name="applyFit">Applies a computed (zoom, canvasWidth, canvasHeight) fit to the host.</param>
+    public WindowFitController(
+        Func<(int width, int height)> getWindowSize,
+        Action<float, float, float> applyFit)
+    {
+        _getWindowSize = getWindowSize;
+        _applyFit = applyFit;
+    }
+
+    /// <summary>
+    /// Enables a zoom-based fit policy: the camera scales so the canvas tracks the current window
+    /// size, using the window dimensions at the first call as the 1:1 reference. The fit is applied
+    /// immediately and then re-applied automatically on each <see cref="PollAndApplyFit"/> call
+    /// whenever the window size changes.
+    /// </summary>
+    /// <param name="mode">
+    /// Whether window height or window width drives the zoom factor. The dominant axis fully fills
+    /// the window; the other axis gets extra space or is cropped depending on the window's aspect
+    /// ratio relative to the reference. Defaults to height-dominant.
+    /// </param>
+    /// <param name="defaultZoom">
+    /// A multiplier applied on top of the computed zoom — i.e., the zoom factor at the reference
+    /// resolution.
+    /// </param>
+    /// <remarks>
+    /// Calling this replaces any previously enabled fit policy (including one set by
+    /// <see cref="EnableExpandToWindow"/>). The reference resolution is captured on the first call
+    /// and persists for the lifetime of this instance.
+    /// </remarks>
+    public void EnableZoomToWindow(WindowZoomMode mode = WindowZoomMode.HeightDominant, float defaultZoom = 1f)
+    {
+        _fitPolicy = FitPolicy.Zoom;
+        _fitZoomMode = mode;
+        _fitDefaultZoom = defaultZoom;
+        ApplyCurrentFit();
+    }
+
+    /// <summary>
+    /// Enables an expand-based fit policy: the canvas is resized to match the current window so
+    /// authored UI gets more (or less) space rather than scaling. The fit is applied immediately and
+    /// then re-applied automatically on each <see cref="PollAndApplyFit"/> call whenever the window
+    /// size changes.
+    /// </summary>
+    /// <param name="defaultZoom">
+    /// A camera zoom multiplier. With <c>1f</c> the canvas matches the window pixel-for-pixel.
+    /// </param>
+    /// <remarks>
+    /// Calling this replaces any previously enabled fit policy (including one set by
+    /// <see cref="EnableZoomToWindow"/>).
+    /// </remarks>
+    public void EnableExpandToWindow(float defaultZoom = 1f)
+    {
+        _fitPolicy = FitPolicy.Expand;
+        _fitDefaultZoom = defaultZoom;
+        ApplyCurrentFit();
+    }
+
+    private void ApplyCurrentFit()
+    {
+        if (_fitPolicy == FitPolicy.None)
+        {
+            return;
+        }
+
+        var (windowWidth, windowHeight) = _getWindowSize();
+        _lastSeenWindowWidth = windowWidth;
+        _lastSeenWindowHeight = windowHeight;
+        ApplyFitForSize(windowWidth, windowHeight);
+    }
+
+    /// <summary>
+    /// Call once per frame. Re-applies the active fit policy only when the window size has changed
+    /// since the last call.
+    /// </summary>
+    public void PollAndApplyFit()
+    {
+        if (_fitPolicy == FitPolicy.None)
+        {
+            return;
+        }
+
+        var (windowWidth, windowHeight) = _getWindowSize();
+        if (windowWidth == _lastSeenWindowWidth && windowHeight == _lastSeenWindowHeight)
+        {
+            return;
+        }
+
+        _lastSeenWindowWidth = windowWidth;
+        _lastSeenWindowHeight = windowHeight;
+        ApplyFitForSize(windowWidth, windowHeight);
+    }
+
+    /// <summary>
+    /// Applies the active fit policy for an explicit window size, bypassing the change-detection
+    /// <see cref="PollAndApplyFit"/> does. Exposed for tests; hosts should normally call
+    /// <see cref="PollAndApplyFit"/> instead.
+    /// </summary>
+    public void ApplyFitForSize(int windowWidth, int windowHeight)
+    {
+        switch (_fitPolicy)
+        {
+            case FitPolicy.Zoom:
+                _zoomReferenceWidth ??= windowWidth;
+                _zoomReferenceHeight ??= windowHeight;
+                var (zoom, zoomCanvasW, zoomCanvasH) = WindowFitMath.ComputeZoom(
+                    windowWidth, windowHeight,
+                    _zoomReferenceWidth.Value, _zoomReferenceHeight.Value,
+                    _fitZoomMode, _fitDefaultZoom);
+                _applyFit(zoom, zoomCanvasW, zoomCanvasH);
+                break;
+            case FitPolicy.Expand:
+                var (expandZoom, expandCanvasW, expandCanvasH) = WindowFitMath.ComputeExpand(
+                    windowWidth, windowHeight, _fitDefaultZoom);
+                _applyFit(expandZoom, expandCanvasW, expandCanvasH);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Clears the active fit policy and captured reference size. Called by the owning service's
+    /// <c>Uninitialize</c>.
+    /// </summary>
+    public void Reset()
+    {
+        _zoomReferenceWidth = null;
+        _zoomReferenceHeight = null;
+        _fitPolicy = FitPolicy.None;
+        _lastSeenWindowWidth = 0;
+        _lastSeenWindowHeight = 0;
+    }
+}

--- a/GumCommon/HostServices/WindowFitMath.cs
+++ b/GumCommon/HostServices/WindowFitMath.cs
@@ -1,6 +1,11 @@
 namespace Gum;
 
-internal static class WindowFitMath
+/// <summary>
+/// Pure zoom/canvas-size math backing <see cref="WindowFitController"/>. Lives in GumCommon (not a
+/// MonoGame/Raylib-specific project) so any host — including Skia-family hosts via
+/// <c>GumServiceSkiaBase</c> — can compute the same fit behavior (issue #4452).
+/// </summary>
+public static class WindowFitMath
 {
     public static (float zoom, float canvasWidth, float canvasHeight) ComputeZoom(
         int windowWidth, int windowHeight,

--- a/GumCommon/HostServices/WindowZoomMode.cs
+++ b/GumCommon/HostServices/WindowZoomMode.cs
@@ -1,10 +1,8 @@
-// Companion enum to Gum.GumService (issue #3119) — lives in the same namespace so
-// EnableZoomToWindow callers need only `using Gum;`.
 namespace Gum;
 
 /// <summary>
 /// Controls which window axis drives the zoom factor in
-/// <see cref="GumService.ZoomToWindow(WindowZoomMode, float)"/>.
+/// <see cref="WindowFitController.EnableZoomToWindow(WindowZoomMode, float)"/>.
 /// </summary>
 public enum WindowZoomMode
 {

--- a/MonoGameGum.Tests/Forms/TextBoxTests.cs
+++ b/MonoGameGum.Tests/Forms/TextBoxTests.cs
@@ -573,6 +573,23 @@ public class TextBoxTests : BaseTestClass
     }
 
     [Fact]
+    public void HandleCharEntered_ShouldHidePlaceholder_WhenTypingIntoEmptyTextBox()
+    {
+        TextBox textBox = new();
+        textBox.Placeholder = "Enter text";
+
+        TextBoxBaseVisual visual = (TextBoxBaseVisual)textBox.Visual;
+        visual.PlaceholderTextInstance.Visible.ShouldBeTrue(
+            "sanity: placeholder should show while the text box is empty");
+
+        textBox.HandleCharEntered('a');
+
+        visual.PlaceholderTextInstance.Visible.ShouldBeFalse(
+            "typing routes through SetTextNoTranslate, which sets the TextNoTranslate " +
+            "property -- HandleTextComponentPropertyChanged must also react to that, not just Text");
+    }
+
+    [Fact]
     public void HandleCharEntered_ShouldUpdateBindingSource_OnEnterNoAcceptsReturn()
     {
         TextBox textBox = new();

--- a/MonoGameGum.Tests/Hot/HotReloadAnimationReloadTests.cs
+++ b/MonoGameGum.Tests/Hot/HotReloadAnimationReloadTests.cs
@@ -41,7 +41,9 @@ public class HotReloadAnimationReloadTests : BaseTestClass
             Directory.CreateDirectory(screensDirectory);
             File.WriteAllBytes(Path.Combine(screensDirectory, "MainScreenAnimations.ganx"), Ganx());
 
-            GumHotReloadManager manager = new GumHotReloadManager();
+            GumHotReloadManager manager = new GumHotReloadManager(
+                GumService.ApplyProjectTextureFilter, GumService.LoadAnimationsFromProvider,
+                path => RenderingLibrary.Content.LoaderManager.Self.Dispose(path));
             manager.Start(gumxPath);
             // Release the OS watcher immediately; Start has already recorded the source path.
             manager.Stop();

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -1009,6 +1009,17 @@ public class TextRuntime : InteractiveGue
 #endif
     }
 
+    /// <summary>
+    /// Raises the <see cref="Text"/> PropertyChanged notification without touching the underlying
+    /// renderable. Used by Skia's property dispatcher (<c>Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs</c>),
+    /// which sets <c>Text</c>/<c>RawText</c> directly instead of delegating back into <see cref="Text"/>
+    /// or <see cref="SetTextNoTranslate"/> (doing so would re-enter <c>SetProperty</c> and recurse) —
+    /// so it has no other way to notify subscribers like <c>TextBoxBase.OnTextChanged</c>, which
+    /// TextBox's placeholder visibility and <c>TextChangedByUi</c> depend on. Internal: this is an
+    /// implementation seam for same-assembly property dispatchers, not public API.
+    /// </summary>
+    internal void NotifyTextChanged() => NotifyPropertyChanged(nameof(Text));
+
     bool _localizeText = true;
 
     /// <summary>

--- a/MonoGameGum/GumService.cs
+++ b/MonoGameGum/GumService.cs
@@ -110,24 +110,6 @@ public partial class GumService : IGumService
     private IGumHotReloadManager? _hotReloadManager;
 #endif
 
-    private int? _zoomReferenceWidth;
-    private int? _zoomReferenceHeight;
-
-    private enum FitPolicy
-    {
-        None,
-        Zoom,
-        Expand,
-    }
-
-    private FitPolicy _fitPolicy;
-    private WindowZoomMode _fitZoomMode;
-    private float _fitDefaultZoom;
-    // Update() polls these against the current window size each frame so resize
-    // detection is platform-agnostic — no resize-event subscription on either backend.
-    private int _lastSeenWindowWidth;
-    private int _lastSeenWindowHeight;
-
     /// <summary>
     /// Gets or sets the width of the canvas, which acts as the root-most coordiante space. This value
     /// represents the "internal coordinates" which can be adjusted by Camera zoom.
@@ -147,6 +129,19 @@ public partial class GumService : IGumService
         get => GraphicalUiElement.CanvasHeight;
         set => GraphicalUiElement.CanvasHeight = value;
     }
+
+    // Composed rather than owned inline so GumServiceSkiaBase (issue #4452) shares the same policy
+    // state/math instead of a second copy. GetWindowSize is the platform partial's own method group.
+    private WindowFitController? _windowFit;
+    private WindowFitController WindowFit => _windowFit ??= new WindowFitController(
+        GetWindowSize,
+        (zoom, canvasWidth, canvasHeight) =>
+        {
+            SystemManagers.Renderer.Camera.Zoom = zoom;
+            CanvasWidth = canvasWidth;
+            CanvasHeight = canvasHeight;
+            Root.UpdateLayout();
+        });
 
     /// <summary>
     /// Enables a zoom-based fit policy: the camera scales so the Gum canvas tracks the
@@ -171,13 +166,8 @@ public partial class GumService : IGumService
     /// the first call to <c>EnableZoomToWindow</c> and persists for the lifetime of this
     /// instance.
     /// </remarks>
-    public void EnableZoomToWindow(WindowZoomMode mode = WindowZoomMode.HeightDominant, float defaultZoom = 1f)
-    {
-        _fitPolicy = FitPolicy.Zoom;
-        _fitZoomMode = mode;
-        _fitDefaultZoom = defaultZoom;
-        ApplyCurrentFit();
-    }
+    public void EnableZoomToWindow(WindowZoomMode mode = WindowZoomMode.HeightDominant, float defaultZoom = 1f) =>
+        WindowFit.EnableZoomToWindow(mode, defaultZoom);
 
     /// <summary>
     /// Enables an expand-based fit policy: the Gum canvas is resized to match the current
@@ -196,70 +186,13 @@ public partial class GumService : IGumService
     /// Calling this replaces any previously enabled fit policy (including one set by
     /// <see cref="EnableZoomToWindow(WindowZoomMode, float)"/>).
     /// </remarks>
-    public void EnableExpandToWindow(float defaultZoom = 1f)
-    {
-        _fitPolicy = FitPolicy.Expand;
-        _fitDefaultZoom = defaultZoom;
-        ApplyCurrentFit();
-    }
+    public void EnableExpandToWindow(float defaultZoom = 1f) =>
+        WindowFit.EnableExpandToWindow(defaultZoom);
 
-    private void ApplyCurrentFit()
-    {
-        if (_fitPolicy == FitPolicy.None)
-        {
-            return;
-        }
+    private void PollWindowSizeAndApplyFit() => WindowFit.PollAndApplyFit();
 
-        var (windowWidth, windowHeight) = GetWindowSize();
-        _lastSeenWindowWidth = windowWidth;
-        _lastSeenWindowHeight = windowHeight;
-        ApplyFitForSize(windowWidth, windowHeight);
-    }
-
-    private void PollWindowSizeAndApplyFit()
-    {
-        if (_fitPolicy == FitPolicy.None)
-        {
-            return;
-        }
-
-        var (windowWidth, windowHeight) = GetWindowSize();
-        if (windowWidth == _lastSeenWindowWidth && windowHeight == _lastSeenWindowHeight)
-        {
-            return;
-        }
-
-        _lastSeenWindowWidth = windowWidth;
-        _lastSeenWindowHeight = windowHeight;
-        ApplyFitForSize(windowWidth, windowHeight);
-    }
-
-    internal void ApplyFitForSize(int windowWidth, int windowHeight)
-    {
-        switch (_fitPolicy)
-        {
-            case FitPolicy.Zoom:
-                _zoomReferenceWidth ??= windowWidth;
-                _zoomReferenceHeight ??= windowHeight;
-                var (zoom, zoomCanvasW, zoomCanvasH) = WindowFitMath.ComputeZoom(
-                    windowWidth, windowHeight,
-                    _zoomReferenceWidth.Value, _zoomReferenceHeight.Value,
-                    _fitZoomMode, _fitDefaultZoom);
-                SystemManagers.Renderer.Camera.Zoom = zoom;
-                CanvasWidth = zoomCanvasW;
-                CanvasHeight = zoomCanvasH;
-                Root.UpdateLayout();
-                break;
-            case FitPolicy.Expand:
-                var (expandZoom, expandCanvasW, expandCanvasH) = WindowFitMath.ComputeExpand(
-                    windowWidth, windowHeight, _fitDefaultZoom);
-                SystemManagers.Renderer.Camera.Zoom = expandZoom;
-                CanvasWidth = expandCanvasW;
-                CanvasHeight = expandCanvasH;
-                Root.UpdateLayout();
-                break;
-        }
-    }
+    internal void ApplyFitForSize(int windowWidth, int windowHeight) =>
+        WindowFit.ApplyFitForSize(windowWidth, windowHeight);
 
     // GetWindowSize() is platform-specific (XNA back-buffer vs raylib render size) and lives in the
     // per-platform partials (issue #3608).
@@ -601,7 +534,8 @@ public partial class GumService : IGumService
     /// </param>
     public void EnableHotReload(string absoluteGumxSourcePath)
     {
-        _hotReloadManager = new GumHotReloadManager();
+        _hotReloadManager = new GumHotReloadManager(
+            ApplyProjectTextureFilter, LoadAnimationsFromProvider, path => LoaderManager.Self.Dispose(path));
         _hotReloadManager.ReloadCompleted += () => HotReloadCompleted?.Invoke();
         _hotReloadManager.Start(absoluteGumxSourcePath);
     }
@@ -1156,11 +1090,7 @@ public partial class GumService : IGumService
         GraphicalUiElement.CanvasWidth = 0;
         GraphicalUiElement.CanvasHeight = 0;
 
-        _zoomReferenceWidth = null;
-        _zoomReferenceHeight = null;
-        _fitPolicy = FitPolicy.None;
-        _lastSeenWindowWidth = 0;
-        _lastSeenWindowHeight = 0;
+        _windowFit?.Reset();
 
         SystemManagers.Default = null;
         ISystemManagers.Default = null;

--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -136,10 +136,9 @@
 		<Compile Include="..\..\MonoGameGum\GueDeriving\PolygonRuntime.cs" Link="GueDeriving\PolygonRuntime.cs" />
 		<Compile Include="..\..\MonoGameGum\GumService.cs" Link="GumService.cs" />
 		<Compile Include="..\..\MonoGameGum\GumServiceCompat.cs" Link="GumServiceCompat.cs" />
-		<Compile Include="..\..\MonoGameGum\WindowFitMath.cs" Link="WindowFitMath.cs" />
-		<Compile Include="..\..\MonoGameGum\WindowZoomMode.cs" Link="WindowZoomMode.cs" />
-		<Compile Include="..\..\MonoGameGum\Async\SingleThreadSynchronizationContext.cs" Link="Async\SingleThreadSynchronizationContext.cs" />
-		<Compile Include="..\..\MonoGameGum\GumHotReloadManager.cs" Link="GumHotReloadManager.cs" />
+		<!-- WindowFitMath/WindowZoomMode/SingleThreadSynchronizationContext/GumHotReloadManager moved
+		     to GumCommon (issue #4452), arriving via the GumCommon ProjectReference below instead of
+		     a file-link. -->
 		<Compile Include="..\..\GumRuntime\Input\ButtonState.cs" Link="Input\ButtonState.cs" />
 		<Compile Include="..\..\GumRuntime\Input\MouseState.cs" Link="Input\MouseState.cs" />
 		<Compile Include="..\..\GumRuntime\Input\TouchCollection.cs" Link="Input\TouchCollection.cs" />

--- a/Runtimes/SilkNetGum/GumService.Silk.cs
+++ b/Runtimes/SilkNetGum/GumService.Silk.cs
@@ -1,12 +1,11 @@
-// SILK arm of the partial GumService (issue #3608) — compiled only for the Gum.SilkNet host. The
-// shared majority lives in MonoGameGum's GumService.cs (file-linked into SilkNetGum.csproj); this
-// file holds the SILK-divergent members: the SKCanvas/IInputContext Initialize family and its
-// renderer/forms bootstrap, the Silk input factories, the double-typed Update, HandleResize, and the
-// concrete Default. SilkNet has NO [Obsolete] back-compat subclass (unlike MonoGame/Raylib), so
-// GumServiceCompat.cs is not linked here and Default returns Gum.GumService directly. SilkNet renders
-// through SkiaGum and pumps real Silk.NET.Input, so more of its body is genuinely platform-specific
-// than the Raylib arm. The #if SILK wrap is belt-and-suspenders: only SilkNetGum compiles this file,
-// and SILK is always defined there.
+// Silk.NET's GumService, as a subclass of GumServiceSkiaBase (issue #4452 phase 2). Overrides the
+// CreateCursor/CreateKeyboard/ApplyGamePadState capability hooks with real Silk.NET.Input-backed
+// implementations, and Update to also pump FormsUtilities' per-frame cursor/keyboard/gamepad
+// activity (the base's Update is render-only and has no input to pump). Everything else --
+// rendering, .gumx loading, non-interactive Forms controls, hot reload, window-fit, the sync
+// context -- comes from the shared base, the same way SkiaGum.Wpf/SkiaGum.Maui/any bring-your-own
+// -canvas consumer gets it, so this class also serves as the reference example for writing a custom
+// interactive Skia host.
 #if SILK
 #nullable enable
 
@@ -14,54 +13,34 @@ using Gum.Forms;
 using Gum.Forms.Controls;
 using Gum.Input;
 using Gum.Wireframe;
-using Gum.GueDeriving;
 using RenderingLibrary;
-using RenderingLibrary.Graphics;
-using SkiaGum.Renderables;
 using SkiaSharp;
 using Silk.NET.Input;
 using System;
-// Silk.NET.Input also defines an ICursor (the OS mouse-cursor appearance); alias to Gum's input
-// abstraction so IGumService.Cursor / CreateCursor resolve unambiguously.
 using ICursor = Gum.Wireframe.ICursor;
 
 namespace Gum;
 
-public partial class GumService
+public class GumService : GumServiceSkiaBase, IGumService
 {
-    #region Default
+    private static GumService? _default;
 
     /// <summary>
-    /// The singleton service instance. Assigned as <see cref="IGumService.Default"/> during
-    /// <see cref="Initialize(SKCanvas, IInputContext, string?)"/>. Unlike MonoGame/Raylib, SilkNet
-    /// has no <c>[Obsolete]</c> back-compat subclass, so Default is the concrete <see cref="GumService"/>.
+    /// The singleton service instance.
     /// </summary>
     public static GumService Default => _default ??= new GumService();
 
-    #endregion
-
     private IInputContext? _inputContext;
 
-    private double _previousTotalSeconds;
-    private bool _hasReceivedUpdate;
+    /// <summary>
+    /// Gets the default cursor, which represents either mouse or touch screen depending on hardware capabilities.
+    /// </summary>
+    public Cursor Cursor => (FormsUtilities.Cursor as Cursor)!;
 
-    /// <inheritdoc/>
-    float? IGumService.GameTime => _hasReceivedUpdate ? (float?)_previousTotalSeconds : null;
-
-    // SilkNetGum requires a canvas + input context, so the host-agnostic no-arg Initialize overloads
-    // are not supported -- callers must use Initialize(SKCanvas, IInputContext, ...).
-    void IGumService.Initialize() =>
-        throw new NotSupportedException(
-            "SilkNetGum requires a canvas and input context. Call " +
-            "GumService.Default.Initialize(SKCanvas, IInputContext, ...) instead.");
-
-    void IGumService.Initialize(string gumProjectFile) =>
-        throw new NotSupportedException(
-            "SilkNetGum requires a canvas and input context. Call " +
-            "GumService.Default.Initialize(SKCanvas, IInputContext, ..., gumProjectFile) instead.");
-
-    /// <inheritdoc/>
-    IRenderable IGumService.CreateSpriteRenderable() => new Sprite();
+    /// <summary>
+    /// Gets the default keyboard.
+    /// </summary>
+    public Keyboard Keyboard => (FormsUtilities.Keyboard as Keyboard)!;
 
     /// <inheritdoc/>
     ICursor? IGumService.CreateCursor()
@@ -101,29 +80,6 @@ public partial class GumService
         }
     }
 
-    // AssignClipboard is implemented below via Silk.NET.Input's IKeyboard.ClipboardText (#3651).
-    // The AssignNativeTextInput / UninitializePlatform / ApplyTextureFilterPlatform /
-    // ExtractUnresolvedTextures partial seams remain intentionally unimplemented (elided) on SILK:
-    // Silk.NET.Input exposes no IME/composition API to back NativeTextInput (KeyChar only reports
-    // committed characters), so TextBox/PasswordBox type through GetStringTyped same as Raylib; Skia
-    // has no Skia-specific Uninitialize teardown or global texture filter; and there is no embedded
-    // snapshot texture PNG export. This matches the prior standalone service.
-    partial void AssignClipboard()
-    {
-        if (_inputContext != null)
-        {
-            Clipboard = new global::Gum.Input.SilkGumClipboard(_inputContext);
-        }
-    }
-
-    // GetWindowSize backs the shared window-fit helpers. SilkNet has no OS window (the caller owns it
-    // and hands us an SKCanvas), so report the current canvas size. SilkNet's own resize path is
-    // HandleResize; the inherited zoom/expand fit policies are degenerate against a canvas host.
-    private (int width, int height) GetWindowSize() =>
-        ((int)GraphicalUiElement.CanvasWidth, (int)GraphicalUiElement.CanvasHeight);
-
-    #region Initialize
-
     /// <summary>
     /// Initializes Gum for a Silk.NET application, optionally loading a Gum project. The canvas size
     /// is read from <see cref="SKCanvas.DeviceClipBounds"/>; use the explicit-size overload if that
@@ -159,83 +115,24 @@ public partial class GumService
     /// <param name="gumProjectFile">An optional .gumx project file to load.</param>
     public void Initialize(SKCanvas canvas, IInputContext inputContext, int width, int height, string? gumProjectFile = null)
     {
-        // Stored before InitializeDefaults so the CreateCursor/CreateKeyboard overrides it invokes can
-        // build Silk-backed input from this context.
+        // Stored before base.Initialize, which calls FormsUtilities.InitializeDefaults, which
+        // dispatches back to this instance's CreateCursor/CreateKeyboard overrides above.
         _inputContext = inputContext;
+        Clipboard = new SilkGumClipboard(inputContext);
 
-        // The ctor-time AssignClipboard() call (GumService.cs) runs before this Initialize -- Default's
-        // lazy new GumService() constructs the instance on first access, which normally happens before
-        // Initialize assigns _inputContext above -- so its null-guard always failed and Clipboard stayed
-        // null. Re-run it now that _inputContext is guaranteed non-null (#3651).
-        AssignClipboard();
-
-        var managers = new SystemManagers();
-        this.SystemManagers = managers;
-        SystemManagers.Default = managers;
-        ISystemManagers.Default = managers;
-        managers.Canvas = canvas;
-        managers.Initialize();
-        managers.Renderer.ClearsCanvas = false;
-
-        // Size the canvas coordinate space before FinishInitialize adds and lays out Root so the
-        // RelativeToParent root has something to resolve against.
-        GraphicalUiElement.CanvasWidth = width;
-        GraphicalUiElement.CanvasHeight = height;
-
-        // Wire this service as the runtime-agnostic default BEFORE InitializeDefaults, which calls back
-        // into CreateCursor/CreateKeyboard and creates PopupRoot/ModalRoot.
-        IGumService.Default = this;
-
-        FormsUtilities.InitializeDefaults(managers, DefaultVisualsVersion.V3);
-
-        // Shared tail: adds the ctor-created Root to managers, reinserts it at the bottom of the main
-        // layer, and (when a path is given) loads the project + its localization/standards/texture
-        // filter. SilkNet's canvas/renderer/forms bootstrap above is the only Initialize divergence.
-        FinishInitialize(gumProjectFile);
-
-        IsInitialized = true;
+        base.Initialize(canvas, width, height, gumProjectFile);
     }
 
-    #endregion
-
     /// <summary>
-    /// Updates the canvas coordinate space and re-runs layout on the root container. Call this from
-    /// your window-resized callback so Gum-layouted elements reposition to the new window size.
-    /// </summary>
-    /// <param name="width">The new canvas width.</param>
-    /// <param name="height">The new canvas height.</param>
-    public void HandleResize(int width, int height)
-    {
-        GraphicalUiElement.CanvasWidth = width;
-        GraphicalUiElement.CanvasHeight = height;
-        Root?.UpdateLayout();
-    }
-
-    #region Update
-
-    /// <summary>
-    /// Per-frame tick. Call once per frame, before <see cref="Draw"/>, with total elapsed seconds
-    /// since startup. Pumps Forms input (cursor/keyboard activity, control events) and advances
-    /// AnimationChain playback on <see cref="Root"/> and its descendants.
+    /// Per-frame tick. Call once per frame, before <see cref="GumServiceSkiaBase.Draw"/>, with total
+    /// elapsed seconds since startup. Runs the base's deferred-queue/animation tick, then pumps Forms
+    /// input (cursor/keyboard activity, control events) — the base has no input to pump.
     /// </summary>
     /// <param name="totalSeconds">Total elapsed time in seconds since startup.</param>
-    public void Update(double totalSeconds)
+    public override void Update(double totalSeconds)
     {
-        double delta = _hasReceivedUpdate ? totalSeconds - _previousTotalSeconds : 0;
-
-        roots.Clear();
-        roots.Add(Root);
-
-        UpdatePreamble(roots);
-
-        _previousTotalSeconds = totalSeconds;
-        _hasReceivedUpdate = true;
-
+        base.Update(totalSeconds);
         FormsUtilities.Update(totalSeconds, Root);
-
-        AnimateRoots(delta, roots);
     }
-
-    #endregion
 }
 #endif

--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -49,100 +49,19 @@
 		<DefineConstants>TRACE;SKIA;SILK</DefineConstants>
 	</PropertyGroup>
 
-	<!-- ===== SkiaGum's local render source (globbed by directory; AssemblyAttributes.cs at the
-	     SkiaGum root is intentionally NOT globbed — this project ships its own). ===== -->
-	<ItemGroup>
-		<Compile Include="..\SkiaGum\Renderables\**\*.cs" Link="Renderables\%(RecursiveDir)%(Filename)%(Extension)" />
-		<Compile Include="..\SkiaGum\GueDeriving\**\*.cs" Link="GueDeriving\%(RecursiveDir)%(Filename)%(Extension)" />
-		<Compile Include="..\SkiaGum\Helpers\**\*.cs" Link="Helpers\%(RecursiveDir)%(Filename)%(Extension)" />
-		<Compile Include="..\SkiaGum\Content\**\*.cs" Link="Content\%(RecursiveDir)%(Filename)%(Extension)" />
-		<Compile Include="..\SkiaGum\RenderingLibrary\**\*.cs" Link="RenderingLibrary\%(RecursiveDir)%(Filename)%(Extension)" />
-		<Compile Include="..\SkiaGum\CustomSetPropertyOnRenderable.cs" Link="CustomSetPropertyOnRenderable.cs" />
-	</ItemGroup>
-
-	<!-- ===== Shared render source (mirrors SkiaGum.csproj's file-link list) ===== -->
-	<ItemGroup>
-		<Compile Include="..\..\Gum\RenderingLibrary\IPositionedSizedObjectExtensionMethods.cs" Link="RenderingLibrary\IPositionedSizedObjectExtensionMethods.cs" />
-		<Compile Include="..\..\Gum\SvgPlugin\Managers\DefaultStateManager.cs" Link="DefaultStateManager.cs" />
-		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChain.cs" Link="Animation\AnimationChain.cs" />
-		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainList.cs" Link="Animation\AnimationChainList.cs" />
-		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationFrame.cs" Link="Animation\AnimationFrame.cs" />
-		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\AnimationChainLogic.cs" Link="Animation\AnimationChainLogic.cs" />
-		<Compile Include="..\..\RenderingLibrary\Graphics\Animation\SpriteAnimationLogic.cs" Link="Animation\SpriteAnimationLogic.cs" />
-		<!-- Shared markup model + run-splitter (InlineVariable, StyledSubstring, StyledSubstringSplitter)
-		     so Skia's Text can render BBCode inline styling (#3679); mirrors SkiaGum.csproj's link. -->
-		<Compile Include="..\..\RenderingLibrary\Graphics\StyledSubstringSplitter.cs" Link="RenderingLibrary\StyledSubstringSplitter.cs" />
-		<!-- Render-target cache base subclassed by SkiaRenderTargetService (#3988); mirrors SkiaGum.csproj's link. -->
-		<Compile Include="..\..\RenderingLibrary\Graphics\RenderTargetService.cs" Link="RenderingLibrary\RenderTargetService.cs" />
-		<!-- ContainerRuntime.Blend/BlendState (unblocked for Skia in #3989); mirrors SkiaGum.csproj's link. -->
-		<Compile Include="..\..\Gum\RenderingLibrary\BlendExtensions.cs" Link="RenderingLibrary\BlendExtensions.cs" />
-		<!-- IAnimatable intentionally NOT linked (arrives via GumCommon); a local copy would create
-		     two distinct same-FQN types and silently break AnimateSelf — see SkiaGum.csproj. -->
-		<Compile Include="..\..\MonoGameGum\GueDeriving\CircleRuntime.cs" Link="GueDeriving\CircleRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\ColoredRectangleRuntime.cs" Link="GueDeriving\ColoredRectangleRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\ContainerRuntime.cs" Link="GueDeriving\ContainerRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\NineSliceRuntime.cs" Link="GueDeriving\NineSliceRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\PolygonRuntime.cs" Link="GueDeriving\PolygonRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\RectangleRuntime.cs" Link="GueDeriving\RectangleRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\TextRuntime.cs" Link="GueDeriving\TextRuntime.cs" />
-		<Compile Include="..\..\MonoGameGum\GueDeriving\SpriteRuntime.cs" Link="GueDeriving\SpriteRuntime.cs" />
-	</ItemGroup>
+	<!-- ===== SkiaGum's render/GueDeriving/Forms source (issue #4452 phase 2): the V3 default
+	     visuals, DefaultFromFileVisuals, and FormsUtilities.cs are no longer file-linked here —
+	     they arrive via the SkiaGum ProjectReference below, which also
+	     supplies GumServiceSkiaBase. FormsUtilities in particular MUST come from that single
+	     compiled copy, not a second local one: Silk's CursorExtensions (kept below) reaches
+	     FormsUtilities.LastEventRoots (internal — see the InternalsVisibleTo in SkiaGum.csproj),
+	     and GumServiceSkiaBase.Initialize calls FormsUtilities.InitializeDefaults on ITS copy;
+	     two separately-compiled FormsUtilities types with the same FQN would silently split state
+	     between them (the IAnimatable trap SkiaGum.csproj already documents). ===== -->
 
 	<ItemGroup>
 		<!-- ScreenBase stays per-backend (news up ContainerRuntime); Window.cs arrives via GumCommon. -->
 		<Compile Include="..\..\MonoGameGum\Forms\ScreenBase.cs" Link="Forms\ScreenBase.cs" />
-	</ItemGroup>
-
-	<!-- Forms code-only V3 default visuals (the only generation ported to Skia). -->
-	<ItemGroup>
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ButtonVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\CheckBoxVisual.cs" Link="Forms\DefaultVisuals\V3\CheckBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ColorPickerVisual.cs" Link="Forms\DefaultVisuals\V3\ColorPickerVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ComboBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ComboBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\DialogBoxVisual.cs" Link="Forms\DefaultVisuals\V3\DialogBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ItemsControlVisual.cs" Link="Forms\DefaultVisuals\V3\ItemsControlVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\LabelVisual.cs" Link="Forms\DefaultVisuals\V3\LabelVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ListBoxItemVisual.cs" Link="Forms\DefaultVisuals\V3\ListBoxItemVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ListBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ListBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\MenuItemVisual.cs" Link="Forms\DefaultVisuals\V3\MenuItemVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\MenuVisual.cs" Link="Forms\DefaultVisuals\V3\MenuVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\PasswordBoxVisual.cs" Link="Forms\DefaultVisuals\V3\PasswordBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\RadioButtonVisual.cs" Link="Forms\DefaultVisuals\V3\RadioButtonVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ScrollBarVisual.cs" Link="Forms\DefaultVisuals\V3\ScrollBarVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ScrollViewerVisual.cs" Link="Forms\DefaultVisuals\V3\ScrollViewerVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ScrollViewerVisualSizedToChildren.cs" Link="Forms\DefaultVisuals\V3\ScrollViewerVisualSizedToChildren.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\SliderVisual.cs" Link="Forms\DefaultVisuals\V3\SliderVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\SplitterVisual.cs" Link="Forms\DefaultVisuals\V3\SplitterVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\Styling.cs" Link="Forms\DefaultVisuals\V3\Styling.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ToggleButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ToggleButtonVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TextBoxBaseVisual.cs" Link="Forms\DefaultVisuals\V3\TextBoxBaseVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TextBoxVisual.cs" Link="Forms\DefaultVisuals\V3\TextBoxVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\TooltipVisual.cs" Link="Forms\DefaultVisuals\V3\TooltipVisual.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\WindowVisual.cs" Link="Forms\DefaultVisuals\V3\WindowVisual.cs" />
-	</ItemGroup>
-
-	<!-- Forms from-file default visuals + behavior->Forms property bridge (mirrors SkiaGum.csproj). -->
-	<ItemGroup>
-		<Compile Include="..\..\MonoGameGum\Forms\BehaviorFormsPropertyApplier.cs" Link="Forms\BehaviorFormsPropertyApplier.cs" />
-		<Compile Include="..\..\MonoGameGum\Forms\DefaultFromFileVisuals\*.cs"
-				 Link="Forms\DefaultFromFileVisuals\%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<!-- FormsUtilities: registers V3 defaults and pumps input each frame. -->
-	<ItemGroup>
-		<Compile Include="..\..\MonoGameGum\Forms\FormsUtilities.cs" Link="Forms\FormsUtilities.cs" />
-	</ItemGroup>
-
-	<!-- ===== Shared game-host GumService: the partial base + its companions. The SILK-divergent
-	     GumService.Silk.cs and the SilkNet-local CustomSetPropertyOnRenderable.Localization.cs are
-	     auto-globbed from this project dir (no explicit include needed). GumServiceCompat.cs is
-	     intentionally NOT linked — SilkNet has no [Obsolete] back-compat subclass. Issue #3608. ===== -->
-	<ItemGroup>
-		<Compile Include="..\..\MonoGameGum\GumService.cs" Link="GumService.cs" />
-		<Compile Include="..\..\MonoGameGum\WindowFitMath.cs" Link="WindowFitMath.cs" />
-		<Compile Include="..\..\MonoGameGum\WindowZoomMode.cs" Link="WindowZoomMode.cs" />
-		<Compile Include="..\..\MonoGameGum\GumHotReloadManager.cs" Link="GumHotReloadManager.cs" />
-		<Compile Include="..\..\MonoGameGum\Async\SingleThreadSynchronizationContext.cs" Link="Async\SingleThreadSynchronizationContext.cs" />
 	</ItemGroup>
 
 	<!-- ===== Input host half (the stack SkiaGum omits because it is render-only) ===== -->
@@ -188,6 +107,11 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
+		<!-- Supplies GumServiceSkiaBase + the render/Forms source this project used to file-link
+		     directly (issue #4452, see the comment above). SkiaGum.csproj carries no concrete
+		     GumService of its own (that lives in SkiaGum.Standalone.csproj), so this is a normal
+		     reference — no Gum.GumService naming collision with this project's own GumService. -->
+		<ProjectReference Include="..\SkiaGum\SkiaGum.csproj" />
 	</ItemGroup>
 
 	<!--

--- a/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
+++ b/Runtimes/SkiaGum.Maui/SkiaGum.Maui.csproj
@@ -26,7 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
+    <!-- Was SkiaGum.csproj directly; the concrete GumService moved to SkiaGum.Standalone.csproj
+         (issue #4452 phase 2), which still brings SkiaGum.csproj transitively. -->
+    <ProjectReference Include="..\..\Runtimes\SkiaGum.Standalone\SkiaGum.Standalone.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Runtimes/SkiaGum.Standalone/GumService.cs
+++ b/Runtimes/SkiaGum.Standalone/GumService.cs
@@ -2,9 +2,13 @@
 // host (WPF, MAUI, bring-your-own-canvas) actually types. All Skia rendering/init/update logic
 // lives in the shared GumServiceSkiaBase (issue #4452 phase 1); this class exists to carry the
 // public GumService name and a Default singleton scoped to this assembly. Each Skia-family host
-// assembly (SkiaGum itself, and previously each of SkiaGum.Wpf/SkiaGum.Maui before they compiled
+// assembly (this project, and previously each of SkiaGum.Wpf/SkiaGum.Maui before they compiled
 // this type via ProjectReference instead of file-linking it) gets its own Gum.GumService with its
 // own Default -- never two in one app, mirroring how MonoGame/Raylib/SilkNet each keep their own.
+// EXPERIMENTAL (#4452 phase 2 spike): moved out of SkiaGum.csproj into its own project so that
+// project can be referenced as a pure base (GumServiceSkiaBase + shared render source) by hosts
+// that need their own differently-behaved concrete GumService, without a Gum.GumService naming
+// collision -- see Runtimes/SilkNetGum/GumService.Silk.cs.
 namespace Gum;
 
 public class GumService : GumServiceSkiaBase

--- a/Runtimes/SkiaGum.Standalone/SkiaGum.Standalone.csproj
+++ b/Runtimes/SkiaGum.Standalone/SkiaGum.Standalone.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		The concrete default Gum.GumService for Skia hosts that don't need custom input (WPF, MAUI,
+		true bring-your-own-canvas). Split out of SkiaGum.csproj (issue #4452 phase 2)
+		so that project can ship JUST GumServiceSkiaBase plus shared render source. A host that needs
+		real input (e.g. Silk.NET) references SkiaGum.csproj directly and defines its own concrete
+		GumService, without colliding with this one (see Runtimes/SilkNetGum/GumService.Silk.cs).
+	-->
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<PackageId>Gum.SkiaSharp.Standalone</PackageId>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Version>2026.4.5.1</Version>
+
+		<NoWarn>1591</NoWarn>
+
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DefineConstants>TRACE;SKIA;FULL_DIAGNOSTICS</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DefineConstants>TRACE;SKIA;FULL_DIAGNOSTICS</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_No_Diagnostics|AnyCPU'">
+		<DefineConstants>TRACE;SKIA</DefineConstants>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SkiaGum\SkiaGum.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj
+++ b/Runtimes/SkiaGum.Wpf/SkiaGum.Wpf.csproj
@@ -12,7 +12,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
-    <ProjectReference Include="..\SkiaGum\SkiaGum.csproj" />
+    <!-- Was SkiaGum.csproj directly; the concrete GumService moved to SkiaGum.Standalone.csproj
+         (issue #4452 phase 2), which still brings SkiaGum.csproj transitively. -->
+    <ProjectReference Include="..\SkiaGum.Standalone\SkiaGum.Standalone.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1577,6 +1577,13 @@ public partial class CustomSetPropertyOnRenderable
             {
                 gue.UpdateLayout();
             }
+            // The MonoGame/Raylib dispatcher delegates "Text"/"TextNoTranslate" to
+            // TextRuntime.Text/SetTextNoTranslate, which each explicitly notify. This method sets
+            // RawText directly instead (can't delegate there without re-entering SetProperty and
+            // recursing), so it must notify itself -- otherwise TextBoxBase.OnTextChanged (and the
+            // placeholder-visibility/TextChangedByUi behavior it drives) never runs when a Skia-family
+            // host's Text changes via SetProperty, e.g. every character a TextBox user types.
+            gueAsTextRuntime?.NotifyTextChanged();
             handled = true;
         }
         else if (propertyName == "LocalizeText")

--- a/Runtimes/SkiaGum/GumServiceSkiaBase.cs
+++ b/Runtimes/SkiaGum/GumServiceSkiaBase.cs
@@ -5,23 +5,27 @@ using Gum.Managers;
 using Gum.Threading;
 using Gum.Wireframe;
 using RenderingLibrary;
+using RenderingLibrary.Content;
 using RenderingLibrary.Graphics;
 using Gum.GueDeriving;
 using SkiaGum.Renderables;
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using ToolsUtilities;
 
-// The shared, render-only base for every Skia-family GumService (WPF, MAUI, bring-your-own-canvas,
-// and -- pending #4452 phase 2 -- Silk.NET). Built only against SKCanvas and the IGumService
-// capability-interface pattern (CreateCursor/CreateKeyboard default to null per ADR
+// The shared base for every Skia-family GumService (WPF, MAUI, bring-your-own-canvas, and
+// Silk.NET). Built only against SKCanvas and the IGumService capability-interface pattern
+// (CreateCursor/CreateKeyboard default to null per ADR
 // 0006-runtimes-declare-capabilities-through-igumservice.md), so any Skia host gets identical
-// instantiation syntax, rendering, .gumx project loading, and non-interactive Forms controls for
-// free; a host that wants real mouse/touch/keyboard input derives and overrides the two Create*
-// hooks. Named GumServiceSkiaBase, not GumServiceBase -- that name stays free for a possible future
-// cross-engine base spanning MonoGame/raylib/Skia/Sokol (#4451). Compiled directly into
-// Gum.SkiaSharp (issue #4452 phase 1); WPF/MAUI/standalone consumers get it through the
-// SkiaGum.csproj ProjectReference they already have instead of file-linking shared source.
+// instantiation syntax, rendering, .gumx project loading, non-interactive Forms controls, window-fit,
+// hot reload, and the sync context for free; a host that wants real mouse/touch/keyboard input
+// derives and overrides the two Create* hooks (see Runtimes/SilkNetGum/GumService.Silk.cs for a
+// worked example). Named GumServiceSkiaBase, not GumServiceBase -- that name stays free for a
+// possible future cross-engine base spanning MonoGame/raylib/Skia/Sokol (#4451). Compiled directly
+// into Gum.SkiaSharp (issue #4452); the concrete default Gum.GumService for hosts that don't need
+// custom input lives in the separate SkiaGum.Standalone.csproj (referenced by WPF/MAUI/standalone),
+// keeping this base free of a competing concrete type for Silk.NET's own GumService to collide with.
 namespace Gum;
 
 public abstract class GumServiceSkiaBase : IGumService
@@ -39,6 +43,18 @@ public abstract class GumServiceSkiaBase : IGumService
     /// become children of this container. Null until <c>Initialize</c> is called.
     /// </summary>
     public InteractiveGue Root { get; private set; } = null!;
+
+    /// <summary>
+    /// Overlaid above <see cref="Root"/>; for non-modal popups. Created by
+    /// <see cref="FormsUtilities.InitializeDefaults"/> during <c>Initialize</c>.
+    /// </summary>
+    public InteractiveGue PopupRoot => FrameworkElement.PopupRoot;
+
+    /// <summary>
+    /// Topmost layer; blocks input to everything below. Created by
+    /// <see cref="FormsUtilities.InitializeDefaults"/> during <c>Initialize</c>.
+    /// </summary>
+    public InteractiveGue ModalRoot => FrameworkElement.ModalRoot;
 
     #region IGumService implementation
 
@@ -81,11 +97,146 @@ public abstract class GumServiceSkiaBase : IGumService
 
     float? IGumService.GameTime => _hasReceivedUpdate ? (float?)_previousTotalSeconds : null;
 
-    // Skia has no native on-screen keyboard or OS clipboard implementation.
-    INativeTextInput? IGumService.NativeTextInput => null;
-    IGumClipboard? IGumService.Clipboard => null;
+    /// <inheritdoc/>
+    // Skia has no native on-screen keyboard implementation. Settable (not just IGumService's DIM
+    // default) so a subclass with a real one to offer (e.g. Silk's IKeyboard-backed clipboard) can
+    // assign it during its own Initialize; implicitly satisfies IGumService.NativeTextInput too.
+    public INativeTextInput? NativeTextInput { get; protected set; }
+
+    /// <inheritdoc/>
+    public IGumClipboard? Clipboard { get; protected set; }
+
+    /// <summary>
+    /// The <see cref="global::RenderingLibrary.SystemManagers"/> this service initialized.
+    /// Convenience accessor for <see cref="global::RenderingLibrary.SystemManagers.Default"/>,
+    /// valid after <c>Initialize</c>.
+    /// </summary>
+    public SystemManagers SystemManagers => SystemManagers.Default;
+
+    /// <summary>
+    /// The collection of connected gamepads available to the application.
+    /// </summary>
+    public Gum.Input.GamePad[] Gamepads => FormsUtilities.Gamepads;
+
+    /// <summary>
+    /// Registers this service's keyboard (created via <see cref="IGumService.CreateKeyboard"/> during
+    /// <c>Initialize</c>) as one of <see cref="FrameworkElement.KeyboardsForUiControl"/>, so Forms
+    /// controls respond to it by default without the host having to wire that up manually.
+    /// </summary>
+    public void UseKeyboardDefaults() =>
+        FrameworkElement.KeyboardsForUiControl.Add(FormsUtilities.Keyboard);
+
+    /// <summary>
+    /// Registers this service's <see cref="Gamepads"/> as <see cref="FrameworkElement.GamePadsForUiControl"/>,
+    /// so Forms controls respond to gamepad input by default without the host having to wire that up manually.
+    /// </summary>
+    public void UseGamepadDefaults() =>
+        FrameworkElement.GamePadsForUiControl.AddRange(Gamepads);
 
     IRenderable IGumService.CreateSpriteRenderable() => new Sprite();
+
+    #endregion
+
+    #region Window fit
+
+    // Composed rather than owned inline so this shares WindowFitController/WindowFitMath with
+    // GumService (the MonoGame/Raylib/Silk-partial family) instead of a second copy (issue #4452).
+    private WindowFitController? _windowFit;
+    private WindowFitController WindowFit => _windowFit ??= new WindowFitController(
+        GetWindowSize,
+        (zoom, canvasWidth, canvasHeight) =>
+        {
+            SystemManagers.Renderer.Camera.Zoom = zoom;
+            GraphicalUiElement.CanvasWidth = canvasWidth;
+            GraphicalUiElement.CanvasHeight = canvasHeight;
+            Root.UpdateLayout();
+        });
+
+    /// <summary>
+    /// Returns the current window size used as the fit-policy reference. This render-only base has
+    /// no OS window of its own — the caller owns it and reports resizes via <see cref="HandleResize"/>
+    /// — so the default reports the current canvas size, making <see cref="EnableZoomToWindow"/> and
+    /// <see cref="EnableExpandToWindow"/> degenerate (canvas and "window" are the same value) unless a
+    /// subclass that does own a real window overrides this.
+    /// </summary>
+    protected virtual (int width, int height) GetWindowSize() =>
+        ((int)GraphicalUiElement.CanvasWidth, (int)GraphicalUiElement.CanvasHeight);
+
+    /// <inheritdoc cref="WindowFitController.EnableZoomToWindow"/>
+    public void EnableZoomToWindow(WindowZoomMode mode = WindowZoomMode.HeightDominant, float defaultZoom = 1f) =>
+        WindowFit.EnableZoomToWindow(mode, defaultZoom);
+
+    /// <inheritdoc cref="WindowFitController.EnableExpandToWindow"/>
+    public void EnableExpandToWindow(float defaultZoom = 1f) =>
+        WindowFit.EnableExpandToWindow(defaultZoom);
+
+    #endregion
+
+    #region Hot reload
+
+    private IGumHotReloadManager? _hotReloadManager;
+    private readonly List<GraphicalUiElement> _hotReloadRoots = new();
+
+    /// <summary>
+    /// Starts watching the Gum project source files at the given path.
+    /// When any .gumx, .gucx, .gusx, or .gutx file changes, the project
+    /// is reloaded and active elements in Root have their state reapplied.
+    /// </summary>
+    /// <param name="absoluteGumxSourcePath">
+    /// Absolute path to the source .gumx file (not the bin/Content copy).
+    /// </param>
+    /// <remarks>
+    /// Reloads the element tree and re-applies the project's texture filter, matching the render-only
+    /// base's own capabilities. Skia has no global texture-filter setting to re-apply (elided, same as
+    /// the prior Silk.NET implementation), and *Animations.ganx/.ganj reload during hot reload is not
+    /// yet ported to this base (tracked as a follow-up alongside <c>ExportSnapshot</c>/<c>LoadAnimations</c>).
+    /// </remarks>
+    public void EnableHotReload(string absoluteGumxSourcePath)
+    {
+        _hotReloadManager = new GumHotReloadManager(
+            applyProjectTextureFilter: _ => { },
+            loadAnimationsFromProvider: (_, _) => 0,
+            disposeCachedAsset: path => LoaderManager.Self.Dispose(path));
+        _hotReloadManager.ReloadCompleted += () => HotReloadCompleted?.Invoke();
+        _hotReloadManager.Start(absoluteGumxSourcePath);
+    }
+
+    /// <summary>
+    /// Raised after a hot-reload pass completes (Root.Children rebuilt from updated
+    /// ElementSaves). Subscribe to react to project changes — e.g. rebuild
+    /// entity-attached Gum visuals that aren't part of Root.Children and therefore weren't
+    /// touched by the in-place patch.
+    /// </summary>
+    public event Action? HotReloadCompleted;
+
+    #endregion
+
+    #region Sync context
+
+    private Gum.Async.SingleThreadSynchronizationContext? _syncContext;
+
+    /// <summary>
+    /// The active single-threaded synchronization context, or <c>null</c> if
+    /// <see cref="UseSingleThreadedAsync"/> has not been called.
+    /// </summary>
+    public Gum.Async.SingleThreadSynchronizationContext? SynchronizationContext => _syncContext;
+
+    /// <summary>
+    /// Installs a <see cref="Gum.Async.SingleThreadSynchronizationContext"/> on the calling
+    /// thread so that <c>await</c> continuations (including
+    /// <c>await dialogBox.ShowAsync(...)</c>) resume on the host's primary thread. Call once,
+    /// after <c>Initialize</c>. Subsequent calls are no-ops.
+    /// </summary>
+    /// <remarks>
+    /// Off by default. Skip this call if you've already installed your own
+    /// <see cref="System.Threading.SynchronizationContext"/> — installing two would
+    /// route continuations through the wrong queue.
+    /// </remarks>
+    public void UseSingleThreadedAsync()
+    {
+        if (_syncContext != null) return;
+        _syncContext = new Gum.Async.SingleThreadSynchronizationContext();
+    }
 
     #endregion
 
@@ -205,9 +356,18 @@ public abstract class GumServiceSkiaBase : IGumService
     /// become children of <see cref="Root"/>.
     /// </summary>
     /// <param name="totalSeconds">Total elapsed time in seconds since startup.</param>
-    public void Update(double totalSeconds)
+    public virtual void Update(double totalSeconds)
     {
+        _windowFit?.PollAndApplyFit();
+
+        _syncContext?.Update();
         DeferredQueue?.ProcessPending();
+        if (_hotReloadManager != null)
+        {
+            _hotReloadRoots.Clear();
+            _hotReloadRoots.Add(Root);
+            _hotReloadManager.Update(_hotReloadRoots);
+        }
 
         double delta = _hasReceivedUpdate ? totalSeconds - _previousTotalSeconds : 0;
         _previousTotalSeconds = totalSeconds;

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -178,6 +178,10 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="SkiaGum.Tests" />
+		<!-- Lets SilkNetGum's CursorExtensions reach FormsUtilities.LastEventRoots (internal) across
+		     the assembly boundary — SilkNetGum references this project for GumServiceSkiaBase
+		     instead of file-linking FormsUtilities.cs (issue #4452 phase 2). -->
+		<InternalsVisibleTo Include="SilkNetGum" />
 	</ItemGroup>
 
 	<!--

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -102,7 +102,8 @@
 			arrive through the Forms\Controls\**\*.cs glob above and are explicitly removed
 			below to avoid double-compilation.
 		-->
-		<Compile Include="..\..\MonoGameGum\Async\SingleThreadSynchronizationContext.cs" Link="Async\SingleThreadSynchronizationContext.cs" />
+		<!-- SingleThreadSynchronizationContext moved to GumCommon (issue #4452), arriving via the
+		     GumCommon ProjectReference below instead of a file-link. -->
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ButtonVisual.cs" Link="Forms\DefaultVisuals\V3\ButtonVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\CheckBoxVisual.cs" Link="Forms\DefaultVisuals\V3\CheckBoxVisual.cs" />
 		<Compile Include="..\..\MonoGameGum\Forms\DefaultVisuals\V3\ComboBoxVisual.cs" Link="Forms\DefaultVisuals\V3\ComboBoxVisual.cs" />

--- a/Tests/RaylibGum.Tests/Hot/GumHotReloadTextureFilterTests.cs
+++ b/Tests/RaylibGum.Tests/Hot/GumHotReloadTextureFilterTests.cs
@@ -48,7 +48,9 @@ public class GumHotReloadTextureFilterTests : BaseTestClass
             GumProjectSave project = new GumProjectSave { TextureFilter = "Linear" };
             project.Save(gumxPath, saveElements: false);
 
-            GumHotReloadManager manager = new GumHotReloadManager();
+            GumHotReloadManager manager = new GumHotReloadManager(
+                GumService.ApplyProjectTextureFilter, GumService.LoadAnimationsFromProvider,
+                path => LoaderManager.Self.Dispose(path));
             manager.Start(gumxPath);
             // Release the OS watcher immediately; Start has already recorded the source path.
             manager.Stop();
@@ -79,7 +81,9 @@ public class GumHotReloadTextureFilterTests : BaseTestClass
             GumProjectSave project = new GumProjectSave { TextureFilter = "Point" };
             project.Save(gumxPath, saveElements: false);
 
-            GumHotReloadManager manager = new GumHotReloadManager();
+            GumHotReloadManager manager = new GumHotReloadManager(
+                GumService.ApplyProjectTextureFilter, GumService.LoadAnimationsFromProvider,
+                path => LoaderManager.Self.Dispose(path));
             manager.Start(gumxPath);
             manager.Stop();
 

--- a/Tests/SilkNetGum.Tests/Forms/FormsInteractionTests.cs
+++ b/Tests/SilkNetGum.Tests/Forms/FormsInteractionTests.cs
@@ -1,6 +1,7 @@
 using Gum;
 using Gum.Forms;
 using Gum.Forms.Controls;
+using Gum.Forms.DefaultVisuals.V3;
 using Gum.Input;
 using Gum.Wireframe;
 using Moq;
@@ -38,6 +39,33 @@ public class FormsInteractionTests : BaseTestClass
         GumService.Default.Root.DoUiActivityRecursively(FrameworkElement.MainCursor, keyboard.Object, 0);
 
         textBox.Text.ShouldBe("hi");
+    }
+
+    [Fact]
+    public void DoUiActivityRecursively_KeyCharsTyped_HidesPlaceholder()
+    {
+        // Regression test: Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs's TrySetPropertyOnText
+        // sets the Skia Text renderable's RawText directly instead of delegating to
+        // TextRuntime.Text/SetTextNoTranslate (which the shared MonoGame/Raylib dispatcher does), so
+        // it never raises PropertyChanged("Text") -- TextBoxBase.OnTextChanged, and therefore
+        // UpdatePlaceholderVisibility, never runs when the user types.
+        TextBox textBox = new();
+        textBox.Placeholder = "Enter text here";
+        textBox.AddToRoot();
+        textBox.IsFocused = true;
+
+        TextBoxBaseVisual visual = (TextBoxBaseVisual)textBox.Visual;
+        visual.PlaceholderTextInstance.Visible.ShouldBeTrue(
+            "sanity: placeholder should show while the text box is empty");
+
+        Mock<IInputReceiverKeyboard> keyboard = new();
+        keyboard.Setup(k => k.KeysTyped).Returns(new List<Keys>());
+        keyboard.Setup(k => k.GetStringTyped()).Returns("a");
+
+        GumService.Default.Root.DoUiActivityRecursively(FrameworkElement.MainCursor, keyboard.Object, 0);
+
+        visual.PlaceholderTextInstance.Visible.ShouldBeFalse(
+            "typing should hide the placeholder now that real text is present");
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
+++ b/Tests/SkiaGum.Tests/SkiaGum.Tests.csproj
@@ -16,7 +16,9 @@
 		<PackageReference Include="xunit.runner.visualstudio" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
+	  <!-- Was SkiaGum.csproj directly; the concrete GumService moved to SkiaGum.Standalone.csproj
+	       (issue #4452 phase 2), which still brings SkiaGum.csproj transitively. -->
+	  <ProjectReference Include="..\..\Runtimes\SkiaGum.Standalone\SkiaGum.Standalone.csproj" />
 	  <!-- PixelComparer/PixelDiffResult (used by GoldenImages/*Tests.cs) live in the dependency-free
 	       Gum.ImageDiff so gumcli diff-screenshots (#4174) can reuse the same comparer instead of
 	       duplicating it. -->

--- a/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
+++ b/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
@@ -8,7 +8,9 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Gum.ProjectServices\Gum.ProjectServices.csproj" />
-		<ProjectReference Include="..\..\Runtimes\SkiaGum\SkiaGum.csproj" />
+		<!-- Was SkiaGum.csproj directly; the concrete GumService moved to SkiaGum.Standalone.csproj
+		     (issue #4452 phase 2), which still brings SkiaGum.csproj transitively. -->
+		<ProjectReference Include="..\..\Runtimes\SkiaGum.Standalone\SkiaGum.Standalone.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #4452.

## What changed

Silk.NET's `GumService` now subclasses `GumServiceSkiaBase` instead of independently recompiling shared source through the MonoGame-partial file-link family (the drift risk this issue tracked). Overrides `CreateCursor`/`CreateKeyboard`/`ApplyGamePadState` with real Silk.NET.Input; everything else (rendering, `.gumx` loading, Forms controls, window-fit, hot reload, sync context) comes from the base, so this class also serves as the reference example for a custom interactive Skia host.

**`SkiaGum.csproj` split**: it now ships only `GumServiceSkiaBase` + shared render source. The concrete render-only default `GumService` (WPF/MAUI/standalone) moved to a new `SkiaGum.Standalone.csproj`. Without this split, Silk referencing `SkiaGum.csproj` for the base type collides with its own concrete `GumService` (both named `Gum.GumService`) for any real downstream consumer — confirmed against the `SilkNetGumSample` before making this change.

**GumCommon extraction**: window-fit (`WindowFitController`), hot reload (`GumHotReloadManager`), and the single-threaded sync context moved out of the MonoGame/Raylib-only `GumService` partial into `GumCommon`, composed by both `GumService` and `GumServiceSkiaBase` instead of duplicated. `GumHotReloadManager`'s hardcoded calls into the concrete `GumService`'s static texture-filter/animation-loading methods are now constructor-injected delegates.

**`GumServiceSkiaBase` gains** (all platform-neutral, so WPF/MAUI/standalone pick them up too): `Clipboard`/`NativeTextInput` (now overridable), `PopupRoot`/`ModalRoot`, `SystemManagers`, `Gamepads`, `UseKeyboardDefaults`, `UseGamepadDefaults`, `EnableZoomToWindow`/`EnableExpandToWindow`, `EnableHotReload`/`HotReloadCompleted`, `UseSingleThreadedAsync`/`SynchronizationContext`.

**Not ported**: `ExportSnapshot`/`LoadAnimations` aren't on `GumServiceSkiaBase` yet — not exercised by any current Silk consumer (sample or tests). Filing a follow-up issue.

## Testing

- `SilkNetGum.Tests` (33), `SkiaGum.Tests` (430), `MonoGameGum.Tests` (2177), `MonoGameGum.Tests.V3` (154), `MonoGameGum.IntegrationTests` (85), `RaylibGum.Tests` (598), `Gum.ProjectServices.SkiaGum.Tests` (12) — all green.
- `SilkNetGumSample` and `SkiaGum.Wpf`/`SkiaGum.Maui`/`SkiaGum.Tests`/`Gum.ProjectServices.SkiaGum` build clean against the new `SkiaGum.Standalone.csproj` reference.
- `SokolGum.csproj` not build-verified — Sokol submodule isn't initialized in this worktree (repo convention, unrelated to this change); only touched one now-redundant file-link line there.
- FRB canary: not needed — `GumService.cs` and the extracted `HostServices` classes aren't in `GumCoreShared.projitems` (FRB has no `GumService`).

Manual test: built `SilkNetGumSample`, opened its `.sln` in Visual Studio for the user to run — verifies init/render/input/button-click still work end to end after the rearchitecture.
