### PR TITLE
Support per-frame Alpha from .achx/.achj animation chains

### DIFF
--- a/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
@@ -202,7 +202,7 @@ namespace Gum.Content.AnimationChain
         // Property names match FlatRedBall2's AnimationChain.Common .achj writer (camelCase) so a
         // file authored by the FlatRedBall Animation Editor loads into Gum without a conversion
         // step. Fields FRB2 added that Gum's AnimationFrameSave doesn't model yet —
-        // Red/Green/Blue/Alpha, ColorOperation, per-frame shapes (#4477, #4479) — are simply
+        // Red/Green/Blue, ColorOperation, per-frame shapes (#4477, #4479) — are simply
         // not read; JsonObject's indexer returns null for a missing key, so those files still load,
         // just without that data.
         private static AnimationChainListSave ParseJson(JsonObject root)
@@ -256,6 +256,7 @@ namespace Gum.Content.AnimationChain
                 FlipDiagonal = BoolProperty(frameObj, "flipDiagonal"),
                 RelativeX = FloatProperty(frameObj, "relativeX"),
                 RelativeY = FloatProperty(frameObj, "relativeY"),
+                Alpha = IntProperty(frameObj, "alpha"),
             };
         }
 
@@ -264,6 +265,9 @@ namespace Gum.Content.AnimationChain
 
         private static bool BoolProperty(JsonObject parent, string name, bool defaultValue = false) =>
             parent[name] is JsonValue value ? value.GetValue<bool>() : defaultValue;
+
+        private static int? IntProperty(JsonObject parent, string name) =>
+            parent[name] is JsonValue value ? value.GetValue<int>() : (int?)null;
 
         #endregion
 

--- a/Gum/Graphics/Animation/Content/AnimationFrameSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationFrameSave.cs
@@ -48,6 +48,16 @@ namespace Gum.Content.AnimationChain
         }
 
         /// <summary>
+        /// The alpha (0-255) to scale the frame's render alpha by. Null means the frame doesn't
+        /// author an alpha and playback should leave the current alpha unchanged.
+        /// </summary>
+        public int? Alpha;
+        public bool ShouldSerializeAlpha()
+        {
+            return Alpha.HasValue;
+        }
+
+        /// <summary>
         /// Used in XML Serialization of AnimationChains - this should
         /// not explicitly be set by the user.
         /// </summary>

--- a/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
+++ b/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
@@ -55,7 +55,8 @@ public class AnimationChainListSaveAchjTests
                   "flipHorizontal": true,
                   "flipDiagonal": true,
                   "relativeX": 2.5,
-                  "relativeY": -1.5
+                  "relativeY": -1.5,
+                  "alpha": 128
                 }
               ]
             }
@@ -82,6 +83,7 @@ public class AnimationChainListSaveAchjTests
             frame.FlipDiagonal.ShouldBeTrue();
             frame.RelativeX.ShouldBe(2.5f);
             frame.RelativeY.ShouldBe(-1.5f);
+            frame.Alpha.ShouldBe(128);
         });
     }
 
@@ -107,13 +109,14 @@ public class AnimationChainListSaveAchjTests
             frame.FlipDiagonal.ShouldBeFalse();
             frame.RelativeX.ShouldBe(0f);
             frame.RelativeY.ShouldBe(0f);
