### PR TITLE
Honor a non-uniform Width on SvgRuntime for the Apos.Shapes backend

### DIFF
--- a/Runtimes/GumShapes/GueDeriving/SvgRuntime.cs
+++ b/Runtimes/GumShapes/GueDeriving/SvgRuntime.cs
@@ -23,23 +23,15 @@ namespace Gum.GueDeriving;
 /// gated on nearly every member. Both types carry the same fully-qualified name in different
 /// assemblies, which never meet in one build. Issue #4506.
 ///
-/// Two deliberate differences from the Skia runtime:
-/// <list type="bullet">
-/// <item><description>
-/// <b>No color API.</b> Skia's <c>Color</c>/<c>Red</c>/<c>Green</c>/<c>Blue</c>/<c>Alpha</c>
-/// modulate the drawing through an <c>SKColorFilter</c> color matrix. Apos's colored
-/// <c>DrawSvg</c> overload instead <i>replaces</i> every paint in the file, producing a
-/// silhouette. Exposing the same property names for a different result is worse than omitting
-/// them, so this draws the file's own colors. A silhouette override can be added later under a
-/// name that says so.
-/// </description></item>
-/// <item><description>
-/// <b>Height-dominant sizing.</b> See <see cref="Svg.Render"/> — height drives a uniform scale, so
-/// a Width that disagrees with the file's aspect ratio is not honored. Skia squashes to fill the
-/// box instead. Accepted divergence, tracked in issue #4509; the default
-/// <c>MaintainFileAspectRatio</c> height units keep the two backends in agreement.
-/// </description></item>
-/// </list>
+/// One deliberate difference from the Skia runtime: <b>no color API</b>. Skia's
+/// <c>Color</c>/<c>Red</c>/<c>Green</c>/<c>Blue</c>/<c>Alpha</c> modulate the drawing through an
+/// <c>SKColorFilter</c> color matrix. Apos's colored <c>DrawSvg</c> overload instead
+/// <i>replaces</i> every paint in the file, producing a silhouette. Exposing the same property
+/// names for a different result is worse than omitting them, so this draws the file's own colors.
+/// A silhouette override can be added later under a name that says so.
+///
+/// Sizing matches Skia, including a Width that disagrees with the file's aspect ratio — see
+/// <see cref="Svg.Render"/> for what that costs on this backend.
 /// </remarks>
 public class SvgRuntime : InteractiveGue
 {

--- a/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
+++ b/Runtimes/GumShapes/Renderables/ShapeRenderer.cs
@@ -23,7 +23,14 @@ public class ShapeRenderer
     Microsoft.Xna.Framework.Matrix? _currentView;
     RasterizerState? _currentRasterizerState;
     Gum.RenderingLibrary.Blend _currentBlend;
+    BlendState? _currentXnaBlendState;
     bool _isBatchBegun;
+
+    // Issue #4509 — the view the batch was opened with, saved while a single renderable draws
+    // through a transformed one. Apos.Shapes has no per-draw transform, so a non-uniformly scaled
+    // SVG has to re-open the batch around its own draw and restore the view afterwards.
+    Microsoft.Xna.Framework.Matrix? _viewBeforePush;
+    bool _isViewPushed;
 
     // Per-frame ShapeBatch begin counter, owned by the active Renderer and reset each frame.
     // Captured in BeginBatch so EnsureBlend's mid-run re-begins are counted too. Null when the
@@ -48,10 +55,12 @@ public class ShapeRenderer
         _currentView = view;
         _currentRasterizerState = rasterizerState;
         _currentBlend = shape.Blend;
+        _currentXnaBlendState = shape.GetEffectiveXnaBlendState();
         _isBatchBegun = true;
+        _isViewPushed = false;
         _statistics = statistics;
         _statistics?.RecordShapeBatchBegin();
-        _sb.Begin(view: view, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: rasterizerState);
+        _sb.Begin(view: view, blendState: _currentXnaBlendState, rasterizerState: rasterizerState);
     }
 
     /// <summary>
@@ -70,8 +79,48 @@ public class ShapeRenderer
         }
         _sb.End();
         _currentBlend = shape.Blend;
