### PR TITLE
Clamp overflowing numeric input instead of producing Infinity

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
@@ -163,4 +163,41 @@ public class TextBoxDisplayLogicTests
         succeeded.ShouldBeTrue();
         result.ShouldBe(expected);
     }
+
+    public static IEnumerable<object[]> OverflowingIntegerData()
+    {
+        yield return new object[] { "1e30", typeof(long), long.MaxValue };
+        yield return new object[] { "-1e30", typeof(long), long.MinValue };
+        yield return new object[] { "1e30", typeof(decimal), decimal.MaxValue };
+        yield return new object[] { "-1e30", typeof(decimal), decimal.MinValue };
+        yield return new object[] { "300", typeof(byte), byte.MaxValue };
+        yield return new object[] { "-5", typeof(byte), byte.MinValue };
+        yield return new object[] { "40000", typeof(short), short.MaxValue };
+        yield return new object[] { "-40000", typeof(short), short.MinValue };
+    }
+
+    [Theory]
+    [MemberData(nameof(OverflowingIntegerData))]
+    public void TryParseNumeric_OverflowingIntegerInput_ClampsInsteadOfRejecting(
+        string input, Type targetType, object expected)
+    {
+        // long/decimal/byte/short.TryParse fail outright on overflow (no Infinity concept
+        // for these types) - clamp through a double intermediate instead of rejecting the
+        // input, mirroring the pre-existing int-overflow clamp (FlatRedBall#2150 follow-up).
+        bool succeeded = TextBoxDisplayLogic.TryParseNumeric(input, targetType, out object result);
+
+        succeeded.ShouldBeTrue();
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void TryParseNumeric_NonOverflowingMalformedInput_ReturnsFalseForLong()
+    {
+        // A fractional value is invalid for a long field but is not an overflow - it must
+        // still be rejected (not silently truncated) so the caller falls through to the
+        // normal invalid-syntax handling instead of accepting bad input.
+        bool succeeded = TextBoxDisplayLogic.TryParseNumeric("123.5", typeof(long), out object result);
+
+        succeeded.ShouldBeFalse();
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/TextBoxDisplayLogicTests.cs
@@ -147,4 +147,20 @@ public class TextBoxDisplayLogicTests
     {
         TextBoxDisplayLogic.ClampToRange(-5, null, null).ShouldBe(-5m);
     }
+
+    [Theory]
+    [InlineData("1e309", typeof(float), float.MaxValue)]
+    [InlineData("-1e309", typeof(float), float.MinValue)]
+    [InlineData("1e309", typeof(double), double.MaxValue)]
+    [InlineData("-1e309", typeof(double), double.MinValue)]
+    public void TryParseNumeric_OverflowingInput_ClampsInsteadOfReturningInfinity(
+        string input, Type targetType, object expected)
+    {
+        // .NET Core 3.0+ float/double.TryParse succeeds on overflow and yields
+        // Infinity/-Infinity instead of failing (FlatRedBall#2150).
+        bool succeeded = TextBoxDisplayLogic.TryParseNumeric(input, targetType, out object result);
+
+        succeeded.ShouldBeTrue();
+        result.ShouldBe(expected);
+    }
 }

--- a/WpfDataUi/Controls/TextBoxDisplayLogic.cs
+++ b/WpfDataUi/Controls/TextBoxDisplayLogic.cs
@@ -560,7 +560,7 @@ namespace WpfDataUi.Controls
         /// Returns true if the string was successfully parsed, with the result in <paramref name="result"/>.
         /// Falls through to false for non-numeric types so the caller can use ConvertFromString.
         /// </summary>
-        private static bool TryParseNumeric(string text, Type targetType, out object result)
+        public static bool TryParseNumeric(string text, Type targetType, out object result)
         {
             result = null;
 
@@ -568,6 +568,17 @@ namespace WpfDataUi.Controls
             {
                 if (float.TryParse(text, out float f))
                 {
+                    // Since .NET Core 3.0, float.TryParse succeeds on overflow and returns
+                    // +/-Infinity instead of failing. Clamp to a real value rather than letting
+                    // Infinity flow onto the bound property (FlatRedBall#2150).
+                    if (float.IsPositiveInfinity(f))
+                    {
+                        f = float.MaxValue;
+                    }
+                    else if (float.IsNegativeInfinity(f))
+                    {
+                        f = float.MinValue;
+                    }
                     result = f;
                     return true;
                 }
@@ -584,6 +595,15 @@ namespace WpfDataUi.Controls
             {
                 if (double.TryParse(text, out double d))
                 {
+                    // Same overflow-to-Infinity behavior as float.TryParse above (FlatRedBall#2150).
+                    if (double.IsPositiveInfinity(d))
+                    {
+                        d = double.MaxValue;
+                    }
+                    else if (double.IsNegativeInfinity(d))
+                    {
+                        d = double.MinValue;
+                    }
                     result = d;
                     return true;
                 }

--- a/WpfDataUi/Controls/TextBoxDisplayLogic.cs
+++ b/WpfDataUi/Controls/TextBoxDisplayLogic.cs
@@ -615,12 +615,38 @@ namespace WpfDataUi.Controls
                     result = l;
                     return true;
                 }
+                // long.TryParse fails outright on overflow (no Infinity concept for integer
+                // types). Only clamp when the text is a genuinely-overflowing number - a
+                // malformed value like "123.5" must still be rejected (FlatRedBall#2150).
+                else if (IsOverflowingNumber(text, long.MinValue, long.MaxValue, out double asDouble))
+                {
+                    result = asDouble > 0 ? (object)long.MaxValue : (object)long.MinValue;
+                    return true;
+                }
             }
             else if (targetType == typeof(decimal) || targetType == typeof(decimal?))
             {
                 if (decimal.TryParse(text, out decimal m))
                 {
                     result = m;
+                    return true;
+                }
+                else if (IsOverflowingNumber(text, (double)decimal.MinValue, (double)decimal.MaxValue, out double asDouble))
+                {
+                    result = asDouble > 0 ? (object)decimal.MaxValue : (object)decimal.MinValue;
+                    return true;
+                }
+            }
+            else if (targetType == typeof(short) || targetType == typeof(short?))
+            {
+                if (short.TryParse(text, out short s))
+                {
+                    result = s;
+                    return true;
+                }
+                else if (IsOverflowingNumber(text, short.MinValue, short.MaxValue, out double asDouble))
+                {
+                    result = asDouble > 0 ? (object)short.MaxValue : (object)short.MinValue;
                     return true;
                 }
             }
@@ -631,9 +657,25 @@ namespace WpfDataUi.Controls
                     result = b;
                     return true;
                 }
+                else if (IsOverflowingNumber(text, byte.MinValue, byte.MaxValue, out double asDouble))
+                {
+                    result = asDouble > 0 ? (object)byte.MaxValue : (object)byte.MinValue;
+                    return true;
+                }
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Detects a number whose magnitude is outside [min, max] by parsing through double
+        /// (which has far more range than the integer/decimal types this backs). Used to tell
+        /// a genuine overflow apart from other TryParse failures (e.g. non-numeric or
+        /// fractional text) so only real overflows get clamped rather than silently accepted.
+        /// </summary>
+        private static bool IsOverflowingNumber(string text, double min, double max, out double asDouble)
+        {
+            return double.TryParse(text, out asDouble) && (asDouble < min || asDouble > max);
         }
 
         private static bool ContainsMathOperator(string text)


### PR DESCRIPTION
## Summary
float/double.TryParse succeeds on overflow since .NET Core 3.0 and returns +/-Infinity instead of failing. That Infinity flowed straight through to the bound property (Scale, Width, Height, position, etc.) with no error shown. Clamp to MaxValue/MinValue instead, matching the existing int-overflow clamp precedent (`TryConvertingToIntThroughDouble`) already in this file.

Fixes vchelaru/FlatRedBall#2150

## Test plan
- [x] `TextBoxDisplayLogicTests.TryParseNumeric_OverflowingInput_ClampsInsteadOfReturningInfinity` (new, red before fix / green after)
- [x] Full `TextBoxDisplayLogicTests` suite green
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZPZC4nqJKp3SbmupyA4ZY