### PR TITLE
Log per-phase timings on HTML import

### DIFF
--- a/Tool/HtmlToGum/HtmlImportTimingLog.cs
+++ b/Tool/HtmlToGum/HtmlImportTimingLog.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace HtmlToGumPlugin;
+
+/// <summary>One measured phase of an HTML import.</summary>
+public sealed class ImportTimingPhase
+{
+    /// <summary>Phase label, e.g. "converter process" or "primary.goto".</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>Wall-clock duration of the phase.</summary>
+    [JsonPropertyName("ms")]
+    public long Milliseconds { get; set; }
+}
+
+/// <summary>Contents of the timings.json convert.ts writes into its staging folder.</summary>
+public sealed class ConverterTimings
+{
+    /// <summary>Converter phases in the order they ran.</summary>
+    [JsonPropertyName("phases")]
+    public List<ImportTimingPhase> Phases { get; set; } = new();
+
+    /// <summary>Page-size figures (node/instance/image/font counts) a run can be normalized against.</summary>
+    [JsonPropertyName("counts")]
+    public Dictionary<string, long> Counts { get; set; } = new();
+
+    /// <summary>Total converter wall clock, which exceeds the sum of the phases by untimed glue.</summary>
+    [JsonPropertyName("totalMs")]
+    public long TotalMilliseconds { get; set; }
+}
+
+/// <summary>A single Content → Import → HTML run, converter and plugin phases together.</summary>
+public sealed class ImportTimingRun
+{
+    /// <summary>When the import finished.</summary>
+    public DateTime TimestampUtc { get; set; }
+
+    /// <summary>Imported URL or local HTML path.</summary>
+    public string Source { get; set; } = "";
+
+    /// <summary>Name of the screen the import produced.</summary>
+    public string ScreenName { get; set; } = "";
+
+    /// <summary>Converter viewport width.</summary>
+    public int ViewportWidth { get; set; }
+
+    /// <summary>Converter viewport height.</summary>
+    public int ViewportHeight { get; set; }
+
+    /// <summary>False when the import ran with --no-responsive, which skips the training passes.</summary>
+    public bool Responsive { get; set; }
+
+    /// <summary>Plugin-side phases in the order they ran.</summary>
+    public List<ImportTimingPhase> PluginPhases { get; set; } = new();
+
+    /// <summary>Total plugin wall clock, including the converter process it waited on.</summary>
+    public long PluginTotalMilliseconds { get; set; }
+
+    /// <summary>Converter phases, or null when the converter did not get far enough to write them.</summary>
+    public ConverterTimings? ConverterTimings { get; set; }
+}
+
+/// <summary>
+/// Collects plugin-side phase durations for one import. Phases are recorded even when the
+/// measured work throws, so a failed import still shows where its time went.
+/// </summary>
+public sealed class ImportPhaseRecorder
+{
+    private readonly List<ImportTimingPhase> _phases;
+    private readonly Func<TimeSpan> _elapsed;
+    private long _total;
+
+    /// <summary>Starts recording against a wall clock.</summary>
+    public ImportPhaseRecorder() : this(StartStopwatch())
+    {
+    }
+
+    /// <summary>Starts recording against <paramref name="elapsed"/>, which reports time since the run began.</summary>
+    public ImportPhaseRecorder(Func<TimeSpan> elapsed)
+    {
+        _phases = new List<ImportTimingPhase>();
+        _elapsed = elapsed;
+        _total = 0;
+    }
+
+    private static Func<TimeSpan> StartStopwatch()
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        return () => stopwatch.Elapsed;
+    }
+
+    /// <summary>Recorded phases, in the order they completed.</summary>
+    public IReadOnlyList<ImportTimingPhase> Phases => _phases;
+
+    /// <summary>
+    /// Milliseconds from construction to the end of the most recently recorded phase. Stops at
+    /// the last phase rather than reading the clock, so time the user spends on a modal dialog
+    /// afterwards doesn't land in the run's total.
+    /// </summary>
+    public long Total => _total;
+
+    /// <summary>Runs <paramref name="work"/>, recording its duration as <paramref name="name"/>.</summary>
+    public void Measure(string name, Action work)
+    {
+        Measure(name, () =>
+        {
+            work();
+            return true;
+        });
+    }
+
+    /// <inheritdoc cref="Measure(string, Action)"/>
+    public T Measure<T>(string name, Func<T> work)
+    {
+        TimeSpan start = _elapsed();
+        try
+        {
+            return work();
+        }
+        finally
+        {
+            Record(name, start);
+        }
+    }
+
+    /// <inheritdoc cref="Measure(string, Action)"/>
+    public async Task<T> MeasureAsync<T>(string name, Func<Task<T>> work)
+    {
+        TimeSpan start = _elapsed();
+        try
+        {
+            return await work().ConfigureAwait(true);
+        }
+        finally
+        {
+            Record(name, start);
+        }
+    }
+
+    private void Record(string name, TimeSpan start)
+    {
+        TimeSpan end = _elapsed();
+        _total = (long)end.TotalMilliseconds;
+        _phases.Add(new ImportTimingPhase
+        {
+            Name = name,
+            Milliseconds = (long)(end - start).TotalMilliseconds,
+        });
+    }
+}
+
+/// <summary>
+/// Formats and appends the per-import timing log. HTML import spans a Chromium converter
+/// process and a stretch of UI-thread work; without a per-phase record a slow import can only
+/// be guessed at.
+/// </summary>
+public static class HtmlImportTimingLog
+{
+    private const string ConverterTimingsFileName = "timings.json";
+
+    /// <summary>Log the plugin appends one entry to per import, next to its import-prefs.json.</summary>
+    public static string LogPath =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "HtmlToGumPlugin", "import-timings.log");
+
+    /// <summary>Reads the converter's timings.json out of its staging folder; null if it wasn't written.</summary>
+    public static ConverterTimings? TryReadConverterTimings(string stageDir)
+    {
+        try
+        {
+            string path = Path.Combine(stageDir, ConverterTimingsFileName);
+            return File.Exists(path) ? ParseConverterTimings(File.ReadAllText(path)) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Parses converter timings JSON, returning null rather than throwing on malformed input.</summary>
+    public static ConverterTimings? ParseConverterTimings(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<ConverterTimings>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Renders one run as an aligned block so phases line up when runs are compared.</summary>
+    public static string Format(ImportTimingRun run)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine(
+            $"=== {run.TimestampUtc:yyyy-MM-dd HH:mm:ss}Z  screen={run.ScreenName}  " +
+            $"viewport={run.ViewportWidth}x{run.ViewportHeight}  " +
+            $"responsive={(run.Responsive ? "on" : "off")}");
+        sb.AppendLine($"    source={run.Source}");
+
+        if (run.ConverterTimings is null)
+        {
+            sb.AppendLine($"{"converter",-11}(no {ConverterTimingsFileName} — converter did not finish)");
+        }
+        else
+        {
+            foreach (ImportTimingPhase phase in run.ConverterTimings.Phases)
+            {
+                AppendPhase(sb, "converter", phase.Name, phase.Milliseconds);
+            }
+            AppendPhase(sb, "converter", "(total)", run.ConverterTimings.TotalMilliseconds);
+        }
+
+        foreach (ImportTimingPhase phase in run.PluginPhases)
+        {
+            AppendPhase(sb, "plugin", phase.Name, phase.Milliseconds);
+        }
+        AppendPhase(sb, "plugin", "(total)", run.PluginTotalMilliseconds);
+
+        if (run.ConverterTimings is { Counts.Count: > 0 })
+        {
+            string counts = string.Join(" ", run.ConverterTimings.Counts.Select(c => $"{c.Key}={c.Value}"));
+            sb.AppendLine($"{"counts",-11}{counts}");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Appends an entry to the log. Best-effort — a failure here never fails an import.</summary>
+    public static void Append(string logPath, string entry)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+            File.AppendAllText(logPath, entry + Environment.NewLine);
+        }
+        catch
+        {
+            // Timing log is diagnostic only.
+        }
+    }
+
+    private static void AppendPhase(StringBuilder sb, string origin, string name, long milliseconds)
+    {
+        sb.AppendLine($"{origin,-11}{name,-30}{milliseconds,8} ms");
+    }
+}

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -125,6 +125,8 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         var stageDir = Path.Combine(Path.GetTempPath(), "html-to-gum-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(stageDir);
 
+        var recorder = new ImportPhaseRecorder();
+
         using var progress = new ImportProgressForm();
         progress.Show();
         progress.SetStatus("Running converter…");
@@ -135,8 +137,9 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             if (useTs && !File.Exists(tsxCli))
             {
                 progress.SetStatus("Installing converter dependencies (first run only)…");
-                var (installExitCode, installStdout, installStderr) = await RunProcessAsync(
-                        "cmd.exe", "/c npm install", converterDir, progress)
+                var (installExitCode, installStdout, installStderr) = await recorder
+                    .MeasureAsync("npm install", () => RunProcessAsync(
+                        "cmd.exe", "/c npm install", converterDir, progress))
                     .ConfigureAwait(true);
 
                 if (installExitCode != 0 || !File.Exists(tsxCli))
@@ -158,7 +161,8 @@ public class MainHtmlToGumPlugin : WpfPluginBase
                 : $"\"{convertMjs}\" {scriptArgs}";
 
             progress.SetStatus($"{(useTs ? "tsx convert.ts" : "node convert.mjs")} → {screenName}");
-            var (exitCode, stdout, stderr) = await RunProcessAsync(nodePath, args, converterDir, progress)
+            var (exitCode, stdout, stderr) = await recorder
+                .MeasureAsync("converter process", () => RunProcessAsync(nodePath, args, converterDir, progress))
                 .ConfigureAwait(true);
 
             if (exitCode != 0)
@@ -179,18 +183,24 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             }
 
             progress.SetStatus("Copying Images / Fonts / FontCache…");
-            CopyAssetTree(Path.Combine(stageDir, "Images"), Path.Combine(projectDir, "Images"));
-            CopyAssetTree(Path.Combine(stageDir, "Fonts"), Path.Combine(projectDir, "Fonts"));
-            CopyAssetTree(Path.Combine(stageDir, "FontCache"), Path.Combine(projectDir, "FontCache"));
+            recorder.Measure("asset copy", () =>
+            {
+                CopyAssetTree(Path.Combine(stageDir, "Images"), Path.Combine(projectDir, "Images"));
+                CopyAssetTree(Path.Combine(stageDir, "Fonts"), Path.Combine(projectDir, "Fonts"));
+                CopyAssetTree(Path.Combine(stageDir, "FontCache"), Path.Combine(projectDir, "FontCache"));
+            });
 
             progress.SetStatus("Importing screen into project…");
-            var screenSave = ElementReference.DeserializeElement<ScreenSave>(gusx, GumProjectSave.NativeVersion);
+            var screenSave = recorder.Measure(
+                "deserialize screen",
+                () => ElementReference.DeserializeElement<ScreenSave>(gusx, GumProjectSave.NativeVersion));
             if (subfolder != null)
             {
                 screenSave.Name = HtmlImportNaming.QualifyScreenName(screenSave.Name, subfolder);
             }
             var qualifiedScreenName = screenSave.Name;
-            var imported = importLogic.ImportScreen(screenSave, saveProject: false);
+            var imported = recorder.Measure(
+                "ImportScreen", () => importLogic.ImportScreen(screenSave, saveProject: false));
             if (imported is null)
             {
                 progress.Hide();
@@ -198,24 +208,29 @@ public class MainHtmlToGumPlugin : WpfPluginBase
                 return;
             }
 
-            fileCommands.TryAutoSaveProject();
+            // The remaining phases run on the UI thread, which is why the result dialog can come
+            // up unresponsive — keep them separately timed rather than lumped into one number.
+            recorder.Measure("TryAutoSaveProject", () => { fileCommands.TryAutoSaveProject(); });
             var gumxPath = projectState.GumProjectSave?.FullFileName;
             if (!string.IsNullOrEmpty(gumxPath))
             {
-                fileCommands.LoadProject(gumxPath);
+                recorder.Measure("LoadProject", () => { fileCommands.LoadProject(gumxPath); });
             }
 
-            // Re-resolve after reload so selection points at the live ElementSave.
-            var live = ObjectFinder.Self.GetElementSave(qualifiedScreenName);
-            if (live != null)
+            recorder.Measure("select screen", () =>
             {
-                selectedState.SelectedElement = live;
-            }
+                // Re-resolve after reload so selection points at the live ElementSave.
+                var live = ObjectFinder.Self.GetElementSave(qualifiedScreenName);
+                if (live != null)
+                {
+                    selectedState.SelectedElement = live;
+                }
+            });
 
             progress.Hide();
             ImportResultForm.Show(
                 $"Imported and selected screen \"{qualifiedScreenName}\".",
-                SummarizeConverterLog(stdout, maxLines: 300));
+                $"Timing log: {HtmlImportTimingLog.LogPath}\n\n" + SummarizeConverterLog(stdout, maxLines: 300));
         }
         catch (Exception ex)
         {
@@ -224,6 +239,18 @@ public class MainHtmlToGumPlugin : WpfPluginBase
         }
         finally
         {
+            HtmlImportTimingLog.Append(HtmlImportTimingLog.LogPath, HtmlImportTimingLog.Format(new ImportTimingRun
+            {
+                TimestampUtc = DateTime.UtcNow,
+                Source = opts.HtmlPath,
+                ScreenName = screenName,
+                ViewportWidth = opts.Width,
+                ViewportHeight = opts.Height,
+                Responsive = !opts.NoResponsive,
+                PluginPhases = recorder.Phases.ToList(),
+                PluginTotalMilliseconds = recorder.Total,
+                ConverterTimings = HtmlImportTimingLog.TryReadConverterTimings(stageDir),
+            }));
             try { Directory.Delete(stageDir, recursive: true); } catch { /* temp cleanup best-effort */ }
         }
     }

