### PR TITLE
Clarify unqualified vs qualified instance variable references in docs

### DIFF
--- a/docs/gum-tool/gum-elements/general-properties/variable-references.md
+++ b/docs/gum-tool/gum-elements/general-properties/variable-references.md
@@ -119,6 +119,14 @@ Instances can reference their own variables, but these must be qualified. For ex
 Width = ColoredRectangleInstance.Height
 ```
 
+<a id="unqualified-instance-warning"></a>
+
+{% hint style="warning" %}
+Skipping the qualification isn't an error, it's a different reference. `X = Height` on an instance resolves `Height` against the **containing component**, not the instance. To reference the instance's own `Height`, qualify it: `X = ColoredRectangleInstance.Height`.
+
+The Variable References grid protects you from this by auto-qualifying bare names to the selected instance when you tab out, so this mix-up mostly only happens in hand-edited or generated project XML.
+{% endhint %}
+
 Variables can be assigned to constant values, essentially locking the value:
 
 ```csharp
@@ -300,7 +308,7 @@ Y = Components/SameComponent.InstanceInComponent.Y
 Y = InstanceInComponent.Y
 ```
 
-Instances must qualify their own variables as shown in the following code:
+Instances must qualify their own variables. See [the warning above](#unqualified-instance-warning) for what an unqualified name means instead:
 
 ```csharp
 X = SameInstance.Y


### PR DESCRIPTION
## Summary
Instance-scoped Variable References must qualify their own variable references (e.g. `X = SameInstance.Y`), but the docs never explained *why* - what an unqualified name (`X = Y`) resolves to instead. Verified against `ApplyVariableReferencesOnSpecificOwner`/`RecursiveVariableFinder` and `EvaluatedSyntax.Evaluate`: an unqualified right-side name on an instance's reference row resolves against the containing component, not the instance, since instance-owned variables are namespaced `InstanceName.Y` in state data.

Adds a warning hint spelling this out, plus notes the grid auto-qualifies bare names on tab-out so the ambiguity mostly only bites hand-edited/generated project XML. Trimmed the second "must qualify" mention further down the page to link back instead of repeating the rule.

## Test plan
- [x] Docs-only change, GitBook markdown syntax follows existing page conventions (hint block, anchor link)