+        _currentXnaBlendState = shape.GetEffectiveXnaBlendState();
         _statistics?.RecordShapeBatchBegin();
-        _sb.Begin(view: _currentView, blendState: shape.GetEffectiveXnaBlendState(), rasterizerState: _currentRasterizerState);
+        _sb.Begin(view: _currentView, blendState: _currentXnaBlendState, rasterizerState: _currentRasterizerState);
+    }
+
+    /// <summary>
+    /// Re-opens the ShapeBatch with <paramref name="view"/> applied on top of the view it was
+    /// opened with, so the next draw is transformed in world space and still sees the camera.
+    /// Must be paired with <see cref="PopView"/> around that draw. No-op when no batch is open
+    /// (e.g. unit tests with no device) or a view is already pushed.
+    /// </summary>
+    public void PushView(Microsoft.Xna.Framework.Matrix view)
+    {
+        if (!_isBatchBegun || _isViewPushed)
+        {
+            return;
+        }
+        _viewBeforePush = _currentView;
+        _isViewPushed = true;
+        _sb.End();
+        // Row-vector order: the caller's world-space transform runs first, then the camera view
+        // BeginBatch was handed (zoom, scroll, any GumBatch.Begin forced matrix).
+        _currentView = _viewBeforePush.HasValue ? view * _viewBeforePush.Value : view;
+        _statistics?.RecordShapeBatchBegin();
+        _sb.Begin(view: _currentView, blendState: _currentXnaBlendState, rasterizerState: _currentRasterizerState);
+    }
+
+    /// <summary>
+    /// Restores the view <see cref="PushView"/> replaced, re-opening the ShapeBatch so following
+    /// shapes draw untransformed. No-op when no view is pushed.
+    /// </summary>
+    public void PopView()
+    {
+        if (!_isBatchBegun || !_isViewPushed)
+        {
+            return;
+        }
+        _isViewPushed = false;
+        _sb.End();
+        _currentView = _viewBeforePush;
+        _statistics?.RecordShapeBatchBegin();
+        _sb.Begin(view: _currentView, blendState: _currentXnaBlendState, rasterizerState: _currentRasterizerState);
     }
 
     /// <summary>
@@ -81,6 +130,7 @@ public class ShapeRenderer
     public void EndBatch()
     {
         _isBatchBegun = false;
+        _isViewPushed = false;
         _sb.End();
     }
 
@@ -153,8 +203,11 @@ public class ShapeRenderer
 
         IsInitialized = false;
         _isBatchBegun = false;
+        _isViewPushed = false;
         _currentView = null;
+        _viewBeforePush = null;
         _currentRasterizerState = null;
+        _currentXnaBlendState = null;
         _statistics = null;
     }
 }

--- a/Runtimes/GumShapes/Renderables/Svg.cs
+++ b/Runtimes/GumShapes/Renderables/Svg.cs
@@ -45,6 +45,52 @@ internal class Svg : RenderableShapeBase, IAspectRatio
         }
     }
 
