### PR TITLE
Support Multiply per-frame color from .achx/.achj animation chains

### DIFF
--- a/.claude/skills/gum-runtime-animation-chains/SKILL.md
+++ b/.claude/skills/gum-runtime-animation-chains/SKILL.md
@@ -5,7 +5,7 @@ description: AnimationChain playback on Sprites and NineSlices — .achx -> Anim
 
 # Runtime Animation Chains
 
-Gum plays back FRB-style `.achx` animations on `Sprite` and `NineSlice`. An `.achx` is an XML file (deserialized as `AnimationChainListSave`) holding one or more named chains; each chain is a list of frames with a texture, source rect, frame length, optional flip flags, and optional `RelativeX`/`RelativeY` per-frame offsets.
+Gum plays back FRB-style `.achx`/`.achj` animations on `Sprite` and `NineSlice`. `.achx` (XML) and `.achj` (JSON, matching FlatRedBall2's `AnimationChain.Common` writer) both deserialize into `AnimationChainListSave` — see `AnimationChainListSave.FromFile`. Each chain is a list of frames with a texture, source rect, frame length, optional flip flags, optional `RelativeX`/`RelativeY` per-frame offsets, and optional per-frame color (see below).
 
 ## Pipeline: Save → Runtime
 
@@ -46,7 +46,11 @@ To match FRB visuals on a height-tracking Sprite, the offset has to be applied a
 
 XNA `NineSlice` now composes `AnimationChainLogic` (same pattern as Sprite) — the inline tick loop is gone. Its `ApplyFrame` handler distributes the frame's texture to all 9 internal sprites via `SetSingleTexture`, derives the `SourceRectangle` from the frame's UV coords, and copies `FlipHorizontal`. It does **not** apply `RelativeX/Y`. If `RelativeX/Y` support is ever needed on NineSlice, add the offset application in NineSlice's render path the same way Sprite does.
 
-Skia and Raylib `NineSlice` renderables do not yet expose `AnimationLogic` — animation on those backends is a follow-up tracked under #2753.
+Skia and Raylib `NineSlice` renderables also compose `AnimationLogic` and apply frames the same way as XNA — each has its own `ApplyAnimationFrame` in `Runtimes/{RaylibGum,SkiaGum}/Renderables/NineSlice.cs`.
+
+## Per-frame color (Alpha/Multiply/Add)
+
+`AnimationFrameSave`/`AnimationFrame` carry nullable `Red`/`Green`/`Blue`/`Alpha` (0-255) and an `AnimationFrameColorOperation?` (`Multiply`/`Add`), matching FRB2's Animation Editor fields. Each backend's `ApplyAnimationFrame` sets the renderable's own `Alpha` when authored, and `Red`/`Green`/`Blue` only when `ColorOperation == Multiply` (unset channel defaults to 255) — snapshotted once per frame change, not re-combined at render time, so a frame that authors neither leaves the renderable's current color alone. Alpha (#4489) and Multiply (#4490) are applied on all of XNA/Raylib/Skia; Skia's `Sprite` additionally needed a `Color`-driven `SKColorFilter.CreateBlendMode(..., Modulate)` in `GetPaint` since it previously ignored RGB entirely (NineSlice already had this filter). `Add` parses but isn't applied to rendering anywhere yet — it needs a per-backend pixel shader (#4477).
 
 ## Key Files
 
@@ -59,4 +63,5 @@ Skia and Raylib `NineSlice` renderables do not yet expose `AnimationLogic` — a
 | `RenderingLibrary/Graphics/Animation/AnimationChainList.cs` | `List<AnimationChain>`; `.achx` deserialization entry point |
 | `RenderingLibrary/Graphics/Sprite.cs` | `ApplyAnimationFrame` (frame-change side) and `Render` (per-render `RelativeX/Y` application) |
 | `RenderingLibrary/Graphics/NineSlice.cs` | `ApplyAnimationFrame` distributes frame texture across 9 slices; no `RelativeX/Y` support |
-| `Gum/Graphics/Animation/Content/AnimationFrameSave.cs` | XML-serializable frame; pixel or UV coords per `AnimationChainListSave.CoordinateType` |
+| `Gum/Graphics/Animation/Content/AnimationFrameSave.cs` | XML/JSON-serializable frame; pixel or UV coords per `AnimationChainListSave.CoordinateType`; per-frame color fields |
+| `Gum/Graphics/Animation/Content/AnimationChainListSave.cs` | `.achx` (XmlSerializer) and `.achj` (`ParseJson`/`ParseFrameJson`) parsing, dialect picked by extension in `FromFile` |

--- a/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationChainListSave.cs
@@ -201,10 +201,9 @@ namespace Gum.Content.AnimationChain
 
         // Property names match FlatRedBall2's AnimationChain.Common .achj writer (camelCase) so a
         // file authored by the FlatRedBall Animation Editor loads into Gum without a conversion
-        // step. Fields FRB2 added that Gum's AnimationFrameSave doesn't model yet —
-        // Red/Green/Blue, ColorOperation, per-frame shapes (#4477, #4479) — are simply
-        // not read; JsonObject's indexer returns null for a missing key, so those files still load,
-        // just without that data.
+        // step. Per-frame shapes (#4479) are the one FRB2 addition Gum's AnimationFrameSave
+        // doesn't model yet — simply not read; JsonObject's indexer returns null for a missing
+        // key, so those files still load, just without that data.
         private static AnimationChainListSave ParseJson(JsonObject root)
         {
             AnimationChainListSave result = new AnimationChainListSave();
@@ -257,6 +256,10 @@ namespace Gum.Content.AnimationChain
                 RelativeX = FloatProperty(frameObj, "relativeX"),
                 RelativeY = FloatProperty(frameObj, "relativeY"),
                 Alpha = IntProperty(frameObj, "alpha"),
+                Red = IntProperty(frameObj, "red"),
+                Green = IntProperty(frameObj, "green"),
+                Blue = IntProperty(frameObj, "blue"),
+                ColorOperation = ColorOperationProperty(frameObj, "colorOperation"),
             };
         }
 
@@ -268,6 +271,9 @@ namespace Gum.Content.AnimationChain
 
         private static int? IntProperty(JsonObject parent, string name) =>
             parent[name] is JsonValue value ? value.GetValue<int>() : (int?)null;
+
+        private static AnimationFrameColorOperation? ColorOperationProperty(JsonObject parent, string name) =>
+            parent[name] is JsonValue value ? Enum.Parse<AnimationFrameColorOperation>(value.GetValue<string>()!) : null;
 
         #endregion
 

--- a/Gum/Graphics/Animation/Content/AnimationFrameSave.cs
+++ b/Gum/Graphics/Animation/Content/AnimationFrameSave.cs
@@ -15,6 +15,22 @@ namespace Gum.Content.AnimationChain
         Second
     }
 
