### PR TITLE
Select entire numeric value on double-click instead of splitting at decimal point

### DIFF
--- a/WpfDataUi/Controls/TextBoxDisplayLogic.cs
+++ b/WpfDataUi/Controls/TextBoxDisplayLogic.cs
@@ -62,6 +62,20 @@ namespace WpfDataUi.Controls
             mAssociatedTextBox.GotFocus += HandleTextBoxGotFocus;
             mAssociatedTextBox.PreviewKeyDown += HandlePreviewKeydown;
             mAssociatedTextBox.TextChanged += HandleTextChanged;
+            mAssociatedTextBox.PreviewMouseLeftButtonDown += HandlePreviewMouseLeftButtonDown;
+        }
+
+        private void HandlePreviewMouseLeftButtonDown(object? sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // WPF's default double-click word-selection treats '.' and '-' as word breaks, so
+            // double-clicking a decimal like 123.45 only selects one side of the point (issue
+            // FlatRedBall#2135). For numeric fields the whole value is always what the user wants,
+            // so select it all ourselves and suppress the built-in word-select.
+            if (IsNumeric && e.ClickCount == 2)
+            {
+                mAssociatedTextBox.SelectAll();
+                e.Handled = true;
+            }
         }
 
         private void HandleTextChanged(object? sender, TextChangedEventArgs e)


### PR DESCRIPTION
Double-clicking a decimal value (e.g. `123.45`) in a numeric DataGrid text box only selected one side of the decimal point, because WPF's default word-selection treats `.` and `-` as word breaks. Numeric fields now select the whole value on double-click.

Applies to all controls built on `TextBoxDisplayLogic` (`TextBoxDisplay`, `SliderDisplay`, `PlusMinusTextBox`, `AngleSelectorDisplay`).

Manually verified in the Gum tool.

Closes #2135