### PR TITLE
Fix Sokol TextBox placeholder never hiding when the user types

### DIFF
--- a/Runtimes/SokolGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SokolGum/CustomSetPropertyOnRenderable.cs
@@ -105,6 +105,14 @@ public static class CustomSetPropertyOnRenderable
                 {
                     var s = value as string ?? string.Empty;
                     text.RawText = LocalizationTranslate is { } tr ? tr(s) : s;
+                    // The MonoGame/Raylib dispatcher delegates "Text"/"TextNoTranslate" to
+                    // TextRuntime.Text/SetTextNoTranslate, which each explicitly notify. This
+                    // method sets RawText directly instead (delegating would call back into
+                    // SetProperty here and recurse), so it must notify itself — otherwise
+                    // TextBoxBase.OnTextChanged (and the placeholder-visibility/TextChangedByUi
+                    // behavior it drives) never runs when a Sokol host's Text changes via
+                    // SetProperty, e.g. every character a TextBox user types.
+                    textRuntime?.NotifyTextChanged();
                     // If the text's size is driven by its children (glyphs), layout
                     // must re-run so the parent's measured size picks up the new text.
                     RequestLayoutIfSizedToChildren(element);
@@ -112,6 +120,7 @@ public static class CustomSetPropertyOnRenderable
                 }
             case "TextNoTranslate":
                 text.RawText = value as string ?? string.Empty;
+                textRuntime?.NotifyTextChanged();
                 RequestLayoutIfSizedToChildren(element);
                 return true;
 

--- a/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
+++ b/Runtimes/SokolGum/GueDeriving/TextRuntime.cs
@@ -69,6 +69,15 @@ public class TextRuntime : InteractiveGue
         NotifyPropertyChanged(nameof(Text));
     }
 
+    /// <summary>
+    /// Raises the <see cref="Text"/> PropertyChanged notification without touching the underlying
+    /// renderable. Used by <see cref="SokolGum.CustomSetPropertyOnRenderable"/>'s "Text"/"TextNoTranslate"
+    /// dispatch, which sets <c>ContainedText.RawText</c> directly rather than going through
+    /// <see cref="Text"/>/<see cref="SetTextNoTranslate"/> (those route back through SetProperty and
+    /// would recurse into the dispatcher that's calling this).
+    /// </summary>
+    internal void NotifyTextChanged() => NotifyPropertyChanged(nameof(Text));
+
     public TextOverflowHorizontalMode TextOverflowHorizontalMode
     {
         get => ContainedText.TextOverflowHorizontalMode;

--- a/Tests/SokolGum.Tests/CustomSetPropertyOnRenderableTests.cs
+++ b/Tests/SokolGum.Tests/CustomSetPropertyOnRenderableTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Gum.GueDeriving;
 using Gum.Renderables;
 using RenderingLibrary.Graphics;
@@ -108,5 +109,37 @@ public class CustomSetPropertyOnRenderableTests : BaseTestClass
         CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
             renderable, text, "OutlineThickness", 3);
         renderable.OutlineThickness.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SetProperty_Text_ShouldRaisePropertyChanged()
+    {
+        // TrySetPropertyOnText sets Text.RawText directly rather than delegating
+        // to TextRuntime.Text (which would recurse back into SetPropertyOnRenderable),
+        // so it must explicitly notify. Without this, TextBoxBase.OnTextChanged (and
+        // the placeholder-visibility it drives) never runs when a Sokol TextBox user types.
+        var text = new TextRuntime();
+        var renderable = (Text)text.RenderableComponent;
+        var raisedPropertyNames = new List<string?>();
+        text.PropertyChanged += (_, args) => raisedPropertyNames.Add(args.PropertyName);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, text, "Text", "hello world");
+
+        raisedPropertyNames.ShouldContain(nameof(TextRuntime.Text));
+    }
+
+    [Fact]
+    public void SetProperty_TextNoTranslate_ShouldRaisePropertyChanged()
+    {
+        var text = new TextRuntime();
+        var renderable = (Text)text.RenderableComponent;
+        var raisedPropertyNames = new List<string?>();
+        text.PropertyChanged += (_, args) => raisedPropertyNames.Add(args.PropertyName);
+
+        CustomSetPropertyOnRenderable.SetPropertyOnRenderable(
+            renderable, text, "TextNoTranslate", "hello world");
+
+        raisedPropertyNames.ShouldContain(nameof(TextRuntime.Text));
     }
 }


### PR DESCRIPTION
Closes #4461.

## What changed

Sokol's `TrySetPropertyOnText` (`Runtimes/SokolGum/CustomSetPropertyOnRenderable.cs`) set the Text renderable's `RawText` directly for both `"Text"` and `"TextNoTranslate"` and never raised `PropertyChanged`, so `TextBoxBase.OnTextChanged`/`TextChangedByUi` never fired and a typed-into `TextBox`/`PasswordBox` placeholder stayed visible over the typed text — same bug just fixed on Skia in #4459.

**Premise correction vs. the issue text:** #4459 added `NotifyTextChanged()` to the *shared* `MonoGameGum/GueDeriving/TextRuntime.cs`. Sokol doesn't use that type — it has its own forked `Runtimes/SokolGum/GueDeriving/TextRuntime.cs` (separate assembly, coincidentally same namespace), so that method wasn't reachable here (confirmed via a `CS1061`/build error before adjusting). Added an equivalent `internal NotifyTextChanged()` to Sokol's own `TextRuntime` and call it after each `RawText` assignment in the `Text`/`TextNoTranslate` cases, guarded on `textRuntime != null`.

## Testing

- `SokolGum.Tests` (109) — added two tests pinning that `SetPropertyOnRenderable("Text"/"TextNoTranslate", ...)` raises `PropertyChanged(nameof(Text))`; both failed before the fix (no `PropertyChanged` observed) and pass after.
- FRB canary: not needed — Sokol source isn't included in `GumCoreShared.projitems`/`FlatRedBall.Forms.Shared.projitems`.

Manual test: `Samples/SokolGum`'s `Screen2` already has two `TextBox`es with a `Placeholder` set and `UseKeyboardDefaults()` wired in `Program.cs`, so no sample edit was needed — built the sample and opened its `.slnx` in Visual Studio for the user. Steps: run, press the Right arrow to switch to Screen2, click a TextBox, and type — the placeholder should disappear immediately instead of staying visible under the typed text.
