### PR TITLE
Raylib: surface in-memory font creator failures via PropertyAssignmentError

### DIFF
--- a/.claude/skills/gum-runtime-fonts/SKILL.md
+++ b/.claude/skills/gum-runtime-fonts/SKILL.md
@@ -47,6 +47,8 @@ Examples: `FontCache/Font18Arial.fnt`, `FontCache/Font24Times_New_Roman_o1_Bold.
 
 **Key gotcha:** Unless an `IInMemoryFontCreator` or `IRuntimeFontService` is registered, the `.fnt` file must already exist in `FontCache/`. Users often set `FontSize = 24` expecting it to work, but silently get `DefaultBitmapFont` because `Font24Arial.fnt` was never generated. There is no error or warning — the text just renders in the default font.
 
+On MonoGame/KNI, a *registered* creator that throws is silently swallowed the same way (`GetOrCreateBakedFont`'s catch, `Gum/Wireframe/CustomSetPropertyOnRenderable.cs`) — see #4464. Raylib's equivalent catch sites already raise `CustomSetPropertyOnRenderable.PropertyAssignmentError` instead.
+
 ### Path 3: In-Memory Font Creation (IInMemoryFontCreator) — New
 
 Generates a `BitmapFont` entirely in memory at runtime — no pre-built `.fnt` files needed. The loading code already checks for this; it slots into the cascade between embedded resources and disk-based generation.

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2685,6 +2685,16 @@ public partial class CustomSetPropertyOnRenderable
                     {
                         fontFromGum = loaderManager.LoadContent<Raylib_cs.Font>(asText.FontFamily);
                     }
+                    // A wired InMemoryFontCreator declining (returning null) is a documented, normal
+                    // signal -- IRaylibFontCreator.TryCreateFont falls through to disk/system-font on
+                    // purpose, and that fallback succeeding here is not a failure worth reporting. Only
+                    // surface it once NOTHING resolved a usable font, so this can't fire for a creator
+                    // that's working exactly as designed.
+                    if (InMemoryFontCreator != null && fontFromGum.BaseSize == 0)
+                    {
+                        PropertyAssignmentError?.Invoke(
+                            $"No usable font could be resolved for '{textRuntime.Font}' (in-memory creator, disk cache, and system font all failed) - falling back to raylib's default font.");
+                    }
                     AssignFontIfChanged(asText, fontFromGum);
                 }
             }

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2170,9 +2170,12 @@ public partial class CustomSetPropertyOnRenderable
                     return createdFont.Value;
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Fall through to null - the caller uses the base font / base-atlas scale fallback.
+                // Fall through to null - the caller uses the base font / base-atlas scale fallback -
+                // but surface the failure instead of leaving it completely silent.
+                PropertyAssignmentError?.Invoke(
+                    $"Error creating in-memory font '{fontNameStack.Peek()}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
             }
 
             return null;
@@ -2667,9 +2670,13 @@ public partial class CustomSetPropertyOnRenderable
                                 return;
                             }
                         }
-                        catch
+                        catch (Exception ex)
                         {
-                            // Fall through to the disk / system-font path.
+                            // Fall through to the disk / system-font path, but surface the failure -
+                            // previously silent, leaving Raylib's default font on screen with no
+                            // indication the in-memory creator failed.
+                            PropertyAssignmentError?.Invoke(
+                                $"Error creating in-memory font '{textRuntime.Font}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
                         }
                     }
 

--- a/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/InMemoryFontCreatorTests.cs
@@ -24,16 +24,24 @@ public class InMemoryFontCreatorTests : BaseTestClass
         }
     }
 
+    // Always throws, simulating a rasterizer failure (e.g. KernSmith failing under a WASM host) so
+    // UpdateToFontValues's catch block around InMemoryFontCreator.TryCreateFont is exercised.
+    private sealed class ThrowingFontCreator : IRaylibFontCreator
+    {
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+            => throw new InvalidOperationException("Simulated font rasterization failure.");
+    }
+
     [Fact]
     public void UpdateToFontValues_WhenInMemoryFontCreatorSet_ConsultsItWithCurrentFontProperties()
     {
         // A GUID-suffixed font name, not a fixed one like "Arial": LoaderManager's font cache is a
-        // process-wide static that TextMarkupTests (which doesn't inherit BaseTestClass and never
-        // resets it) can populate with a real Arial+Bold+20 font from a working font creator. If this
-        // test also requests Arial+Bold+20, a cache-hit early-return in UpdateToFontValues can return
-        // before ever consulting THIS test's creator, leaving LastReceived stale from an earlier
-        // property assignment - order-dependent, so it passed locally but failed in CI (whichever test
-        // happens to run first differs by environment). A name unique to this test can never collide.
+        // process-wide static that other tests (e.g. TextMarkupTests) populate with a real
+        // Arial+Bold+20 font from a working font creator. If this test also requests Arial+Bold+20, a
+        // cache-hit early-return in UpdateToFontValues can return before ever consulting THIS test's
+        // creator, leaving LastReceived stale from an earlier property assignment - order-dependent,
+        // so it passed locally but failed in CI (whichever test happens to run first differs by
+        // environment). A name unique to this test can never collide.
         string uniqueFontName = "GumInMemoryFontCreatorTest_" + Guid.NewGuid().ToString("N");
         RecordingFontCreator creator = new RecordingFontCreator();
         IRaylibFontCreator? saved = CustomSetPropertyOnRenderable.InMemoryFontCreator;
@@ -55,6 +63,35 @@ public class InMemoryFontCreatorTests : BaseTestClass
         finally
         {
             CustomSetPropertyOnRenderable.InMemoryFontCreator = saved;
+        }
+    }
+
+    // The bug this pins: an InMemoryFontCreator that throws (e.g. KernSmith failing under a WASM
+    // host) was previously swallowed by a bare catch with no way for the game/developer to find out -
+    // text silently fell back to the default font with zero diagnostics anywhere.
+    [Fact]
+    public void UpdateToFontValues_WhenInMemoryFontCreatorThrows_ShouldInvokePropertyAssignmentError()
+    {
+        string uniqueFontName = "GumThrowingFontCreatorTest_" + Guid.NewGuid().ToString("N");
+        ThrowingFontCreator creator = new ThrowingFontCreator();
+        IRaylibFontCreator? saved = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        string? capturedMessage = null;
+        void Handler(string message) => capturedMessage = message;
+        CustomSetPropertyOnRenderable.PropertyAssignmentError += Handler;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new TextRuntime();
+            textRuntime.Font = uniqueFontName;
+            textRuntime.FontSize = 20;
+
+            capturedMessage.ShouldNotBeNull();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = saved;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
         }
     }
 }

--- a/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/TextMarkupTests.cs
@@ -192,6 +192,49 @@ public class TextMarkupTests : BaseTestClass
         }
     }
 
+    // The bug this pins: a wired creator that throws for the inline run specifically (base font at 21
+    // still succeeds) was previously swallowed by a bare catch, silently falling back to the raw-size
+    // float behavior with no way for the game/developer to find out. Resetting capturedMessage after
+    // the base-font assignment isolates the inline run's own failure from the base font's.
+    [Fact]
+    public void Text_WithFontSizeMarkup_WhenFontCreatorThrows_FallsBackAndInvokesPropertyAssignmentError()
+    {
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        string? capturedMessage = null;
+        void Handler(string message) => capturedMessage = message;
+        CustomSetPropertyOnRenderable.PropertyAssignmentError += Handler;
+        try
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new ThrowsAboveSizeFontCreator(throwAboveSize: 21);
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 21;
+
+            capturedMessage = null;
+            textRuntime.Text = "Big [FontSize=40]text[/FontSize]";
+
+            Text internalText = (Text)textRuntime.RenderableComponent;
+
+            // The swap-in run (size 40) throws and falls back to the raw-size float behavior; the
+            // pop-back-to-base run (size 21, at the throw threshold) still succeeds and resolves to a
+            // crisp font -- same two-run shape as the fully-successful case, just with the first run
+            // degraded instead of crisp.
+            internalText.InlineVariables.Count.ShouldBe(2);
+            internalText.InlineVariables[0].VariableName.ShouldBe("BitmapFont");
+            internalText.InlineVariables[0].Value.ShouldBe(40f);
+            internalText.InlineVariables[1].VariableName.ShouldBe("BitmapFont");
+            Raylib_cs.Font popBackFont = internalText.InlineVariables[1].Value.ShouldBeOfType<Raylib_cs.Font>();
+            popBackFont.BaseSize.ShouldBe(21);
+            capturedMessage.ShouldNotBeNull();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+        }
+    }
+
     // #3624 (no-creator characterization): [IsBold], [IsItalic], [OutlineThickness], and [Font=Name] are
     // recognized tags, so their markup IS stripped from the visible RawText, but applying them requires a
     // rasterized atlas that only a wired font creator can produce - so with no creator they remain unapplied
@@ -798,6 +841,29 @@ public class TextMarkupTests : BaseTestClass
         public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
         {
             Requests.Add(bmfcSave);
+            return _inner.TryCreateFont(bmfcSave);
+        }
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator so requests at or below _throwAboveSize still produce a
+    // genuinely usable font (the base font resolves normally), while a request above that size throws -
+    // isolating a failure to one specific inline run.
+    private sealed class ThrowsAboveSizeFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+        private readonly int _throwAboveSize;
+
+        public ThrowsAboveSizeFontCreator(int throwAboveSize)
+        {
+            _throwAboveSize = throwAboveSize;
+        }
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            if (bmfcSave.FontSize > _throwAboveSize)
+            {
+                throw new InvalidOperationException("Simulated font rasterization failure.");
+            }
             return _inner.TryCreateFont(bmfcSave);
         }
     }

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeFontCachingRegressionTests.cs
@@ -138,6 +138,84 @@ public class TextRuntimeFontCachingRegressionTests : BaseTestClass
         }
     }
 
+    // Always declines (returns null) -- IRaylibFontCreator.TryCreateFont's own documented contract
+    // for "I can't produce this, fall through," not a failure. Used to prove PropertyAssignmentError
+    // distinguishes that normal decline (silent, when a later fallback tier still resolves a font)
+    // from a genuine total failure (nothing left to fall back to).
+    private sealed class DecliningFontCreator : IRaylibFontCreator
+    {
+        public int CallCount { get; private set; }
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave)
+        {
+            CallCount++;
+            return null;
+        }
+    }
+
+    // The gap this pins: a wired creator returning null (not throwing) was never routed through the
+    // exception-catch diagnostic, so when nothing else could resolve a font either, the text still
+    // silently ended up on raylib's default font with zero indication anything went wrong.
+    [Fact]
+    public void UpdateToFontValues_WhenCreatorDeclinesAndNoFallbackResolves_ShouldInvokePropertyAssignmentError()
+    {
+        WithCachingOnAndNoFontFiles(() =>
+        {
+            DecliningFontCreator creator = new();
+            IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+            string? capturedMessage = null;
+            void Handler(string message) => capturedMessage = message;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError += Handler;
+            try
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+                TextRuntime textRuntime = new();
+                textRuntime.SetProperty("Font", "GumNoFallbackFontTest_" + Guid.NewGuid().ToString("N"));
+                textRuntime.SetProperty("FontSize", 18);
+
+                creator.CallCount.ShouldBeGreaterThan(0);
+                capturedMessage.ShouldNotBeNull();
+            }
+            finally
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+                CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+            }
+        });
+    }
+
+    // The guard the fix above must not break: a creator declining is normal when a later fallback
+    // tier (here, the disk FontCache) still resolves a usable font -- that must stay completely
+    // silent, or every project using a partial-coverage-by-design creator would get spurious errors.
+    [Fact]
+    public void UpdateToFontValues_WhenCreatorDeclinesButDiskFallbackResolves_ShouldNotInvokePropertyAssignmentError()
+    {
+        WithFont18ArialCached(() =>
+        {
+            DecliningFontCreator creator = new();
+            IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+            string? capturedMessage = null;
+            void Handler(string message) => capturedMessage = message;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError += Handler;
+            try
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+                TextRuntime textRuntime = NewArial18Text("Declined but disk-cached");
+
+                creator.CallCount.ShouldBeGreaterThan(0);
+                textRuntime.AbsoluteHeight.ShouldBeGreaterThan(0);
+                capturedMessage.ShouldBeNull();
+            }
+            finally
+            {
+                CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+                CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+            }
+        });
+    }
+
     // Positive guard for the user-visible symptom: with valid fonts, a vertical stack must reflow to the
     // summed line heights (2 x 21) and the second item must sit below the first.
     [Fact]


### PR DESCRIPTION
## Summary
- Raylib's two `InMemoryFontCreator.TryCreateFont` catch sites (inline BBCode-run resolution, and the main `UpdateToFontValues` path) silently swallowed any thrown failure and fell back to raylib's default font with zero diagnostics — reported via a KernSmith+WebAssembly bug report where a custom font silently never applied.
- Both now raise `CustomSetPropertyOnRenderable.PropertyAssignmentError` with the caught exception before falling through.
- Extended the main `UpdateToFontValues` path further: `TryCreateFont` returning `null` (not throwing) is `IRaylibFontCreator`'s documented "can't produce this, fall through" signal, so it never hit the exception-catch. Now it also fires `PropertyAssignmentError`, but **only** once disk cache and system-font fallback have both also failed — a creator that intentionally declines some fonts by design, with a working fallback tier, stays completely silent.
- Filed #4464 for the matching gap in the MonoGame/KNI (`GetOrCreateBakedFont`) path, left out of this PR's scope.
- Updated `gum-runtime-fonts` skill to note the fix and the remaining MonoGame/KNI asymmetry.

## Test plan
- [x] `UpdateToFontValues_WhenInMemoryFontCreatorThrows_ShouldInvokePropertyAssignmentError` (new) — red before the fix, green after.
- [x] `Text_WithFontSizeMarkup_WhenFontCreatorThrows_FallsBackAndInvokesPropertyAssignmentError` (new) — red before the fix, green after.
- [x] `UpdateToFontValues_WhenCreatorDeclinesAndNoFallbackResolves_ShouldInvokePropertyAssignmentError` (new) — red before the fix, green after.
- [x] `UpdateToFontValues_WhenCreatorDeclinesButDiskFallbackResolves_ShouldNotInvokePropertyAssignmentError` (new) — verified this catches a naive "always fire on decline" implementation (temporarily swapped in, confirmed red, reverted).
- [x] Full `RaylibGum.Tests` suite: 602/602 passing, no regressions.
- [x] No new compiler warnings.
- FRB canary: not needed — all edits are entirely inside `#if RAYLIB` blocks, never compiled for FRB1.
- Manual test: not needed — the fix only changes diagnostic behavior (an event now fires on genuine failure); the fallback rendering behavior itself is unchanged and already covered by existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)