### PR TITLE
Fix #4527: RegisterFont resolves paths from FileManager.RelativeDirectory

### DIFF
--- a/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
@@ -57,8 +57,8 @@ public class KernSmithFontCreator : IInMemoryFontCreator
     /// </summary>
     /// <param name="familyName">Font family name (e.g., "Arial").</param>
     /// <param name="filePath">
-    /// Path to a .ttf, .otf, or .woff font file, relative to the
-    /// title container root (typically the Content directory).
+    /// Path to a .ttf, .otf, or .woff font file, relative to <see cref="FileManager.RelativeDirectory"/>
+    /// - the same base a <c>Font</c>/<c>CustomFontFile</c> path uses (#4527).
     /// </param>
     /// <param name="style">
     /// Optional style name (e.g., "Bold", "Italic", "Bold Italic").
@@ -75,26 +75,40 @@ public class KernSmithFontCreator : IInMemoryFontCreator
     }
 
     /// <summary>
-    /// Prefers FileManager's stream hook so a bundled font registers like one on disk (#4523),
-    /// falling back to the title container: FileManager routes exclusively to the hook once one is
-    /// installed, and a hook that doesn't carry this font must not hide the shipped copy.
+    /// Resolves <paramref name="filePath"/> from <see cref="FileManager.RelativeDirectory"/> via
+    /// <see cref="GumFontGenerator.ReadFontFileBytes"/> - the stream hook when one is installed,
+    /// otherwise disk - the same base and resolution order <c>Font</c>/<c>CustomFontFile</c> use.
+    /// Falls back to <see cref="TitleContainer"/>, which knows where content lives on platforms
+    /// plain file I/O can't reach (Android, iOS, consoles); the fallback path is translated to stay
+    /// relative to <see cref="FileManager.RelativeDirectory"/> too, so both routes accept the same
+    /// string for the same file (#4527). The translation only applies when RelativeDirectory sits
+    /// under the executable directory (the common desktop case); elsewhere <paramref name="filePath"/>
+    /// is handed to TitleContainer unchanged, matching prior behavior.
     /// </summary>
     private static byte[] ReadFontBytes(string filePath)
     {
-        if (FileManager.CustomGetStreamFromFile != null)
+        try
         {
-            try
+            return GumFontGenerator.ReadFontFileBytes(filePath);
+        }
+        catch (IOException)
+        {
+            // Not behind the hook and not on disk at the FileManager.RelativeDirectory-resolved
+            // path; fall through to the title container below.
+        }
+
+        string titleContainerPath = filePath;
+        if (FileManager.IsRelative(filePath))
+        {
+            string absolutePath = FileManager.MakeAbsolute(filePath);
+            string exeLocation = FileManager.ExeLocation;
+            if (absolutePath.StartsWith(exeLocation, StringComparison.OrdinalIgnoreCase))
             {
-                return GumFontGenerator.ReadFontFileBytes(filePath);
-            }
-            catch (IOException)
-            {
-                // Not in the hook and not at the absolute path it resolves to; the title container
-                // below still knows where this platform keeps its content.
+                titleContainerPath = absolutePath.Substring(exeLocation.Length).Replace('\\', '/');
             }
         }
 
-        using Stream stream = TitleContainer.OpenStream(filePath);
+        using Stream stream = TitleContainer.OpenStream(titleContainerPath);
         using MemoryStream memoryStream = new();
         stream.CopyTo(memoryStream);
         return memoryStream.ToArray();

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorRegisterFontTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorRegisterFontTests.cs
@@ -16,6 +16,14 @@ namespace MonoGameGum.IntegrationTests.MonoGameGum.Fonts;
 /// falling back to the title container. Both the hook and KernSmith's font registry are global
 /// mutable state, so each test restores them.
 /// </summary>
+/// <remarks>
+/// <see cref="FileManager.RelativeDirectory"/> is also global mutable state, and RegisterFont's path
+/// resolution now depends on it (#4527) - other tests in this assembly leave it wherever they last
+/// set it (e.g. <c>GumService.Uninitialize</c> sets it to <c>"Content/"</c>, relative to the exe
+/// directory), so ambient state left over from suite ordering is not safe to assume here. Each test
+/// pins it explicitly instead, either via the constructor's <see cref="ContentDirectory"/> baseline
+/// or by overriding it for a scenario that needs a different value.
+/// </remarks>
 public class KernSmithFontCreatorRegisterFontTests : IDisposable
 {
     private const string FamilyName = "GumOrbitronFixture";
@@ -29,6 +37,7 @@ public class KernSmithFontCreatorRegisterFontTests : IDisposable
         _previousHook = FileManager.CustomGetStreamFromFile;
         _previousRelativeDirectory = FileManager.RelativeDirectory;
         FileManager.CustomGetStreamFromFile = null;
+        FileManager.RelativeDirectory = ContentDirectory;
         KernSmithFontCreator.UnregisterFont(FamilyName);
     }
 
@@ -42,7 +51,7 @@ public class KernSmithFontCreatorRegisterFontTests : IDisposable
     [Fact]
     public void RegisterFont_WhenTheFileIsOnlyServedByAStreamHook_RegistersTheFont()
     {
-        const string bundledPath = "Content/Fonts/BundledOnly.ttf";
+        const string bundledPath = "Fonts/BundledOnly.ttf";
         byte[] fontBytes = File.ReadAllBytes(FixtureFontPath);
         File.Exists(FileManager.MakeAbsolute(bundledPath)).ShouldBeFalse();
 
@@ -58,7 +67,8 @@ public class KernSmithFontCreatorRegisterFontTests : IDisposable
 
     /// <summary>
     /// A host hook that doesn't carry this font must not hide a copy on disk: FileManager routes
-    /// exclusively to the hook once one is installed.
+    /// exclusively to the hook once one is installed. Also the #4527 regression case: the path is
+    /// relative to FileManager.RelativeDirectory (ContentDirectory), not the title container root.
     /// </summary>
     [Fact]
     public void RegisterFont_WhenTheHookDoesNotHaveTheFontButDiskDoes_RegistersTheFont()
@@ -66,45 +76,45 @@ public class KernSmithFontCreatorRegisterFontTests : IDisposable
         FileManager.CustomGetStreamFromFile = requestedPath =>
             throw new FileNotFoundException($"'{requestedPath}' is not in this bundle.", requestedPath);
 
-        KernSmithFontCreator.RegisterFont(FamilyName, RelativeFixtureFontPath);
+        KernSmithFontCreator.RegisterFont(FamilyName, RelativeDirectoryRelativeFontPath);
 
         GeneratedCodepoints().ShouldContain(CodepointA);
     }
 
     /// <summary>
     /// The title container is what knows where content lives on Android, iOS and consoles, so it
-    /// has to stay reachable when FileManager resolves the path somewhere the font isn't.
+    /// has to stay reachable when FileManager resolves the path somewhere the font isn't. When the
+    /// configured RelativeDirectory can't be translated to a title-container-relative path (it sits
+    /// outside the exe directory entirely, as here), the fallback hands TitleContainer the path
+    /// unchanged - the pre-#4527 exe-root-relative convention.
     /// </summary>
     [Fact]
     public void RegisterFont_WhenFileManagerResolvesElsewhere_FallsBackToTheTitleContainer()
     {
         FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(), "GumNoFontsHere") + Path.DirectorySeparatorChar;
-        File.Exists(FileManager.MakeAbsolute(RelativeFixtureFontPath)).ShouldBeFalse();
+        File.Exists(FileManager.MakeAbsolute(TitleContainerRelativeFontPath)).ShouldBeFalse();
 
         FileManager.CustomGetStreamFromFile = requestedPath =>
             throw new FileNotFoundException($"'{requestedPath}' is not in this bundle.", requestedPath);
 
-        KernSmithFontCreator.RegisterFont(FamilyName, RelativeFixtureFontPath);
+        KernSmithFontCreator.RegisterFont(FamilyName, TitleContainerRelativeFontPath);
 
         GeneratedCodepoints().ShouldContain(CodepointA);
     }
 
     /// <summary>
