### PR TITLE
Report GUM0006 warning when an instance file variable is missing on disk

### DIFF
--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -1031,4 +1031,85 @@ public class HeadlessErrorCheckerTests : BaseTestClass
     }
 
     #endregion
+
+    #region GUM0006 — Missing referenced external file
+
+    [Fact]
+    public void GetErrorsFor_ShouldReportGum0006_WhenInstanceSourceFileIsMissing()
+    {
+        // Issue #4493: an instance's SourceFile (texture, .achx, etc.) pointing at a file that
+        // isn't on disk was never checked anywhere in the interactive Errors tab / tree "!" - only
+        // GumProjectDependencyWalker's gumcli-pack path caught it. Reuse that same walker (scoped
+        // to a single element) so this isn't a second, divergent implementation.
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "GumErrorChecker_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            Project.FullFileName = Path.Combine(tempDirectory, "Project.gumx");
+
+            ComponentSave component = new ComponentSave { Name = "BrokenSpriteHolder" };
+            component.Instances.Add(new InstanceSave { Name = "MySprite", BaseType = "Sprite" });
+            StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = "MySprite.SourceFile",
+                Value = "Textures/DoesNotExist.png",
+                Type = "string",
+                IsFile = true,
+            });
+            component.States.Add(defaultState);
+            Project.Components.Add(component);
+
+            IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+            ErrorResult error = errors.ShouldHaveSingleItem();
+            error.Code.ShouldBe("GUM0006");
+            error.ElementName.ShouldBe("BrokenSpriteHolder");
+            error.Severity.ShouldBe(ErrorSeverity.Warning);
+            error.Message.ShouldContain("MySprite");
+            error.Message.ShouldContain("Textures/DoesNotExist.png");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetErrorsFor_ShouldNotReportGum0006_WhenInstanceSourceFileExists()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "GumErrorChecker_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            Project.FullFileName = Path.Combine(tempDirectory, "Project.gumx");
+
+            string texturesDirectory = Path.Combine(tempDirectory, "Textures");
+            Directory.CreateDirectory(texturesDirectory);
+            File.WriteAllText(Path.Combine(texturesDirectory, "Exists.png"), string.Empty);
+
+            ComponentSave component = new ComponentSave { Name = "GoodSpriteHolder" };
+            component.Instances.Add(new InstanceSave { Name = "MySprite", BaseType = "Sprite" });
+            StateSave defaultState = new StateSave { Name = "Default", ParentContainer = component };
+            defaultState.Variables.Add(new VariableSave
+            {
+                Name = "MySprite.SourceFile",
+                Value = "Textures/Exists.png",
+                Type = "string",
+                IsFile = true,
+            });
+            component.States.Add(defaultState);
+            Project.Components.Add(component);
+
+            IReadOnlyList<ErrorResult> errors = _sut.GetErrorsFor(component, Project);
+
+            errors.ShouldNotContain(e => e.Code == "GUM0006");
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    #endregion
 }

--- a/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
+++ b/Tools/Gum.ProjectServices/ErrorDocsRegistry.cs
@@ -18,6 +18,7 @@ public class ErrorDocsRegistry : IErrorDocsRegistry
             ["GUM0003"] = "gum-tool/gum-elements/states/categories#gum0003-category-state-sets-its-own-category-selector",
             ["GUM0004"] = "gum-tool/project-files#missing-source-files-gum0004",
             ["GUM0005"] = "gum-tool/code-tab/orphaned-code-files",
+            ["GUM0006"] = "gum-tool/project-files#missing-referenced-external-file-gum0006",
         };
     }
 

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -1,3 +1,4 @@
+using Gum.Bundle;
 using Gum.Content.AnimationChain;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
@@ -103,6 +104,7 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
             errors.AddRange(GetBehaviorErrorsFor(asComponent, project));
         }
         errors.AddRange(GetMissingSourceFileErrorsFor(element));
+        errors.AddRange(GetMissingExternalFileErrorsFor(element, project));
         errors.AddRange(GetMissingElementBaseTypeErrorFor(element));
         errors.AddRange(GetMissingBaseTypeErrorsFor(element));
         errors.AddRange(GetParentErrorsFor(element));