--- a/Tool/HtmlToGum/README.md
+++ b/Tool/HtmlToGum/README.md
@@ -62,6 +62,15 @@ Useful flags: `--no-responsive`, `--responsive=n,w`, `--tag=name`, `--no-forms` 
 
 Fonts: `npm run gumcli -- fonts <project.gumx>` (wraps in-repo `Tools/Gum.Cli`).
 
+## Import timings
+
+Every import writes a per-phase wall-clock record so a slow run can be attributed instead of guessed at:
+
+* The converter writes `timings.json` next to its output (`--out=<dir>`), with per-phase durations and page-size counts (nodes, instances, images, web fonts).
+* The plugin merges that with its own phases — converter process, asset copy, `ImportScreen`, `TryAutoSaveProject`, `LoadProject`, screen selection — and appends one aligned entry per import to `%APPDATA%\HtmlToGumPlugin\import-timings.log` (the path is also shown under "Show details" in the import result dialog).
+
+The UI-thread phases (`TryAutoSaveProject`, `LoadProject`, `select screen`) are timed separately because they, not the converter, are what leaves the result dialog unresponsive on a large page.
+
 ## Site fidelity (dev loop)
 
 Crawl a live site (same-origin links), convert each page, screenshot via `gumcli screenshot`, and pixel-diff against Chromium until every page is under a threshold (default **5%**). Harness sources live in `Tool/HtmlToGum/fidelity/`; the convert pipeline stays in `converter/`. Output is gitignored under `Tool/HtmlToGum/.site-fidelity/`.

