### PR TITLE
Fix crash adding a child object of a type not in the project

### DIFF
--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs
@@ -26,17 +26,28 @@ public partial class ElementTreeViewManager
 
     #region Menu helpers
 
-    private static readonly string[] StandardInstanceTypes =
+    /// <summary>
+    /// The standard element type names that can be added as a child/sibling instance for
+    /// <paramref name="gumProject"/>. Reads the project's actual <see cref="GumProjectSave.StandardElements"/>
+    /// instead of a hardcoded list, so a type that isn't seeded into this project (e.g. the deprecated
+    /// "ColoredRectangle", excluded from new projects since #2965 phase 2) never appears as a choice that
+    /// would crash when instantiated (#4499). "Component" is excluded because it's a StandardElementSave
+    /// used internally for default-value lookups, not a type meant to be instantiated directly.
+    /// </summary>
+    internal static List<string> GetAvailableStandardInstanceTypes(GumProjectSave? gumProject)
     {
-        "Circle",
-        "ColoredRectangle",
-        "Container",
-        "NineSlice",
-        "Polygon",
-        "Rectangle",
-        "Sprite",
-        "Text",
-    };
+        if (gumProject == null)
+        {
+            return new List<string>();
+        }
+
+        var typeNames = gumProject.StandardElements
+            .Where(standard => standard.Name != "Component")
+            .Select(standard => standard.Name)
+            .ToList();
+
+        return SortStandardTypeNamesForPalette(typeNames);
+    }
 
     private void AddMenuItem(string text, Action clickAction)
     {
@@ -487,7 +498,7 @@ public partial class ElementTreeViewManager
             parentMenuItem.Items.Add(new Separator());
         }
 
-        foreach (var type in StandardInstanceTypes)
+        foreach (var type in GetAvailableStandardInstanceTypes(_projectState.GumProjectSave))
         {
             var menuItem = new MenuItem
             {
@@ -522,7 +533,7 @@ public partial class ElementTreeViewManager
         var parentMenuItem = new MenuItem { Header = itemText };
         _contextMenu.Items.Add(parentMenuItem);
 
-        foreach (var type in StandardInstanceTypes)
+        foreach (var type in GetAvailableStandardInstanceTypes(_projectState.GumProjectSave))
         {
             var menuItem = new MenuItem
             {

--- a/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.cs
@@ -547,15 +547,9 @@ public partial class ElementTreeViewManager : IRecipient<ThemeChangedMessage>, I
 
     private void RefreshStandardsPaletteChips()
     {
-        var gumProject = _projectState.GumProjectSave;
-        List<string> typeNames = gumProject == null
-            ? new List<string>()
-            : gumProject.StandardElements
-                .Where(standard => standard.Name != "Component")
-                .Select(standard => standard.Name)
-                .ToList();
+        var typeNames = GetAvailableStandardInstanceTypes(_projectState.GumProjectSave);
 
-        _viewCreator.StandardsPalette.RefreshChips(SortStandardTypeNamesForPalette(typeNames));
+        _viewCreator.StandardsPalette.RefreshChips(typeNames);
     }
 
     /// <summary>

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerAddChildMenuTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/TreeView/ElementTreeViewManagerAddChildMenuTests.cs
@@ -1,0 +1,45 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.TreeView;
+
+public class ElementTreeViewManagerAddChildMenuTests : BaseTestClass
+{
+    [Fact]
+    public void GetAvailableStandardInstanceTypes_ProjectWithoutColoredRectangle_DoesNotIncludeColoredRectangle()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(new StandardElementSave { Name = "Container" });
+        project.StandardElements.Add(new StandardElementSave { Name = "Rectangle" });
+
+        var result = ElementTreeViewManager.GetAvailableStandardInstanceTypes(project);
+
+        result.ShouldNotContain("ColoredRectangle");
+    }
+
+    [Fact]
+    public void GetAvailableStandardInstanceTypes_LegacyProjectWithColoredRectangle_IncludesColoredRectangle()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(new StandardElementSave { Name = "ColoredRectangle" });
+
+        var result = ElementTreeViewManager.GetAvailableStandardInstanceTypes(project);
+
+        result.ShouldContain("ColoredRectangle");
+    }
+
+    [Fact]
+    public void GetAvailableStandardInstanceTypes_ExcludesComponent()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.StandardElements.Add(new StandardElementSave { Name = "Component" });
+        project.StandardElements.Add(new StandardElementSave { Name = "Container" });
+
+        var result = ElementTreeViewManager.GetAvailableStandardInstanceTypes(project);
+
+        result.ShouldNotContain("Component");
+        result.ShouldContain("Container");
+    }
+}


### PR DESCRIPTION
## Summary
- The "Add Child Object" right-click menu built its type list from a hardcoded array containing "ColoredRectangle", a standard element deprecated and no longer seeded into new projects. Selecting it called `ObjectFinder.GetElementSave(type)!` on a type absent from the project, crashing the tool.
- Replaced the hardcoded list with `ElementTreeViewManager.GetAvailableStandardInstanceTypes`, which reads the project's actual `StandardElements`, so the menu only ever offers types that exist for that project (legacy projects that still have ColoredRectangle keep seeing it).
- Consolidated `RefreshStandardsPaletteChips` to reuse the same helper instead of duplicating the filter/sort logic (caught in code review).

## Test plan
- [x] New unit tests (`ElementTreeViewManagerAddChildMenuTests`) cover: new project excludes ColoredRectangle, legacy project with ColoredRectangle still includes it, "Component" is always excluded.
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings.
- [x] `dotnet test Tool/Tests/GumToolUnitTests` — full suite green (1289 passed).

Fixes #4499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wgV5WLkCAxwepfVBLQu2H