### PR TITLE
Document Font .ttf packaging in gumcli pack docs

### DIFF
--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -17,7 +17,11 @@ The Gum WYSIWYG editor still saves loose files. `.gumpkg` is purely a packaging 
 - `--include <categories>` — Comma-separated list of file categories to include. Defaults to `core,fontcache,external`. Valid values:
   - `core` — the `.gumx` plus all `.gusx`, `.gucx`, `.gutx`, and `.behx` files referenced by the project
   - `fontcache` — generated bitmap font files under `FontCache/` (`.fnt` + `.png` pages)
-  - `external` — files referenced by the project but outside Core/FontCache, such as sprite source `.png` textures and custom font files outside `FontCache/`
+  - `external` — files referenced by the project but outside Core/FontCache, such as sprite source `.png` textures, `CustomFontFile` paths, and a `Font` value that points at a project-relative `.ttf` file rather than a system font family name (e.g. `Fonts/MyFont.ttf` vs. `Arial`)
+
+{% hint style="info" %}
+**Shipping September 2026:** Packing a `.ttf` referenced through the `Font` property (not just `CustomFontFile`) will ship in the September release, or now if building Gum from source. Before this, only `CustomFontFile` paths were bundled as external font files.
+{% endhint %}
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- #4511 bundles a plain `Font` value as an external file when it's a project-relative `.ttf` path, not just `CustomFontFile`.
- `docs/cli/pack.md`'s `external` category bullet only mentioned `CustomFontFile`; added the `Font` case and a hint block flagging the September 2026 ship date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1xks5rJnNbVyomTymUUsV