--- a/Tool/HtmlToGum/converter/convert.ts
+++ b/Tool/HtmlToGum/converter/convert.ts
@@ -17,6 +17,8 @@
 //                               instead of ../.out. Chromium shots go in <dir> when --out
 //                               is set; otherwise under ../.regress/ (gitignored).
 //
+// Per-phase wall clock lands in <out>/timings.json (see timings.ts).
+//
 // After emit: gumcli fonts (via gumcli.ts) bakes FontCache from Font/FontSize and any
 // Fonts/*.ttf web-font instances.
 //
@@ -45,6 +47,7 @@ import { samplePath } from './samples-path.js';
 import { nodeTsxArgs } from './tsx-run.js';
 import { treeHasFormControls } from './forms.js';
 import { intersectScreenshotClip } from './screenshot-clip.js';
+import { createPhaseTimer } from './timings.js';
 import {
   isolateElementForTransparentScreenshot,
   restoreRasterIsolation,
@@ -150,7 +153,9 @@ const chromiumTagged = flags.out
   : join(regressDir, `chromium-${tag}.png`);
 if (!flags.out) mkdirSync(regressDir, { recursive: true });
 
-async function renderTree(browser, width, height, { captureFonts = false } = {}) {
+const timer = createPhaseTimer();
+
+async function renderTree(browser, width, height, { captureFonts = false, label = 'render' } = {}) {
   const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 });
   await installTsxEvaluateShim(page);
   const capturedFonts = captureFonts ? attachFontCapture(page) : null;
@@ -160,40 +165,44 @@ async function renderTree(browser, width, height, { captureFonts = false } = {})
   const capturedImages = attachImageCapture(page);
   const url = /^https?:\/\//i.test(htmlFile) ? htmlFile : pathToFileURL(htmlFile).href;
   const gotoTimeoutMs = Number(process.env.HTMLTOGUM_GOTO_TIMEOUT_MS || 0);
-  await page.goto(url, {
+  await timer.time(`${label}.goto`, () => page.goto(url, {
     waitUntil: 'networkidle',
     ...(gotoTimeoutMs > 0 ? { timeout: gotoTimeoutMs } : {}),
+  }));
+  await timer.time(`${label}.quiescence`, async () => {
+    await installTsxEvaluateShim(page); // re-apply after navigation clears some contexts
+    await page.evaluate(() => document.fonts.ready);
+    // SPA / framework roots (e.g. Gameface Solid #root) need a beat after networkidle.
+    try {
+      await page.waitForFunction(
+        (sel) => {
+          const el = document.querySelector(sel);
+          return el && (el.children.length > 0 || (el.textContent || '').trim().length > 0);
+        },
+        rootSelector,
+        { timeout: 8000 },
+      );
+    } catch {
+      /* static pages already have content */
+    }
+    // Content exists now, but a framework-driven page may still be actively re-rendering it
+    // (hydration, lazy-loaded sections) — wait for it to settle before reading the DOM.
+    await waitForDomQuiescence(page);
   });
-  await installTsxEvaluateShim(page); // re-apply after navigation clears some contexts
-  await page.evaluate(() => document.fonts.ready);
-  // SPA / framework roots (e.g. Gameface Solid #root) need a beat after networkidle.
-  try {
-    await page.waitForFunction(
-      (sel) => {
-        const el = document.querySelector(sel);
-        return el && (el.children.length > 0 || (el.textContent || '').trim().length > 0);
-      },
-      rootSelector,
-      { timeout: 8000 },
-    );
-  } catch {
-    /* static pages already have content */
-  }
-  // Content exists now, but a framework-driven page may still be actively re-rendering it
-  // (hydration, lazy-loaded sections) — wait for it to settle before reading the DOM.
-  await waitForDomQuiescence(page);
   // Pin carousels / kill timers BEFORE extract so the box tree and the later chromium.png
   // reference show the same slide (Team Liquid hero, etc.). Do not debug this race in
   // site-fidelity agents — stabilizeDynamicMedia is the fix.
-  const captureMeta = await stabilizeDynamicMedia(page);
+  const captureMeta = await timer.time(`${label}.stabilize`, () => stabilizeDynamicMedia(page));
   if (captureMeta.suspectedRotatingMedia) {
     console.log(
       `stabilizeDynamicMedia: pinned ${captureMeta.pinnedSlideGroups} slide group(s), `
       + `paused ${captureMeta.pausedAnimations} animation(s)`,
     );
   }
-  const fontFaceRules = captureFonts ? await collectFontFaceRules(page) : [];
-  const tree = await page.evaluate(extractBoxTree, rootSelector);
+  const fontFaceRules = captureFonts
+    ? await timer.time(`${label}.font rules`, () => collectFontFaceRules(page))
+    : [];
+  const tree = await timer.time(`${label}.extract`, () => page.evaluate(extractBoxTree, rootSelector));
   return {
     page, tree, width, height, capturedFonts, capturedImages, fontFaceRules, pageUrl: url,
     captureMeta,
@@ -423,8 +432,15 @@ function runGumcliNew(gumxPath, template = 'empty') {
   if (r.status !== 0) throw new Error(`gumcli new exited ${r.status}`);
 }
 
+/** Box-tree size, so a slow run can be normalized against how big the page actually was. */
+function countBoxTreeNodes(node) {
+  let count = 1;
+  for (const child of node.children || []) count += countBoxTreeNodes(child);
+  return count;
+}
+
 async function main() {
-  const browser = await chromium.launch();
+  const browser = await timer.time('browser launch', () => chromium.launch());
   let tree;
   let responsiveMap = null;
   let mismatches = [];
@@ -433,7 +449,8 @@ async function main() {
   // Geometry always comes from the requested VIEWPORT. Training samples (when
   // responsive) only drive unit inference — PercentageOfParent / RelativeToParent /
   // Absolute — and must not replace the design-size box tree.
-  const primary = await renderTree(browser, VIEWPORT.width, VIEWPORT.height, { captureFonts: true });
+  const primary = await renderTree(
+    browser, VIEWPORT.width, VIEWPORT.height, { captureFonts: true, label: 'primary' });
   tree = primary.tree;
   shotPage = primary.page;
   const capturedFonts = primary.capturedFonts || new Map();
@@ -444,27 +461,27 @@ async function main() {
   if (flags.responsive) {
     const cache = new Map();
     cache.set(`${VIEWPORT.width}x${VIEWPORT.height}`, primary.tree);
-    async function treeAt(w, h) {
+    async function treeAt(w, h, label) {
       const key = `${w}x${h}`;
       if (cache.has(key)) return cache.get(key);
-      const r = await renderTree(browser, w, h);
+      const r = await renderTree(browser, w, h, { label });
       await r.page.close();
       cache.set(key, r.tree);
       return r.tree;
     }
-    const treeNarrow = await treeAt(TRAIN_NARROW, TRAIN_H);
-    const treeWide = await treeAt(TRAIN_WIDE, TRAIN_H);
-    ({ map: responsiveMap, mismatches } = computeResponsiveMap(
+    const treeNarrow = await treeAt(TRAIN_NARROW, TRAIN_H, 'train narrow');
+    const treeWide = await treeAt(TRAIN_WIDE, TRAIN_H, 'train wide');
+    ({ map: responsiveMap, mismatches } = await timer.time('responsive map', () => computeResponsiveMap(
       treeNarrow, treeWide,
       { width: TRAIN_NARROW, height: TRAIN_H },
       { width: TRAIN_WIDE, height: TRAIN_H },
-    ));
+    )));
   }
 
   rmSync(outProjectDir, { recursive: true, force: true });
   const gumxPath = join(outProjectDir, 'Generated.gumx');
   const useForms = flags.forms && treeHasFormControls(tree);
-  runGumcliNew(gumxPath, useForms ? 'forms' : 'empty');
+  await timer.time('gumcli new', () => runGumcliNew(gumxPath, useForms ? 'forms' : 'empty'));
   if (useForms) {
     console.log('forms: mapping HTML controls → Controls/* (pass --no-forms for visual-only)');
   } else if (!flags.forms) {
@@ -474,7 +491,8 @@ async function main() {
   const fontsDir = join(outProjectDir, 'Fonts');
 
   const assetMap = new Map();
-  await rasterizeEffects(shotPage, tree, imagesDir, assetMap, rootSelector);
+  await timer.time(
+    'raster capture', () => rasterizeEffects(shotPage, tree, imagesDir, assetMap, rootSelector));
 
   // Intersect root box with the viewport. Clamping only the origin (max(0,y)) while
   // keeping the full measured height overshoots when y is negative (mdbook body at
@@ -491,69 +509,81 @@ async function main() {
     VIEWPORT.height,
   );
   if (!clip) throw new Error('root screenshot clip is empty / outside the viewport');
-  await shotPage.screenshot({ path: chromiumPng, clip });
-  copyFileSync(chromiumPng, chromiumTagged);
-  await shotPage.close();
+  await timer.time('root screenshot', async () => {
+    await shotPage.screenshot({ path: chromiumPng, clip });
+    copyFileSync(chromiumPng, chromiumTagged);
+    await shotPage.close();
+  });
 
   // Reuse the still-open browser for SVG rasterization inside downloadImages() instead
   // of paying a second Chromium launch — close only after it's done with it.
-  const { assetMap: downloaded, assetSizeMap } = await downloadImages(tree, imagesDir, browser, capturedImages);
+  const { assetMap: downloaded, assetSizeMap } = await timer.time(
+    'image download', () => downloadImages(tree, imagesDir, browser, capturedImages));
   for (const [k, v] of downloaded) assetMap.set(k, v);
-  await browser.close();
+  await timer.time('browser close', () => browser.close());
 
-  const fontMap = await materializeWebFonts({
+  const fontMap = await timer.time('font materialize', () => materializeWebFonts({
     tree, captured: capturedFonts, rules: fontFaceRules, fontsDir, pageUrl,
+  }));
+  const nineSliceMap = await timer.time(
+    'nineslice', () => generateNineSliceAssets(tree, imagesDir, assetMap));
+
+  const screens = await timer.time('map to screen', () => {
+    const mapped = mapTreeToScreen(
+      tree, assetMap, responsiveMap, fontMap, nineSliceMap, assetSizeMap, useForms);
+    const result = [{ name: screenName, mapped, gusx: toGusx(screenName, mapped) }];
+
+    if (flags.responsive && flags.compareNaive) {
+      const naive = mapTreeToScreen(tree, assetMap, null, fontMap, nineSliceMap, assetSizeMap, useForms);
+      const naiveName = `${screenName}Naive`;
+      result.push({ name: naiveName, mapped: naive, gusx: toGusx(naiveName, naive) });
+    }
+    return result;
   });
-  const nineSliceMap = generateNineSliceAssets(tree, imagesDir, assetMap);
 
-  const mapped = mapTreeToScreen(tree, assetMap, responsiveMap, fontMap, nineSliceMap, assetSizeMap, useForms);
-  const screens = [{ name: screenName, mapped, gusx: toGusx(screenName, mapped) }];
-
-  if (flags.responsive && flags.compareNaive) {
-    const naive = mapTreeToScreen(tree, assetMap, null, fontMap, nineSliceMap, assetSizeMap, useForms);
-    const naiveName = `${screenName}Naive`;
-    screens.push({ name: naiveName, mapped: naive, gusx: toGusx(naiveName, naive) });
-  }
-
-  const screenRefs = screens.map((s) => `  <ScreenReference Name="${s.name}" />`).join('\n');
-  let gumx = readFileSync(gumxPath, 'utf8');
-  // forms template ships Demo screen refs — drop them so only our converted screen(s) remain.
-  gumx = gumx.replace(/^\s*<ScreenReference\b[^>]*\/>\s*\r?\n/gm, '');
-  // gumcli new --template empty emits no <ScreenReference> (empty list serializes to nothing);
-  // insert ours right before the first <StandardElementReference>, matching GumProjectSave's
-  // field order (ScreenReferences before StandardElementReferences).
-  const anchor = gumx.indexOf('  <StandardElementReference');
-  if (anchor === -1) {
-    throw new Error(`gumcli new did not produce a <StandardElementReference> anchor in ${gumxPath}`);
-  }
-  writeFileSync(gumxPath, gumx.slice(0, anchor) + screenRefs + '\n' + gumx.slice(anchor));
-  for (const s of screens) writeFileSync(join(outProjectDir, 'Screens', `${s.name}.gusx`), s.gusx);
-  writeFileSync(join(outProjectDir, 'boxtree.json'), JSON.stringify(tree, null, 2));
-  writeFileSync(
-    join(outProjectDir, 'capture-meta.json'),
-    JSON.stringify({
-      ...primary.captureMeta,
-      note: primary.captureMeta?.suspectedRotatingMedia
-        ? 'Rotating media was stabilized before extract. Do not probe timer races in fidelity agents.'
-        : undefined,
-    }, null, 2),
-  );
+  await timer.time('write project', async () => {
+    const screenRefs = screens.map((s) => `  <ScreenReference Name="${s.name}" />`).join('\n');
+    let gumx = readFileSync(gumxPath, 'utf8');
+    // forms template ships Demo screen refs — drop them so only our converted screen(s) remain.
+    gumx = gumx.replace(/^\s*<ScreenReference\b[^>]*\/>\s*\r?\n/gm, '');
+    // gumcli new --template empty emits no <ScreenReference> (empty list serializes to nothing);
+    // insert ours right before the first <StandardElementReference>, matching GumProjectSave's
+    // field order (ScreenReferences before StandardElementReferences).
+    const anchor = gumx.indexOf('  <StandardElementReference');
+    if (anchor === -1) {
+      throw new Error(`gumcli new did not produce a <StandardElementReference> anchor in ${gumxPath}`);
+    }
+    writeFileSync(gumxPath, gumx.slice(0, anchor) + screenRefs + '\n' + gumx.slice(anchor));
+    for (const s of screens) writeFileSync(join(outProjectDir, 'Screens', `${s.name}.gusx`), s.gusx);
+    writeFileSync(join(outProjectDir, 'boxtree.json'), JSON.stringify(tree, null, 2));
+    writeFileSync(
+      join(outProjectDir, 'capture-meta.json'),
+      JSON.stringify({
+        ...primary.captureMeta,
+        note: primary.captureMeta?.suspectedRotatingMedia
+          ? 'Rotating media was stabilized before extract. Do not probe timer races in fidelity agents.'
+          : undefined,
+      }, null, 2),
+    );
+  });
 
   // B-first: bake FontCache from Font/FontSize (+ .ttf paths) before the MonoGame host loads.
-  try {
-    runGumcliFonts(join(outProjectDir, 'Generated.gumx'));
-    const { repaired } = repairEmptyCustomFonts(outProjectDir);
-    if (repaired.length) {
-      console.warn(
-        `  ! empty FontCache atlas for ${repaired.length} custom font(s) `
-        + `(${repaired.slice(0, 3).join(', ')}${repaired.length > 3 ? '…' : ''}) `
-        + `— falling back to Arial and re-baking`,
-      );
+  await timer.time('gumcli fonts', async () => {
+    try {
       runGumcliFonts(join(outProjectDir, 'Generated.gumx'));
+      const { repaired } = repairEmptyCustomFonts(outProjectDir);
+      if (repaired.length) {
+        console.warn(
+          `  ! empty FontCache atlas for ${repaired.length} custom font(s) `
+          + `(${repaired.slice(0, 3).join(', ')}${repaired.length > 3 ? '…' : ''}) `
+          + `— falling back to Arial and re-baking`,
+        );
+        runGumcliFonts(join(outProjectDir, 'Generated.gumx'));
+      }
+    } catch (e) {
+      console.warn(`  ! gumcli fonts failed: ${e.message}`);
     }
-  } catch (e) {
-    console.warn(`  ! gumcli fonts failed: ${e.message}`);
-  }
+  });
 
   console.log(`box tree root: ${tree.tag}#${tree.id} (${Math.round(tree.rect.width)}x${Math.round(tree.rect.height)})`);
   if (flags.responsive) {
@@ -584,6 +614,20 @@ async function main() {
   } else {
     console.log('warnings: none');
   }
+
+  // Machine-comparable phase record — the plugin merges this into its own import timing log.
+  writeFileSync(
+    join(outProjectDir, 'timings.json'),
+    JSON.stringify(timer.toJSON({
+      nodes: countBoxTreeNodes(tree),
+      instances: screens[0].mapped.instances.length,
+      variables: screens[0].mapped.variables.length,
+      imagesDownloaded: downloaded.size,
+      rastersCaptured: rasterCount,
+      webFonts: fontMap.size,
+      nineSlices: nineSliceMap.size,
+    }), null, 2),
+  );
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/Tool/HtmlToGum/converter/timings.test.ts
+++ b/Tool/HtmlToGum/converter/timings.test.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPhaseTimer } from './timings.js';
+
+/** Deterministic clock: each read advances by the next queued step. */
+function fakeClock(steps) {
+  let t = 0;
+  let i = 0;
+  return () => {
+    const v = t;
+    t += steps[i] ?? 0;
+    i++;
+    return v;
+  };
+}
+
+test('createPhaseTimer: records phases in order and returns the wrapped value', async () => {
+  // Reads: start=0, p1 t0=10, p1 t1=20, p2 t0=25, p2 t1=100, toJSON=140.
+  const timer = createPhaseTimer(fakeClock([10, 10, 5, 75, 40]));
+
+  const value = await timer.time('goto', async () => 'page');
+  await timer.time('extract', async () => {});
+  timer.mark('external', 12.4);
+
+  assert.equal(value, 'page');
+  assert.deepEqual(timer.toJSON({ nodes: 3 }), {
+    phases: [
+      { name: 'goto', ms: 10 },
+      { name: 'extract', ms: 75 },
+      { name: 'external', ms: 12 },
+    ],
+    counts: { nodes: 3 },
+    totalMs: 140,
+  });
+});
+
+test('createPhaseTimer: records a phase even when the wrapped work throws', async () => {
+  const timer = createPhaseTimer(fakeClock([0, 30, 0]));
+
+  await assert.rejects(() => timer.time('image download', async () => {
+    throw new Error('boom');
+  }));
+
+  assert.deepEqual(timer.toJSON().phases, [{ name: 'image download', ms: 30 }]);
+});

--- a/Tool/HtmlToGum/converter/timings.ts
+++ b/Tool/HtmlToGum/converter/timings.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+// Per-phase wall clock for convert.ts, written to <out>/timings.json. The Gum plugin reads
+// that file and merges it with its own phase timings into one comparable log entry, so a slow
+// import can be attributed to a converter phase rather than guessed at.
+
+/**
+ * @param {() => number} now monotonic clock in milliseconds
+ */
+export function createPhaseTimer(now = () => performance.now()) {
+  const phases = [];
+  const start = now();
+
+  /** Times `fn`, recording the phase whether it resolves or throws. */
+  async function time(name, fn) {
+    const startedAt = now();
+    try {
+      return await fn();
+    } finally {
+      phases.push({ name, ms: Math.round(now() - startedAt) });
+    }
+  }
+
+  /** Records a duration measured elsewhere (e.g. summed across a loop). */
+  function mark(name, ms) {
+    phases.push({ name, ms: Math.round(ms) });
+  }
+
+  /** @param {Record<string, number>} counts page-size figures a run can be normalized against */
+  function toJSON(counts = {}) {
+    return { phases: [...phases], counts, totalMs: Math.round(now() - start) };
+  }
+
+  return { time, mark, toJSON };
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportTimingLogTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/HtmlToGumPlugin/HtmlImportTimingLogTests.cs
@@ -1,0 +1,141 @@
+using HtmlToGumPlugin;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GumToolUnitTests.Plugins.HtmlToGumPlugin;
+
+public class ImportPhaseRecorderTests
+{
+    /// <summary>Elapsed-time stub returning each queued reading in turn.</summary>
+    private static Func<TimeSpan> Clock(params int[] readingsMs)
+    {
+        int index = 0;
+        return () => TimeSpan.FromMilliseconds(readingsMs[index++]);
+    }
+
+    [Fact]
+    public async Task Measure_RecordsPhasesInOrderAndReturnsResult()
+    {
+        ImportPhaseRecorder recorder = new(Clock(10, 30, 30, 130));
+
+        int deserialized = recorder.Measure("deserialize", () => 7);
+        string imported = await recorder.MeasureAsync("ImportScreen", () => Task.FromResult("screen"));
+
+        deserialized.ShouldBe(7);
+        imported.ShouldBe("screen");
+        recorder.Phases.Select(p => $"{p.Name}={p.Milliseconds}")
+            .ShouldBe(["deserialize=20", "ImportScreen=100"]);
+        recorder.Total.ShouldBe(130);
+    }
+
+    [Fact]
+    public void Measure_RecordsThePhaseEvenWhenTheWorkThrows()
+    {
+        ImportPhaseRecorder recorder = new(Clock(0, 45));
+
+        Should.Throw<InvalidOperationException>(
+            () => recorder.Measure("LoadProject", () => throw new InvalidOperationException("boom")));
+
+        recorder.Phases.Single().Milliseconds.ShouldBe(45);
+    }
+}
+
+public class HtmlImportTimingLogTests
+{
+    /// <summary>Collapses column padding so assertions pin content, not alignment.</summary>
+    private static string Collapse(string line) => Regex.Replace(line, @"\s+", " ").Trim();
+
+    [Fact]
+    public void ParseConverterTimings_ReadsPhasesCountsAndTotal()
+    {
+        string json = """
+            {
+              "phases": [ { "name": "browser launch", "ms": 412 }, { "name": "primary.goto", "ms": 5100 } ],
+              "counts": { "nodes": 1520, "instances": 812 },
+              "totalMs": 36000
+            }
+            """;
+
+        ConverterTimings? parsed = HtmlImportTimingLog.ParseConverterTimings(json);
+
+        parsed.ShouldNotBeNull();
+        parsed.Phases.Select(p => $"{p.Name}={p.Milliseconds}")
+            .ShouldBe(["browser launch=412", "primary.goto=5100"]);
+        parsed.Counts["nodes"].ShouldBe(1520);
+        parsed.TotalMilliseconds.ShouldBe(36000);
+    }
+
+    [Fact]
+    public void ParseConverterTimings_ReturnsNullForUnparseableJson()
+    {
+        HtmlImportTimingLog.ParseConverterTimings("not json").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Format_ListsConverterThenPluginPhasesWithTotalsAndCounts()
+    {
+        ImportTimingRun run = new()
+        {
+            TimestampUtc = new DateTime(2026, 8, 27, 14, 3, 22, DateTimeKind.Utc),
+            Source = "https://example.com",
+            ScreenName = "Example",
+            ViewportWidth = 800,
+            ViewportHeight = 600,
+            Responsive = true,
+            PluginPhases =
+            [
+                new ImportTimingPhase { Name = "converter process", Milliseconds = 37200 },
+                new ImportTimingPhase { Name = "LoadProject", Milliseconds = 110000 },
+            ],
+            PluginTotalMilliseconds = 155700,
+            ConverterTimings = new ConverterTimings
+            {
+                Phases = [new ImportTimingPhase { Name = "browser launch", Milliseconds = 412 }],
+                Counts = new Dictionary<string, long> { ["instances"] = 812, ["nodes"] = 1520 },
+                TotalMilliseconds = 36000,
+            },
+        };
+
+        string[] lines = HtmlImportTimingLog.Format(run).Replace("\r\n", "\n").TrimEnd('\n').Split('\n');
+
+        lines.Select(Collapse).ShouldBe(
+        [
+            "=== 2026-08-27 14:03:22Z screen=Example viewport=800x600 responsive=on",
+            "source=https://example.com",
+            "converter browser launch 412 ms",
+            "converter (total) 36000 ms",
+            "plugin converter process 37200 ms",
+            "plugin LoadProject 110000 ms",
+            "plugin (total) 155700 ms",
+            "counts instances=812 nodes=1520",
+        ]);
+    }
+
+    [Fact]
+    public void Format_SaysSoWhenTheConverterWroteNoTimings()
+    {
+        ImportTimingRun run = new()
+        {
+            TimestampUtc = new DateTime(2026, 8, 27, 14, 3, 22, DateTimeKind.Utc),
+            Source = @"C:\pages\local.html",
+            ScreenName = "Local",
+            ViewportWidth = 800,
+            ViewportHeight = 600,
+            Responsive = false,
+            PluginPhases = [new ImportTimingPhase { Name = "converter process", Milliseconds = 900 }],
+            PluginTotalMilliseconds = 900,
+            ConverterTimings = null,
+        };
+
+        string formatted = HtmlImportTimingLog.Format(run);
+
+        formatted.ShouldContain("responsive=off");
+        formatted.ShouldContain("converter  (no timings.json — converter did not finish)");
+        formatted.ShouldNotContain("counts");
+    }
+}


### PR DESCRIPTION
Instruments HTML import end to end so a slow run can be attributed instead of guessed at.

**Converter** (`convert.ts`): a new `timings.ts` phase timer wraps browser launch, each render pass (`goto` / `quiescence` / `stabilize` / `extract`, labelled `primary` / `train narrow` / `train wide` so the responsive training cost is visible), responsive map, `gumcli new`, raster capture, root screenshot, image download, font materialize, nineslice, map, write, and `gumcli fonts`. Written to `<out>/timings.json` with counts (nodes, instances, variables, images, rasters, web fonts, nineslices).

**Plugin**: `ImportPhaseRecorder` times npm install, converter process, asset copy, deserialize, `ImportScreen`, `TryAutoSaveProject`, `LoadProject`, and screen selection — the last three separately, since they run on the UI thread and are what leaves the result dialog unresponsive. `HtmlImportTimingLog` merges both sides into one aligned entry appended to `%APPDATA%\HtmlToGumPlugin\import-timings.log`; the path shows in the result dialog's details pane. Written in a `finally`, so a failed import still logs where its time went.

Log location deviates from the issue's "next to the project or under temp" — AppData sits next to the plugin's existing `import-prefs.json`, survives temp cleaning, and doesn't drop untracked files into the user's project.

Sample entry:

```
=== 2026-08-27 14:03:22Z  screen=Example  viewport=800x600  responsive=on
    source=https://example.com
converter  browser launch                    1676 ms
converter  primary.goto                       546 ms
converter  (total)                           6007 ms
plugin     converter process                 7200 ms
plugin     LoadProject                     110000 ms
plugin     (total)                         155700 ms
counts     nodes=5 instances=5 variables=52
```

Instrumentation only; no behavior change.

Closes #4518
