### PR TITLE
Don't crash loading a project with unnamed element references

### DIFF
--- a/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
+++ b/Gum/DataTypes/GumProjectSaveExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Gum.Managers;
 using Gum.DataTypes.Variables;
@@ -203,32 +204,26 @@ namespace Gum.DataTypes
             return "; added: " + string.Join(", ", added);
         }
 
+        /// <summary>
+        /// Sorts the project's elements, behaviors, and their reference lists by name. Malformed
+        /// projects (missing or nil entries, entries with no name) are tolerated rather than
+        /// failing the load - unnamed entries sort to the front.
+        /// </summary>
         public static void SortElementAndBehaviors(this GumProjectSave gumProjectSave)
         {
-            gumProjectSave.ScreenReferences?.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.ComponentReferences?.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.StandardElementReferences?.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.BehaviorReferences?.Sort((first, second) =>
-            {
-                if (first?.Name == null)
-                {
-                    return 0;
-                }
-                else if (second?.Name == null)
-                {
-                    return 0;
-                }
-                else
-                {
-                    return first?.Name.CompareTo(second?.Name) ?? 0;
-                }
-            });
+            gumProjectSave.ScreenReferences?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.ComponentReferences?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.StandardElementReferences?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.BehaviorReferences?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
 
-            gumProjectSave.Screens.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.Components.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.StandardElements.Sort((first, second) => first.Name.CompareTo(second.Name));
-            gumProjectSave.Behaviors.Sort((first, second) => first.Name?.CompareTo(second.Name) ?? 0);
+            gumProjectSave.Screens?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.Components?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.StandardElements?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
+            gumProjectSave.Behaviors?.Sort((first, second) => CompareByName(first?.Name, second?.Name));
         }
+
+        private static int CompareByName(string? first, string? second) =>
+            string.Compare(first, second, StringComparison.CurrentCulture);
 
         /// <summary>
         /// Adds any Standard Elements that have been created since the project was last saved.  This should be called

--- a/Tool/Tests/GumToolUnitTests/DataTypes/GumProjectSaveExtensionMethodsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/DataTypes/GumProjectSaveExtensionMethodsTests.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
 using Gum.Managers;
 using Shouldly;
 using Xunit;
@@ -37,5 +38,49 @@ public class GumProjectSaveExtensionMethodsTests : BaseTestClass
         ObjectFinder.Self.GumProjectSave = project;
 
         Should.NotThrow(() => project.Initialize(tolerateMissingDefaultStates: true));
+    }
+
+    // A malformed .gumx (a reference or element with no Name, or a nil entry) must not take down the
+    // whole project load. The sort comparers used to dereference Name directly, which surfaced as
+    // InvalidOperationException("Failed to compare two elements in the array").
+    [Fact]
+    public void SortElementAndBehaviors_DoesNotThrow_AndSortsNamedItems_WhenNamesAreNull()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.ScreenReferences.Add(new ElementReference { Name = "ZScreen" });
+        project.ScreenReferences.Add(new ElementReference { Name = null });
+        project.ScreenReferences.Add(new ElementReference { Name = "AScreen" });
+        project.ComponentReferences.Add(new ElementReference { Name = null });
+        project.StandardElementReferences.Add(new ElementReference { Name = null });
+        project.BehaviorReferences.Add(new BehaviorReference { Name = null });
+
+        project.Screens.Add(new ScreenSave { Name = "ZScreen" });
+        project.Screens.Add(new ScreenSave { Name = null });
+        project.Screens.Add(new ScreenSave { Name = "AScreen" });
+        project.Components.Add(new ComponentSave { Name = null });
+        project.StandardElements.Add(new StandardElementSave { Name = null });
+        project.Behaviors.Add(new BehaviorSave { Name = null });
+
+        Should.NotThrow(() => project.SortElementAndBehaviors());
+
+        project.ScreenReferences[1].Name.ShouldBe("AScreen");
+        project.ScreenReferences[2].Name.ShouldBe("ZScreen");
+        project.Screens[1].Name.ShouldBe("AScreen");
+        project.Screens[2].Name.ShouldBe("ZScreen");
+    }
+
+    [Fact]
+    public void SortElementAndBehaviors_DoesNotThrow_WhenListsContainNullEntries()
+    {
+        GumProjectSave project = new GumProjectSave();
+        project.ScreenReferences.Add(new ElementReference { Name = "ZScreen" });
+        project.ScreenReferences.Add(null!);
+        project.ScreenReferences.Add(new ElementReference { Name = "AScreen" });
+        project.BehaviorReferences.Add(null!);
+        project.Screens.Add(new ScreenSave { Name = "ZScreen" });
+        project.Screens.Add(null!);
+        project.Behaviors.Add(null!);
+
+        Should.NotThrow(() => project.SortElementAndBehaviors());
     }
 }


### PR DESCRIPTION
A `.gumx` with a `ScreenReference`/`ComponentReference`/`StandardElementReference` that has no `Name` (or a nil entry) crashed Gum on startup:

```
System.InvalidOperationException: Failed to compare two elements in the array.
 ---> System.NullReferenceException
   at GumProjectSaveExtensionMethods.SortElementAndBehaviors
```

`SortElementAndBehaviors` dereferenced `Name` directly in seven of its eight comparers. Everything else in the load path already tolerates a bad reference (`PopulateElementSavesFromReferences` catches per reference and records it in `GumLoadResult`), so the sort was the only thing turning a malformed project into a hard crash.

All eight sorts now share one null-tolerant comparer; unnamed entries sort first. Note the element lists get the same treatment, not just the reference lists: a reference whose file is missing produces a placeholder `ElementSave` carrying that same null name.

Tests in `GumProjectSaveExtensionMethodsTests` cover null names and null entries.