@@ -539,6 +541,49 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
                     $"\"{expectedRelativePath}\" but could not find it on disk. The element still exists " +
                     $"in the project in memory - saving it will recreate the file, or restore the file " +
                     $"to resolve this error."
+            });
+        }
+
+        return errors;
+    }
+
+    #endregion
+
+    #region GUM0006 — Missing referenced external file
+
+    /// <summary>
+    /// Surfaces instance/element variables flagged IsFile (Sprite/Svg/LottieAnimation SourceFile,
+    /// custom font files, etc.) whose value does not resolve to an existing file on disk. Reuses
+    /// <see cref="GumProjectDependencyWalker"/> scoped to a single element - the same walk
+    /// `gumcli pack` already performs to catch these before bundling - so missing references are
+    /// no longer silently ignored by the interactive Errors tab / tree "!" (issue #4493).
+    /// A Warning, not an Error: unlike a missing element/behavior file, a missing texture/font
+    /// doesn't affect codegen correctness, and <c>CodegenCommand</c> treats any Error as blocking
+    /// generation for that element - the same reasoning <see cref="GetAchxOriginErrorsFor"/>
+    /// already uses for its content-drift warning.
+    /// </summary>
+    private static List<ErrorResult> GetMissingExternalFileErrorsFor(ElementSave element, GumProjectSave project)
+    {
+        var errors = new List<ErrorResult>();
+
+        if (string.IsNullOrEmpty(project.FullFileName))
+        {
+            return errors;
+        }
+
+        var projectRootDirectory = FileManager.GetDirectory(project.FullFileName);
+        var walker = new GumProjectDependencyWalker();
+        var result = walker.Walk(project, projectRootDirectory, GumBundleInclusion.ExternalFiles, element);
+
+        foreach (var warning in result.MissingFiles)
+        {
+            errors.Add(new ErrorResult
+            {
+                ElementName = element.Name,
+                Code = "GUM0006",
+                Severity = ErrorSeverity.Warning,
+                Message = $"{warning.ReferencedFromElementName} references \"{warning.ReferencedPath}\", " +
+                    $"which was not found on disk."
             });
         }
 

--- a/docs/gum-tool/project-files/README.md
+++ b/docs/gum-tool/project-files/README.md
@@ -137,6 +137,12 @@ When this happens the Gum tool reports a **GUM0004** error in the [Errors tab](.
 
 GUM0004 is a listed error only; it does not block saving the project.
 
+## Missing Referenced External File (GUM0006)
+
+An instance or element variable that references an external file, such as a Sprite's `Source File` (including `.achx`/`.achj` animation chains), or a `Custom Font File`, can point at a path that does not exist on disk, for example after a typo, a rename, or a moved file.
+
+When this happens the Gum tool reports a **GUM0006** warning in the [Errors tab](../editor-tab.md), naming the instance and the path it referenced. To resolve it, either point the variable at the correct file or restore the missing file to the expected location.
+
 ## Version Control (.gitignore)
 
 The following `.gitignore` entries are recommended for Gum projects:


### PR DESCRIPTION
## Summary
- Closes #4493. A Sprite's `SourceFile` (or `.achx`/`.achj`, `Svg`/`LottieAnimation` SourceFile, custom font file) pointing at a nonexistent path was never checked by the interactive Errors tab or tree "!" - only `gumcli pack` caught it, via `GumProjectDependencyWalker`.
- `HeadlessErrorChecker` now runs that same walker scoped to a single element and reports missing references as a new **GUM0006** warning.
- Warning, not Error: `CodegenCommand` treats `ErrorSeverity.Error` as blocking codegen for that element, and a missing texture/font has no bearing on codegen correctness - same reasoning the existing achx-origin-drift check uses.

## Test plan
- [x] New unit tests in `HeadlessErrorCheckerTests` (missing file reports GUM0006 warning; existing file reports nothing)
- [x] `dotnet test Tests/Gum.ProjectServices.Tests` - 518 passed
- [x] `dotnet test Tests/Gum.Cli.Tests` - 71 passed (codegen/check commands unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgsXgFk95t7Sqknub9AUG1
