### PR TITLE
Fix silent case-mangling in FileManager.Standardize/MakeRelative call sites

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2216,7 +2216,7 @@ public partial class CustomSetPropertyOnRenderable
 
             }
 
-            var fullFileName = ToolsUtilities.FileManager.RemoveDotDotSlash(ToolsUtilities.FileManager.Standardize(fontFileNameName, false, true));
+            var fullFileName = ToolsUtilities.FileManager.RemoveDotDotSlash(ToolsUtilities.FileManager.Standardize(fontFileNameName, preserveCase: true, makeAbsolute: true));
 #if ANDROID || IOS
             fullFileName = fullFileName.ToLowerInvariant();
 #endif

--- a/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFontCachingRegressionTests.cs
+++ b/MonoGameGum.Tests/Runtimes/TextRuntimeBbCodeFontCachingRegressionTests.cs
@@ -151,14 +151,14 @@ public class TextRuntimeBbCodeFontCachingRegressionTests : BaseTestClass
             .Replace('\\', '/') + "/";
 
     // Mirrors CustomSetPropertyOnRenderable.GetFontFileName: the same GetFontCacheFileNameFor call
-    // followed by the same RemoveDotDotSlash(Standardize(name, false, true)) normalization.
+    // followed by the same RemoveDotDotSlash(Standardize(name, preserveCase: true, true)) normalization.
     private static string GetBoldFontCacheKey()
     {
         string cacheFileName = BmfcSave.GetFontCacheFileNameFor(
             UnstubbedFontSize, UnstubbedFontName, outline: 0, useFontSmoothing: true,
             isItalic: false, isBold: true, fontFilePath: null);
         return FileManager.RemoveDotDotSlash(
-            FileManager.Standardize(cacheFileName, preserveCase: false, makeAbsolute: true));
+            FileManager.Standardize(cacheFileName, preserveCase: true, makeAbsolute: true));
     }
 
     // A cached IDisposable that is not a BitmapFont, so the resolver's "GetDisposable(...) as

--- a/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
+++ b/MonoGameGum.Tests/ToolsUtilities/FileManagerTests.cs
@@ -138,6 +138,52 @@ public class FileManagerTests : IDisposable
     }
 
     [Fact]
