### PR TITLE
Document .ttf file indirection and bold/italic synthesis for KernSmith fonts

### DIFF
--- a/.claude/skills/gum-docs-writing/SKILL.md
+++ b/.claude/skills/gum-docs-writing/SKILL.md
@@ -137,6 +137,22 @@ Then flag accordingly in a `{% hint style="info" %}` block (same pattern as date
 - **Shipped in preview** — note that it's a preview feature.
 - **Fully shipped** — no flag; write it as current behavior.
 
+## Prose Style: Clarity Beats Brevity
+
+Cut length that adds *reading*, never length that adds *understanding*. Density and clarity are separate axes, and a longer sentence that lands the first time beats a compressed one the reader has to decode. Trimming a page is not the same as making it clearer, and a reader who has to re-read a sentence has not been saved anything.
+
+Three habits that cost words without buying understanding:
+
+- **Restating a claim as its own negation.** "The font is generated automatically, not something you opt into" is one fact wearing two coats. Keep the positive half and delete the rest.
+- **Naming the mechanism instead of the effect.** A reader wants to know what changes on screen and which property to set. The internal class, cache, or algorithm that does it belongs in a skill or a code comment, not in a user-facing page, unless the reader has to call it.
+- **Imperatives that hide the subject.** "Set `Font` to a `.ttf` path to bypass family lookup" makes the reader the subject and the property an object. Make the property the subject so the line reads as reference material a reader can scan.
+
+**Read-aloud test.** If a clause repeats the clause before it, or the sentence runs out of breath, rewrite it. Do not shorten it.
+
+❌ "Set `text.Font` to a path ending in `.ttf` to bypass family name resolution and route the value through the file backed rasterization path rather than the operating system font lookup. This happens automatically, and there is nothing to enable."
+
+✅ "Gum loads a `Font` value ending in `.ttf` as a font file rather than looking it up as an installed font family. It decides this from the extension alone, so there is no setting to turn on."
+
 ## Tone and Style
 
 - Second person ("you"), present tense, instructional tone.

--- a/.claude/skills/skills-writer/SKILL.md
+++ b/.claude/skills/skills-writer/SKILL.md
@@ -31,6 +31,33 @@ A skill is rarely written whole; it grows as **pulls** act on it — and a pull 
 
 **Signpost quality bar.** A nudge must name *where to look* — a file, class, or relationship — not merely assert that something exists. "Animation events interact with children" raises a question without reducing search cost; "see event dispatch in `X.cs` — children suppress Y because Z" reduces it. A vague signpost is worse than none: it costs context and resolves nothing.
 
+## Prose Style — Clarity Beats Brevity
+
+Cut length that adds *reading*, never length that adds *understanding*. Density and clarity are
+separate axes: a longer sentence that lands the first time beats a compressed one the reader has to
+decode. The damping rules above govern which *facts* earn a line, not how tightly the sentence
+carrying them gets compressed.
+
+Three habits that buy density with clarity:
+
+- **Em-dash restatement.** `<claim> — <same claim, negated>` is one fact in two coats. Keep the
+  positive half and delete the rest.
+- **Algorithm name in place of observable effect.** Say what changes for the reader and point at an
+  API member they can inspect, not at the technique's academic name.
+- **Imperative that hides the subject.** "Set X to Y to do Z" makes the reader the subject and the
+  API an object. Make the API the subject so the line reads as documentation, not a command.
+
+**Read-aloud test.** If a clause after a dash repeats the clause before it, or the sentence runs out
+of breath, rewrite it. Do not shorten it.
+
+❌ "Set `Factory<T>.PartitionAxis = Axis.X` (or `Axis.Y`) to replace the default O(n×m) pairwise
+check with sweep-and-prune broad-phase culling. It engages automatically — nothing to opt into on
+the relationship itself."
+
+✅ "Setting `Factory<T>.PartitionAxis` to either `Axis.X` or `Axis.Y` enables axis-based
+partitioning, which reduces the deep collision count. Once the `PartitionAxis` is set, partitioning
+happens automatically."
+
 ## Authoritative Sources (do not duplicate)
 
 Before writing anything, identify where the ground truth already lives:

--- a/docs/code/files-and-fonts/advanced-font-effects.md
+++ b/docs/code/files-and-fonts/advanced-font-effects.md
@@ -87,24 +87,24 @@ When `HasDropshadow` is true on the property path, `GumFontGenerator` leaves `Ch
 
 ## Forcing Synthetic Bold and Italic
 
-`TextRuntime.IsBold` and `IsItalic` map onto `options.Bold` and `options.Italic`, which prefer a real bold or italic face and only synthesize one when no such face exists. See [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face) for what that means on the property path.
+`TextRuntime.IsBold` and `IsItalic` set `options.Bold` and `options.Italic`. Those two prefer a real bold or italic face and build one out of the regular letters only when no real face exists. See [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face) for what that means on the property path.
 
-`ForceSyntheticBold` and `ForceSyntheticItalic` override that preference and synthesize even when a real face is available. `TextRuntime` does not expose them, so this is the only way to reach them:
+`ForceSyntheticBold` and `ForceSyntheticItalic` override that preference and build the style even when a real face is available. `TextRuntime` does not expose them, so this is the only way to reach them:
 
 ```csharp
 // Initialize
 var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
 options.Bold = true;
-options.ForceSyntheticBold = true;   // embolden the regular outlines
+options.ForceSyntheticBold = true;   // thicken the regular letters
 options.Italic = true;
-options.ForceSyntheticItalic = true; // shear the regular outlines
+options.ForceSyntheticItalic = true; // slant the regular letters
 
 KernSmith.BmFontResult result =
     KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
 BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
 ```
 
-This is mostly useful for consistency: if a family ships a bold face on one platform but not another, forcing synthesis makes every platform render the same shapes. A real bold face is otherwise the better-looking choice.
+This mostly buys you consistency. If a family ships a bold face on one platform but not another, forcing the built style makes every platform draw the same letters. Otherwise a real bold face looks better.
 
 ## Gradient Fill
 

--- a/docs/code/files-and-fonts/advanced-font-effects.md
+++ b/docs/code/files-and-fonts/advanced-font-effects.md
@@ -85,6 +85,27 @@ Because the shadow is baked into the glyph's own atlas cell, you may need to inc
 When `HasDropshadow` is true on the property path, `GumFontGenerator` leaves `ChannelConfig` unset so KernSmith keeps full RGBA in the atlas. A custom `Channels` assignment on a shadowed font routes through KernSmith's channel compositor and can discard baked shadow color — the same reason outlined fonts use a different layout than plain text. On the direct path, mirror that rule: do not override `Channels` when baking shadow unless you know the compositor layout you need.
 {% endhint %}
 
+## Forcing Synthetic Bold and Italic
+
+`TextRuntime.IsBold` and `IsItalic` map onto `options.Bold` and `options.Italic`, which prefer a real bold or italic face and only synthesize one when no such face exists. See [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face) for what that means on the property path.
+
+`ForceSyntheticBold` and `ForceSyntheticItalic` override that preference and synthesize even when a real face is available. `TextRuntime` does not expose them, so this is the only way to reach them:
+
+```csharp
+// Initialize
+var options = KernSmith.Gum.GumFontGenerator.BuildOptions(bmfcSave);
+options.Bold = true;
+options.ForceSyntheticBold = true;   // embolden the regular outlines
+options.Italic = true;
+options.ForceSyntheticItalic = true; // shear the regular outlines
+
+KernSmith.BmFontResult result =
+    KernSmith.BmFont.GenerateFromSystem(bmfcSave.FontName, options);
+BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
+```
+
+This is mostly useful for consistency: if a family ships a bold face on one platform but not another, forcing synthesis makes every platform render the same shapes. A real bold face is otherwise the better-looking choice.
+
 ## Gradient Fill
 
 Gradient fills run vertically by default (top color to bottom color). Set both start and end colors and KernSmith fills each glyph with the gradient:

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -69,12 +69,12 @@ This means a published build can ship a single `.gumpkg` next to the executable 
 
 ### Serving Files From Your Own Source
 
-`FileManager.CustomGetStreamFromFile` is the hook the `.gumpkg` loader uses, and your game can install one too. Set it to a function that takes a file path and returns a `Stream`, and Gum reads through it instead of the filesystem. This covers every file type Gum loads, including `.ttf` files rasterized at runtime, so a game whose assets live in a zip, an embedded resource store, or a download cache does not need loose files on disk.
+`FileManager.CustomGetStreamFromFile` holds a function that takes a file path and returns a `Stream`. When you assign one, Gum reads through it instead of reading the filesystem. This is the same property the `.gumpkg` loader uses, and your game can assign its own. It covers every file Gum loads, `.ttf` files included, so a game that keeps its assets in a zip, an embedded resource store, or a download cache can run with no loose files on disk.
 
-This is a lower-level hook than the `IContentLoader` described below. `IContentLoader` hands back an already-loaded object (a `Texture2D`, for example); `CustomGetStreamFromFile` hands back raw bytes and lets Gum do its normal parsing.
+`CustomGetStreamFromFile` sits below the `IContentLoader` described further down. `IContentLoader` returns a finished object, such as a `Texture2D`. `CustomGetStreamFromFile` returns raw bytes and leaves Gum to parse them as it normally would.
 
 {% hint style="info" %}
-**Shipping September 2026:** `.ttf` files reading through this hook ships in the September release, or now if building Gum from source. Before this, a `.ttf` was read straight off the filesystem while every other asset type honored the hook.
+**Shipping September 2026:** `.ttf` files reading through this function ships in the September release, or now if building Gum from source. Before this, Gum read a `.ttf` straight off the filesystem while every other kind of file went through the function.
 {% endhint %}
 
 ### File Caching

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -63,7 +63,19 @@ In addition to loose files, Gum can load a project from a single-file `.gumpkg` 
 * If the loose `.gumx` exists, Gum loads from loose files (the dev-time path; hot reload also works in this mode).
 * If only a sibling `.gumpkg` exists, Gum reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory.
 
+"Fonts" here covers both kinds: the baked `FontCache` `.fnt` and `.png` pages, and a `.ttf` the project rasterizes at runtime.
+
 This means a published build can ship a single `.gumpkg` next to the executable instead of a folder tree of `.gusx`/`.gucx`/`.png`/`.fnt` files. See the [pack](../../cli/pack.md) page for the producer side and the runtime contract.
+
+### Serving Files From Your Own Source
+
+`FileManager.CustomGetStreamFromFile` is the hook the `.gumpkg` loader uses, and your game can install one too. Set it to a function that takes a file path and returns a `Stream`, and Gum reads through it instead of the filesystem. This covers every file type Gum loads, including `.ttf` files rasterized at runtime, so a game whose assets live in a zip, an embedded resource store, or a download cache does not need loose files on disk.
+
+This is a lower-level hook than the `IContentLoader` described below. `IContentLoader` hands back an already-loaded object (a `Texture2D`, for example); `CustomGetStreamFromFile` hands back raw bytes and lets Gum do its normal parsing.
+
+{% hint style="info" %}
+**Shipping September 2026:** `.ttf` files reading through this hook ships in the September release, or now if building Gum from source. Before this, a `.ttf` was read straight off the filesystem while every other asset type honored the hook.
+{% endhint %}
 
 ### File Caching
 

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -140,7 +140,7 @@ For these reasons, registering your own `.ttf` (or `.otf`) files is recommended 
 There are two ways to use a `.ttf` file with KernSmith:
 
 * **Register it under a family name**, then set `Font` to that family name. That is what this section covers.
-* **Point `Font` (or `CustomFontFile`) straight at the `.ttf` path**, with no register call at all. See [Using a .ttf Path Directly](font-strategies.md#using-a-ttf-path-directly) below.
+* **Assign the `.ttf` path to `Font` or `CustomFontFile`** and skip registration. See [Using a .ttf Path Directly](font-strategies.md#using-a-ttf-path-directly) below.
 
 To register a `.ttf` file:
 
@@ -198,7 +198,7 @@ Registered fonts take priority over system fonts. If you register a font with th
 
 ### Using a .ttf Path Directly
 
-Instead of registering a family name, you can set `Font` to the path of a `.ttf` file. Gum recognizes any `Font` value ending in `.ttf` as a file to rasterize rather than a family name to look up, so no register call is needed:
+Gum loads a `Font` value ending in `.ttf` as a font file rather than looking it up as an installed font family. It decides this from the extension alone, so a path works with no register call:
 
 ```csharp
 // Initialize
@@ -209,31 +209,31 @@ text.FontSize = 24;
 text.AddToRoot();
 ```
 
-The same works with `CustomFontFile` when `UseCustomFont` is `true`. Paths resolve relative to `FileManager.RelativeDirectory` (your **Content** folder, or the folder holding your `.gumx` project), just like every other Gum asset. See [File Loading](file-loading.md).
+`CustomFontFile` accepts a `.ttf` path the same way when `UseCustomFont` is `true`. Both properties resolve their paths relative to `FileManager.RelativeDirectory`, which is your **Content** folder, or the folder holding your `.gumx` project. This is the same starting point every other Gum asset uses. See [File Loading](file-loading.md).
 
 {% hint style="warning" %}
-On MonoGame, KNI, and FNA this is not the same base directory `RegisterFont` uses. `RegisterFont`'s `filePath` starts at your game's root, so a font at `Content/Fonts/MyFont.ttf` on disk is written `"Content/Fonts/MyFont.ttf"` there, but `"Fonts/MyFont.ttf"` when assigned to `Font` with the usual `Content/` relative directory. Tracked as [issue 4527](https://github.com/vchelaru/Gum/issues/4527).
+On MonoGame, KNI, and FNA, `RegisterFont` starts from a different folder. Its `filePath` starts at your game's root rather than at `RelativeDirectory`. A font sitting at `Content/Fonts/MyFont.ttf` is therefore written `"Content/Fonts/MyFont.ttf"` when you register it, and `"Fonts/MyFont.ttf"` when you assign it to `Font`. Tracked as [issue 4527](https://github.com/vchelaru/Gum/issues/4527).
 {% endhint %}
 
 {% hint style="info" %}
-Only the `.ttf` extension is recognized. An `.otf` file assigned this way is treated as a family name and will not resolve. Register `.otf` files by family name instead, using `RegisterFont`.
+Gum recognizes only the `.ttf` extension here. It reads an `.otf` value as a family name, so an `.otf` path will not resolve. Register `.otf` files under a family name with `RegisterFont` instead.
 {% endhint %}
 
 ### Where a .ttf Can Live
 
-A `.ttf` is read through the same file indirection as every other Gum asset, on both the register-by-path route and the `.ttf`-path route. That means it does not have to be a loose file next to your executable. A font packed into a [`.gumpkg` bundle](../../cli/pack.md), or served by a game that has installed its own `FileManager.CustomGetStreamFromFile` hook (an asset zip, an embedded resource store, a download cache), loads the same way a file on disk does.
+Gum reads a `.ttf` the same way it reads any other asset, whether you hand the path to `RegisterFont` or assign it to `Font`. A font packed into a [`.gumpkg` bundle](../../cli/pack.md) loads exactly like a file on disk, and so does one served by your own `FileManager.CustomGetStreamFromFile` function. That lets you keep fonts in an asset zip, an embedded resource store, or a download cache.
 
-If neither source has the font, Gum falls back to the default embedded 18 pixel Arial without raising an error. Subscribe to `CustomSetPropertyOnRenderable.PropertyAssignmentError` to see the failure.
+When no source has the font, Gum quietly falls back to the 18 pixel Arial embedded in the libraries. Subscribe to `CustomSetPropertyOnRenderable.PropertyAssignmentError` to see what went wrong.
 
 {% hint style="info" %}
-**Shipping September 2026:** reading a `.ttf` through the file indirection ships in the September release, or now if building Gum from source. Before this, a `.ttf` was read straight off the filesystem, so a bundled or custom-sourced font was unreachable and the `byte[]` overload of `RegisterFont` was the workaround.
+**Shipping September 2026:** loading a `.ttf` from a bundle or a custom source ships in the September release, or now if building Gum from source. Before this, Gum read a `.ttf` straight off the filesystem, and the `byte[]` overload of `RegisterFont` was the workaround.
 {% endhint %}
 
 ### Bold and Italic With One Registered Face
 
-`IsBold` and `IsItalic` do not require you to register a bold or italic file. KernSmith uses a real bold or italic face when one is available, and synthesizes the style when one is not: emboldening the regular outlines for bold, and shearing them for italic (often called faux bold and faux italic).
+KernSmith uses a real bold or italic face when one is available. When none is, it builds the style out of the regular letters instead, thickening them for bold and slanting them for italic. Type designers call that faux bold and faux italic.
 
-"Available" means either a style you registered for that family, or, for a system font, a styled face the operating system has installed. So all three of these produce bold text:
+A face counts as available if you registered it under that family name, or, for a system font, if the operating system has it installed. All three of these produce bold text:
 
 ```csharp
 // Initialize
@@ -251,13 +251,13 @@ text.Font = "Arial";
 text.IsBold = true;
 ```
 
-A real bold face is almost always better looking than a synthesized one, so register the styles you care about when you have them. But nothing silently renders as regular, and nothing silently swaps in a different typeface.
+A real bold face almost always looks better than a built one, so register the styles you care about when you have the files. Either way the text comes out bold, and it stays in your typeface.
 
 {% hint style="info" %}
 This is KernSmith's behavior, so it covers MonoGame, KNI, FNA, and raylib. SkiaGum and Silk.NET behave differently, see [Bold and Italic on SkiaGum](font-strategies.md#bold-and-italic-on-skiagum).
 {% endhint %}
 
-KernSmith can also synthesize the style even when a real face exists, which is useful for making every platform render identically. `TextRuntime` does not expose that, so it needs the direct KernSmith path: see [Forcing Synthetic Bold and Italic](advanced-font-effects.md#forcing-synthetic-bold-and-italic) on the Advanced Font Effects page.
+KernSmith can also build the style even when a real face exists, which makes every platform render the same letters. `TextRuntime` does not expose that option, so reaching it means calling KernSmith yourself. See [Forcing Synthetic Bold and Italic](advanced-font-effects.md#forcing-synthetic-bold-and-italic) on the Advanced Font Effects page.
 
 ### When to Use This Strategy
 
@@ -295,9 +295,9 @@ text.Font = "Content/Fonts/Bungee-Regular.ttf";
 text.FontSize = 24;
 ```
 
-The file is read through the same indirection as every other Gum asset, so a `.ttf` inside a [`.gumpkg` bundle](../../cli/pack.md) or behind a `FileManager.CustomGetStreamFromFile` hook loads the same as one on disk. See [Where a .ttf Can Live](font-strategies.md#where-a-ttf-can-live).
+SkiaGum reads the file the same way it reads any other asset, so a `.ttf` inside a [`.gumpkg` bundle](../../cli/pack.md), or one served by your own `FileManager.CustomGetStreamFromFile` function, loads exactly like a file on disk. See [Where a .ttf Can Live](font-strategies.md#where-a-ttf-can-live).
 
-For a font loaded from bytes (an embedded resource, for example) rather than a file on disk, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` directly and then assign `Font = familyName`. That method also takes an optional style name, so you can register a `Bold` or `Italic` cut alongside the regular one.
+For a font you already hold as bytes, an embedded resource for example, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` and then assign `Font = familyName`. That method also takes an optional style name, so you can register a bold or italic version alongside the regular one.
 
 {% hint style="info" %}
 `Font`/`CustomFontFile` is detected as a file path purely by whether the string ends in `.ttf` — not by whether it looks like a path. A bare filename with no directory (`"MyFont.ttf"`) is loaded from disk the same as a full path; there's no slash detection involved, and it never falls through to an OS font-name lookup. Only the `.ttf` extension is recognized — `.otf` files are not auto-routed through this path today and resolve as a (likely-missing) system font family name instead.
@@ -305,11 +305,11 @@ For a font loaded from bytes (an embedded resource, for example) rather than a f
 
 ### Bold and Italic on SkiaGum
 
-SkiaGum and Silk.NET pick a typeface for `IsBold`/`IsItalic`; they do not synthesize one. This differs from the KernSmith runtimes, which fall back to faux bold and faux italic (see [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face)). What you get depends on where the font came from:
+SkiaGum and Silk.NET answer `IsBold` and `IsItalic` by picking a typeface, never by building one. The KernSmith runtimes instead fall back to faux bold and faux italic (see [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face)). What you get here depends on where the font came from:
 
-* **A font registered with `GumFontMapper.RegisterFont`** that has no cut for the requested style falls back to the family's regular cut. The text stays in your font, but it is not bolder or slanted. Register a `Bold` and `Italic` cut if you need those styles.
-* **A `.ttf` assigned by path** resolves to that one file, so it renders exactly as that file draws, whatever `IsBold` and `IsItalic` are set to.
-* **A system font family name** is resolved by SkiaSharp, which returns the closest installed face for the requested weight and slant.
+* **A font registered with `GumFontMapper.RegisterFont`** falls back to the family's regular version when you have not registered one for the style you asked for. The text stays in your font, at regular weight. Register a `Bold` and an `Italic` version if you need those styles.
+* **A `.ttf` assigned by path** points at one file, and that file is what you get whatever `IsBold` and `IsItalic` are set to.
+* **A system font family name** goes to SkiaSharp, which returns the closest face the operating system has installed for the weight and slant you asked for.
 
 {% hint style="info" %}
 A dedicated SkiaGum fonts page is planned. For now, this section is the canonical reference. If something is unclear, ask on Discord or [open an issue](https://github.com/vchelaru/Gum/issues).

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -137,20 +137,32 @@ For these reasons, registering your own `.ttf` (or `.otf`) files is recommended 
 
 ### Registering Custom .ttf Fonts
 
-{% hint style="info" %}
-This section covers MonoGame/KNI's `KernSmithFontCreator.RegisterFont`. SkiaGum and Silk.NET load a `.ttf` file a different way — point `Font`/`CustomFontFile` directly at the `.ttf` path instead of calling a register method; see [Custom .ttf Files](font-strategies.md#custom-ttf-files) under Dynamic Generation on SkiaGum.
-{% endhint %}
+There are two ways to use a `.ttf` file with KernSmith:
 
-To use a `.ttf` file with KernSmith:
+* **Register it under a family name**, then set `Font` to that family name. That is what this section covers.
+* **Point `Font` (or `CustomFontFile`) straight at the `.ttf` path**, with no register call at all. See [Using a .ttf Path Directly](font-strategies.md#using-a-ttf-path-directly) below.
+
+To register a `.ttf` file:
 
 1. Add the `.ttf` file to your project's **Content** folder.
 2. Set its **Copy to Output Directory** to **Copy if newer**. For an easier approach that handles all content files at once, see the wildcard `.csproj` setup in [Loading a Gum Project (.gumx)](../getting-started/setup/loading-a-gum-project-.gumx.md#adding-the-gum-project-to-your-csproj).
-3. Call `KernSmithFontCreator.RegisterFont` before using the font:
+3. Call `RegisterFont` before using the font. The method is on the font creator type for your runtime: `KernSmithFontCreator` on MonoGame, KNI, and FNA, and `KernSmithRaylibFontCreator` on raylib. The parameters are the same on both.
 
+{% tabs %}
+{% tab title="MonoGame / KNI / FNA" %}
 ```csharp
 // Initialize
 KernSmithFontCreator.RegisterFont("Bungee", "Content/Fonts/Bungee-Regular.ttf");
 ```
+{% endtab %}
+
+{% tab title="Raylib" %}
+```csharp
+// Initialize
+KernSmithRaylibFontCreator.RegisterFont("Bungee", "Content/Fonts/Bungee-Regular.ttf");
+```
+{% endtab %}
+{% endtabs %}
 
 Once registered, use the font by its family name just like a system font:
 
@@ -180,6 +192,73 @@ A `byte[]` overload is also available for fonts loaded from embedded resources, 
 Registered fonts take priority over system fonts. If you register a font with the family name "Arial", KernSmith uses your registered `.ttf` instead of the system-installed Arial.
 {% endhint %}
 
+{% hint style="info" %}
+**Shipping September 2026:** the raylib `KernSmithRaylibFontCreator.RegisterFont(familyName, filePath)` overload ships in the September release, or now if building Gum from source. Before this, raylib had only the `byte[]` overload, so a raylib game had to read the file itself.
+{% endhint %}
+
+### Using a .ttf Path Directly
+
+Instead of registering a family name, you can set `Font` to the path of a `.ttf` file. Gum recognizes any `Font` value ending in `.ttf` as a file to rasterize rather than a family name to look up, so no register call is needed:
+
+```csharp
+// Initialize
+var text = new TextRuntime();
+text.Text = "Hello, World!";
+text.Font = "Fonts/Bungee-Regular.ttf";
+text.FontSize = 24;
+text.AddToRoot();
+```
+
+The same works with `CustomFontFile` when `UseCustomFont` is `true`. Paths resolve relative to `FileManager.RelativeDirectory` (your **Content** folder, or the folder holding your `.gumx` project), just like every other Gum asset. See [File Loading](file-loading.md).
+
+{% hint style="warning" %}
+On MonoGame, KNI, and FNA this is not the same base directory `RegisterFont` uses. `RegisterFont`'s `filePath` starts at your game's root, so a font at `Content/Fonts/MyFont.ttf` on disk is written `"Content/Fonts/MyFont.ttf"` there, but `"Fonts/MyFont.ttf"` when assigned to `Font` with the usual `Content/` relative directory. Tracked as [issue 4527](https://github.com/vchelaru/Gum/issues/4527).
+{% endhint %}
+
+{% hint style="info" %}
+Only the `.ttf` extension is recognized. An `.otf` file assigned this way is treated as a family name and will not resolve. Register `.otf` files by family name instead, using `RegisterFont`.
+{% endhint %}
+
+### Where a .ttf Can Live
+
+A `.ttf` is read through the same file indirection as every other Gum asset, on both the register-by-path route and the `.ttf`-path route. That means it does not have to be a loose file next to your executable. A font packed into a [`.gumpkg` bundle](../../cli/pack.md), or served by a game that has installed its own `FileManager.CustomGetStreamFromFile` hook (an asset zip, an embedded resource store, a download cache), loads the same way a file on disk does.
+
+If neither source has the font, Gum falls back to the default embedded 18 pixel Arial without raising an error. Subscribe to `CustomSetPropertyOnRenderable.PropertyAssignmentError` to see the failure.
+
+{% hint style="info" %}
+**Shipping September 2026:** reading a `.ttf` through the file indirection ships in the September release, or now if building Gum from source. Before this, a `.ttf` was read straight off the filesystem, so a bundled or custom-sourced font was unreachable and the `byte[]` overload of `RegisterFont` was the workaround.
+{% endhint %}
+
+### Bold and Italic With One Registered Face
+
+`IsBold` and `IsItalic` do not require you to register a bold or italic file. KernSmith uses a real bold or italic face when one is available, and synthesizes the style when one is not: emboldening the regular outlines for bold, and shearing them for italic (often called faux bold and faux italic).
+
+"Available" means either a style you registered for that family, or, for a system font, a styled face the operating system has installed. So all three of these produce bold text:
+
+```csharp
+// Initialize
+// A registered Bold face is used as-is.
+KernSmithFontCreator.RegisterFont("Crimson Pro", "Content/Fonts/CrimsonPro-Regular.ttf");
+KernSmithFontCreator.RegisterFont("Crimson Pro", "Content/Fonts/CrimsonPro-Bold.ttf",
+    style: "Bold");
+
+// Only a regular face is registered, so bold is synthesized.
+KernSmithFontCreator.RegisterFont("Bungee", "Content/Fonts/Bungee-Regular.ttf");
+
+// A system font, where the OS supplies Arial Bold.
+var text = new TextRuntime();
+text.Font = "Arial";
+text.IsBold = true;
+```
+
+A real bold face is almost always better looking than a synthesized one, so register the styles you care about when you have them. But nothing silently renders as regular, and nothing silently swaps in a different typeface.
+
+{% hint style="info" %}
+This is KernSmith's behavior, so it covers MonoGame, KNI, FNA, and raylib. SkiaGum and Silk.NET behave differently, see [Bold and Italic on SkiaGum](font-strategies.md#bold-and-italic-on-skiagum).
+{% endhint %}
+
+KernSmith can also synthesize the style even when a real face exists, which is useful for making every platform render identically. `TextRuntime` does not expose that, so it needs the direct KernSmith path: see [Forcing Synthetic Bold and Italic](advanced-font-effects.md#forcing-synthetic-bold-and-italic) on the Advanced Font Effects page.
+
 ### When to Use This Strategy
 
 * You're using Latin, Cyrillic, Greek, or another small-charset script.
@@ -206,7 +285,7 @@ text.IsBold = true;
 
 ### Custom .ttf Files
 
-Point `Font` (or `CustomFontFile` with `UseCustomFont = true`) at a `.ttf` path instead of a family name — SkiaGum/Silk.NET load and cache the file automatically, the same way KernSmith's `RegisterFont` does for MonoGame/KNI:
+Point `Font` (or `CustomFontFile` with `UseCustomFont = true`) at a `.ttf` path instead of a family name. SkiaGum/Silk.NET load and cache the file automatically, the same as the [`.ttf`-path route](font-strategies.md#using-a-ttf-path-directly) on the KernSmith runtimes:
 
 ```csharp
 // Initialize
@@ -216,11 +295,21 @@ text.Font = "Content/Fonts/Bungee-Regular.ttf";
 text.FontSize = 24;
 ```
 
-For a font loaded from bytes (an embedded resource, for example) rather than a file on disk, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` directly and then assign `Font = familyName`.
+The file is read through the same indirection as every other Gum asset, so a `.ttf` inside a [`.gumpkg` bundle](../../cli/pack.md) or behind a `FileManager.CustomGetStreamFromFile` hook loads the same as one on disk. See [Where a .ttf Can Live](font-strategies.md#where-a-ttf-can-live).
+
+For a font loaded from bytes (an embedded resource, for example) rather than a file on disk, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` directly and then assign `Font = familyName`. That method also takes an optional style name, so you can register a `Bold` or `Italic` cut alongside the regular one.
 
 {% hint style="info" %}
 `Font`/`CustomFontFile` is detected as a file path purely by whether the string ends in `.ttf` — not by whether it looks like a path. A bare filename with no directory (`"MyFont.ttf"`) is loaded from disk the same as a full path; there's no slash detection involved, and it never falls through to an OS font-name lookup. Only the `.ttf` extension is recognized — `.otf` files are not auto-routed through this path today and resolve as a (likely-missing) system font family name instead.
 {% endhint %}
+
+### Bold and Italic on SkiaGum
+
+SkiaGum and Silk.NET pick a typeface for `IsBold`/`IsItalic`; they do not synthesize one. This differs from the KernSmith runtimes, which fall back to faux bold and faux italic (see [Bold and Italic With One Registered Face](font-strategies.md#bold-and-italic-with-one-registered-face)). What you get depends on where the font came from:
+
+* **A font registered with `GumFontMapper.RegisterFont`** that has no cut for the requested style falls back to the family's regular cut. The text stays in your font, but it is not bolder or slanted. Register a `Bold` and `Italic` cut if you need those styles.
+* **A `.ttf` assigned by path** resolves to that one file, so it renders exactly as that file draws, whatever `IsBold` and `IsItalic` are set to.
+* **A system font family name** is resolved by SkiaSharp, which returns the closest installed face for the requested weight and slant.
 
 {% hint style="info" %}
 A dedicated SkiaGum fonts page is planned. For now, this section is the canonical reference. If something is unclear, ask on Discord or [open an issue](https://github.com/vchelaru/Gum/issues).
@@ -241,6 +330,10 @@ text.AddToRoot();
 
 {% hint style="warning" %}
 This path loads the `.fnt` file as-is and bypasses KernSmith entirely, so `HasDropshadow` and the other KernSmith-driven properties (`OutlineThickness`, `IsBold`, `IsItalic`, `UseFontSmoothing`) have no effect here. If you need baked drop shadow with a font you own, register it as a `.ttf` and drive it through `Font`/`FontSize` instead — see [Registering Custom .ttf Fonts](font-strategies.md#registering-custom-ttf-fonts).
+{% endhint %}
+
+{% hint style="info" %}
+`CustomFontFile` also accepts a `.ttf` path, which is a different strategy: the font is rasterized on demand and the style properties above do apply. See [Using a .ttf Path Directly](font-strategies.md#using-a-ttf-path-directly). Everything on this page's **Custom Font File** section is about the `.fnt` case.
 {% endhint %}
 
 For information on creating your own `.fnt` file with Angelcode Bitmap Font Generator, see the [Use Custom Font](../../gum-tool/gum-elements/text/use-custom-font.md) page.

--- a/docs/code/standard-visuals/textruntime/fonts.md
+++ b/docs/code/standard-visuals/textruntime/fonts.md
@@ -10,10 +10,10 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 
 | Property | Type | Purpose |
 |---|---|---|
-| `Font` (a.k.a. `FontFamily`) | `string` | Font family name (e.g. `"Arial"`, `"Noto Sans CJK"`). |
+| `Font` (a.k.a. `FontFamily`) | `string` | Font family name (e.g. `"Arial"`, `"Noto Sans CJK"`), or the path of a `.ttf` file to rasterize (see [Font file paths](#font-file-paths)). |
 | `FontSize` | `int` | Point size. |
-| `IsBold` | `bool` | Bold style. |
-| `IsItalic` | `bool` | Italic style. |
+| `IsBold` | `bool` | Bold style (see [Bold and italic](#bold-and-italic)). |
+| `IsItalic` | `bool` | Italic style (see [Bold and italic](#bold-and-italic)). |
 | `OutlineThickness` | `int` | Outline thickness in pixels (0 = no outline). |
 | `HasDropshadow` | `bool` | When `true`, draws a drop shadow under the text at runtime (see [Drop shadow](#drop-shadow)). |
 | `DropshadowColor` | `Color` | Shadow color, applied at draw time independently of the text `Color`. Shortcut for the four channel properties below. |
@@ -22,8 +22,16 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 | `DropshadowBlur` | `float` | Blur radius in pixels. `0` is a sharp shadow; larger values soften the edges. Single scalar (like shape `DropshadowBlur`), not a per-axis pair. |
 | `UseFontSmoothing` | `bool` | Whether to use anti-aliased glyph rasterization. |
 | `UseCustomFont` | `bool` | When `true`, ignore the property combo and load `CustomFontFile` directly. |
-| `CustomFontFile` | `string` | Path to a specific `.fnt` file (only used when `UseCustomFont` is `true`). |
+| `CustomFontFile` | `string` | Path to a specific `.fnt` or `.ttf` file (only used when `UseCustomFont` is `true`). See [Font file paths](#font-file-paths). |
 | `BitmapFont` | `BitmapFont` | A directly-assigned font instance — bypasses the property-driven font system entirely. |
+
+### Bold and italic
+
+On MonoGame, KNI, FNA, and raylib, `IsBold` and `IsItalic` do not require a matching font file. A real bold or italic face is used when one is available, and the style is synthesized from the regular outlines when one is not, so setting `IsBold` never silently renders as regular. SkiaGum and Silk.NET instead select the closest available typeface without synthesizing. For the full rules on both, see [Bold and Italic With One Registered Face](../../files-and-fonts/font-strategies.md#bold-and-italic-with-one-registered-face) on the Font Strategies page.
+
+### Font file paths
+
+`Font` normally holds a family name, but a value ending in `.ttf` is treated as a file to rasterize instead. `CustomFontFile` works the same way: a `.fnt` value loads a pre-baked atlas, while a `.ttf` value is rasterized on demand. Paths resolve relative to `FileManager.RelativeDirectory` like every other Gum asset, so a `.ttf` inside a `.gumpkg` bundle or behind a custom stream hook loads the same as one on disk. See [Using a .ttf Path Directly](../../files-and-fonts/font-strategies.md#using-a-ttf-path-directly) on the Font Strategies page.
 
 ### Drop shadow
 
@@ -57,7 +65,7 @@ For KernSmith-only extras on the direct-assignment path (`HardShadow`, custom `P
 A `TextRuntime`'s font is chosen by one of these paths, in priority order:
 
 1. **`BitmapFont` is set directly** → that font is used; the component properties are ignored.
-2. **`UseCustomFont` is `true`** → `CustomFontFile` is loaded from disk.
+2. **`UseCustomFont` is `true`** → `CustomFontFile` is loaded. A `.fnt` value is loaded as a pre-baked atlas; a `.ttf` value is rasterized through the same path as a `.ttf` assigned to `Font`.
 3. **`UseCustomFont` is `false` and an `InMemoryFontCreator` is registered** (e.g. KernSmith) → the font is generated in memory from the component properties, including `HasDropshadow` and the dropshadow fields when enabled.
 4. **`UseCustomFont` is `false` and no `InMemoryFontCreator` is registered** → Gum looks for a matching `.fnt` file in the project's `FontCache` folder, named according to the component properties.
 

--- a/docs/code/standard-visuals/textruntime/fonts.md
+++ b/docs/code/standard-visuals/textruntime/fonts.md
@@ -10,7 +10,7 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 
 | Property | Type | Purpose |
 |---|---|---|
-| `Font` (a.k.a. `FontFamily`) | `string` | Font family name (e.g. `"Arial"`, `"Noto Sans CJK"`), or the path of a `.ttf` file to rasterize (see [Font file paths](#font-file-paths)). |
+| `Font` (a.k.a. `FontFamily`) | `string` | Font family name (e.g. `"Arial"`, `"Noto Sans CJK"`), or the path of a `.ttf` file to load (see [Font file paths](#font-file-paths)). |
 | `FontSize` | `int` | Point size. |
 | `IsBold` | `bool` | Bold style (see [Bold and italic](#bold-and-italic)). |
 | `IsItalic` | `bool` | Italic style (see [Bold and italic](#bold-and-italic)). |
@@ -27,11 +27,11 @@ By default all `TextRuntime` instances use an Arial 18-point font embedded in th
 
 ### Bold and italic
 
-On MonoGame, KNI, FNA, and raylib, `IsBold` and `IsItalic` do not require a matching font file. A real bold or italic face is used when one is available, and the style is synthesized from the regular outlines when one is not, so setting `IsBold` never silently renders as regular. SkiaGum and Silk.NET instead select the closest available typeface without synthesizing. For the full rules on both, see [Bold and Italic With One Registered Face](../../files-and-fonts/font-strategies.md#bold-and-italic-with-one-registered-face) on the Font Strategies page.
+On MonoGame, KNI, FNA, and raylib, you do not need a bold or italic font file to use these properties. KernSmith takes a real bold or italic face when one is available, and otherwise builds the style out of the regular letters, so `IsBold` always produces bold text. SkiaGum and Silk.NET instead pick the closest typeface they have and never build one. For the full rules on both, see [Bold and Italic With One Registered Face](../../files-and-fonts/font-strategies.md#bold-and-italic-with-one-registered-face) on the Font Strategies page.
 
 ### Font file paths
 
-`Font` normally holds a family name, but a value ending in `.ttf` is treated as a file to rasterize instead. `CustomFontFile` works the same way: a `.fnt` value loads a pre-baked atlas, while a `.ttf` value is rasterized on demand. Paths resolve relative to `FileManager.RelativeDirectory` like every other Gum asset, so a `.ttf` inside a `.gumpkg` bundle or behind a custom stream hook loads the same as one on disk. See [Using a .ttf Path Directly](../../files-and-fonts/font-strategies.md#using-a-ttf-path-directly) on the Font Strategies page.
+`Font` usually holds a family name, but a value ending in `.ttf` names a font file to load instead. `CustomFontFile` works the same way: a `.fnt` value loads a ready-made atlas, and a `.ttf` value is turned into one as needed. Both resolve their paths from `FileManager.RelativeDirectory`, the same starting point every other Gum asset uses, so a `.ttf` inside a `.gumpkg` bundle or served by a custom stream function loads exactly like one on disk. See [Using a .ttf Path Directly](../../files-and-fonts/font-strategies.md#using-a-ttf-path-directly) on the Font Strategies page.
 
 ### Drop shadow
 
@@ -65,7 +65,7 @@ For KernSmith-only extras on the direct-assignment path (`HardShadow`, custom `P
 A `TextRuntime`'s font is chosen by one of these paths, in priority order:
 
 1. **`BitmapFont` is set directly** → that font is used; the component properties are ignored.
-2. **`UseCustomFont` is `true`** → `CustomFontFile` is loaded. A `.fnt` value is loaded as a pre-baked atlas; a `.ttf` value is rasterized through the same path as a `.ttf` assigned to `Font`.
+2. **`UseCustomFont` is `true`** → Gum loads `CustomFontFile`. A `.fnt` value loads as a ready-made atlas. A `.ttf` value takes the same route as a `.ttf` assigned to `Font`.
 3. **`UseCustomFont` is `false` and an `InMemoryFontCreator` is registered** (e.g. KernSmith) → the font is generated in memory from the component properties, including `HasDropshadow` and the dropshadow fields when enabled.
 4. **`UseCustomFont` is `false` and no `InMemoryFontCreator` is registered** → Gum looks for a matching `.fnt` file in the project's `FontCache` folder, named according to the component properties.
 


### PR DESCRIPTION
Answers both open questions in #4521, plus the stale claim found while checking them.

**Q1 - a bundled `.ttf`.** Now that #4515 and #4525 have landed, the answer is "it works, on every route and every backend." Documented as:

* New **Where a .ttf Can Live** section in `font-strategies.md`: a `.ttf` reads through the same file indirection as every other asset, so `.gumpkg` bundles and `FileManager.CustomGetStreamFromFile` hooks both work.
* New **Serving Files From Your Own Source** section in `file-loading.md`, and the `.gumpkg` bullet now says which kind of "fonts" it means.
* New **Font file paths** section in the `TextRuntime` fonts reference; `Font` and `CustomFontFile` rows updated to mention `.ttf`.

**Stale hint fixed.** `font-strategies.md` claimed the `.ttf`-path-as-`Font` model was SkiaGum/Silk.NET-only. Replaced with a **Using a .ttf Path Directly** section covering it on the KernSmith runtimes.

**Raylib `RegisterFont(family, path)`** is now documented alongside MonoGame/KNI/FNA's, in tabs.

**Q2 - `IsBold`/`IsItalic` with one face.** KernSmith synthesizes: faux bold, faux italic, never silent-regular and never a typeface swap. Confirmed from KernSmith 0.20.0's published XML docs that this holds on the system-font path too (`DefaultSystemFontProvider.SelectBestMatch` returns null on a missing style specifically so the caller falls back to synthesis). SkiaGum/Silk.NET differ: they pick the closest typeface without synthesizing, per `GumFontMapper.TypefaceFromStyle`. Both are documented, and `ForceSyntheticBold`/`ForceSyntheticItalic` are covered on the direct-KernSmith page.

Release-status hints use "Shipping September 2026", matching the existing hints in `pack.md`, since neither #4515 nor #4525 is on NuGet yet.

Filed #4527 along the way: `RegisterFont(family, path)` resolves from the game root while `Font`-as-`.ttf`-path resolves from `FileManager.RelativeDirectory`, so the same file needs two different strings. The docs carry a warning describing the mismatch until it is fixed.

**Guidance files bundled in.** `skills-writer` had drifted behind the canonical PersonalAiFiles copy and is resynced with its **Prose Style: Clarity Beats Brevity** section; `gum-docs-writing` gets a docs-flavored equivalent. The font docs above were then passed over against it: claims restated as their own negation removed, mechanism names (embolden, shear, rasterize, "file indirection", "hook") replaced with what the reader actually gets, the property made the subject instead of the reader, and over-long sentences split.

Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhUYu3jdBqacTL9TAS5xu4