+            frame.Alpha.ShouldBeNull();
         });
     }
 
     [Fact]
     public void FromFile_AchjExtension_UnknownFrbTwoOnlyFields_AreIgnoredNotThrown()
     {
-        // Red/Green/Blue/Alpha, ColorOperation, and shapes are FRB2 additions Gum doesn't model
+        // Red/Green/Blue, ColorOperation, and shapes are FRB2 additions Gum doesn't model
         // yet (#4477, #4479) — an achj file carrying them must still load.
         WithTempFile(".achj", """
         {
@@ -127,7 +130,6 @@ public class AnimationChainListSaveAchjTests
                   "red": 255,
                   "green": 0,
                   "blue": 0,
-                  "alpha": 255,
                   "colorOperation": "Add",
                   "shapes": { "rectangles": [], "circles": [], "polygons": [] }
                 }
@@ -162,6 +164,7 @@ public class AnimationChainListSaveAchjTests
               <TopCoordinate>0</TopCoordinate>
               <BottomCoordinate>1</BottomCoordinate>
               <FlipDiagonal>true</FlipDiagonal>
+              <Alpha>200</Alpha>
             </Frame>
           </AnimationChain>
         </AnimationChainArraySave>
@@ -172,6 +175,7 @@ public class AnimationChainListSaveAchjTests
             save.AnimationChains.Count.ShouldBe(1);
             save.AnimationChains[0].Frames[0].TextureName.ShouldBe("walk_0.png");
             save.AnimationChains[0].Frames[0].FlipDiagonal.ShouldBeTrue();
+            save.AnimationChains[0].Frames[0].Alpha.ShouldBe(200);
         });
     }
 

--- a/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -49,7 +49,7 @@ public class SpriteRuntimeTests : BaseTestClass
 
         var chain = new AnimationChain { Name = "TestChain" };
         chain.Add(new AnimationFrame { FrameLength = 1.0f, FlipHorizontal = false, FlipVertical = false, FlipDiagonal = false });
-        chain.Add(new AnimationFrame { FrameLength = 1.0f, FlipHorizontal = true, FlipVertical = true, FlipDiagonal = true });
+        chain.Add(new AnimationFrame { FrameLength = 1.0f, FlipHorizontal = true, FlipVertical = true, FlipDiagonal = true, Alpha = 128 });
 
         var chainList = new AnimationChainList();
         chainList.Add(chain);
@@ -63,6 +63,27 @@ public class SpriteRuntimeTests : BaseTestClass
         sprite.FlipHorizontal.ShouldBeTrue();
         sprite.FlipVertical.ShouldBeTrue();
         sprite.FlipDiagonal.ShouldBeTrue();
+        sprite.Alpha.ShouldBe(128);
+    }
+
+    [Fact]
+    public void AnimateSelf_ShouldLeaveSpriteAlphaUnchanged_WhenFrameAlphaIsNull()
+    {
+        // Alpha is nullable so authors can set it only on the frames that need it (e.g. a flash
+        // effect). A frame transitioning to a frame with no Alpha authored must not reset alpha
+        // back to opaque.
+        var sprite = new Sprite((Texture2D?)null) { Alpha = 64 };
+
+        var chain = new AnimationChain { Name = "TestChain" };
+        chain.Add(new AnimationFrame { FrameLength = 1.0f, Alpha = null });
+
+        var chainList = new AnimationChainList();
+        chainList.Add(chain);
+
+        sprite.AnimationChains = chainList;
+        sprite.CurrentChainName = "TestChain";
+
+        sprite.Alpha.ShouldBe(64);
     }
 
     [Fact]

--- a/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
+++ b/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
@@ -65,6 +65,12 @@ namespace Gum.Graphics.Animation
         /// </summary>
         public bool FlipDiagonal;
 
+        /// <summary>
+        /// The alpha (0-255) to scale the frame's render alpha by. Null means the frame doesn't
+        /// author an alpha and playback should leave the current alpha unchanged.
+        /// </summary>
+        public int? Alpha;
+
         #region XML Docs
         /// <summary>
         /// Used in XML Serialization of AnimationChains - this should
@@ -274,6 +280,7 @@ namespace Gum.Graphics.Animation
             frame.FlipHorizontal = animationFrameSave.FlipHorizontal;
             frame.FlipVertical = animationFrameSave.FlipVertical;
             frame.FlipDiagonal = animationFrameSave.FlipDiagonal;
+            frame.Alpha = animationFrameSave.Alpha;
 
             if (coordinateType == TextureCoordinateType.UV)
             {

--- a/RenderingLibrary/Graphics/NineSlice.cs
+++ b/RenderingLibrary/Graphics/NineSlice.cs
@@ -1138,6 +1138,11 @@ public class NineSlice : SpriteBatchRenderableBase,
 
         FlipHorizontal = frame.FlipHorizontal;
         FlipDiagonal = frame.FlipDiagonal;
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     public void SetSingleTexture(Texture2D? texture)

--- a/RenderingLibrary/Graphics/Sprite.cs
+++ b/RenderingLibrary/Graphics/Sprite.cs
@@ -376,6 +376,11 @@ public class Sprite : SpriteBatchRenderableBase,
         FlipHorizontal = frame.FlipHorizontal;
         FlipVertical = frame.FlipVertical;
         FlipDiagonal = frame.FlipDiagonal;
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     public override void Render(ISystemManagers managers)

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -63,6 +63,11 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
         // (no FlipHorizontal field on this renderable, and DrawTextureNPatch
         // does not support negative src rects). If/when flip support is added,
         // copy frame.FlipHorizontal / frame.FlipVertical here.
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     /// <inheritdoc/>

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -521,6 +521,11 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
 
         FlipHorizontal = frame.FlipHorizontal;
         FlipVertical = frame.FlipVertical;
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     public bool AnimateSelf(double secondDifference)

--- a/Runtimes/SkiaGum/Renderables/NineSlice.cs
+++ b/Runtimes/SkiaGum/Renderables/NineSlice.cs
@@ -55,6 +55,11 @@ public class NineSlice : RenderableShapeBase, IAnimatable, ICloneable, ITextureC
         {
             SourceRectangle = null;
         }
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     /// <inheritdoc/>

--- a/Runtimes/SkiaGum/Renderables/Sprite.cs
+++ b/Runtimes/SkiaGum/Renderables/Sprite.cs
@@ -101,6 +101,11 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
         {
             SourceRectangle = null;
         }
+
+        if (frame.Alpha.HasValue)
+        {
+            Alpha = frame.Alpha.Value;
+        }
     }
 
     public bool AnimateSelf(double secondDifference)

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/AnimatedFrame1.achx
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/AnimatedFrame1.achx
@@ -12,6 +12,7 @@
       <RightCoordinate>16</RightCoordinate>
       <TopCoordinate>0</TopCoordinate>
       <BottomCoordinate>16</BottomCoordinate>
+      <Alpha>255</Alpha>
       <ShapeCollectionSave>
         <Shapes />
         <AxisAlignedCubeSaves />
@@ -25,6 +26,7 @@
       <RightCoordinate>16</RightCoordinate>
       <TopCoordinate>0</TopCoordinate>
       <BottomCoordinate>16</BottomCoordinate>
+      <Alpha>60</Alpha>
       <ShapeCollectionSave>
         <Shapes />
         <AxisAlignedCubeSaves />

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SpriteScreen.cs
@@ -236,8 +236,9 @@ internal class SpriteScreen : FrameworkElement
         }
 
         // AnimationChain-driven sprite — same .achx pipeline NineSliceScreen uses.
-        // 200% of source so the frame swaps are easy to see.
-        AddLabel(container, "AnimationChain-driven sprite (AnimatedFrame1.achx):");
+        // 200% of source so the frame swaps are easy to see. AnimatedFrame1.achx also
+        // authors per-frame Alpha (255 then 60), so the sprite should flash dim every cycle.
+        AddLabel(container, "AnimationChain-driven sprite, with per-frame Alpha (AnimatedFrame1.achx):");
         var animated = new SpriteRuntime();
         animated.WidthUnits = Gum.DataTypes.DimensionUnitType.PercentageOfSourceFile;
         animated.HeightUnits = Gum.DataTypes.DimensionUnitType.PercentageOfSourceFile;

--- a/Tests/RaylibGum.Tests/Content/AnimationChainTextureLoadingTests.cs
+++ b/Tests/RaylibGum.Tests/Content/AnimationChainTextureLoadingTests.cs
@@ -78,6 +78,42 @@ public class AnimationChainTextureLoadingTests : BaseTestClass
         }, count: 2);
     }
 
+    [Fact]
+    public void SpriteRuntime_AnimateSelfWithAlphaFrame_ShouldApplyAlpha()
+    {
+        WithTempTextures((tempRoot, fileNames) =>
+        {
+            AnimationChainListSave save = new AnimationChainListSave();
+            save.FileName = Path.Combine(tempRoot, "alpha.achx").Replace('\\', '/');
+            save.FileRelativeTextures = true;
+            save.AnimationChains = new List<AnimationChainSave>
+            {
+                new AnimationChainSave
+                {
+                    Name = "TestChain",
+                    Frames = new List<AnimationFrameSave>
+                    {
+                        new AnimationFrameSave { TextureName = fileNames[0], FrameLength = 0.1f, Alpha = 255 },
+                        new AnimationFrameSave { TextureName = fileNames[1], FrameLength = 0.1f, Alpha = 60 },
+                    }
+                }
+            };
+
+            AnimationChainList list = save.ToAnimationChainList();
+
+            SpriteRuntime spriteRuntime = new();
+            spriteRuntime.AnimationChains = list;
+            spriteRuntime.CurrentChainName = "TestChain";
+            spriteRuntime.Animate = true;
+
+            spriteRuntime.Alpha.ShouldBe(255);
+
+            spriteRuntime.AnimateSelf(0.15);
+
+            spriteRuntime.Alpha.ShouldBe(60);
+        }, count: 2);
+    }
+
     // Regression for #3549: the Pixel-coordinate conversion block in
     // AnimationFrame.ToAnimationFrame was gated behind
     // `#if MONOGAME || KNI || XNA4 || SOKOL`, missing RAYLIB and SKIA. On those

--- a/Tests/RaylibGum.Tests/Runtimes/NineSliceRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/NineSliceRuntimeTests.cs
@@ -41,6 +41,7 @@ public class NineSliceRuntimeTests : BaseTestClass
             RightCoordinate = 0.5f,
             TopCoordinate = 0f,
             BottomCoordinate = 0.5f,
+            Alpha = 255,
         };
         AnimationFrame frameB = new AnimationFrame
         {
@@ -50,6 +51,7 @@ public class NineSliceRuntimeTests : BaseTestClass
             RightCoordinate = 1f,
             TopCoordinate = 0.5f,
             BottomCoordinate = 1f,
+            Alpha = 60,
         };
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
@@ -68,6 +70,7 @@ public class NineSliceRuntimeTests : BaseTestClass
 
         contained.Texture.ShouldNotBeNull();
         contained.Texture.Value.Id.ShouldBe<uint>(1);
+        sut.Alpha.ShouldBe(255);
 
         contained.AnimationLogic.AnimateSelf(1.1);
 
@@ -77,6 +80,7 @@ public class NineSliceRuntimeTests : BaseTestClass
         contained.SourceRectangle.Value.Y.ShouldBe(20f);
         contained.SourceRectangle.Value.Width.ShouldBe(20f);
         contained.SourceRectangle.Value.Height.ShouldBe(20f);
+        sut.Alpha.ShouldBe(60);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
@@ -126,6 +126,7 @@ public class NineSliceRuntimeTests
             RightCoordinate = 0.5f,
             TopCoordinate = 0f,
             BottomCoordinate = 0.5f,
+            Alpha = 255,
         };
         AnimationFrame frameB = new AnimationFrame
         {
@@ -135,6 +136,7 @@ public class NineSliceRuntimeTests
             RightCoordinate = 1f,
             TopCoordinate = 0.5f,
             BottomCoordinate = 1f,
+            Alpha = 60,
         };
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
@@ -154,6 +156,7 @@ public class NineSliceRuntimeTests
 
         NineSlice contained = (NineSlice)sut.RenderableComponent;
         contained.Texture.ShouldBe(textureA);
+        sut.Alpha.ShouldBe(255);
 
         // Advance past the first frame.
         ((NineSlice)sut.RenderableComponent).AnimationLogic.AnimateSelf(1.1);
@@ -164,6 +167,7 @@ public class NineSliceRuntimeTests
         contained.SourceRectangle.Value.Top.ShouldBe(20);
         contained.SourceRectangle.Value.Width.ShouldBe(20);
         contained.SourceRectangle.Value.Height.ShouldBe(20);
+        sut.Alpha.ShouldBe(60);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
@@ -300,8 +300,8 @@ public class SpriteRuntimeTests
         SKBitmap textureB = new SKBitmap(4, 4);
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
-        chain.Add(new AnimationFrame { Texture = textureA, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f });
-        chain.Add(new AnimationFrame { Texture = textureB, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f });
+        chain.Add(new AnimationFrame { Texture = textureA, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f, Alpha = 255 });
+        chain.Add(new AnimationFrame { Texture = textureB, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f, Alpha = 60 });
 
         AnimationChainList chains = new AnimationChainList();
         chains.Add(chain);
@@ -312,6 +312,7 @@ public class SpriteRuntimeTests
         sut.Animate = true;
 
         sut.AnimationChainFrameIndex.ShouldBe(0);
+        sut.Alpha.ShouldBe(255);
 
         // Tick through GraphicalUiElement.AnimateSelf — same path GumService.Update
         // walks. If IAnimatable is duplicated across GumCommon and SkiaGum, the
@@ -319,6 +320,7 @@ public class SpriteRuntimeTests
         sut.AnimateSelf(0.15);
 
         sut.AnimationChainFrameIndex.ShouldBe(1);
+        sut.Alpha.ShouldBe(60);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds a nullable `Alpha` (0-255) to `AnimationFrameSave`, parsed/written for both `.achx` (XML) and `.achj` (JSON).
- Threads `Alpha` through `AnimationFrame` into `Sprite`/`NineSlice` playback (`ApplyAnimationFrame`) — scales the existing `Alpha` property when the frame authors a value, left unchanged when the frame's `Alpha` is null (so authors can set it only on frames that need it, e.g. a flash effect).
- Scoped independently from #4477 (Red/Green/Blue + ColorOperation) since Alpha needs no per-backend shader work — just a draw-alpha scale.
- Also updates `MonoGameGumInCode`'s `SpriteScreen` sample (`AnimatedFrame1.achx`) to author per-frame Alpha, for manual verification.

Closes #4488

## Test plan
- [x] `dotnet test MonoGameGum.Tests/MonoGameGum.Tests.csproj` — 2192 passed
- [x] `KniGum`/`RaylibGum`/`SkiaGum` build clean, 0 new warnings
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`) — 0 errors
- [ ] Manual: MonoGameGumInCode's SpriteScreen, "AnimationChain-driven sprite" row — bear should flash dim (alpha 60) briefly each loop cycle

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