+    /// <summary>
+    /// Half a world unit of disagreement between the drawn width and the element's Width is
+    /// treated as none, so float noise doesn't cost two batch flushes. Not scaled by camera zoom -
+    /// a zoomed-in camera can magnify a skipped mismatch to a visible pixel or two.
+    /// </summary>
+    internal const float NonUniformScaleTolerance = 0.5f;
+
+    /// <summary>
+    /// Whether the width Apos.Shapes draws from the height differs visibly from the width the
+    /// element reports to layout. False for the <c>MaintainFileAspectRatio</c> default and for
+    /// degenerate dimensions, so the stretch path costs nothing in the common case.
+    /// </summary>
+    internal static bool RequiresNonUniformScale(float width, float height, float documentAspectRatio)
+    {
+        if (width <= 0 || height <= 0 || documentAspectRatio <= 0)
+        {
+            return false;
+        }
+
+        float drawnWidth = height * documentAspectRatio;
+
+        return System.Math.Abs(width - drawnWidth) > NonUniformScaleTolerance;
+    }
+
+    /// <summary>
+    /// The transform that turns Apos.Shapes' height-driven uniform scale into the non-uniform one
+    /// SkiaGum's <c>VectorSprite</c> produces, for use as a pre-multiplied view matrix.
+    /// </summary>
+    /// <remarks>
+    /// Apos maps a point of the drawing to <c>T(topLeft) * R(rotation) * S(height, height)</c>;
+    /// Skia composes <c>T * R * S(scaleX, scaleY)</c>. The heights already agree, so only x needs
+    /// correcting, and conjugating the x scale by the element's own rotation and position stretches
+    /// along the element's local axis rather than shearing a rotated drawing.
+    /// </remarks>
+    internal static Matrix CreateNonUniformScaleMatrix(float width, float height,
+        float documentAspectRatio, Vector2 topLeft, float rotationRadians)
+    {
+        float horizontalScale = width / (height * documentAspectRatio);
+
+        return Matrix.CreateTranslation(-topLeft.X, -topLeft.Y, 0)
+            * Matrix.CreateRotationZ(-rotationRadians)
+            * Matrix.CreateScale(horizontalScale, 1, 1)
+            * Matrix.CreateRotationZ(rotationRadians)
+            * Matrix.CreateTranslation(topLeft.X, topLeft.Y, 0);
+    }
+
     public override void Render(ISystemManagers managers)
     {
         if (Document == null)
@@ -57,28 +103,38 @@ internal class Svg : RenderableShapeBase, IAspectRatio
 
         var sb = ShapeRenderer.ShapeBatch;
 
-        // DrawSvg's `size` is one em in world units, and one em is the viewBox's HEIGHT - so this
-        // is a uniform scale driven by Height, and the drawn width follows the file's aspect ratio.
-        //
-        // Height-dominant is the accepted behavior here, NOT a match for SkiaGum's VectorSprite,
-        // which computes scaleX and scaleY independently and squashes the drawing to fill its box.
-        // When Width and Height disagree with the file's ratio this draws wider than the Width it
-        // reports to layout, so it can overrun a sibling. Tracked in issue #4509 along with the two
-        // ways out: scaling the batch through ShapeBatch.Begin's view matrix (Skia parity, at two
-        // batch flushes per stretched SVG), or a Vector2-size DrawSvg upstream. The common case is
-        // unaffected - SvgRuntime defaults to MaintainFileAspectRatio, where the dimensions already
-        // agree and both backends match.
-        //
+        var topLeft = new Vector2(this.GetAbsoluteLeft(), this.GetAbsoluteTop());
+        var rotationRadians = MathHelper.ToRadians(-this.GetAbsoluteRotation());
+
+        // Issue #4509 - DrawSvg's `size` is one em in world units, and one em is the viewBox's
+        // HEIGHT, so the drawn width always follows the file's aspect ratio. When Width disagrees,
+        // the batch is re-opened with a view matrix that stretches x, matching SkiaGum's
+        // VectorSprite (which scales x and y independently) including its effect on strokes, whose
+        // pen becomes elliptical. That costs two batch flushes, so it only happens on a real
+        // mismatch - the MaintainFileAspectRatio default never pays for it.
+        var requiresNonUniformScale = RequiresNonUniformScale(Width, Height, AspectRatio);
+
+        if (requiresNonUniformScale)
+        {
+            ShapeRenderer.PushView(
+                CreateNonUniformScaleMatrix(Width, Height, AspectRatio, topLeft, rotationRadians));
+        }
+
         // `rotation` turns around `position` and `origin` is the pivot measured out from the top
         // left, so passing Vector2.Zero rotates around the top-left corner - Gum's own convention.
         // That is why this needs no AdjustPositionForCenterRotation, unlike the center-rotating
         // DrawRectangle/DrawCircle paths.
         sb.DrawSvg(
             Document,
-            new Vector2(this.GetAbsoluteLeft(), this.GetAbsoluteTop()),
+            topLeft,
             Height,
-            rotation: MathHelper.ToRadians(-this.GetAbsoluteRotation()),
+            rotation: rotationRadians,
             origin: Vector2.Zero,
             aaSize: IsAntialiased ? 1 : 0);
+
+        if (requiresNonUniformScale)
+        {
+            ShapeRenderer.PopView();
+        }
     }
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SvgScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/SvgScreen.cs
@@ -58,8 +58,8 @@ internal class SvgScreen : FrameworkElement
             BuildRotationRow()));
 
         right.AddChild(BuildSection(
-            "Absolute height, aspect-locked width",
-            BuildAbsoluteHeightRow()));
+            "Absolute width and height (square box, 2:1 file - squashed)",
+            BuildSquashedRow()));
         right.AddChild(BuildSection(
             "CSS <style> colors: honored on Skia, ignored by Apos.Shapes",
             BuildCssStyledRow()));
