### PR TITLE
Bump Apos.Shapes to 0.8.1, fix DrawRing thickness regression

### DIFF
--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -42,14 +42,12 @@
 			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
 			ship is gone; consumers just reference the package.
 
-			0.7.10, not the latest (0.8.1): upstream's own changelog says the OpenGL shader
-			"still failed to load ... with Shader Compilation Failed" on macOS/WebGL through
-			0.7.9, fixed in 0.7.10 (#4410 - same exception this repo hit on Mesa llvmpipe).
-			0.7.11 changes DrawRing's second-radius semantics (rings render 2x thicker) with
-			no compensating change in Arc.cs, so staying at 0.7.10 avoids that behavior change
-			until Arc.cs and its tests are updated deliberately.
+			Bumped from 0.7.10 to 0.8.1 for issue #4473 (RectangleRuntime crashed on macOS/Linux
+			GL drivers under the pinned 0.7.10 shader). 0.7.11's DrawRing second-radius semantics
+			change (rings would render 2x thicker) is compensated for in Arc.cs's DrawRing call —
+			see AposShapeGeometryTests for the pixel-level regression guard.
 		-->
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.7.10" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="0.8.1" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -42,14 +42,12 @@
 			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
 			ship is gone; consumers just reference the package.
 
-			0.7.10, not the latest (0.8.1): upstream's own changelog says the OpenGL shader
-			"still failed to load ... with Shader Compilation Failed" on macOS/WebGL through
-			0.7.9, fixed in 0.7.10 (#4410 - same exception this repo hit on Mesa llvmpipe).
-			0.7.11 changes DrawRing's second-radius semantics (rings render 2x thicker) with
-			no compensating change in Arc.cs, so staying at 0.7.10 avoids that behavior change
-			until Arc.cs and its tests are updated deliberately.
+			Bumped from 0.7.10 to 0.8.1 for issue #4473 (RectangleRuntime crashed on macOS/Linux
+			GL drivers under the pinned 0.7.10 shader). 0.7.11's DrawRing second-radius semantics
+			change (rings would render 2x thicker) is compensated for in Arc.cs's DrawRing call —
+			see AposShapeGeometryTests for the pixel-level regression guard.
 		-->
