### PR TITLE
Fix uncompilable setup snippet and document ListBoxItem states

### DIFF
--- a/docs/code/controls/listboxitem/styling-in-gum-tool.md
+++ b/docs/code/controls/listboxitem/styling-in-gum-tool.md
@@ -14,3 +14,21 @@ The following are optional:
 
 * Text instance named `TextInstance` . This is used by the `ListBoxItem`'s UpdateToObject method.
 
+## States
+
+Adding the `ListBoxItemBehavior` behavior creates a category named `ListBoxItemCategory` on your component, along with the states the behavior requires:
+
+* `Enabled`
+* `Highlighted`
+* `Selected`
+* `Focused`
+
+Set variables such as colors and visibility in each of these states so the item gives the player visual feedback as they move over it and select it.
+
+Two more states are recognized at runtime, but the behavior does not create them:
+
+* `Disabled`, applied when the item or one of its parents is not enabled. The ListBoxItem added by **Add Forms Components** already includes this state, so you only need to add it if you built your component from scratch.
+* `SelectedHighlighted`, applied when the cursor is over an item that is already selected. No ListBoxItem includes this state by default. If it is missing, a selected item stays in its `Selected` state while the cursor is over it.
+
+To add either one, select `ListBoxItemCategory` in the **States** tab and add a state with the matching name. For more information see the [Categories](../../../gum-tool/gum-elements/states/categories.md) page.
+

--- a/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/monogame-kni-fna/README.md
@@ -199,10 +199,10 @@ public class Game1 : Game
     protected override void Initialize()
     {
 <strong>        GumUI.Initialize(this);
-</strong><strong>        ShapeRenderer.Self.Initialize(); // Recommended, optional: shape fill/gradient/shadow
+</strong><strong>        MonoGameAndGum.Renderables.ShapeRenderer.Self.Initialize(); // Recommended, optional: shape fill/gradient/shadow
 </strong><strong>        Gum.Wireframe.CustomSetPropertyOnRenderable.InMemoryFontCreator =
 </strong><strong>            new KernSmith.Gum.KernSmithFontCreator(GraphicsDevice); // Recommended, optional: dynamic fonts
-</strong><strong>        GumExpressionService.Initialize(); // Optional: arithmetic expressions in variable references
+</strong><strong>        Gum.Expressions.GumExpressionService.Initialize(); // Optional: arithmetic expressions in variable references
 </strong>        base.Initialize();
     }
 
@@ -236,10 +236,10 @@ public class Game1 : Core
         base.Initialize();
 
 <strong>        GumUI.Initialize(Core.GraphicsDevice);
-</strong><strong>        ShapeRenderer.Self.Initialize(); // Recommended, optional: shape fill/gradient/shadow
+</strong><strong>        MonoGameAndGum.Renderables.ShapeRenderer.Self.Initialize(); // Recommended, optional: shape fill/gradient/shadow
 </strong><strong>        Gum.Wireframe.CustomSetPropertyOnRenderable.InMemoryFontCreator =
 </strong><strong>            new KernSmith.Gum.KernSmithFontCreator(Core.GraphicsDevice); // Recommended, optional: dynamic fonts
-</strong><strong>        GumExpressionService.Initialize(); // Optional: arithmetic expressions in variable references
+</strong><strong>        Gum.Expressions.GumExpressionService.Initialize(); // Optional: arithmetic expressions in variable references
 </strong>        
         Scene = new BasicScene();
     }

--- a/docs/code/standard-visuals/shapes-apos.shapes.md
+++ b/docs/code/standard-visuals/shapes-apos.shapes.md
@@ -82,8 +82,10 @@ Whether you are using code-only or the Gum tool, add the following line of code 
 ```csharp
 // Initialize
 GumUI.Initialize(...);
-ShapeRenderer.Self.Initialize();
+MonoGameAndGum.Renderables.ShapeRenderer.Self.Initialize();
 ```
+
+`ShapeRenderer` lives in the `MonoGameAndGum.Renderables` namespace. The line above spells the namespace out so it can be pasted as-is. If you prefer, add `using MonoGameAndGum.Renderables;` to the file and call `ShapeRenderer.Self.Initialize();` instead.
 
 {% hint style="info" %}
 **December 2025 and earlier** used a different signature that took the graphics device and content manager: `ShapeRenderer.Self.Initialize(GraphicsDevice, Content);`. From January 2026 on, the parameterless `Initialize()` is the form to use.
@@ -125,7 +127,7 @@ public class Game1 : Game
     {
         GumUI.Initialize(this);
         // Initialize shape renderer after GumUI:
-        ShapeRenderer.Self.Initialize();
+        MonoGameAndGum.Renderables.ShapeRenderer.Self.Initialize();
 
         var circle = new CircleRuntime();
         circle.AddToRoot();


### PR DESCRIPTION
Two unrelated doc defects, both hit while following the docs to build a real app.

**Setup snippet did not compile.** The "Adding Gum to Game" snippet on the MonoGame/KNI/FNA setup page lists usings for `Gum`, `Gum.Forms`, and `Gum.Forms.Controls`, but two of its lines resolve to neither: `ShapeRenderer` is in `MonoGameAndGum.Renderables`, and `GumExpressionService` is in `Gum.Expressions`. Both fail with CS0103 as printed. That matters most for the `ShapeRenderer` line, because skipping it fails *silently* at runtime (circle fills and rectangle corner radii just don't draw), so a reader hitting the compile error deletes the line and ships a degraded UI.

Fully qualified both, matching the already-qualified `Gum.Wireframe.CustomSetPropertyOnRenderable` and `KernSmith.Gum.KernSmithFontCreator` lines beside them. A `using` would have been worse: these lines are optional, and deleting one when you skip its package would leave an orphan using that doesn't compile. Same fix on the two `ShapeRenderer` snippets on the Apos.Shapes page.

**ListBoxItem styling page never mentioned states.** It listed the required behavior and the optional `TextInstance` and stopped, so someone theming an item had no way to discover why it gave no visual feedback. Added a States section: attaching `ListBoxItemBehavior` auto-creates `ListBoxItemCategory` with Enabled/Highlighted/Selected/Focused, plus the two states read at runtime that the behavior does not create — `Disabled` (shipped in the default ListBoxItem, absent from a hand-built one) and `SelectedHighlighted` (absent everywhere, falls back to `Selected`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB9hGYRNHBudoxqkmJKMPn