@@ -148,37 +148,24 @@ internal class SvgScreen : FrameworkElement
         return row;
     }
 
-    // Height-driven: both dimensions absolute, with Width deliberately set to a value the file's
-    // 2:1 aspect ratio does NOT agree with. Skia squashes the drawing to fill the box exactly
-    // (scaleX and scaleY are computed independently in VectorSprite.Render); Apos.Shapes scales
-    // uniformly off the height and keeps the file's proportions, because its DrawSvg takes a single
-    // em size (one em = the viewBox's height). Known, accepted divergence — tracked in issue #4509.
-    //
-    // Each drawing gets a host container twice its height wide, because on the Apos backend the
-    // drawing is wider than the Width the element reports to layout — without the container the
-    // 2:1 drawings would overrun the square boxes the stack is spacing them by and overlap each
-    // other, which reads as a rendering bug rather than the sizing difference being demonstrated.
-    private static ContainerRuntime BuildAbsoluteHeightRow()
+    // Both dimensions absolute, with Width deliberately set to a value the file's 2:1 aspect ratio
+    // does NOT agree with, so the square boxes squash the drawing. Both backends fill the box
+    // exactly: Skia computes scaleX and scaleY independently in VectorSprite.Render, and
+    // Apos.Shapes reaches the same result by re-opening the ShapeBatch with a stretching view
+    // matrix, since its DrawSvg takes a single em size (one em = the viewBox's height) - #4509.
+    private static ContainerRuntime BuildSquashedRow()
     {
         ContainerRuntime row = BuildRow();
 
-        foreach (var height in new float[] { 40, 70, 100 })
+        foreach (var size in new float[] { 40, 70, 100 })
         {
-            ContainerRuntime cell = new();
-            cell.WidthUnits = DimensionUnitType.Absolute;
-            cell.HeightUnits = DimensionUnitType.Absolute;
-            cell.Width = height * 2;
-            cell.Height = height;
-
             SvgRuntime svg = new();
             svg.SourceFile = DemoSvg;
             svg.HeightUnits = DimensionUnitType.Absolute;
-            svg.Height = height;
+            svg.Height = size;
             svg.WidthUnits = DimensionUnitType.Absolute;
-            svg.Width = height; // intentionally square, i.e. inconsistent with the 2:1 file
-            cell.AddChild(svg);
-
-            row.AddChild(cell);
+            svg.Width = size; // intentionally square, i.e. inconsistent with the 2:1 file
+            row.AddChild(svg);
         }
 
         return row;

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/SvgNonUniformScaleRenderTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/SvgNonUniformScaleRenderTests.cs
@@ -1,0 +1,182 @@
+using System.IO;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Gum.DataTypes;
+using Gum.Forms;
+using Gum.GueDeriving;
+using MonoGameAndGum.Renderables;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+using XnaColor = Microsoft.Xna.Framework.Color;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Issue #4509: Apos.Shapes' <c>DrawSvg</c> takes a scalar em size measured off the viewBox's
+/// height, so a Width that disagrees with the file's aspect ratio used to be ignored — a 2:1
+/// drawing in a square box rendered at full 2:1 width and overran its siblings, where SkiaGum's
+/// <c>VectorSprite</c> squashes it to fill the box. <c>Svg.Render</c> now re-opens the ShapeBatch
+/// with a stretching view matrix when the mismatch is real.
+///
+/// The document is full-bleed (blue left half, red right half of a 2:1 viewBox) so the assertions
+/// read the drawing's own halves rather than depending on where a partial drawing anchors.
+/// </summary>
+public class SvgNonUniformScaleRenderTests : BaseTestClass
+{
+    private const string TwoByOneHalvesSvg =
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
+          <rect x="0" y="0" width="100" height="100" fill="#0000ff" />
+          <rect x="100" y="0" width="100" height="100" fill="#ff0000" />
+        </svg>
+        """;
+
+    [Fact]
+    public void AbsoluteWidth_NarrowerThanTheFilesAspectRatio_SquashesTheDrawingIntoTheBox()
+    {
+        XnaColor[] pixels = RenderSquashedSvg(rotation: 0);
+
+        // Squashed, the drawing's blue half occupies x 50-100 and its red half x 100-150, so the
+        // far side of the box is red. Unsquashed the red half starts at x 150 and this is blue.
+        XnaColor insideBoxFarSide = pixels[(100 * CaptureWidth) + 125];
+        insideBoxFarSide.R.ShouldBeGreaterThan((byte)200);
+        insideBoxFarSide.B.ShouldBeLessThan((byte)60);
+
+        // And nothing spills past the Width layout stacks siblings against.
+        pixels[(100 * CaptureWidth) + 160].ShouldBe(BackgroundColor);
+    }
+
+    [Fact]
+    public void Rotated_SquashedDrawing_StretchesAlongItsOwnAxisRatherThanShearing()
+    {
+        // Rotation pivots on the top-left corner, so -90 lays the drawing's long axis down the
+        // screen from y 50 and swings its short axis out to x 0-50.
+        XnaColor[] pixels = RenderSquashedSvg(rotation: -90);
+
+        // Squashed, the long axis is 100 and its red half runs y 100-150. Unsquashed the axis is
+        // 200 long and y 125 is still inside the blue half.
+        XnaColor alongAxisFarSide = pixels[(125 * CaptureWidth) + 25];
+        alongAxisFarSide.R.ShouldBeGreaterThan((byte)200);
+        alongAxisFarSide.B.ShouldBeLessThan((byte)60);
+
+        // Past the squashed length nothing is drawn - the stretch followed the rotated axis
+        // rather than shearing the drawing across the screen's own.
+        pixels[(200 * CaptureWidth) + 25].ShouldBe(BackgroundColor);
+    }
+
+    [Fact]
+    public void ZoomedCamera_SquashedDrawing_StillHonorsTheCameraView()
+    {
+        // The stretch is applied by re-opening the ShapeBatch, so it has to compose onto the view
+        // the batch was opened with rather than replace it - otherwise the drawing drops out of the
+        // camera while every sibling shape stays in it.
+        XnaColor[] pixels = RenderSquashedSvg(rotation: 0, zoom: 2);
+
+        // At 2x the 100x100 box at (50,50) covers 200x200 at (100,100), so its red half runs
+        // x 200-300. Ignoring the camera would leave the drawing back at x 50-150.
+        XnaColor insideZoomedBox = pixels[(150 * CaptureWidth) + 250];
+        insideZoomedBox.R.ShouldBeGreaterThan((byte)200);
+        insideZoomedBox.B.ShouldBeLessThan((byte)60);
+
+        pixels[(150 * CaptureWidth) + 75].ShouldBe(BackgroundColor);
+    }
+
+    /// <summary>
+    /// Draws the 2:1 document in a 100x100 box at (50,50) - a deliberate aspect mismatch - and
+    /// returns the captured frame.
+    /// </summary>
+    private static XnaColor[] RenderSquashedSvg(float rotation, float zoom = 1)
+    {
+        string svgPath = Path.Combine(Path.GetTempPath(), $"gum-svg-4509-{System.Guid.NewGuid():N}.svg");
+        File.WriteAllText(svgPath, TwoByOneHalvesSvg);
+
+        try
+        {
+            using MinimalGame game = new();
+            game.RunOneFrame();
+
+            GraphicsDevice gd = game.GraphicsDevice;
+            SystemManagers managers = SystemManagers.Default;
+            Renderer renderer = managers.Renderer;
+            renderer.Camera.Zoom = zoom;
+
+            SvgRuntime svg = new SvgRuntime();
+            svg.SourceFile = svgPath;
+            svg.WidthUnits = DimensionUnitType.Absolute;
+            svg.HeightUnits = DimensionUnitType.Absolute;
+            svg.Width = 100;
+            svg.Height = 100;
+            svg.X = 50;
+            svg.Y = 50;
+            svg.Rotation = rotation;
+            svg.AddToManagers(managers, null);
+            svg.UpdateLayout();
+
+            return CapturePixels(gd, renderer, managers);
+        }
+        finally
+        {
+            File.Delete(svgPath);
+        }
+    }
+
+    private const int CaptureWidth = 300;
+    private const int CaptureHeight = 300;
+    private static readonly XnaColor BackgroundColor = XnaColor.Black;
+
+    private static XnaColor[] CapturePixels(GraphicsDevice gd, Renderer renderer, SystemManagers managers)
+    {
+        using RenderTarget2D capture = new(gd, CaptureWidth, CaptureHeight, false, SurfaceFormat.Color,
+            DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
+
+        for (int i = 0; i < 2; i++)
+        {
+            gd.SetRenderTarget(capture);
+            gd.Clear(BackgroundColor);
+            renderer.Draw(managers);
+        }
+        gd.SetRenderTarget(null);
+
+        XnaColor[] pixels = new XnaColor[CaptureWidth * CaptureHeight];
+        capture.GetData(pixels);
+        return pixels;
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this)
+            {
+                // Apos.Shapes uses an SM4 effect the default Reach profile can't load - #4403.
+                GraphicsProfile = GraphicsProfile.HiDef,
+            };
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Gum.GumService.Default.Initialize(this, DefaultVisualsVersion.V3);
+            ShapeRenderer.Self.Initialize(GraphicsDevice, Content);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(BackgroundColor);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (Gum.GumService.Default.IsInitialized)
+            {
+                Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.Shapes.Tests/SvgNonUniformScaleTests.cs
+++ b/Tests/MonoGameGum.Shapes.Tests/SvgNonUniformScaleTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Xna.Framework;
+using MonoGameAndGum.Renderables;
+using Shouldly;
+
+namespace MonoGameGum.Shapes.Tests;
+
+// Issue #4509 — Apos.Shapes' DrawSvg takes a scalar em size, so a Width that disagrees with the
+// file's aspect ratio is otherwise ignored. Svg.Render corrects it by re-opening the ShapeBatch
+// with a stretched view matrix, which costs two batch flushes, so it does that only when the
+// mismatch is real. The decision and the matrix are pure math and are pinned here; the draw itself
+// is covered by SvgNonUniformScaleRenderTests in MonoGameGum.IntegrationTests.
+public class SvgNonUniformScaleTests
+{
+    [Theory]
+    // Width already follows the file's ratio - the MaintainFileAspectRatio default, and the case
+    // that must never pay for a batch break.
+    [InlineData(200f, 100f, 2f, false)]
+    // A square box on a 2:1 drawing: Apos would draw 200 wide inside a 100 wide element.
+    [InlineData(100f, 100f, 2f, true)]
+    // Sub-pixel disagreement isn't visible and isn't worth two flushes.
+    [InlineData(200.2f, 100f, 2f, false)]
+    // Degenerate dimensions divide by zero or scale to nothing.
+    [InlineData(0f, 100f, 2f, false)]
+    [InlineData(100f, 0f, 2f, false)]
+    [InlineData(100f, 100f, 0f, false)]
+    public void RequiresNonUniformScale_IsTrueOnlyForAVisibleAspectMismatch(
+        float width, float height, float documentAspectRatio, bool expected)
+    {
+        Svg.RequiresNonUniformScale(width, height, documentAspectRatio).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void CreateNonUniformScaleMatrix_Unrotated_PullsTheDrawnRightEdgeOntoTheBoxRightEdge()
+    {
+        Vector2 topLeft = new Vector2(10, 20);
+        float boxWidth = 100;
+        float boxHeight = 100;
+        float documentAspectRatio = 2;
+
+        Matrix matrix = Svg.CreateNonUniformScaleMatrix(
+            boxWidth, boxHeight, documentAspectRatio, topLeft, rotationRadians: 0);
+
+        // Apos draws the 2:1 document 200 wide off the height, so its right edge lands at x = 210.
+        Vector2 drawnRightEdge = new Vector2(topLeft.X + (boxHeight * documentAspectRatio), topLeft.Y);
+        Vector2 transformed = Vector2.Transform(drawnRightEdge, matrix);
+
+        transformed.X.ShouldBe(topLeft.X + boxWidth, 0.01f);
+        transformed.Y.ShouldBe(topLeft.Y, 0.01f);
+
+        // The top left corner is the pivot and must not move.
+        Vector2 pivot = Vector2.Transform(topLeft, matrix);
+        pivot.X.ShouldBe(topLeft.X, 0.01f);
+        pivot.Y.ShouldBe(topLeft.Y, 0.01f);
+    }
+
+    [Fact]
+    public void CreateNonUniformScaleMatrix_Rotated_StretchesAlongTheElementsLocalAxis()
+    {
+        // Skia's VectorSprite composes translate * rotate * scale, so the stretch happens in the
+        // element's own frame and rotates with it. A world space x scale would shear a rotated
+        // drawing instead.
+        Vector2 topLeft = new Vector2(10, 20);
+        float boxWidth = 100;
+        float boxHeight = 100;
+        float documentAspectRatio = 2;
+        float rotationRadians = MathHelper.PiOver2;
+
+        Matrix matrix = Svg.CreateNonUniformScaleMatrix(
+            boxWidth, boxHeight, documentAspectRatio, topLeft, rotationRadians);
+
+        // Quarter turn: the drawing's local +x runs along world +y, so its far corner sits 200
+        // below the pivot and the stretch must halve that to 100.
+        Vector2 drawnFarCorner = new Vector2(topLeft.X, topLeft.Y + (boxHeight * documentAspectRatio));
+        Vector2 transformed = Vector2.Transform(drawnFarCorner, matrix);
+
+        transformed.X.ShouldBe(topLeft.X, 0.01f);
+        transformed.Y.ShouldBe(topLeft.Y + boxWidth, 0.01f);
+    }
+}


### PR DESCRIPTION
Closes #4509

`SvgRuntime` on the Apos.Shapes backend ignored a `Width` that disagreed with the file's aspect ratio: `DrawSvg` takes a scalar em size measured off the viewBox's height, so a 2:1 drawing in a square box rendered at full 2:1 width and overran the `Width` layout stacks siblings against. SkiaGum's `VectorSprite` squashes the drawing to fill the box.

`Svg.Render` now re-opens the ShapeBatch with a view matrix that stretches x, composed onto the camera view the batch was opened with. The stretch is conjugated by the element's own rotation and position so it runs along the element's local axis — the same `translate * rotate * scale` composition Skia uses — rather than shearing a rotated drawing. Scaling the world also makes a stroke's pen elliptical, which matches Skia too.

That costs two batch flushes, so it's gated on a real mismatch (a half-world-unit compare against `Height * documentAspectRatio`). The `MaintainFileAspectRatio` default — the common case — never pays for it.

Upstream (a `Vector2`-size `DrawSvg`) is still the better end state but isn't available: Apos.Shapes `main` has only the scalar-`size` overloads, and 0.8.1 is both the latest published version and what we're on.

Tests, each verified red before the fix:
- `SvgNonUniformScaleTests` (headless) — the gate predicate and the correction matrix, unrotated and rotated.
- `SvgNonUniformScaleRenderTests` (GPU pixel) — a 2:1 document in a square box fills the box and doesn't spill past `Width`; unrotated, at -90°, and under `Camera.Zoom = 2`.

The `SvgScreen` sample's squashed row no longer needs the double-width host containers that existed only to hide the overrun.