-    /// #4527 — RegisterFont(family, path) must accept the same FileManager.RelativeDirectory-relative
-    /// string a Font/CustomFontFile path does for the same file, not one relative to the title
-    /// container root instead.
+    /// FileManager.RelativeDirectory pinned to the fixture's Content folder, matching how a real game
+    /// configures it (e.g. via GumService initialization) - the base every test in this class resolves
+    /// paths against unless it overrides RelativeDirectory itself.
     /// </summary>
-    [Fact]
-    public void RegisterFont_ResolvesPathFromFileManagerRelativeDirectory_LikeCustomFontFileDoes()
-    {
-        FileManager.RelativeDirectory = Path.Combine(AppContext.BaseDirectory, "Content") + Path.DirectorySeparatorChar;
+    private static string ContentDirectory =>
+        Path.Combine(AppContext.BaseDirectory, "Content") + Path.DirectorySeparatorChar;
 
-        KernSmithFontCreator.RegisterFont(FamilyName, "Fonts/Orbitron-Black.ttf");
+    /// <summary>Relative to FileManager.RelativeDirectory (i.e. ContentDirectory) - the #4527 convention.</summary>
+    private const string RelativeDirectoryRelativeFontPath = "Fonts/Orbitron-Black.ttf";
 
-        GeneratedCodepoints().ShouldContain(CodepointA);
-    }
-
-    private const string RelativeFixtureFontPath = "Content/Fonts/Orbitron-Black.ttf";
+    /// <summary>Relative to the title container root (the exe directory) - the pre-#4527 convention.</summary>
+    private const string TitleContainerRelativeFontPath = "Content/Fonts/Orbitron-Black.ttf";
 
     private static string FixtureFontPath =>
         Path.Combine(AppContext.BaseDirectory, "Content", "Fonts", "Orbitron-Black.ttf");

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorRegisterFontTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorRegisterFontTests.cs
@@ -89,6 +89,21 @@ public class KernSmithFontCreatorRegisterFontTests : IDisposable
         GeneratedCodepoints().ShouldContain(CodepointA);
     }
 
