### PR TITLE
Support .achj (JSON) animation chain format alongside .achx

### DIFF
--- a/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Json.Nodes;
 using System.Xml.Serialization;
 using ToolsUtilities;
 
@@ -73,7 +75,16 @@ namespace Gum.Content.AnimationChain
         {
             AnimationChainListSave? toReturn = null;
 
-            if (ManualDeserialization)
+            if (IsJsonFileName(fileName))
+            {
+                // JsonNode-based parsing does no reflection/codegen, so it works on Android/iOS
+                // (ManualDeserialization) the same as any other platform — no separate branch needed.
+                using (Stream stream = FileManager.GetStreamForFile(fileName))
+                {
+                    toReturn = ParseJson(JsonNode.Parse(stream)!.AsObject());
+                }
+            }
+            else if (ManualDeserialization)
             {
                 throw new NotImplementedException();
                 //toReturn = DeserializeManually(fileName);
@@ -181,6 +192,79 @@ namespace Gum.Content.AnimationChain
         {
             // do nothing, just need this to add it to the loader manager
         }
+
+        #region JSON (.achj)
+
+        /// <summary>True when <paramref name="fileName"/> has a .achj (JSON) extension; false for .achx or anything else.</summary>
+        private static bool IsJsonFileName(string fileName) =>
+            fileName.EndsWith(".achj", StringComparison.OrdinalIgnoreCase);
+
+        // Property names match FlatRedBall2's AnimationChain.Common .achj writer (camelCase) so a
+        // file authored by the FlatRedBall Animation Editor loads into Gum without a conversion
+        // step. Fields FRB2 added that Gum's AnimationFrameSave doesn't model yet — FlipDiagonal,
+        // Red/Green/Blue/Alpha, ColorOperation, per-frame shapes (#4477, #4478, #4479) — are simply
+        // not read; JsonObject's indexer returns null for a missing key, so those files still load,
+        // just without that data.
+        private static AnimationChainListSave ParseJson(JsonObject root)
+        {
+            AnimationChainListSave result = new AnimationChainListSave();
+
+            if (root["fileRelativeTextures"] is JsonValue frt)
+                result.FileRelativeTextures = frt.GetValue<bool>();
+
+            if (root["timeMeasurementUnit"] is JsonValue tmu)
+                result.TimeMeasurementUnit = Enum.Parse<TimeMeasurementUnit>(tmu.GetValue<string>()!);
+
+            if (root["coordinateType"] is JsonValue ct)
+                result.CoordinateType = Enum.Parse<TextureCoordinateType>(ct.GetValue<string>()!);
+
+            if (root["animationChains"] is JsonArray chainsArray)
+            {
+                foreach (JsonNode? chainNode in chainsArray)
+                {
+                    JsonObject chainObj = chainNode!.AsObject();
+                    AnimationChainSave chain = new AnimationChainSave
+                    {
+                        Name = chainObj["name"]?.GetValue<string>() ?? string.Empty
+                    };
+
+                    if (chainObj["frames"] is JsonArray framesArray)
+                    {
+                        foreach (JsonNode? frameNode in framesArray)
+                            chain.Frames.Add(ParseFrameJson(frameNode!.AsObject()));
+                    }
+
+                    result.AnimationChains.Add(chain);
+                }
+            }
+
+            return result;
+        }
+
+        private static AnimationFrameSave ParseFrameJson(JsonObject frameObj)
+        {
+            return new AnimationFrameSave
+            {
+                TextureName = frameObj["textureName"]?.GetValue<string>() ?? string.Empty,
+                FrameLength = FloatProperty(frameObj, "frameLength"),
+                LeftCoordinate = FloatProperty(frameObj, "leftCoordinate"),
+                RightCoordinate = FloatProperty(frameObj, "rightCoordinate", 1f),
+                TopCoordinate = FloatProperty(frameObj, "topCoordinate"),
+                BottomCoordinate = FloatProperty(frameObj, "bottomCoordinate", 1f),
+                FlipHorizontal = BoolProperty(frameObj, "flipHorizontal"),
+                FlipVertical = BoolProperty(frameObj, "flipVertical"),
+                RelativeX = FloatProperty(frameObj, "relativeX"),
+                RelativeY = FloatProperty(frameObj, "relativeY"),
+            };
+        }
+
+        private static float FloatProperty(JsonObject parent, string name, float defaultValue = 0f) =>
+            parent[name] is JsonValue value ? value.GetValue<float>() : defaultValue;
+
+        private static bool BoolProperty(JsonObject parent, string name, bool defaultValue = false) =>
+            parent[name] is JsonValue value ? value.GetValue<bool>() : defaultValue;
+
+        #endregion
 
         #endregion
     }

--- a/Gum/PropertyGridHelpers/Converters/AvailableAnimationNamesConverter.cs
+++ b/Gum/PropertyGridHelpers/Converters/AvailableAnimationNamesConverter.cs
@@ -55,7 +55,7 @@ namespace Gum.PropertyGridHelpers.Converters
 
             var sourceFile = rfv.GetValue<string>(sourceFileVariableName);
 
-            if(sourceFile?.EndsWith(".achx") == true)
+            if(sourceFile?.EndsWith(".achx") == true || sourceFile?.EndsWith(".achj") == true)
             {
                 if(FileManager.IsRelative(sourceFile))
                 {

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -607,7 +607,7 @@ public partial class CustomSetPropertyOnRenderable
         {
             nineSlice.SetSingleTexture(null);
         }
-        else if (value.EndsWith(".achx"))
+        else if (IsAnimationChainFile(value))
         {
             AnimationChainList animationChainList = GetAnimationChainList(ref value, loaderManager);
 
@@ -3022,7 +3022,7 @@ public partial class CustomSetPropertyOnRenderable
 
             graphicalUiElement.UpdateLayout();
         }
-        else if (value.EndsWith(".achx"))
+        else if (IsAnimationChainFile(value))
         {
             AnimationChainList? animationChainList = null;
             try
@@ -3125,6 +3125,13 @@ public partial class CustomSetPropertyOnRenderable
         handled = true;
         return handled;
     }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> is an animation chain source file — .achx (XML) or
+    /// .achj (JSON, see AnimationChainListSave.FromFile).
+    /// </summary>
+    private static bool IsAnimationChainFile(string value) =>
+        value.EndsWith(".achx") || value.EndsWith(".achj");
 
     private static AnimationChainList? GetAnimationChainList(ref string value,
         // fully qualify to avoid Android namign conflicts

--- a/GumCommon/ILLink.Descriptors.xml
+++ b/GumCommon/ILLink.Descriptors.xml
@@ -4,8 +4,8 @@
     <type fullname="Gum.StateAnimation.SaveClasses.*" preserve="all" />
     <type fullname="Gum.Forms.Controls.*" preserve="all" />
     <type fullname="Gum.Wireframe.GraphicalUiElement" preserve="all" />
-    <!-- AnimationChainListSave/AnimationChainSave/AnimationFrameSave: loaded from .achx files by
-         AnimationChainListSave.FromFile, reachable at runtime via
+    <!-- AnimationChainListSave/AnimationChainSave/AnimationFrameSave: loaded from .achx/.achj files
+         by AnimationChainListSave.FromFile, reachable at runtime via
          CustomSetPropertyOnRenderable's AnimationChains property setter. -->
     <type fullname="Gum.Content.AnimationChain.*" preserve="all" />
   </assembly>

--- a/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
+++ b/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using Gum.Content.AnimationChain;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Content;
+
+// Covers AnimationChainListSave.FromFile's .achj (JSON) dialect, added alongside the existing
+// .achx (XML) dialect (issue #4476). The JSON schema matches FlatRedBall2's AnimationChain.Common
+// .achj writer (camelCase property names) so files authored by the FlatRedBall Animation Editor
+// load into Gum without a conversion step.
+public class AnimationChainListSaveAchjTests
+{
+    [Fact]
+    public void FromFile_AchjExtension_ParsesListLevelProperties()
+    {
+        WithTempFile(".achj", """
+        {
+          "fileRelativeTextures": false,
+          "timeMeasurementUnit": "Millisecond",
+          "coordinateType": "Pixel",
+          "animationChains": []
+        }
+        """, path =>
+        {
+            AnimationChainListSave save = AnimationChainListSave.FromFile(path);
+
+            save.FileRelativeTextures.ShouldBeFalse();
+            save.TimeMeasurementUnit.ShouldBe(TimeMeasurementUnit.Millisecond);
+            save.CoordinateType.ShouldBe(TextureCoordinateType.Pixel);
+            save.AnimationChains.ShouldBeEmpty();
+        });
+    }
+
+    [Fact]
+    public void FromFile_AchjExtension_ParsesChainsAndFrames()
+    {
+        WithTempFile(".achj", """
+        {
+          "fileRelativeTextures": true,
+          "timeMeasurementUnit": "Second",
+          "coordinateType": "UV",
+          "animationChains": [
+            {
+              "name": "Walk",
+              "frames": [
+                {
+                  "textureName": "walk_0.png",
+                  "frameLength": 0.1,
+                  "leftCoordinate": 0.0,
+                  "rightCoordinate": 0.5,
+                  "topCoordinate": 0.0,
+                  "bottomCoordinate": 0.5,
+                  "flipHorizontal": true,
+                  "relativeX": 2.5,
+                  "relativeY": -1.5
+                }
+              ]
+            }
+          ]
+        }
+        """, path =>
+        {
+            AnimationChainListSave save = AnimationChainListSave.FromFile(path);
+
+            save.AnimationChains.Count.ShouldBe(1);
+            AnimationChainSave chain = save.AnimationChains[0];
+            chain.Name.ShouldBe("Walk");
+            chain.Frames.Count.ShouldBe(1);
+
+            AnimationFrameSave frame = chain.Frames[0];
+            frame.TextureName.ShouldBe("walk_0.png");
+            frame.FrameLength.ShouldBe(0.1f);
+            frame.LeftCoordinate.ShouldBe(0.0f);
+            frame.RightCoordinate.ShouldBe(0.5f);
+            frame.TopCoordinate.ShouldBe(0.0f);
+            frame.BottomCoordinate.ShouldBe(0.5f);
+            frame.FlipHorizontal.ShouldBeTrue();
+            frame.FlipVertical.ShouldBeFalse();
+            frame.RelativeX.ShouldBe(2.5f);
+            frame.RelativeY.ShouldBe(-1.5f);
+        });
+    }
+
+    [Fact]
+    public void FromFile_AchjExtension_FramesOmittingOptionalFields_UseAchxDefaults()
+    {
+        // Mirrors .achx's XmlDeserialize defaults: RightCoordinate/BottomCoordinate default to 1,
+        // flip flags and RelativeX/Y default to false/0 when the writer omits unset values.
+        WithTempFile(".achj", """
+        {
+          "animationChains": [
+            { "name": "Idle", "frames": [ { "textureName": "idle.png", "frameLength": 0.2 } ] }
+          ]
+        }
+        """, path =>
+        {
+            AnimationFrameSave frame = AnimationChainListSave.FromFile(path).AnimationChains[0].Frames[0];
+
+            frame.RightCoordinate.ShouldBe(1f);
+            frame.BottomCoordinate.ShouldBe(1f);
+            frame.FlipHorizontal.ShouldBeFalse();
+            frame.FlipVertical.ShouldBeFalse();
+            frame.RelativeX.ShouldBe(0f);
+            frame.RelativeY.ShouldBe(0f);
+        });
+    }
+
+    [Fact]
+    public void FromFile_AchjExtension_UnknownFrbTwoOnlyFields_AreIgnoredNotThrown()
+    {
+        // FlipDiagonal, Red/Green/Blue/Alpha, ColorOperation, and shapes are FRB2 additions Gum
+        // doesn't model yet (#4477, #4478, #4479) — an achj file carrying them must still load.
+        WithTempFile(".achj", """
+        {
+          "animationChains": [
+            {
+              "name": "Flash",
+              "frames": [
+                {
+                  "textureName": "flash.png",
+                  "frameLength": 0.05,
+                  "flipDiagonal": true,
+                  "red": 255,
+                  "green": 0,
+                  "blue": 0,
+                  "alpha": 255,
+                  "colorOperation": "Add",
+                  "shapes": { "rectangles": [], "circles": [], "polygons": [] }
+                }
+              ]
+            }
+          ]
+        }
+        """, path =>
+        {
+            Should.NotThrow(() => AnimationChainListSave.FromFile(path))
+                .AnimationChains[0].Frames[0].TextureName.ShouldBe("flash.png");
+        });
+    }
+
+    [Fact]
+    public void FromFile_AchxExtension_StillParsesAsXml()
+    {
+        // Extension-based dialect selection must not regress the existing XML path.
+        WithTempFile(".achx", """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AnimationChainArraySave>
+          <FileRelativeTextures>true</FileRelativeTextures>
+          <TimeMeasurementUnit>Second</TimeMeasurementUnit>
+          <CoordinateType>UV</CoordinateType>
+          <AnimationChain>
+            <Name>Walk</Name>
+            <Frame>
+              <TextureName>walk_0.png</TextureName>
+              <FrameLength>0.1</FrameLength>
+              <LeftCoordinate>0</LeftCoordinate>
+              <RightCoordinate>1</RightCoordinate>
+              <TopCoordinate>0</TopCoordinate>
+              <BottomCoordinate>1</BottomCoordinate>
+            </Frame>
+          </AnimationChain>
+        </AnimationChainArraySave>
+        """, path =>
+        {
+            AnimationChainListSave save = AnimationChainListSave.FromFile(path);
+
+            save.AnimationChains.Count.ShouldBe(1);
+            save.AnimationChains[0].Frames[0].TextureName.ShouldBe("walk_0.png");
+        });
+    }
+
+    private static void WithTempFile(string extension, string content, Action<string> action)
+    {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllText(path, content);
+        try
+        {
+            action(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Tests/Gum.Presentation.Tests/SetVariableLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/SetVariableLogicTests.cs
@@ -85,6 +85,32 @@ public class SetVariableLogicTests : BaseTestClass
     }
 
     [Fact]
+    public void GetWhySourcefileIsInvalid_ShouldReturnNull_WhenExtensionIsAchx()
+    {
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave();
+
+        string result = _setVariableLogic.GetWhySourcefileIsInvalid(
+            "animation.achx", element, instance, "SourceFile");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetWhySourcefileIsInvalid_ShouldReturnNull_WhenExtensionIsAchj()
+    {
+        // .achj (JSON) counterpart of .achx (#4476/#4480) — setting a Sprite's SourceFile to an
+        // .achj must not be rejected by this validation gate.
+        ComponentSave element = new ComponentSave();
+        InstanceSave instance = new InstanceSave();
+
+        string result = _setVariableLogic.GetWhySourcefileIsInvalid(
+            "animation.achj", element, instance, "SourceFile");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
     public void GetWhySourcefileIsInvalid_ShouldReturnNull_WhenPluginAcceptsExtension()
     {
         ComponentSave element = new ComponentSave();
@@ -304,6 +330,77 @@ public class SetVariableLogicTests : BaseTestClass
         response.Succeeded.ShouldBeTrue();
         mocker.GetMock<Gum.Undo.IUndoManager>()
             .Verify(x => x.RecordUndo(), Times.Once());
+    }
+
+    [Fact]
+    public void ReactToPropertyValueChanged_ShouldSetTextureAddressToCustom_WhenSourceFileExtensionIsAchx()
+    {
+        ComponentSave container = new ComponentSave();
+        container.States.Add(new StateSave());
+        container.DefaultState.ParentContainer = container;
+
+        InstanceSave instance = new InstanceSave();
+        instance.Name = "SpriteInstance";
+        instance.BaseType = "Sprite";
+
+        container.DefaultState.SetValue(
+            "SpriteInstance.SourceFile",
+            "animation.achx");
+
+        Mock<ISelectedState> selectedState = mocker.GetMock<ISelectedState>();
+        selectedState
+            .Setup(x => x.SelectedStateSave)
+            .Returns(container.DefaultState);
+
+        GeneralResponse response = _setVariableLogic.ReactToPropertyValueChanged(
+            "SourceFile",
+            "",
+            container,
+            instance,
+            container.DefaultState,
+            refresh: false);
+
+        response.Succeeded.ShouldBeTrue();
+        VariableSave textureAddress = container.DefaultState.GetVariableSave("SpriteInstance.TextureAddress");
+        textureAddress.ShouldNotBeNull();
+        textureAddress.Value.ShouldBe(TextureAddress.Custom);
+    }
+
+    [Fact]
+    public void ReactToPropertyValueChanged_ShouldSetTextureAddressToCustom_WhenSourceFileExtensionIsAchj()
+    {
+        // .achj (JSON) counterpart of the .achx test above (#4476/#4480) — this must not be
+        // rejected by GetWhySourcefileIsInvalid, and must also flip TextureAddress to Custom
+        // the same way .achx does, or per-frame texture coordinates never get applied.
+        ComponentSave container = new ComponentSave();
+        container.States.Add(new StateSave());
+        container.DefaultState.ParentContainer = container;
+
+        InstanceSave instance = new InstanceSave();
+        instance.Name = "SpriteInstance";
+        instance.BaseType = "Sprite";
+
+        container.DefaultState.SetValue(
+            "SpriteInstance.SourceFile",
+            "animation.achj");
+
+        Mock<ISelectedState> selectedState = mocker.GetMock<ISelectedState>();
+        selectedState
+            .Setup(x => x.SelectedStateSave)
+            .Returns(container.DefaultState);
+
+        GeneralResponse response = _setVariableLogic.ReactToPropertyValueChanged(
+            "SourceFile",
+            "",
+            container,
+            instance,
+            container.DefaultState,
+            refresh: false);
+
+        response.Succeeded.ShouldBeTrue();
+        VariableSave textureAddress = container.DefaultState.GetVariableSave("SpriteInstance.TextureAddress");
+        textureAddress.ShouldNotBeNull();
+        textureAddress.Value.ShouldBe(TextureAddress.Custom);
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/TreeNodeFolderExtensionsTests.cs
+++ b/Tests/Gum.Presentation.Tests/TreeNodeFolderExtensionsTests.cs
@@ -60,4 +60,23 @@ public class TreeNodeFolderExtensionsTests
 
         subfolder.Object.IsPartOfComponentsFolderStructure().ShouldBeTrue();
     }
+
+    [Fact]
+    public void IsTopScreenContainerTreeNode_ReturnsFalse_ForNull()
+    {
+        // Repro for the NullReferenceException in #4480: DragDropManager.OnFilesDroppedInTreeView
+        // calls this on IPluginManager.GetTreeNodeOver()'s result, which is legitimately null when
+        // no plugin reports a tree node under the cursor - it must not require a non-null receiver.
+        ITreeNode? node = null;
+
+        node.IsTopScreenContainerTreeNode().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsTopComponentContainerTreeNode_ReturnsFalse_ForNull()
+    {
+        ITreeNode? node = null;
+
+        node.IsTopComponentContainerTreeNode().ShouldBeFalse();
+    }
 }

--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -467,6 +467,32 @@ public class HeadlessErrorCheckerTests : BaseTestClass
         }
     }
 
+    [Fact]
+    public void GetErrorsFor_ShouldWarn_WhenAchjHasOffsetsAndOriginNotCenter()
+    {
+        // .achj counterpart of the .achx test above (#4476) — the origin-offset check must
+        // recognize the JSON dialect too, not just XML.
+        string achjPath = WriteTempAchj(includeOffset: true);
+        try
+        {
+            ComponentSave component = BuildComponentWithSpriteUsingSourceFile(
+                achjPath,
+                xOrigin: HorizontalAlignment.Left,
+                yOrigin: VerticalAlignment.Top);
+
+            IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+            ErrorResult warning = errors.ShouldHaveSingleItem();
+            warning.Severity.ShouldBe(ErrorSeverity.Warning);
+            warning.Message.ShouldContain("Center");
+            warning.Message.ShouldContain("AnimatedSprite");
+        }
+        finally
+        {
+            File.Delete(achjPath);
+        }
+    }
+
     private ComponentSave BuildComponentWithSpriteUsingSourceFile(
         string sourceFile,
         HorizontalAlignment xOrigin,
@@ -517,6 +543,27 @@ public class HeadlessErrorCheckerTests : BaseTestClass
 
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".achx");
         FileManager.XmlSerialize(achx, path);
+        return path;
+    }
+
+    private static string WriteTempAchj(bool includeOffset)
+    {
+        string relativeY = includeOffset ? "\"relativeY\": -3," : string.Empty;
+        string json = $$"""
+        {
+          "animationChains": [
+            {
+              "name": "Chain1",
+              "frames": [
+                { "textureName": "tex.png", "frameLength": 0.1, {{relativeY}} "leftCoordinate": 0 }
+              ]
+            }
+          ]
+        }
+        """;
+
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".achj");
+        File.WriteAllText(path, json);
         return path;
     }
 

--- a/Tests/RaylibGum.Tests/Content/SourceFileAchjAutoLoadTests.cs
+++ b/Tests/RaylibGum.Tests/Content/SourceFileAchjAutoLoadTests.cs
@@ -1,0 +1,105 @@
+using Gum.GueDeriving;
+using Raylib_cs;
+using RenderingLibrary.Content;
+using Shouldly;
+using System;
+using System.IO;
+using ToolsUtilities;
+using Xunit;
+
+namespace RaylibGum.Tests.Content;
+
+// .achj counterpart of SourceFileAchxAutoLoadTests: covers the raylib .achj auto-load path in
+// CustomSetPropertyOnRenderable (AssignSourceFileOnSprite / AssignSourceFileOnNineSlice, gated by
+// IsAnimationChainFile — issue #4476). Setting SourceFile to an .achj must populate
+// AnimationChains and advance to the first frame's texture, same as .achx does today.
+public class SourceFileAchjAutoLoadTests : BaseTestClass
+{
+    [Fact]
+    public void SpriteRuntime_SourceFileSetToAchj_PopulatesAnimationChainsAndFirstFrameTexture()
+    {
+        WithTempAchj(achjPath =>
+        {
+            SpriteRuntime sut = new();
+
+            sut.SourceFileName = achjPath;
+
+            sut.AnimationChains.ShouldNotBeNull();
+            sut.AnimationChains.Count.ShouldBe(1);
+            sut.Texture.ShouldNotBeNull();
+            sut.Texture!.Value.Width.ShouldBe(4);
+        });
+    }
+
+    [Fact]
+    public void NineSliceRuntime_SourceFileSetToAchj_PopulatesAnimationChains()
+    {
+        WithTempAchj(achjPath =>
+        {
+            NineSliceRuntime sut = new();
+
+            sut.SourceFileName = achjPath;
+
+            sut.AnimationChains.ShouldNotBeNull();
+            sut.AnimationChains.Count.ShouldBe(1);
+        });
+    }
+
+    private static void WithTempAchj(Action<string> action)
+    {
+        string tempRoot = Path.Combine(Path.GetTempPath(), "GumRaylibAchjAutoLoad_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+
+        try
+        {
+            const string textureName = "achj_frame.png";
+            Image image = Raylib.GenImageColor(4, 4, Raylib_cs.Color.Blue);
+            try
+            {
+                Raylib.ExportImage(image, Path.Combine(tempRoot, textureName));
+            }
+            finally
+            {
+                Raylib.UnloadImage(image);
+            }
+
+            string achjPath = Path.Combine(tempRoot, "test.achj").Replace('\\', '/');
+            File.WriteAllText(achjPath, $$"""
+            {
+              "fileRelativeTextures": true,
+              "animationChains": [
+                {
+                  "name": "TestChain",
+                  "frames": [
+                    {
+                      "textureName": "{{textureName}}",
+                      "frameLength": 0.1,
+                      "leftCoordinate": 0.0,
+                      "rightCoordinate": 1.0,
+                      "topCoordinate": 0.0,
+                      "bottomCoordinate": 1.0
+                    }
+                  ]
+                }
+              ]
+            }
+            """);
+
+            LoaderManager.Self.CacheTextures = false;
+
+            action(achjPath);
+        }
+        finally
+        {
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+}

--- a/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
+++ b/Tool/EditorTabPlugin_XNA/MainEditorTabPlugin.cs
@@ -1092,7 +1092,7 @@ internal class MainEditorTabPlugin : PriorityPlugin, IRecipient<UiBaseFontSizeCh
             {
                 foreach (string file in validFiles)
                 {
-                    string fileName = FileManager.MakeRelative(file, _fileLocations.ProjectFolder);
+                    string fileName = FileManager.MakeRelative(file, _fileLocations.ProjectFolder, preserveCase: true);
                     AddNewInstanceForDrop(fileName, worldX, worldY);
                     shouldUpdate = true;
                 }

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -515,6 +515,28 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void IsValidExtensionForFileDrop_ShouldAcceptAchxFiles()
+    {
+        // Act
+        bool result = _dragDropManager.IsValidExtensionForFileDrop("animations/Walk.achx");
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValidExtensionForFileDrop_ShouldAcceptAchjFiles()
+    {
+        // .achj (JSON) counterpart of .achx (#4476) — dropping one onto a Screen/Component must
+        // create a Sprite the same way .achx does.
+        // Act
+        bool result = _dragDropManager.IsValidExtensionForFileDrop("animations/Walk.achj");
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
     public void IsValidExtensionForFileDrop_ShouldRejectUnknownExtensions()
     {
         // Act

--- a/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs
@@ -547,6 +547,21 @@ public class DragDropManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void OnFilesDroppedInTreeView_ShouldNotThrow_WhenNoTreeNodeIsUnderCursor()
+    {
+        // Repro for #4480: IPluginManager.GetTreeNodeOver() legitimately returns null when no
+        // plugin reports a tree node under the drop cursor (e.g. dropping directly on a Screen's
+        // own tree node rather than a folder). OnFilesDroppedInTreeView called
+        // .IsTopScreenContainerTreeNode() on that null result without a guard, throwing a
+        // NullReferenceException instead of just no-op'ing like it does for any other drop target.
+        _mocker.GetMock<IPluginManager>()
+            .Setup(x => x.GetTreeNodeOver())
+            .Returns((ITreeNode?)null);
+
+        Should.NotThrow(() => _dragDropManager.OnFilesDroppedInTreeView(new[] { "C:/project/CharacterA.achj" }));
+    }
+
+    [Fact]
     public void OnNodeObjectDroppedInWireframe_ShouldHoldUndoLockWhenAddingInstance()
     {
         // Issue #2658: dropping a component into the wireframe must bundle the

--- a/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
+++ b/Tools/Gum.Presentation/FileWatchPlugin/FileWatchManager.cs
@@ -149,7 +149,7 @@ public class FileWatchManager : IFileWatchManager
         if(extension is "png" or "csv" or "resx"
             or "gumx" or "gumj" or "gusx" or "gusj" or "gutx" or "gutj" or "gucx" or "gucj"
             or "ganx" or "ganj" or "behx" or "behj" or "fnt"
-            or "achx" or "gif" or "tga" or "bmp")
+            or "achx" or "achj" or "gif" or "tga" or "bmp")
         {
             HandleFileSystemChange(fileName);
         }

--- a/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
+++ b/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
@@ -38,7 +38,7 @@ public class GumxImportService : IGumxImportService
     }
 
     private static readonly HashSet<string> _assetExtensions =
-        new(StringComparer.OrdinalIgnoreCase) { ".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tga", ".achx", ".ttf", ".otf", ".fnt" };
+        new(StringComparer.OrdinalIgnoreCase) { ".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tga", ".achx", ".achj", ".ttf", ".otf", ".fnt" };
 
     /// <inheritdoc/>
     public async Task<ImportResult> ImportAsync(

--- a/Tools/Gum.Presentation/Managers/DragDropManager.cs
+++ b/Tools/Gum.Presentation/Managers/DragDropManager.cs
@@ -105,6 +105,8 @@ public class DragDropManager : IDragDropManager
             yield return "gif";
             yield return "svg";
             yield return "bmp";
+            yield return "achx";
+            yield return "achj";
         }
     }
 

--- a/Tools/Gum.Presentation/Managers/FileChangeReactionLogic.cs
+++ b/Tools/Gum.Presentation/Managers/FileChangeReactionLogic.cs
@@ -56,7 +56,7 @@ namespace Gum.Managers
             {
                 ReactToImageFileChanged(file);
             }
-            else if(extension == "achx")
+            else if(extension == "achx" || extension == "achj")
             {
                 ReactToAnimationChainChanged(file);
             }

--- a/Tools/Gum.Presentation/Managers/TreeNodeFolderExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/TreeNodeFolderExtensions.cs
@@ -7,8 +7,8 @@
 /// </summary>
 public static class TreeNodeFolderExtensions
 {
-    public static bool IsTopScreenContainerTreeNode(this ITreeNode treeNode) =>
-        treeNode.Parent == null && treeNode.Text == "Screens";
+    public static bool IsTopScreenContainerTreeNode(this ITreeNode? treeNode) =>
+        treeNode != null && treeNode.Parent == null && treeNode.Text == "Screens";
 
     public static bool IsScreensFolderTreeNode(this ITreeNode? treeNode) =>
         treeNode != null &&
@@ -16,8 +16,8 @@ public static class TreeNodeFolderExtensions
         treeNode.Parent != null &&
         (treeNode.Parent.IsScreensFolderTreeNode() || treeNode.Parent.IsTopScreenContainerTreeNode());
 
-    public static bool IsTopComponentContainerTreeNode(this ITreeNode treeNode) =>
-        treeNode.Parent == null && treeNode.Text == "Components";
+    public static bool IsTopComponentContainerTreeNode(this ITreeNode? treeNode) =>
+        treeNode != null && treeNode.Parent == null && treeNode.Text == "Components";
 
     public static bool IsComponentsFolderTreeNode(this ITreeNode? treeNode) =>
         treeNode != null &&

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -1082,7 +1082,7 @@ public class SetVariableLogic : ISetVariableLogic
 
                     if (System.IO.File.Exists(absolute))
                     {
-                        if (absolute.ToLowerInvariant().EndsWith(".achx"))
+                        if (absolute.ToLowerInvariant().EndsWith(".achx") || absolute.ToLowerInvariant().EndsWith(".achj"))
                         {
                             // I think this is already loaded here, because when the GUE has
                             // its ACXH set, the texture and texture coordinate values are set

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/SetVariableLogic.cs
@@ -789,7 +789,7 @@ public class SetVariableLogic : ISetVariableLogic
                     return GeneralResponse.UnsuccessfulWith("File copy was cancelled");
                 }
 
-                if (!cancel && filePath.Extension == "achx")
+                if (!cancel && (filePath.Extension == "achx" || filePath.Extension == "achj"))
                 {
                     stateSave.SetValue($"{instancePrefix}TextureAddress", Gum.Managers.TextureAddress.Custom, "TextureAddress");
                     _guiCommands.RefreshVariables(force: true);
@@ -832,7 +832,8 @@ public class SetVariableLogic : ISetVariableLogic
             extension == "jpg" ||
             extension == "png" ||
             extension == "bmp" ||
-            extension == "achx";
+            extension == "achx" ||
+            extension == "achj";
 
         if (!isValidExtension)
         {

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -708,7 +708,9 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         var prefix = instanceName == null ? string.Empty : instanceName + ".";
 
         var sourceFile = rfv.GetValue<string>(prefix + "SourceFile");
-        if (string.IsNullOrEmpty(sourceFile) || !sourceFile.EndsWith(".achx", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(sourceFile) ||
+            !(sourceFile.EndsWith(".achx", StringComparison.OrdinalIgnoreCase) ||
+              sourceFile.EndsWith(".achj", StringComparison.OrdinalIgnoreCase)))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- Adds `.achj` (JSON) support to `AnimationChainListSave.FromFile`, dialect-selected by extension. Schema matches FlatRedBall2's `AnimationChain.Common` `.achj` writer (camelCase properties) so Animation Editor-authored files load into Gum without conversion.
- Updates every tool-side `.achx` extension gate to also recognize `.achj`: Sprite/NineSlice `SourceFile` auto-load, Current Chain Name dropdown, headless per-frame-offset validation, gumx import extension whitelist, hot-reload file watch, and `SetVariableLogic`'s SourceFile validation/TextureAddress-Custom-on-set/copy-file-prompt path.
- Fixes drag-and-drop: dropping a `.achx` or `.achj` file onto a Screen/Component in the editor now creates a Sprite (same as dropping a PNG, including the copy-referenced-files prompt) — this previously didn't work for **either** format, since `DragDropManager.ValidTextureExtensions` only recognized image/font extensions.
- Scoped to fields Gum's `AnimationFrameSave` already models (flip H/V, texture, frame rect, RelativeX/Y). FRB2's newer `FlipDiagonal`, per-frame color operations (`Red`/`Green`/`Blue`/`Alpha`/`ColorOperation`), and per-frame shapes are tracked separately — #4478, #4477, #4479 — since Gum has no render path for any of them yet. An `.achj` carrying those fields still loads; the extra data is just not read.

## Test plan
- [x] `MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs` — new: direct `FromFile` JSON parsing (list-level props, chains/frames, achx-matching defaults, unknown-field tolerance, `.achx` still parses as XML)
- [x] `Tests/RaylibGum.Tests/Content/SourceFileAchjAutoLoadTests.cs` — new: end-to-end `SourceFile` auto-load through `CustomSetPropertyOnRenderable` for Sprite/NineSlice
- [x] `Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs` — new case: origin-offset warning fires for `.achj` same as `.achx`
- [x] `Tests/Gum.Presentation.Tests/SetVariableLogicTests.cs` — new cases: `.achx`/`.achj` pass `GetWhySourcefileIsInvalid`, both set `TextureAddress` to `Custom` on SourceFile assignment
- [x] `Tool/Tests/GumToolUnitTests/Managers/DragDropManagerTests.cs` — new cases: `.achx`/`.achj` accepted by `IsValidExtensionForFileDrop`
- [x] `dotnet test` — MonoGameGum.Tests (2187), RaylibGum.Tests (604), Gum.ProjectServices.Tests (516), Gum.Presentation.Tests (926), GumToolUnitTests (1272/1274, 2 pre-existing skips) — all green, no regressions
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`) — 0 errors, pass

Closes #4476
