### PR TITLE
Fix O(n^2) full-tree error refresh

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/MainTreeViewPlugin.cs
@@ -347,10 +347,22 @@ internal class MainTreeViewPlugin : PriorityPlugin, IRecipient<ApplicationTeardo
         var allElements = project.Screens.Cast<ElementSave>()
             .Concat(project.Components)
             .Concat(project.StandardElements);
-        foreach (var element in allElements)
+        // GetErrorsFor enables/disables ObjectFinder's cache (ref-counted) per call. Without this
+        // outer enable, each call rebuilds the cache from scratch, making a full-tree refresh
+        // O(n^2) in project size. Enabling here once means the per-call enable/disable inside the
+        // loop just increments/decrements the ref count instead of rebuilding (#4495).
+        ObjectFinder.Self.EnableCache();
+        try
         {
-            bool hasErrors = _errorChecker.GetErrorsFor(element, project).Length > 0;
-            _elementTreeViewManager.UpdateErrorIndicatorsForElement(element, hasErrors);
+            foreach (var element in allElements)
+            {
+                bool hasErrors = _errorChecker.GetErrorsFor(element, project).Length > 0;
+                _elementTreeViewManager.UpdateErrorIndicatorsForElement(element, hasErrors);
+            }
+        }
+        finally
+        {
+            ObjectFinder.Self.DisableCache();
         }
     }
 

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -306,12 +306,20 @@ public class GumProjectDependencyWalker
 
         // Build a name -> element lookup once for resolving instance BaseTypes; matches the
         // private dictionary the project-wide walk uses, scoped here to the single-element path.
-        Dictionary<string, ElementSave> elementsByName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
-        foreach (ElementSave e in project.AllElements)
+        // Only built when includeCore is set (the only place it's consulted below) - callers that
+        // scope to ExternalFiles/FontCache only (e.g. the interactive error checker, called once
+        // per element on a full-tree refresh) would otherwise pay this O(n) build for nothing,
+        // turning that refresh into O(n^2) in project size (#4495).
+        Dictionary<string, ElementSave>? elementsByName = null;
+        if (includeCore)
         {
-            if (!string.IsNullOrEmpty(e.Name) && !elementsByName.ContainsKey(e.Name))
+            elementsByName = new Dictionary<string, ElementSave>(StringComparer.OrdinalIgnoreCase);
+            foreach (ElementSave e in project.AllElements)
             {
-                elementsByName[e.Name] = e;
+                if (!string.IsNullOrEmpty(e.Name) && !elementsByName.ContainsKey(e.Name))
+                {
+                    elementsByName[e.Name] = e;
+                }
             }
         }
 
@@ -328,7 +336,7 @@ public class GumProjectDependencyWalker
                 foreach (InstanceSave instance in scopeElement.Instances)
                 {
                     if (includeCore && !string.IsNullOrEmpty(instance.BaseType)
-                        && elementsByName.TryGetValue(instance.BaseType, out ElementSave? instanceElement))
+                        && elementsByName!.TryGetValue(instance.BaseType, out ElementSave? instanceElement))
                     {
                         string? subfolder = instanceElement is ComponentSave ? "Components"
                             : instanceElement is StandardElementSave ? "Standards"


### PR DESCRIPTION
Closes #4495

Verified the issue's premises directly against the code:
- `RefreshErrorIndicatorsForAllElements` had no outer `ObjectFinder.Self.EnableCache()` — each per-element `GetErrorsFor` call rebuilt the ref-counted cache from scratch.
- `CollectForSingleElement` built its `elementsByName` dictionary from `project.AllElements` on every call — now invoked once per element via #4494's GUM0006 check.

Fixes:
1. Wrap `RefreshErrorIndicatorsForAllElements`'s loop in a single `EnableCache`/`DisableCache` pair, so the per-element calls just increment/decrement the ref count.
2. Gate `elementsByName`'s build behind `includeCore` in `CollectForSingleElement` — it's only ever consulted when that flag is set, and the current caller (`GetMissingExternalFileErrorsFor`, `ExternalFiles`-only) was paying the O(n) build for a dictionary it never used. Avoids the issue's speculative `ObjectFinder.Self.GetElementSave` suggestion and its "open question" about `gumcli pack` safety entirely.

Manual test: not needed — pure perf fix, no observable behavior change; covered by unit tests + compilation.