-		<PackageReference Include="Apos.Shapes" Version="0.7.10" />
+		<PackageReference Include="Apos.Shapes" Version="0.8.1" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/Runtimes/GumShapes/Renderables/Arc.cs
+++ b/Runtimes/GumShapes/Renderables/Arc.cs
@@ -188,14 +188,10 @@ internal class Arc : RenderableShapeBase
         }
         else
         {
-            // Apos.Shapes 0.6.x DrawRing's signature is (radius1, radius2) but the shader actually
-            // uses them as (centerline, totalThickness): see RingSDF, abs(length(p) - r) - th * 0.5.
-            // The shader also does radius1 -= 1f internally, so the rendered band sits one pixel
-            // inside what the caller thinks it asked for. Without the +1f compensation here, an Arc
-            // sized to fit a NxN bounding box renders with a visible 1-pixel gap at its outer edge -
-            // confirmed visually by overlaying a thick Arc on a same-size filled Circle and seeing a
-            // thin background-color ring around the outside of the Arc.
-            var compensatedRadius = radius + 1f;
+            // Apos.Shapes 0.7.11+ radius1 is the exact centerline (the prior off-by-one that used
+            // to need a +1f compensation here is fixed upstream), and radius2 is the band's half
+            // thickness, matching DrawArc's endpointRadius convention below.
+            var ringThickness = lineThickness / 2;
 
             if (ShouldPaintGradient(forcedColor))
             {
@@ -203,8 +199,8 @@ internal class Arc : RenderableShapeBase
                 sb.DrawRing(center,
                     startAngleRadians,
                     endAngleRadians,
-                    compensatedRadius,
-                    lineThickness,
+                    radius,
+                    ringThickness,
                     gradient,
                     gradient,
                     1,
@@ -217,8 +213,8 @@ internal class Arc : RenderableShapeBase
                 sb.DrawRing(center,
                     startAngleRadians,
                     endAngleRadians,
-                    compensatedRadius,
-                    lineThickness,
+                    radius,
+                    ringThickness,
                     color,
                     color,
                     1,

--- a/Tests/Gum.ProjectServices.MonoGame.Tests/AposShapeGeometryTests.cs
+++ b/Tests/Gum.ProjectServices.MonoGame.Tests/AposShapeGeometryTests.cs
@@ -1,0 +1,316 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.ProjectServices;
+using Gum.ProjectServices.MonoGame;
+using Gum.ProjectServices.Screenshot;
+using Shouldly;
+using SkiaSharp;
+
+namespace Gum.ProjectServices.MonoGame.Tests;
+
+/// <summary>
+/// Real-GraphicsDevice pixel tests for Apos.Shapes-backed rendering, added ahead of the
+/// Apos.Shapes 0.7.10 -> latest version bump tracked in issue #4473. These run against the same
+/// Mesa llvmpipe software OpenGL CI uses for this project (see build-and-test.yaml), so they
+/// exercise the real shader-compile-and-draw path a plain unit test cannot.
+/// </summary>
+/// <remarks>
+/// <see cref="TakeScreenshot_FilledRoundedRectangle_CutsCorners"/> covers the exact shape from
+/// #4473's repro (RectangleRuntime, IsFilled + CornerRadius) that MonoGameScreenshotServiceTests
+/// only covers for Circle.
+///
+/// <see cref="TakeScreenshot_Arc_RendersStrokeAtRequestedThickness"/> guards against a specific
+/// known risk of upgrading past 0.7.10: Apos.Shapes 0.7.11's changelog says DrawRing's second
+/// radius parameter changed meaning from "total thickness" to "half thickness" ("rings come out
+/// twice as thick as before"). Arc.cs's DrawRing call was never updated for that change (the
+/// version pin in MonoGameGumShapes.csproj exists specifically to avoid it), so bumping the
+/// package without also fixing Arc.cs would silently double every Arc/Ring stroke's rendered
+/// width. This test measures the actual rendered band width in pixels so that regression can't
+/// land unnoticed.
+/// </remarks>
+public class AposShapeGeometryTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public AposShapeGeometryTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(), "GumAposShapeGeometryTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    // ProjectCreator only seeds core Gum's own standards (Circle, Rectangle, etc - see
+    // ProjectCreator.StandardElementNames); "Arc" is shapes-runtime-only, so a headless project
+    // needs its own Standards/Arc.gutx on disk before GumService.Initialize will recognize
+    // ArcInstance's BaseType on load. Content matches the real template the Gum tool writes.
+    private const string ArcStandardTemplate =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <StandardElementSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <Name>Arc</Name>
+          <State>
+            <Name>Default</Name>
+            <Variable><Type>int</Type><Name>Alpha</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Alpha1</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Alpha2</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>Blend</Type><Name>Blend</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Blue</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Blue1</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Blue2</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>DropshadowAlpha</Name><Value xsi:type="xsd:int">255</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>DropshadowBlue</Name><Value xsi:type="xsd:int">0</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>DropshadowBlurX</Name><Value xsi:type="xsd:float">0</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>DropshadowBlurY</Name><Value xsi:type="xsd:float">3</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>DropshadowGreen</Name><Value xsi:type="xsd:int">0</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>DropshadowOffsetX</Name><Value xsi:type="xsd:float">0</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>DropshadowOffsetY</Name><Value xsi:type="xsd:float">3</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>DropshadowRed</Name><Value xsi:type="xsd:int">0</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>ExposeChildrenEvents</Name><Value xsi:type="xsd:boolean">false</Value><Category>Behavior</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientInnerRadius</Name><Value xsi:type="xsd:float">50</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>DimensionUnitType</Type><Name>GradientInnerRadiusUnits</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientOuterRadius</Name><Value xsi:type="xsd:float">100</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>DimensionUnitType</Type><Name>GradientOuterRadiusUnits</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>GradientType</Type><Name>GradientType</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientX1</Name><Value xsi:type="xsd:float">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>GradientX1Units</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientX2</Name><Value xsi:type="xsd:float">100</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>GradientX2Units</Name><Value xsi:type="xsd:int">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientY1</Name><Value xsi:type="xsd:float">0</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>GradientY1Units</Name><Value xsi:type="xsd:int">1</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>GradientY2</Name><Value xsi:type="xsd:float">100</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>GradientY2Units</Name><Value xsi:type="xsd:int">1</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Green</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Green1</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Green2</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>HasDropshadow</Name><Value xsi:type="xsd:boolean">false</Value><Category>Dropshadow</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>HasEvents</Name><Value xsi:type="xsd:boolean">false</Value><Category>Behavior</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>Height</Name><Value xsi:type="xsd:float">100</Value><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>DimensionUnitType</Type><Name>HeightUnits</Name><Value xsi:type="xsd:int">0</Value><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>IgnoredByParentSize</Name><Value xsi:type="xsd:boolean">false</Value><Category>Parent</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>IsEndRounded</Name><Value xsi:type="xsd:boolean">false</Value><Category>Arc</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float?</Type><Name>MaxHeight</Name><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float?</Type><Name>MaxWidth</Name><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float?</Type><Name>MinHeight</Name><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float?</Type><Name>MinWidth</Name><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>string</Type><Name>Parent</Name><Category>Parent</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Red</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Red1</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>int</Type><Name>Red2</Name><Value xsi:type="xsd:int">255</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>StartAngle</Name><Value xsi:type="xsd:float">0</Value><Category>Arc</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>State</Type><Name>State</Name><Value xsi:type="xsd:string">Default</Value><SetsValue>false</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>SweepAngle</Name><Value xsi:type="xsd:float">90</Value><Category>Arc</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>Thickness</Name><Value xsi:type="xsd:float">10</Value><Category>Arc</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>UseGradient</Name><Value xsi:type="xsd:boolean">false</Value><Category>Rendering</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>bool</Type><Name>Visible</Name><Value xsi:type="xsd:boolean">true</Value><Category>States and Visibility</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>Width</Name><Value xsi:type="xsd:float">100</Value><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>DimensionUnitType</Type><Name>WidthUnits</Name><Value xsi:type="xsd:int">0</Value><Category>Dimensions</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>X</Name><Value xsi:type="xsd:float">0</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>HorizontalAlignment</Type><Name>XOrigin</Name><Value xsi:type="xsd:int">0</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>XUnits</Name><Value xsi:type="xsd:int">0</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>float</Type><Name>Y</Name><Value xsi:type="xsd:float">0</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>VerticalAlignment</Type><Name>YOrigin</Name><Value xsi:type="xsd:int">0</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <Variable><Type>PositionUnitType</Type><Name>YUnits</Name><Value xsi:type="xsd:int">1</Value><Category>Position</Category><SetsValue>true</SetsValue></Variable>
+            <VariableList xsi:type="VariableListSaveOfString">
+              <Type>string</Type>
+              <Name>VariableReferences</Name>
+              <Category>References</Category>
+              <IsFile>false</IsFile>
+              <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+              <Value />
+            </VariableList>
+          </State>
+          <Behaviors />
+        </StandardElementSave>
+        """;
+
+    private static void WriteArcStandardTemplate(string projectDirectory)
+    {
+        string standardsDir = Path.Combine(projectDirectory, "Standards");
+        Directory.CreateDirectory(standardsDir);
+        File.WriteAllText(Path.Combine(standardsDir, "Arc.gutx"), ArcStandardTemplate);
+    }
+
+    [Fact]
+    public void TakeScreenshot_Arc_RendersStrokeAtRequestedThickness()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+        WriteArcStandardTemplate(_tempDirectory);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "ArcInstance",
+            BaseType = "Arc",
+            ParentContainer = screen,
+        };
+        screen.Instances.Add(instance);
+
+        // StartAngle/SweepAngle straddle angle 0 (the +X direction from center) so the horizontal
+        // scanline through the center cuts the stroke band where it's aligned with the X axis,
+        // away from the arc's end caps.
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.X", Type = "float", Value = 20f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Y", Type = "float", Value = 20f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Width", Type = "float", Value = 160f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Height", Type = "float", Value = 160f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Thickness", Type = "float", Value = 16f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.StartAngle", Type = "float", Value = -10f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.SweepAngle", Type = "float", Value = 20f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.IsEndRounded", Type = "bool", Value = false, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Red", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Green", Type = "int", Value = 255, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Blue", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "ArcInstance.Alpha", Type = "int", Value = 255, SetsValue = true });
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+        // ProjectCreator only seeds core Gum's own standards (Circle, Rectangle, etc); "Arc" is
+        // shapes-runtime-only, so it must be registered explicitly for a headless project to
+        // recognize ArcInstance's BaseType on load.
+        project.StandardElementReferences.Add(new ElementReference
+        {
+            Name = "Arc",
+            ElementType = ElementType.Standard,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+        MonoGameScreenshotService service = new MonoGameScreenshotService();
+
+        ScreenshotResult result = service.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "Screen",
+            OutputPath = outputPath,
+            Width = 200,
+            Height = 200,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+
+        using SKBitmap bitmap = SKBitmap.Decode(outputPath);
+
+        int bandStart = -1;
+        int bandEnd = -1;
+        for (int x = 140; x < 200; x++)
+        {
+            bool isOpaque = bitmap.GetPixel(x, 100).Alpha > 128;
+            if (isOpaque && bandStart == -1)
+            {
+                bandStart = x;
+            }
+            if (isOpaque)
+            {
+                bandEnd = x;
+            }
+        }
+
+        bandStart.ShouldBeGreaterThan(-1, "expected an opaque stroke band along the scanline but found none");
+
+        int bandWidth = bandEnd - bandStart + 1;
+        // Allows slack for antialiasing around the requested Thickness (16), while staying well
+        // under double that -- what 0.7.11's "half thickness" DrawRing semantics would produce.
+        bandWidth.ShouldBeInRange(10, 22);
+    }
+
+    [Fact]
+    public void TakeScreenshot_FilledRoundedRectangle_CutsCorners()
+    {
+        string projectPath = Path.Combine(_tempDirectory, "Project.gumx");
+
+        ProjectCreator creator = new ProjectCreator();
+        GumProjectSave project = creator.Create(projectPath);
+
+        ScreenSave screen = new ScreenSave { Name = "Screen" };
+        StateSave defaultState = new StateSave { Name = "Default", ParentContainer = screen };
+        screen.States.Add(defaultState);
+
+        InstanceSave instance = new InstanceSave
+        {
+            Name = "RectangleInstance",
+            BaseType = "Rectangle",
+            ParentContainer = screen,
+        };
+        screen.Instances.Add(instance);
+
+        // Same shape as #4473's repro: IsFilled + CornerRadius on a 100x100 RectangleRuntime.
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.X", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Y", Type = "float", Value = 0f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Width", Type = "float", Value = 100f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.Height", Type = "float", Value = 100f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.IsFilled", Type = "bool", Value = true, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.CornerRadius", Type = "float", Value = 10f, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillRed", Type = "int", Value = 255, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillGreen", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillBlue", Type = "int", Value = 0, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.FillAlpha", Type = "int", Value = 255, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Name = "RectangleInstance.StrokeWidth", Type = "float", Value = 0f, SetsValue = true });
+
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = "Screen",
+            ElementType = ElementType.Screen,
+        });
+
+        project.Save(projectPath, saveElements: true);
+
+        string outputPath = Path.Combine(_tempDirectory, "Screen.png");
+        MonoGameScreenshotService service = new MonoGameScreenshotService();
+
+        ScreenshotResult result = service.TakeScreenshot(new ScreenshotRequest
+        {
+            ProjectPath = projectPath,
+            ElementName = "Screen",
+            OutputPath = outputPath,
+            Width = 200,
+            Height = 150,
+        });
+
+        result.Success.ShouldBeTrue(result.ErrorMessage);
+        File.Exists(outputPath).ShouldBeTrue();
+
+        using SKBitmap bitmap = SKBitmap.Decode(outputPath);
+        bitmap.Width.ShouldBe(200);
+        bitmap.Height.ShouldBe(150);
+
+        // Center of the rectangle: opaque fill.
+        SKColor center = bitmap.GetPixel(50, 50);
+        center.Red.ShouldBeInRange((byte)245, (byte)255);
+        center.Green.ShouldBeLessThan((byte)10);
+        center.Blue.ShouldBeLessThan((byte)10);
+        center.Alpha.ShouldBeInRange((byte)245, (byte)255);
+
+        // Edge midpoint, away from any corner: still square here, so still opaque fill.
+        SKColor edgeMidpoint = bitmap.GetPixel(50, 1);
+        edgeMidpoint.Alpha.ShouldBeInRange((byte)245, (byte)255);
+
+        // Tip of the top-left corner: CornerRadius=10 cuts this away, so it must be background
+        // (transparent), not fill color. If corner rounding regresses back to a square rect this
+        // pixel goes opaque and catches it.
+        SKColor cornerTip = bitmap.GetPixel(1, 1);
+        cornerTip.Alpha.ShouldBeLessThan((byte)10);
+
+        // Fully outside the rectangle: background clear must stay fully transparent.
+        SKColor outside = bitmap.GetPixel(150, 120);
+        outside.Alpha.ShouldBeLessThan((byte)10);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Bump `Apos.Shapes` / `Apos.Shapes.KNI` from 0.7.10 to 0.8.1. The pinned 0.7.10 shader still crashed `RectangleRuntime` rendering on macOS/Linux GL drivers (this issue). 0.7.11's shader-size/compile-time reduction is the most likely upstream fix, per the Apos.Shapes changelog.
- Fix `Arc.cs`'s `DrawRing` call for 0.7.11's second-radius semantics change (total thickness to half thickness). Left unfixed, this would have silently doubled every Arc/Ring stroke's rendered width, exactly why the version was pinned at 0.7.10 in the first place.
- Add `AposShapeGeometryTests`: real-`GraphicsDevice` pixel tests (run against Mesa llvmpipe software GL in CI, the same class of driver that caused the earlier related #4410 crash) covering the exact repro shape (filled + `CornerRadius` `RectangleRuntime`) and a stroke-thickness regression guard for the `DrawRing` change. Reverting the `Arc.cs` fix alone made the new Arc test fail with a measured ~2x band width, confirming both the regression risk and the test.

## Verification
Full local suites green against 0.8.1: `Gum.ProjectServices.MonoGame.Tests` (3/3), `MonoGameGum.Shapes.Tests` (225/225), `MonoGameGum.IntegrationTests` (85/85, real `GraphicsDevice`), plus a clean `GumFull.sln` build.

**Not verified: the actual macOS/Linux crash.** Neither this environment (Windows) nor the reporter's Mac could reproduce it locally, even at the pinned 0.7.10, so there's nothing to confirm the fix against directly. The evidence above is indirect, not a reproduction of the original crash.

@greenstack, if you get a chance, could you try this branch (or the next release) against your original repro and confirm the crash is gone? Flagging since we can't verify it ourselves.

Closes #4473