+    /// <summary>
+    /// #4527 — RegisterFont(family, path) must accept the same FileManager.RelativeDirectory-relative
+    /// string a Font/CustomFontFile path does for the same file, not one relative to the title
+    /// container root instead.
+    /// </summary>
+    [Fact]
+    public void RegisterFont_ResolvesPathFromFileManagerRelativeDirectory_LikeCustomFontFileDoes()
+    {
+        FileManager.RelativeDirectory = Path.Combine(AppContext.BaseDirectory, "Content") + Path.DirectorySeparatorChar;
+
+        KernSmithFontCreator.RegisterFont(FamilyName, "Fonts/Orbitron-Black.ttf");
+
+        GeneratedCodepoints().ShouldContain(CodepointA);
+    }
+
     private const string RelativeFixtureFontPath = "Content/Fonts/Orbitron-Black.ttf";
 
     private static string FixtureFontPath =>

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -209,11 +209,7 @@ text.FontSize = 24;
 text.AddToRoot();
 ```
 
-`CustomFontFile` accepts a `.ttf` path the same way when `UseCustomFont` is `true`. Both properties resolve their paths relative to `FileManager.RelativeDirectory`, which is your **Content** folder, or the folder holding your `.gumx` project. This is the same starting point every other Gum asset uses. See [File Loading](file-loading.md).
-
-{% hint style="warning" %}
-On MonoGame, KNI, and FNA, `RegisterFont` starts from a different folder. Its `filePath` starts at your game's root rather than at `RelativeDirectory`. A font sitting at `Content/Fonts/MyFont.ttf` is therefore written `"Content/Fonts/MyFont.ttf"` when you register it, and `"Fonts/MyFont.ttf"` when you assign it to `Font`. Tracked as [issue 4527](https://github.com/vchelaru/Gum/issues/4527).
-{% endhint %}
+`CustomFontFile` accepts a `.ttf` path the same way when `UseCustomFont` is `true`. Both properties resolve their paths relative to `FileManager.RelativeDirectory`, which is your **Content** folder, or the folder holding your `.gumx` project. This is the same starting point every other Gum asset uses, including `RegisterFont`'s `filePath` overload. See [File Loading](file-loading.md).
 
 {% hint style="info" %}
 Gum recognizes only the `.ttf` extension here. It reads an `.otf` value as a family name, so an `.otf` path will not resolve. Register `.otf` files under a family name with `RegisterFont` instead.


### PR DESCRIPTION
Fixes #4527.

## Summary
`KernSmithFontCreator.RegisterFont(family, path)` resolved relative paths against the title container root, while `Font`/`CustomFontFile` resolve against `FileManager.RelativeDirectory` — same file needed two different path strings.

`ReadFontBytes` now tries `GumFontGenerator.ReadFontFileBytes` first (the `RelativeDirectory`-based hook-or-disk lookup, same as `Font`/`CustomFontFile`), and only falls back to `TitleContainer` for platforms plain file I/O can't reach (Android/iOS/consoles) — with that fallback path translated to stay relative to `RelativeDirectory` too when it sits under the executable directory.

`KernSmithRaylibFontCreator` and `KernSmith.KniGum`/`KernSmith.FnaGum` (linked source) needed no change — Raylib already went through `ReadFontFileBytes`.

Also removed the docs warning describing this mismatch (added alongside #4521), now stale.

## Test plan
- [x] `dotnet test Tests/MonoGameGum.IntegrationTests` — `KernSmithFontCreatorRegisterFontTests` (4 tests, including a new one asserting `RegisterFont` accepts the same `RelativeDirectory`-relative path `CustomFontFile` does)
- [x] Confirmed the new test fails against the pre-fix code (via temporary revert) and passes against the fix
- [x] `dotnet build Integrations/KernSmith/KernSmith.KniGum` — 0 errors, no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFu9J6xZzSbNLcyLcT85ND