### PR TITLE
Fix runtime-agnostic font packaging

### DIFF
--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -22,16 +22,25 @@ A value you printed while diagnosing something else is an observation, not a rep
 - **Bug reports get `--label bug`** (label exists, color `#fc2929`). Apply it at creation time.
 - The `bug` label is real and applies silently — don't second-guess it or omit it on later issues.
 
-## Multi-line bodies
-`gh` runs through the **Bash tool (bash, not PowerShell)** — do NOT use PowerShell here-strings (`@'...'@`); a stray `@` leaks onto the first body line. Write the body to a temp file and pass `--body-file`:
+## Multi-line GitHub bodies
+Use a real multi-line value for issue comments, issue bodies, and PR bodies. Never write literal `\n` sequences and expect GitHub Markdown to turn them into line breaks.
+
+Match the syntax to the active shell. In PowerShell, use a here-string:
+
+```powershell
+$githubBody = @'
+...body...
+'@
+gh issue create --title "..." --body $githubBody --label bug
+```
+
+In Bash, use a heredoc or `--body-file`:
 
 ```bash
-cat > /tmp/issue_body.md << 'EOF'
-...body...
-EOF
 gh issue create --title "..." --body-file /tmp/issue_body.md --label bug
-rm /tmp/issue_body.md
 ```
+
+After creating or editing a multi-line body, read it back before reporting success. Use `gh issue view <number> --json body` for issues and `gh pr view <number> --json body` for PRs.
 
 ## Body structure
 Keep it scannable for a future implementer:

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -475,12 +475,16 @@ public class GumProjectDependencyWalker
         HashSet<string> external,
         List<DependencyWarning> missing)
     {
-        // FontReferenceCollector relies on StateSave.ParentContainer (set by ElementSave.Initialize)
-        // and on ObjectFinder.Self resolving instance BaseTypes. Idempotent; calling Initialize
-        // here makes the walker correct even when callers used GumProjectSave.Load directly
-        // without going through ProjectLoader.
+        // Font-cache collection relies on StateSave.ParentContainer (set by ElementSave.Initialize)
+        // and on ObjectFinder.Self resolving instance BaseTypes. Project initialization sorts its
+        // element lists, so avoid it for ExternalFiles-only scoped walks such as gumcli check.
+        // ProjectLoader has already initialized normal pack inputs, and direct Font .ttf references
+        // only need the resolved font values below.
         StandardElementsManager.Self.Initialize();
-        project.Initialize(tolerateMissingDefaultStates: true);
+        if (includeFontCache)
+        {
+            project.Initialize(tolerateMissingDefaultStates: true);
+        }
 
         FontReferenceCollector collector = new FontReferenceCollector(
             instance => ObjectFinder.Self.GetElementSave(instance));

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -86,20 +86,22 @@ public class GumProjectDependencyWalker
                     CollectFileAndFontReferences(project, projectRootDirectory, inclusion, fontCache, external, missing);
                 }
 
-                if (inclusion.HasFlag(GumBundleInclusion.FontCache))
+                if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
                 {
                     CollectFontCacheReferences(project, project.AllElements, projectRootDirectory,
-                        inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
+                        inclusion.HasFlag(GumBundleInclusion.FontCache), inclusion.HasFlag(GumBundleInclusion.ExternalFiles),
+                        fontCache, external, missing);
                 }
             }
             else
             {
                 CollectForSingleElement(project, scopeElement, projectRootDirectory, inclusion, core, fontCache, external, missing, isJsonFormat);
 
-                if (inclusion.HasFlag(GumBundleInclusion.FontCache))
+                if (inclusion.HasFlag(GumBundleInclusion.FontCache) || inclusion.HasFlag(GumBundleInclusion.ExternalFiles))
                 {
                     CollectFontCacheReferences(project, new[] { scopeElement }, projectRootDirectory,
-                        inclusion.HasFlag(GumBundleInclusion.ExternalFiles), fontCache, external, missing);
+                        inclusion.HasFlag(GumBundleInclusion.FontCache), inclusion.HasFlag(GumBundleInclusion.ExternalFiles),
+                        fontCache, external, missing);
                 }
             }
         }