+    public void GetAllFilesInDirectory_ShouldPreserveCase_WhenNoFileTypeSpecified()
+    {
+        // Regression for #4481: the no-fileType branch standardized each result through
+        // Standardize(files[i]) (default preserveCase: false), lowercasing every enumerated
+        // filename even though Directory.GetFiles returns the real on-disk casing.
+        string directory = Path.Combine(Path.GetTempPath(), "GumGetAllFilesInDirectoryTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "MyFile.txt"), "contents");
+
+            List<string> files = FileManager.GetAllFilesInDirectory(directory, null);
+
+            files.ShouldContain(f => Path.GetFileName(f) == "MyFile.txt");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindAndAddExtension_ShouldPreserveCase_WhenMatchFound()
+    {
+        // Regression for #4481: FindAndAddExtension lowercased its input fileName via
+        // Standardize(fileName) (default preserveCase: false) before comparing it against
+        // case-preserved entries from GetAllFilesInDirectory, so a mixed-case lookup mismatched
+        // the actual on-disk file case.
+        string directory = Path.Combine(Path.GetTempPath(), "GumFindAndAddExtensionTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string realFile = Path.Combine(directory, "MyFile.txt");
+            File.WriteAllText(realFile, "contents");
+
+            string result = FileManager.FindAndAddExtension(Path.Combine(directory, "MyFile"));
+
+            Path.GetFileName(result).ShouldBe("MyFile.txt");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void GetMacOSBundleResourcesPath_ShouldResolveRealFile_WhenContentShippedInResources()
     {
         // Build a real .app directory layout in a temp dir: content physically in Resources, nothing

--- a/RenderingLibrary/Content/ContentLoader.cs
+++ b/RenderingLibrary/Content/ContentLoader.cs
@@ -145,7 +145,7 @@ public class ContentLoader : IContentLoader
 
         Renderer renderer = Renderer.Self ?? managers.Renderer;
 
-        string fileNameStandardized = FileManager.Standardize(fileName, false, false);
+        string fileNameStandardized = FileManager.Standardize(fileName, preserveCase: true, makeAbsolute: false);
 
         Texture2D texture;
         using (var stream = GetUrlStream(fileName))

--- a/Tests/Gum.Presentation.Tests/AddScreenDialogViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AddScreenDialogViewModelTests.cs
@@ -67,4 +67,26 @@ public class AddScreenDialogViewModelTests : BaseTestClass
         _projectCommands.Verify(x => x.AddScreen(It.Is<ScreenSave>(s => s.Name == "NewScreen")), Times.Once);
         _selectedState.VerifySet(x => x.SelectedScreen = It.Is<ScreenSave>(s => s.Name == "NewScreen"), Times.Once);
     }
+
+    [Fact]
+    public void OnAffirmative_PreservesFolderCasing_WhenFolderSelected()
+    {
+        // Regression for #4481: MakeRelative's 2-arg overload lowercases by default, so a mixed-case
+        // selected folder ("MyFolder") used to mangle the new screen's Name to "myfolder/NewScreen".
+        var screensRoot = new Mock<ITreeNode>();
+        screensRoot.Setup(x => x.Parent).Returns((ITreeNode?)null);
+        screensRoot.Setup(x => x.Text).Returns("Screens");
+
+        var folderNode = new Mock<ITreeNode>();
+        folderNode.Setup(x => x.Tag).Returns((object?)null);
+        folderNode.Setup(x => x.Parent).Returns(screensRoot.Object);
+        folderNode.Setup(x => x.GetFullFilePath()).Returns(new ToolsUtilities.FilePath("/project/Screens/MyFolder/"));
+
+        _selectedState.Setup(x => x.SelectedTreeNode).Returns(folderNode.Object);
+        _sut.Value = "NewScreen";
+
+        _sut.OnAffirmative();
+
+        _projectCommands.Verify(x => x.AddScreen(It.Is<ScreenSave>(s => s.Name == "MyFolder/NewScreen")), Times.Once);
+    }
 }

--- a/Tools/Gum.Presentation/Dialogs/AddScreenDialogViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/AddScreenDialogViewModel.cs
@@ -56,7 +56,7 @@ public class AddScreenDialogViewModel : GetUserStringDialogBaseViewModel
             path = _projectState.ScreenFilePath.FullPath;
         }
         
-        string relativeToScreens = FileManager.MakeRelative(path, _fileLocations.ScreensFolder);
+        string relativeToScreens = FileManager.MakeRelative(path, _fileLocations.ScreensFolder, preserveCase: true);
 
         // Prevent issues with any code that's looking for a '/' instead of a '\' slash
         relativeToScreens = relativeToScreens.Replace('\\', '/');

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -1071,7 +1071,7 @@ namespace ToolsUtilities
 
         public static string FindAndAddExtension(string fileName)
         {
-            fileName = Standardize(fileName);
+            fileName = Standardize(fileName, preserveCase: true);
             // This takes a little bit of work
             string fileWithoutExtension = FileManager.RemoveExtension(fileName);
 
@@ -1169,7 +1169,7 @@ namespace ToolsUtilities
             {
                 for (int i = 0; i < files.Length; i++)
                 {
-                    files[i] = FileManager.Standardize(files[i]);
+                    files[i] = FileManager.Standardize(files[i], preserveCase: true);
                 }
                 arrayToReturn.AddRange(files);
             }


### PR DESCRIPTION
## Summary
Closes #4481. Audited all ~55 call sites of `FileManager.Standardize`/`MakeRelative` (the case-insensitive-by-default API). Most already pass `preserveCase: true` correctly; fixed the stragglers that were silently lowercasing on-disk paths or user-visible identity strings:

- `FileManager.GetAllFilesInDirectory` (no-fileType branch) and `FindAndAddExtension` lowercased real on-disk filenames before comparing/returning them.
- `CustomSetPropertyOnRenderable`'s font-cache-key generator lowercased custom font file paths before a `FileExists` check — breaks custom fonts on case-sensitive filesystems (untestable on Windows CI; matches the 3 sibling `Standardize` calls in the same file that already use `preserveCase: true`).
- `ContentLoader.LoadTextureFromUrl` lowercased a downloaded texture's `Name`, which `AnimationChain` searches by exact string.
- `AddScreenDialogViewModel`'s 2-arg `MakeRelative` call mangled a selected folder's casing into the new Screen's `Name` — same bug class as #4480, whose sibling `AddComponentDialogViewModel` was already fixed.

The remaining sites (LoaderManager's dictionary cache, tree-node folder lookups) were reviewed and left lowercase deliberately — they're backed by a `StringComparer.OrdinalIgnoreCase` dictionary or an `OrdinalIgnoreCase` string comparison, so lowercasing there is inert, not a bug.

## Test plan
- [x] `MonoGameGum.Tests` (2189 tests) — green
- [x] `Gum.Presentation.Tests` (929 tests) — green
- [x] New regression tests added and red/green verified against each fix individually: `GetAllFilesInDirectory_ShouldPreserveCase_WhenNoFileTypeSpecified`, `FindAndAddExtension_ShouldPreserveCase_WhenMatchFound`, `OnAffirmative_PreservesFolderCasing_WhenFolderSelected`
- [x] `GumFull.sln`, `RaylibGum.csproj`, `SkiaGum.csproj` build clean
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`, since `CustomSetPropertyOnRenderable.cs` is FRB1-shared source): pass
- Manual test: not needed — all four functional fixes are covered by unit tests (or, for the `LoadTextureFromUrl`/font-cache-key sites, are one-line parameter changes matching an already-proven sibling pattern in the same file); no new UI/runtime-visible surface was added.