+    /// <summary>
+    /// How a frame's per-frame color (<see cref="AnimationFrameSave.Red"/>/
+    /// <see cref="AnimationFrameSave.Green"/>/<see cref="AnimationFrameSave.Blue"/>) combines with
+    /// the sprite's texture, matching FlatRedBall2's <c>ColorOperation</c> enum
+    /// (<c>FlatRedBall2.Animation.ColorOperation</c>) authored by the FlatRedBall Animation Editor.
+    /// </summary>
+    public enum AnimationFrameColorOperation
+    {
+        /// <summary>Multiply the texture by the color (darken / colorize). White (255) is the identity.</summary>
+        Multiply,
+
+        /// <summary>Add the color to the texture (brighten / glow / flash). Black (0) is the identity.
+        /// Not applied to rendering by Gum yet (#4477) — requires a per-backend shader.</summary>
+        Add
+    }
+
     [Serializable]
     public class AnimationFrameSave
     {
@@ -55,6 +71,41 @@ namespace Gum.Content.AnimationChain
         public bool ShouldSerializeAlpha()
         {
             return Alpha.HasValue;
+        }
+
+        /// <summary>
+        /// The red channel (0-255) of the frame's per-frame color. Only combined with the texture
+        /// when <see cref="ColorOperation"/> is <see cref="AnimationFrameColorOperation.Multiply"/>;
+        /// null (the identity, 255) if unset.
+        /// </summary>
+        public int? Red;
+        public bool ShouldSerializeRed()
+        {
+            return Red.HasValue;
+        }
+
+        /// <summary>The green channel (0-255) of the frame's per-frame color. See <see cref="Red"/>.</summary>
+        public int? Green;
+        public bool ShouldSerializeGreen()
+        {
+            return Green.HasValue;
+        }
+
+        /// <summary>The blue channel (0-255) of the frame's per-frame color. See <see cref="Red"/>.</summary>
+        public int? Blue;
+        public bool ShouldSerializeBlue()
+        {
+            return Blue.HasValue;
+        }
+
+        /// <summary>
+        /// How <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/> combine with the texture, or
+        /// null if the frame doesn't author a per-frame color.
+        /// </summary>
+        public AnimationFrameColorOperation? ColorOperation;
+        public bool ShouldSerializeColorOperation()
+        {
+            return ColorOperation.HasValue;
         }
 
         /// <summary>

--- a/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
+++ b/MonoGameGum.Tests/Content/AnimationChainListSaveAchjTests.cs
@@ -56,7 +56,11 @@ public class AnimationChainListSaveAchjTests
                   "flipDiagonal": true,
                   "relativeX": 2.5,
                   "relativeY": -1.5,
-                  "alpha": 128
+                  "alpha": 128,
+                  "red": 10,
+                  "green": 20,
+                  "blue": 30,
+                  "colorOperation": "Multiply"
                 }
               ]
             }