@@ -467,6 +469,7 @@ public class GumProjectDependencyWalker
         GumProjectSave project,
         IEnumerable<ElementSave> elements,
         string projectRootDirectory,
+        bool includeFontCache,
         bool includeExternal,
         HashSet<string> fontCache,
         HashSet<string> external,
@@ -486,10 +489,18 @@ public class GumProjectDependencyWalker
 
         foreach (BmfcSave bmfc in fonts.Values)
         {
-            string fntRelative = bmfc.FontCacheFileName;
             string ownerName = string.IsNullOrEmpty(bmfc.FontName) ? "(font)" : bmfc.FontName;
-            AddFontCacheFntAndPages(fntRelative, ownerName, projectRootDirectory,
-                includeFontCache: true, includeExternal, fontCache, external, missing);
+
+            if (!string.IsNullOrEmpty(bmfc.FontFile))
+            {
+                AddExternalOrFontCache(bmfc.FontFile, ownerName, projectRootDirectory,
+                    includeFontCache: false, includeExternal, fontCache, external, missing);
+            }
+
+            if (includeFontCache)
+            {
+                AddFontCacheFntAndPages(bmfc.FontCacheFileName, projectRootDirectory, fontCache);
+            }
         }
     }
 
@@ -529,28 +540,24 @@ public class GumProjectDependencyWalker
 
     private static void AddFontCacheFntAndPages(
         string fntRelative,
-        string ownerName,
         string projectRootDirectory,
-        bool includeFontCache,
-        bool includeExternal,
-        HashSet<string> fontCache,
-        HashSet<string> external,
-        List<DependencyWarning> missing)
+        HashSet<string> fontCache)
     {
         string normalizedFnt = NormalizeRelative(fntRelative);
-        AddExternalOrFontCache(normalizedFnt, ownerName, projectRootDirectory,
-            includeFontCache, includeExternal, fontCache, external, missing);
+        string fntDirectoryRelative = Path.GetDirectoryName(normalizedFnt)?.Replace('\\', '/') ?? "FontCache";
+        string fntFullDir = Path.Combine(projectRootDirectory, fntDirectoryRelative.Replace('/', Path.DirectorySeparatorChar));
+        string fntFullPath = Path.Combine(projectRootDirectory, normalizedFnt.Replace('/', Path.DirectorySeparatorChar));
 
-        if (!includeFontCache)
+        if (!File.Exists(fntFullPath))
         {
             return;
         }
 
+        fontCache.Add(normalizedFnt);
+
         // Multi-page bitmap fonts emit MyFont.png OR MyFont_0.png, MyFont_1.png, etc.
         // Enumerate the FontCache directory for any .png whose name matches the .fnt base.
-        string fntDirectoryRelative = Path.GetDirectoryName(normalizedFnt)?.Replace('\\', '/') ?? "FontCache";
         string fntBaseName = Path.GetFileNameWithoutExtension(normalizedFnt);
-        string fntFullDir = Path.Combine(projectRootDirectory, fntDirectoryRelative.Replace('/', Path.DirectorySeparatorChar));
 
         if (!Directory.Exists(fntFullDir))
         {

--- a/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerFontTests.cs
+++ b/Tests/Gum.Bundle.Tests/GumProjectDependencyWalkerFontTests.cs
@@ -27,6 +27,76 @@ public class GumProjectDependencyWalkerFontTests : IDisposable
     }
 
     [Fact]
+    public void Walk_with_FontCache_and_ExternalFiles_includes_referenced_Font_ttf_without_generated_font_cache()
+    {
+        const string fontFilePath = "Fonts/LiberationSans.ttf";
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Label", fontFilePath, 18);
+
+        StandardElementSave textStandard = TestProjectBuilder.BuildStandard("Text");
+        GumProjectSave project = TestProjectBuilder.BuildProject(
+            screens: new[] { screen },
+            standards: new[] { textStandard });
+
+        string root = CreateProjectRoot(new[]
+        {
+            (fontFilePath, EmptyContent),
+        });
+
+        ObjectFinder.Self.GumProjectSave = project;
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(
+            project, root, GumBundleInclusion.FontCache | GumBundleInclusion.ExternalFiles);
+
+        result.ExternalFiles.ShouldContain(fontFilePath);
+        result.FontCacheFiles.ShouldBeEmpty();
+        result.MissingFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Walk_with_FontCache_does_not_report_missing_derived_cache_for_system_font()
+    {
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Label", "Liberation Sans", 18);
+
+        StandardElementSave textStandard = TestProjectBuilder.BuildStandard("Text");
+        GumProjectSave project = TestProjectBuilder.BuildProject(
+            screens: new[] { screen },
+            standards: new[] { textStandard });
+
+        string root = CreateProjectRoot(Array.Empty<(string, byte[])>());
+
+        ObjectFinder.Self.GumProjectSave = project;
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.FontCache);
+
+        result.FontCacheFiles.ShouldBeEmpty();
+        result.MissingFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Walk_with_ExternalFiles_reports_missing_referenced_Font_ttf()
+    {
+        const string fontFilePath = "Fonts/LiberationSans.ttf";
+        ScreenSave screen = TestProjectBuilder.BuildScreen("MainMenu");
+        TestProjectBuilder.AddTextInstanceWithFontCache(screen, "Label", fontFilePath, 18);
+
+        StandardElementSave textStandard = TestProjectBuilder.BuildStandard("Text");
+        GumProjectSave project = TestProjectBuilder.BuildProject(
+            screens: new[] { screen },
+            standards: new[] { textStandard });
+
+        string root = CreateProjectRoot(Array.Empty<(string, byte[])>());
+
+        ObjectFinder.Self.GumProjectSave = project;
+
+        WalkResult result = new GumProjectDependencyWalker().Walk(project, root, GumBundleInclusion.ExternalFiles);
+
+        result.ExternalFiles.ShouldContain(fontFilePath);
+        result.MissingFiles.ShouldContain(warning => warning.ReferencedPath == fontFilePath);
+    }
+
+    [Fact]
     public void Walk_with_FontCache_collects_font_when_state_sets_all_six_font_variables_directly()
     {
         // Regression guard for the simple direct-on-element path: a screen with a Text instance

--- a/Tests/Gum.Cli.Tests/PackCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/PackCommandTests.cs
@@ -1,5 +1,6 @@
 using Gum.Bundle;
 using Gum.DataTypes;
+using Gum.ProjectServices;
 using Shouldly;
 using ToolsUtilities;
 
@@ -31,6 +32,20 @@ public class PackCommandTests : IDisposable
         Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
         entries.Keys.ShouldContain("Components/SpriteHolder.gucx");
         entries.Keys.ShouldContain("Textures/bg.png");
+    }
+
+    [Fact]
+    public void Pack_includes_project_relative_Font_ttf_without_generated_font_cache()
+    {
+        string projectPath = CreateProjectWithTextFontFile("FontFile");
+        string outputPath = Path.Combine(Path.GetDirectoryName(projectPath)!, "out.gumpkg");
+
+        CliTestHelper result = CliTestHelper.Run("pack", projectPath, "-o", outputPath);
+
+        result.ExitCode.ShouldBe(0, result.StandardError);
+        Dictionary<string, byte[]> entries = ReadBundleEntries(outputPath);
+        entries.Keys.ShouldContain("Fonts/LiberationSans.ttf");
+        entries.Keys.Any(entry => entry.StartsWith("FontCache/", StringComparison.Ordinal)).ShouldBeFalse();
     }
 
     [Fact]
@@ -305,8 +320,8 @@ public class PackCommandTests : IDisposable
 
     /// <summary>
     /// Creates a minimal project on disk (just the .gumx file with no element references)
-    /// and returns the .gumx path. Avoids the gumcli "new" template which pulls in standard
-    /// elements with default font references that show up as missing FontCache files.
+    /// and returns the .gumx path. Avoids the gumcli "new" template so tests that do not need
+    /// standard elements remain focused on their own dependencies.
     /// </summary>
     private string CreateCleanProject(string name)
     {
@@ -354,6 +369,43 @@ public class PackCommandTests : IDisposable
 
         AppendComponentReference(filePath, "SpriteHolder");
         return filePath;
+    }
+
+    private string CreateProjectWithTextFontFile(string name)
+    {
+        string projectDir = Path.Combine(_tempDirectory, name);
+        Directory.CreateDirectory(projectDir);
+        string projectPath = Path.Combine(projectDir, name + ".gumx");
+        new ProjectCreator().Create(projectPath);
+
+        string screenXml =
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <ScreenSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>TextScreen</Name>
+              <State>
+                <Name>Default</Name>
+                <Variable Type="bool" Name="Label.UseCustomFont" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+                <Variable Type="string" Name="Label.Font" IsFont="true" SetsValue="true"><Value xsi:type="xsd:string">Fonts/LiberationSans.ttf</Value></Variable>
+                <Variable Type="int" Name="Label.FontSize" SetsValue="true"><Value xsi:type="xsd:int">18</Value></Variable>
+                <Variable Type="int" Name="Label.OutlineThickness" SetsValue="true"><Value xsi:type="xsd:int">0</Value></Variable>
+                <Variable Type="bool" Name="Label.UseFontSmoothing" SetsValue="true"><Value xsi:type="xsd:boolean">true</Value></Variable>
+                <Variable Type="bool" Name="Label.IsItalic" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+                <Variable Type="bool" Name="Label.IsBold" SetsValue="true"><Value xsi:type="xsd:boolean">false</Value></Variable>
+              </State>
+              <Instance><Name>Label</Name><BaseType>Text</BaseType><DefinedByBase>false</DefinedByBase></Instance>
+            </ScreenSave>
+            """;
+        File.WriteAllText(Path.Combine(projectDir, "Screens", "TextScreen.gusx"), screenXml);
+
+        string projectXml = File.ReadAllText(projectPath);
+        File.WriteAllText(projectPath, projectXml.Replace("</GumProjectSave>",
+            "  <ScreenReference Name=\"TextScreen\" />\n</GumProjectSave>"));
+
+        string fontsDirectory = Path.Combine(projectDir, "Fonts");
+        Directory.CreateDirectory(fontsDirectory);
+        File.WriteAllBytes(Path.Combine(fontsDirectory, "LiberationSans.ttf"), new byte[] { 0x00 });
+        return projectPath;
     }
 
     private static void WriteSpriteHolderComponent(string projectDir, string sourceFileRelative)

--- a/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HeadlessErrorCheckerTests.cs
@@ -40,6 +40,17 @@ public class HeadlessErrorCheckerTests : BaseTestClass
     }
 
     [Fact]
+    public void GetAllErrors_ShouldNotModifyProjectCollectionsWhenCheckingExternalFiles()
+    {
+        Project.FullFileName = Path.Combine(Path.GetTempPath(), "HeadlessErrorChecker", "Project.gumx");
+        Project.Screens.Add(new ScreenSave { Name = "MainMenu" });
+
+        IReadOnlyList<ErrorResult> errors = _sut.GetAllErrors(Project);
+
+        errors.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void GetAllErrors_ShouldReturnError_WhenComponentInstanceHasInvalidBaseType()
     {
         ComponentSave component = new ComponentSave { Name = "BrokenComponent", BaseType = "Container" };

--- a/Tests/Gum.ProjectServices.Tests/ObjectFinderFileReferencesTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ObjectFinderFileReferencesTests.cs
@@ -139,45 +139,6 @@ public class ObjectFinderFileReferencesTests : BaseTestClass
     }
 
     [Fact]
-    public void GetAllFilesInProject_includes_font_cache_fnt_path_for_text_with_default_font_settings()
-    {
-        ScreenSave screen = BuildScreen("MainMenu");
-        AddTextInstanceWithDefaultFont(screen, "Text1", "Arial", 18);
-        Project.Screens.Add(screen);
-        SetProjectFullFileName();
-
-        string fntRelative = BmfcSave.GetFontCacheFileNameFor(
-            fontSize: 18, fontName: "Arial", outline: 0, useFontSmoothing: true, isItalic: false, isBold: false);
-        string expectedFntAbsolute = Standardize(FakeProjectDirectory + fntRelative);
-
-        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
-
-        files.ShouldContain(expectedFntAbsolute);
-    }
-
-    [Fact]
-    public void GetAllFilesInProject_omits_font_cache_but_keeps_other_references_when_font_cache_is_excluded()
-    {
-        const string spriteRelative = "Textures/bg.png";
-
-        ScreenSave screen = BuildScreen("MainMenu");
-        AddSpriteInstance(screen, "Sprite1", spriteRelative);
-        AddTextInstanceWithDefaultFont(screen, "Text1", "Arial", 18);
-        Project.Screens.Add(screen);
-        SetProjectFullFileName();
-
-        string fntRelative = BmfcSave.GetFontCacheFileNameFor(
-            fontSize: 18, fontName: "Arial", outline: 0, useFontSmoothing: true, isItalic: false, isBold: false);
-
-        List<string> files = ObjectFinder.Self
-            .GetAllFilesInProject(GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles)
-            .ToList();
-
-        files.ShouldNotContain(Standardize(FakeProjectDirectory + fntRelative));
-        files.ShouldContain(Standardize(FakeProjectDirectory + spriteRelative));
-    }
-
-    [Fact]
     public void GetAllFilesInProject_includes_gucx_paths_for_component_instances()
     {
         ComponentSave button = BuildComponent("Button");
@@ -207,6 +168,45 @@ public class ObjectFinderFileReferencesTests : BaseTestClass
         IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
 
         files.ShouldContain(Standardize(FakeProjectDirectory + spriteRelative));
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_omits_font_cache_but_keeps_other_references_when_font_cache_is_excluded()
+    {
+        const string spriteRelative = "Textures/bg.png";
+
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddSpriteInstance(screen, "Sprite1", spriteRelative);
+        AddTextInstanceWithDefaultFont(screen, "Text1", "Arial", 18);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(
+            fontSize: 18, fontName: "Arial", outline: 0, useFontSmoothing: true, isItalic: false, isBold: false);
+
+        List<string> files = ObjectFinder.Self
+            .GetAllFilesInProject(GumBundleInclusion.Core | GumBundleInclusion.ExternalFiles)
+            .ToList();
+
+        files.ShouldNotContain(Standardize(FakeProjectDirectory + fntRelative));
+        files.ShouldContain(Standardize(FakeProjectDirectory + spriteRelative));
+    }
+
+    [Fact]
+    public void GetAllFilesInProject_omits_missing_font_cache_fnt_path_for_text_with_default_font_settings()
+    {
+        ScreenSave screen = BuildScreen("MainMenu");
+        AddTextInstanceWithDefaultFont(screen, "Text1", "Arial", 18);
+        Project.Screens.Add(screen);
+        SetProjectFullFileName();
+
+        string fntRelative = BmfcSave.GetFontCacheFileNameFor(
+            fontSize: 18, fontName: "Arial", outline: 0, useFontSmoothing: true, isItalic: false, isBold: false);
+        string expectedFntAbsolute = Standardize(FakeProjectDirectory + fntRelative);
+
+        IEnumerable<string> files = ObjectFinder.Self.GetAllFilesInProject();
+
+        files.ShouldNotContain(expectedFntAbsolute);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #4510.

- Package project-relative `Font` values ending in `.ttf` as external Gum-project assets.
- Do not treat a missing derived FontCache `.fnt/.png` as a missing authored dependency.
- Preserve errors for missing explicitly referenced font files.
- Keep external-only dependency checks non-mutating, so `gumcli check` can validate every element safely.
- Document the verified multi-line GitHub body workflow used for this PR.

Validation:

- `dotnet test Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj --no-restore` (519 passed, 3 intentional skips)
- `dotnet test Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj --no-restore` (75 passed)
- `dotnet test Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj --no-restore` (72 passed)
- `RuntimeSnapshotSerializerProjectTests` CLI-check regressions passed
- `GumCore.DesktopGlNet6` shared-source canary passed.