@@ -84,6 +88,10 @@ public class AnimationChainListSaveAchjTests
             frame.RelativeX.ShouldBe(2.5f);
             frame.RelativeY.ShouldBe(-1.5f);
             frame.Alpha.ShouldBe(128);
+            frame.Red.ShouldBe(10);
+            frame.Green.ShouldBe(20);
+            frame.Blue.ShouldBe(30);
+            frame.ColorOperation.ShouldBe(AnimationFrameColorOperation.Multiply);
         });
     }
 
@@ -110,14 +118,45 @@ public class AnimationChainListSaveAchjTests
             frame.RelativeX.ShouldBe(0f);
             frame.RelativeY.ShouldBe(0f);
             frame.Alpha.ShouldBeNull();
+            frame.Red.ShouldBeNull();
+            frame.Green.ShouldBeNull();
+            frame.Blue.ShouldBeNull();
+            frame.ColorOperation.ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public void FromFile_AchjExtension_ParsesAddColorOperation()
+    {
+        // Add is parsed into the data model like Multiply, even though only Multiply is applied
+        // to rendering today (#4477 tracks Add, which needs a per-backend shader).
+        WithTempFile(".achj", """
+        {
+          "animationChains": [
+            {
+              "name": "Flash",
+              "frames": [
+                { "textureName": "flash.png", "frameLength": 0.05, "red": 255, "green": 0, "blue": 0, "colorOperation": "Add" }
+              ]
+            }
+          ]
+        }
+        """, path =>
+        {
+            AnimationFrameSave frame = AnimationChainListSave.FromFile(path).AnimationChains[0].Frames[0];
+
+            frame.Red.ShouldBe(255);
+            frame.Green.ShouldBe(0);
+            frame.Blue.ShouldBe(0);
+            frame.ColorOperation.ShouldBe(AnimationFrameColorOperation.Add);
         });
     }
 
     [Fact]
     public void FromFile_AchjExtension_UnknownFrbTwoOnlyFields_AreIgnoredNotThrown()
     {
-        // Red/Green/Blue, ColorOperation, and shapes are FRB2 additions Gum doesn't model
-        // yet (#4477, #4479) — an achj file carrying them must still load.
+        // Per-frame shapes are an FRB2 addition Gum doesn't model yet (#4479) — an achj file
+        // carrying them must still load.
         WithTempFile(".achj", """
         {
           "animationChains": [
@@ -127,10 +166,6 @@ public class AnimationChainListSaveAchjTests
                 {
                   "textureName": "flash.png",
                   "frameLength": 0.05,
-                  "red": 255,
-                  "green": 0,
-                  "blue": 0,
-                  "colorOperation": "Add",
                   "shapes": { "rectangles": [], "circles": [], "polygons": [] }
                 }
               ]
@@ -165,6 +200,10 @@ public class AnimationChainListSaveAchjTests
               <BottomCoordinate>1</BottomCoordinate>
               <FlipDiagonal>true</FlipDiagonal>
               <Alpha>200</Alpha>
+              <Red>10</Red>
+              <Green>20</Green>
+              <Blue>30</Blue>
+              <ColorOperation>Multiply</ColorOperation>
             </Frame>
           </AnimationChain>
         </AnimationChainArraySave>
@@ -173,9 +212,14 @@ public class AnimationChainListSaveAchjTests
             AnimationChainListSave save = AnimationChainListSave.FromFile(path);
 
             save.AnimationChains.Count.ShouldBe(1);
-            save.AnimationChains[0].Frames[0].TextureName.ShouldBe("walk_0.png");
-            save.AnimationChains[0].Frames[0].FlipDiagonal.ShouldBeTrue();
-            save.AnimationChains[0].Frames[0].Alpha.ShouldBe(200);
+            AnimationFrameSave frame = save.AnimationChains[0].Frames[0];
+            frame.TextureName.ShouldBe("walk_0.png");
+            frame.FlipDiagonal.ShouldBeTrue();
+            frame.Alpha.ShouldBe(200);
+            frame.Red.ShouldBe(10);
+            frame.Green.ShouldBe(20);
+            frame.Blue.ShouldBe(30);
+            frame.ColorOperation.ShouldBe(AnimationFrameColorOperation.Multiply);
         });
     }
 

--- a/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/MonoGameGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Graphics.Animation;
+﻿using Gum.Content.AnimationChain;
+using Gum.Graphics.Animation;
 using Microsoft.Xna.Framework.Graphics;
 using Gum.GueDeriving;
 using RenderingLibrary.Graphics;
@@ -49,7 +50,18 @@ public class SpriteRuntimeTests : BaseTestClass
 
         var chain = new AnimationChain { Name = "TestChain" };
         chain.Add(new AnimationFrame { FrameLength = 1.0f, FlipHorizontal = false, FlipVertical = false, FlipDiagonal = false });
-        chain.Add(new AnimationFrame { FrameLength = 1.0f, FlipHorizontal = true, FlipVertical = true, FlipDiagonal = true, Alpha = 128 });
+        chain.Add(new AnimationFrame
+        {
+            FrameLength = 1.0f,
+            FlipHorizontal = true,
+            FlipVertical = true,
+            FlipDiagonal = true,
+            Alpha = 128,
+            Red = 10,
+            Green = 20,
+            Blue = 30,
+            ColorOperation = AnimationFrameColorOperation.Multiply,
+        });
 
         var chainList = new AnimationChainList();
         chainList.Add(chain);
@@ -64,6 +76,9 @@ public class SpriteRuntimeTests : BaseTestClass
         sprite.FlipVertical.ShouldBeTrue();
         sprite.FlipDiagonal.ShouldBeTrue();
         sprite.Alpha.ShouldBe(128);
+        sprite.Red.ShouldBe(10);
+        sprite.Green.ShouldBe(20);
+        sprite.Blue.ShouldBe(30);
     }
 
     [Fact]
@@ -84,6 +99,48 @@ public class SpriteRuntimeTests : BaseTestClass
         sprite.CurrentChainName = "TestChain";
 
         sprite.Alpha.ShouldBe(64);
+    }
+
+    [Fact]
+    public void AnimateSelf_ShouldLeaveSpriteColorUnchanged_WhenFrameColorOperationIsNotMultiply()
+    {
+        // ColorOperation is nullable/Add-capable so a frame that doesn't author Multiply must not
+        // reset Red/Green/Blue back to identity — Add is not applied to rendering (tracked
+        // separately in #4477) and an absent ColorOperation means "no per-frame color" entirely.
+        var sprite = new Sprite((Texture2D?)null) { Red = 11, Green = 22, Blue = 33 };
+
+        var chain = new AnimationChain { Name = "TestChain" };
+        chain.Add(new AnimationFrame { FrameLength = 1.0f, Red = 255, Green = 0, Blue = 0, ColorOperation = AnimationFrameColorOperation.Add });
+
+        var chainList = new AnimationChainList();
+        chainList.Add(chain);
+
+        sprite.AnimationChains = chainList;
+        sprite.CurrentChainName = "TestChain";
+
+        sprite.Red.ShouldBe(11);
+        sprite.Green.ShouldBe(22);
+        sprite.Blue.ShouldBe(33);
+    }
+
+    [Fact]
+    public void AnimateSelf_ShouldDefaultUnsetChannelsTo255_WhenFrameColorOperationIsMultiply()
+    {
+        // FRB2's SpriteFrameColor.Apply treats an unset Multiply channel as 255 (identity).
+        var sprite = new Sprite((Texture2D?)null) { Red = 1, Green = 2, Blue = 3 };
+
+        var chain = new AnimationChain { Name = "TestChain" };
+        chain.Add(new AnimationFrame { FrameLength = 1.0f, Green = 40, ColorOperation = AnimationFrameColorOperation.Multiply });
+
+        var chainList = new AnimationChainList();
+        chainList.Add(chain);
+
+        sprite.AnimationChains = chainList;
+        sprite.CurrentChainName = "TestChain";
+
+        sprite.Red.ShouldBe(255);
+        sprite.Green.ShouldBe(40);
+        sprite.Blue.ShouldBe(255);
     }
 
     [Fact]

--- a/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
+++ b/RenderingLibrary/Graphics/Animation/AnimationFrame.cs
@@ -71,6 +71,27 @@ namespace Gum.Graphics.Animation
         /// </summary>
         public int? Alpha;
 
+        /// <summary>
+        /// The red channel (0-255) of the frame's per-frame color. Only applied when
+        /// <see cref="ColorOperation"/> is <see cref="AnimationFrameColorOperation.Multiply"/>;
+        /// null (the identity, 255) if unset.
+        /// </summary>
+        public int? Red;
+
+        /// <summary>The green channel (0-255) of the frame's per-frame color. See <see cref="Red"/>.</summary>
+        public int? Green;
+
+        /// <summary>The blue channel (0-255) of the frame's per-frame color. See <see cref="Red"/>.</summary>
+        public int? Blue;
+
+        /// <summary>
+        /// How <see cref="Red"/>/<see cref="Green"/>/<see cref="Blue"/> combine with the texture, or
+        /// null if the frame doesn't author a per-frame color. Only <see cref="AnimationFrameColorOperation.Multiply"/>
+        /// is applied to rendering today (#4477 tracks <see cref="AnimationFrameColorOperation.Add"/>, which
+        /// needs a per-backend shader).
+        /// </summary>
+        public AnimationFrameColorOperation? ColorOperation;
+
         #region XML Docs
         /// <summary>
         /// Used in XML Serialization of AnimationChains - this should
@@ -281,6 +302,10 @@ namespace Gum.Graphics.Animation
             frame.FlipVertical = animationFrameSave.FlipVertical;
             frame.FlipDiagonal = animationFrameSave.FlipDiagonal;
             frame.Alpha = animationFrameSave.Alpha;
+            frame.Red = animationFrameSave.Red;
+            frame.Green = animationFrameSave.Green;
+            frame.Blue = animationFrameSave.Blue;
+            frame.ColorOperation = animationFrameSave.ColorOperation;
 
             if (coordinateType == TextureCoordinateType.UV)
             {

--- a/RenderingLibrary/Graphics/NineSlice.cs
+++ b/RenderingLibrary/Graphics/NineSlice.cs
@@ -14,6 +14,7 @@ using Rectangle = System.Drawing.Rectangle;
 using Color = System.Drawing.Color;
 using Matrix = System.Numerics.Matrix4x4;
 using Gum;
+using Gum.Content.AnimationChain;
 using Gum.Graphics.Animation;
 using RenderingLibrary.Graphics.Animation;
 using System.Runtime.CompilerServices;
@@ -1142,6 +1143,13 @@ public class NineSlice : SpriteBatchRenderableBase,
         if (frame.Alpha.HasValue)
         {
             Alpha = frame.Alpha.Value;
+        }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
         }
     }
 

--- a/RenderingLibrary/Graphics/Sprite.cs
+++ b/RenderingLibrary/Graphics/Sprite.cs
@@ -9,6 +9,7 @@ using MathHelper = ToolsUtilitiesStandard.Helpers.MathHelper;
 using Vector2 = System.Numerics.Vector2;
 using Color = System.Drawing.Color;
 using Rectangle = System.Drawing.Rectangle;
+using Gum.Content.AnimationChain;
 using Gum.Graphics.Animation;
 using RenderingLibrary.Graphics.Animation;
 using RenderingLibrary.Math;
@@ -380,6 +381,13 @@ public class Sprite : SpriteBatchRenderableBase,
         if (frame.Alpha.HasValue)
         {
             Alpha = frame.Alpha.Value;
+        }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
         }
     }
 

--- a/Runtimes/RaylibGum/Renderables/NineSlice.cs
+++ b/Runtimes/RaylibGum/Renderables/NineSlice.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Graphics.Animation;
+﻿using Gum.Content.AnimationChain;
+using Gum.Graphics.Animation;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
@@ -67,6 +68,13 @@ public class NineSlice : RenderableBase, IAnimatable, ITextureCoordinate, IClone
         if (frame.Alpha.HasValue)
         {
             Alpha = frame.Alpha.Value;
+        }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
         }
     }
 

--- a/Runtimes/RaylibGum/Renderables/Sprite.cs
+++ b/Runtimes/RaylibGum/Renderables/Sprite.cs
@@ -1,4 +1,5 @@
-﻿using Gum.Graphics.Animation;
+﻿using Gum.Content.AnimationChain;
+using Gum.Graphics.Animation;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
@@ -525,6 +526,13 @@ public class Sprite : InvisibleRenderable, IAspectRatio, ITextureCoordinate, IAn
         if (frame.Alpha.HasValue)
         {
             Alpha = frame.Alpha.Value;
+        }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
         }
     }
 

--- a/Runtimes/SkiaGum/Renderables/NineSlice.cs
+++ b/Runtimes/SkiaGum/Renderables/NineSlice.cs
@@ -1,3 +1,4 @@
+using Gum.Content.AnimationChain;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
 using RenderingLibrary.Math;
@@ -59,6 +60,13 @@ public class NineSlice : RenderableShapeBase, IAnimatable, ICloneable, ITextureC
         if (frame.Alpha.HasValue)
         {
             Alpha = frame.Alpha.Value;
+        }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
         }
     }
 

--- a/Runtimes/SkiaGum/Renderables/Sprite.cs
+++ b/Runtimes/SkiaGum/Renderables/Sprite.cs
@@ -1,4 +1,5 @@
-﻿using RenderingLibrary.Graphics;
+﻿using Gum.Content.AnimationChain;
+using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Animation;
 using RenderingLibrary.Math;
 using SkiaSharp;
@@ -76,6 +77,11 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
 
     public Sprite()
     {
+        // RenderableShapeBase defaults Color to red, which would tint every drawn sprite red once
+        // GetPaint routes Color through a Modulate filter (mirrors SkiaGum.Renderables.NineSlice's
+        // constructor). White is the no-tint identity for SKBlendMode.Modulate.
+        Color = SKColors.White;
+
         AnimationLogic.ApplyFrame = ApplyAnimationFrame;
     }
 
@@ -106,6 +112,13 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
         {
             Alpha = frame.Alpha.Value;
         }
+
+        if (frame.ColorOperation == AnimationFrameColorOperation.Multiply)
+        {
+            Red = frame.Red ?? 255;
+            Green = frame.Green ?? 255;
+            Blue = frame.Blue ?? 255;
+        }
     }
 
     public bool AnimateSelf(double secondDifference)
@@ -122,6 +135,13 @@ public class Sprite : RenderableShapeBase, IAspectRatio, ITextureCoordinate, IAn
         // softer rotated-edge look back.
         SKPaint paint = base.GetPaint(boundingRect, absoluteRotation);
         paint.IsAntialias = false;
+
+        // Modulate the image's texels by Color so per-frame Multiply color (#4490) and any
+        // manually-assigned Red/Green/Blue tint the sprite. Mirrors NineSlice.GetPaint — the base
+        // paint's Color is set too, but that only matters for non-image draws; DrawImage needs a
+        // ColorFilter. White (the default Color, see the constructor) is the identity, so this is
+        // a no-op for sprites that never touch Red/Green/Blue.
+        paint.ColorFilter = SKColorFilter.CreateBlendMode(Color, SKBlendMode.Modulate);
         return paint;
     }
 

--- a/Tests/RaylibGum.Tests/Runtimes/NineSliceRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/NineSliceRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Gum.Content.AnimationChain;
 using Gum.Graphics.Animation;
 using Gum.GueDeriving;
 using Gum.Renderables;
@@ -52,6 +53,10 @@ public class NineSliceRuntimeTests : BaseTestClass
             TopCoordinate = 0.5f,
             BottomCoordinate = 1f,
             Alpha = 60,
+            Red = 10,
+            Green = 20,
+            Blue = 30,
+            ColorOperation = AnimationFrameColorOperation.Multiply,
         };
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
@@ -81,6 +86,9 @@ public class NineSliceRuntimeTests : BaseTestClass
         contained.SourceRectangle.Value.Width.ShouldBe(20f);
         contained.SourceRectangle.Value.Height.ShouldBe(20f);
         sut.Alpha.ShouldBe(60);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
     }
 
     [Fact]

--- a/Tests/RaylibGum.Tests/Runtimes/SpriteRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/SpriteRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Gum.Content.AnimationChain;
 using Gum.GueDeriving;
 using Gum.Graphics.Animation;
 using Raylib_cs;
@@ -60,6 +61,38 @@ public class SpriteRuntimeTests : BaseTestClass
         sut.IsAnimationChainLooping = false;
 
         sut.IsAnimationChainLooping.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AnimateSelf_ShouldApplyFrameColorToSprite_WhenFrameChanges()
+    {
+        Gum.Renderables.Sprite sprite = new();
+
+        AnimationChain chain = new AnimationChain { Name = "TestChain" };
+        chain.Add(new AnimationFrame { FrameLength = 1.0f });
+        chain.Add(new AnimationFrame
+        {
+            FrameLength = 1.0f,
+            Alpha = 128,
+            Red = 10,
+            Green = 20,
+            Blue = 30,
+            ColorOperation = AnimationFrameColorOperation.Multiply,
+        });
+
+        AnimationChainList chainList = new AnimationChainList();
+        chainList.Add(chain);
+
+        sprite.AnimationChains = chainList;
+        sprite.Animate = true;
+
+        // 1.5s into chain crosses from frame 0 (ends at 1.0s) into frame 1.
+        sprite.AnimateSelf(1.5);
+
+        sprite.Alpha.ShouldBe(128);
+        sprite.Red.ShouldBe(10);
+        sprite.Green.ShouldBe(20);
+        sprite.Blue.ShouldBe(30);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/NineSliceRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Gum.Content.AnimationChain;
 using Gum.Graphics.Animation;
 using Gum.GueDeriving;
 using Gum.Wireframe;
@@ -137,6 +138,10 @@ public class NineSliceRuntimeTests
             TopCoordinate = 0.5f,
             BottomCoordinate = 1f,
             Alpha = 60,
+            Red = 10,
+            Green = 20,
+            Blue = 30,
+            ColorOperation = AnimationFrameColorOperation.Multiply,
         };
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
@@ -168,6 +173,9 @@ public class NineSliceRuntimeTests
         contained.SourceRectangle.Value.Width.ShouldBe(20);
         contained.SourceRectangle.Value.Height.ShouldBe(20);
         sut.Alpha.ShouldBe(60);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
     }
 
     [Fact]

--- a/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
+++ b/Tests/SkiaGum.Tests/GueDeriving/SpriteRuntimeTests.cs
@@ -7,6 +7,7 @@ using Shouldly;
 using Xunit;
 using RenderingLibrary.Content;
 using System;
+using Gum.Content.AnimationChain;
 using Gum.Graphics.Animation;
 
 namespace SkiaGum.Tests.GueDeriving;
@@ -301,7 +302,20 @@ public class SpriteRuntimeTests
 
         AnimationChain chain = new AnimationChain { Name = "TestChain" };
         chain.Add(new AnimationFrame { Texture = textureA, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f, Alpha = 255 });
-        chain.Add(new AnimationFrame { Texture = textureB, FrameLength = 0.1f, LeftCoordinate = 0f, RightCoordinate = 1f, TopCoordinate = 0f, BottomCoordinate = 1f, Alpha = 60 });
+        chain.Add(new AnimationFrame
+        {
+            Texture = textureB,
+            FrameLength = 0.1f,
+            LeftCoordinate = 0f,
+            RightCoordinate = 1f,
+            TopCoordinate = 0f,
+            BottomCoordinate = 1f,
+            Alpha = 60,
+            Red = 10,
+            Green = 20,
+            Blue = 30,
+            ColorOperation = AnimationFrameColorOperation.Multiply,
+        });
 
         AnimationChainList chains = new AnimationChainList();
         chains.Add(chain);
@@ -321,6 +335,9 @@ public class SpriteRuntimeTests
 
         sut.AnimationChainFrameIndex.ShouldBe(1);
         sut.Alpha.ShouldBe(60);
+        sut.Red.ShouldBe(10);
+        sut.Green.ShouldBe(20);
+        sut.Blue.ShouldBe(30);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds nullable `Red`/`Green`/`Blue` and `AnimationFrameColorOperation` (`Multiply`/`Add`) to `AnimationFrameSave`, parsed for both `.achx` (XML) and `.achj` (JSON).
- `Multiply` applies on frame change by setting the renderable's `Red`/`Green`/`Blue` (unset channel = 255 identity) — same snapshot pattern as per-frame Alpha (#4489).
- Implemented on all three renderer backends: MonoGame/KNI/FNA, raylib, and Skia. Skia's `Sprite` needed a new `Color`-driven `SKColorFilter.CreateBlendMode(Modulate)` since it previously ignored RGB tint entirely; the other two backends' existing tint multiply just needed wiring.
- `Add` parses into the data model but isn't applied to rendering — tracked separately in #4477 (needs a per-backend pixel shader).
- Fixes a stale `gum-runtime-animation-chains` skill claim that Raylib/Skia `NineSlice` don't expose `AnimationLogic` (#2753) — they do — and documents `.achj` and the new per-frame color fields.

Closes #4490.

## Test plan
- [x] `MonoGameGum.Tests` (2195 tests) — full suite green
- [x] `RaylibGum.Tests` (606 tests) — full suite green
- [x] `SkiaGum.Tests` (434 tests) — full suite green
- [x] `SilkNetGum.Tests` (34 tests) — green (shares SkiaGum renderables)
- [x] `MonoGameGum`, `KniGum`, `RaylibGum`, `SkiaGum`, `SkiaGum.Wpf` all build with zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GB2zErp4RLNDYY29wXWLPC