### PR TITLE
Add gumcli import-screen so HTML import's merge step can be tested headlessly

### DIFF
--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -36,6 +36,7 @@ using Gum.Settings;
 using ToolsUtilities;
 using Gum.Logic.FileWatch;
 using Gum.Reflection;
+using Gum.ProjectServices;
 using Gum.ProjectServices.FontGeneration;
 using Gum.Services.Fonts;
 using Gum.Localization;
@@ -212,6 +213,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IStateEditingIndicatorService, StateEditingIndicatorService>();
         services.AddSingleton<IDragDropManager, DragDropManager>();
         services.AddSingleton<MenuStripManager>();
+        services.AddSingleton<IScreenImportService, ScreenImportService>();
         services.AddSingleton<ImportLogic>();
         services.AddSingleton<IImportLogic>(provider => provider.GetRequiredService<ImportLogic>());
         services.AddSingleton<MainOutputViewModel>();

--- a/Tests/Gum.Cli.Tests/ImportScreenCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/ImportScreenCommandTests.cs
@@ -1,0 +1,135 @@
+using Shouldly;
+
+namespace Gum.Cli.Tests;
+
+public class ImportScreenCommandTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public ImportScreenCommandTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumCliImportScreenTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldAddReferenceAndWriteScreenFile()
+    {
+        string projectPath = CreateTestProject("Basic");
+        string screenPath = WriteStagedScreen("Basic", "Imported");
+
+        CliTestHelper result = CliTestHelper.Run("import-screen", projectPath, screenPath);
+
+        result.ExitCode.ShouldBe(0);
+        result.StandardOutput.ShouldContain("Imported screen \"Imported\"");
+
+        string projectDirectory = Path.GetDirectoryName(projectPath)!;
+        File.Exists(Path.Combine(projectDirectory, "Screens", "Imported.gusx")).ShouldBeTrue();
+        File.ReadAllText(projectPath).ShouldContain("Imported");
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldUniquifyName_WhenScreenAlreadyExists()
+    {
+        string projectPath = CreateTestProject("Conflict");
+        string firstScreenPath = WriteStagedScreen("Conflict", "Dupe", stagingFolderName: "staged1");
+        CliTestHelper.Run("import-screen", projectPath, firstScreenPath).ExitCode.ShouldBe(0);
+
+        string secondScreenPath = WriteStagedScreen("Conflict", "Dupe", stagingFolderName: "staged2");
+        CliTestHelper result = CliTestHelper.Run("import-screen", projectPath, secondScreenPath);
+
+        result.ExitCode.ShouldBe(0);
+        result.StandardOutput.ShouldContain("Imported screen \"Dupe_2\"");
+
+        string projectDirectory = Path.GetDirectoryName(projectPath)!;
+        File.Exists(Path.Combine(projectDirectory, "Screens", "Dupe_2.gusx")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldQualifyNameWithSubfolder()
+    {
+        string projectPath = CreateTestProject("Subfoldered");
+        string screenPath = WriteStagedScreen("Subfoldered", "MyScreen");
+
+        CliTestHelper result = CliTestHelper.Run(
+            "import-screen", projectPath, screenPath, "--subfolder", "Section1");
+
+        result.ExitCode.ShouldBe(0);
+        result.StandardOutput.ShouldContain("Imported screen \"Section1/MyScreen\"");
+
+        string projectDirectory = Path.GetDirectoryName(projectPath)!;
+        File.Exists(Path.Combine(projectDirectory, "Screens", "Section1", "MyScreen.gusx")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldCopyStagedAssets_WhenAssetsOptionProvided()
+    {
+        string projectPath = CreateTestProject("WithAssets");
+        string screenPath = WriteStagedScreen("WithAssets", "AssetScreen", stagingFolderName: "staged");
+
+        string stagingDirectory = Path.Combine(Path.GetDirectoryName(projectPath)!, "..", "staged");
+        stagingDirectory = Path.GetFullPath(stagingDirectory);
+        Directory.CreateDirectory(Path.Combine(stagingDirectory, "Images"));
+        File.WriteAllText(Path.Combine(stagingDirectory, "Images", "icon.png"), "fake-png");
+
+        CliTestHelper result = CliTestHelper.Run(
+            "import-screen", projectPath, screenPath, "--assets", stagingDirectory);
+
+        result.ExitCode.ShouldBe(0);
+
+        string projectDirectory = Path.GetDirectoryName(projectPath)!;
+        File.Exists(Path.Combine(projectDirectory, "Images", "icon.png")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ImportScreen_NonexistentProject_ExitCode2()
+    {
+        string fakeProjectPath = Path.Combine(_tempDirectory, "nonexistent.gumx");
+        string screenPath = WriteStagedScreen("Unused", "Screen1");
+
+        CliTestHelper result = CliTestHelper.Run("import-screen", fakeProjectPath, screenPath);
+
+        result.ExitCode.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ImportScreen_NonexistentScreenFile_ExitCode2()
+    {
+        string projectPath = CreateTestProject("MissingScreen");
+        string fakeScreenPath = Path.Combine(_tempDirectory, "nonexistent.gusx");
+
+        CliTestHelper result = CliTestHelper.Run("import-screen", projectPath, fakeScreenPath);
+
+        result.ExitCode.ShouldBe(2);
+    }
+
+    private string CreateTestProject(string name)
+    {
+        string filePath = Path.Combine(_tempDirectory, name, name + ".gumx");
+        CliTestHelper.Run("new", filePath);
+        return filePath;
+    }
+
+    private string WriteStagedScreen(string projectName, string screenName, string stagingFolderName = "staged")
+    {
+        string stagingDirectory = Path.Combine(_tempDirectory, projectName, stagingFolderName);
+        Directory.CreateDirectory(stagingDirectory);
+        string screenPath = Path.Combine(stagingDirectory, screenName + ".gusx");
+        File.WriteAllText(screenPath,
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <ScreenSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>{screenName}</Name>
+            </ScreenSave>
+            """);
+        return screenPath;
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/AssetTreeCopierTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/AssetTreeCopierTests.cs
@@ -1,0 +1,60 @@
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+public class AssetTreeCopierTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public AssetTreeCopierTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumAssetTreeCopierTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CopyStagedAssets_ShouldCopyNestedFilesFromEachAssetFolder()
+    {
+        string stagedDir = Path.Combine(_tempDirectory, "staged");
+        string imagesSubdir = Path.Combine(stagedDir, "Images", "icons");
+        Directory.CreateDirectory(imagesSubdir);
+        File.WriteAllText(Path.Combine(imagesSubdir, "icon.png"), "fake-png");
+
+        string fontsDir = Path.Combine(stagedDir, "Fonts");
+        Directory.CreateDirectory(fontsDir);
+        File.WriteAllText(Path.Combine(fontsDir, "Arial18.fnt"), "fake-fnt");
+
+        string projectDir = Path.Combine(_tempDirectory, "project");
+        Directory.CreateDirectory(projectDir);
+
+        AssetTreeCopier.CopyStagedAssets(stagedDir, projectDir);
+
+        File.Exists(Path.Combine(projectDir, "Images", "icons", "icon.png")).ShouldBeTrue();
+        File.Exists(Path.Combine(projectDir, "Fonts", "Arial18.fnt")).ShouldBeTrue();
+        Directory.Exists(Path.Combine(projectDir, "FontCache")).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CopyStagedAssets_ShouldOverwriteExistingFiles()
+    {
+        string stagedDir = Path.Combine(_tempDirectory, "staged");
+        Directory.CreateDirectory(Path.Combine(stagedDir, "Images"));
+        File.WriteAllText(Path.Combine(stagedDir, "Images", "icon.png"), "new-content");
+
+        string projectDir = Path.Combine(_tempDirectory, "project");
+        Directory.CreateDirectory(Path.Combine(projectDir, "Images"));
+        File.WriteAllText(Path.Combine(projectDir, "Images", "icon.png"), "old-content");
+
+        AssetTreeCopier.CopyStagedAssets(stagedDir, projectDir);
+
+        File.ReadAllText(Path.Combine(projectDir, "Images", "icon.png")).ShouldBe("new-content");
+    }
+}

--- a/Tests/Gum.ProjectServices.Tests/HtmlImportNamingTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HtmlImportNamingTests.cs
@@ -1,9 +1,7 @@
-using HtmlToGumPlugin;
 using Shouldly;
 using System.Collections.Generic;
-using Xunit;
 
-namespace GumToolUnitTests.Plugins.HtmlToGumPlugin;
+namespace Gum.ProjectServices.Tests;
 
 public class HtmlImportNamingTests
 {

--- a/Tests/Gum.ProjectServices.Tests/ScreenImportServiceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/ScreenImportServiceTests.cs
@@ -1,0 +1,43 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Shouldly;
+
+namespace Gum.ProjectServices.Tests;
+
+public class ScreenImportServiceTests : BaseTestClass
+{
+    private readonly ScreenImportService _sut = new();
+
+    public ScreenImportServiceTests()
+    {
+        ObjectFinder.Self.GumProjectSave = Project;
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldAddScreenAndReference_WhenNameIsFree()
+    {
+        ScreenSave screenSave = new() { Name = "NewScreen" };
+
+        ScreenImportResult result = _sut.ImportScreen(Project, screenSave);
+
+        result.Success.ShouldBeTrue();
+        result.ImportedScreen.ShouldBeSameAs(screenSave);
+        Project.Screens.ShouldContain(screenSave);
+        Project.ScreenReferences.ShouldContain(r => r.Name == "NewScreen" && r.ElementType == ElementType.Screen);
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldFailWithConflict_WhenNameAlreadyExists()
+    {
+        ScreenSave existing = new() { Name = "Dupe" };
+        Project.Screens.Add(existing);
+        Project.ScreenReferences.Add(new ElementReference { Name = "Dupe", ElementType = ElementType.Screen });
+
+        ScreenSave incoming = new() { Name = "Dupe" };
+        ScreenImportResult result = _sut.ImportScreen(Project, incoming);
+
+        result.Success.ShouldBeFalse();
+        result.ConflictingScreenName.ShouldBe("Dupe");
+        Project.Screens.ShouldNotContain(incoming);
+    }
+}

--- a/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
+++ b/Tool/HtmlToGum/MainHtmlToGumPlugin.cs
@@ -15,6 +15,7 @@ using Gum.Managers;
 using Gum.Plugins;
 using Gum.Plugins.BaseClasses;
 using Gum.Plugins.ImportPlugin.Manager;
+using Gum.ProjectServices;
 using Gum.Services;
 using Gum.Services.Dialogs;
 using Gum.ToolStates;
@@ -183,12 +184,7 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             }
 
             progress.SetStatus("Copying Images / Fonts / FontCache…");
-            recorder.Measure("asset copy", () =>
-            {
-                CopyAssetTree(Path.Combine(stageDir, "Images"), Path.Combine(projectDir, "Images"));
-                CopyAssetTree(Path.Combine(stageDir, "Fonts"), Path.Combine(projectDir, "Fonts"));
-                CopyAssetTree(Path.Combine(stageDir, "FontCache"), Path.Combine(projectDir, "FontCache"));
-            });
+            recorder.Measure("asset copy", () => AssetTreeCopier.CopyStagedAssets(stageDir, projectDir));
 
             progress.SetStatus("Importing screen into project…");
             var screenSave = recorder.Measure(
@@ -387,19 +383,6 @@ public class MainHtmlToGumPlugin : WpfPluginBase
             .Where(l => !l.StartsWith('>'))
             .TakeLast(maxLines);
         return string.Join("\n", lines);
-    }
-
-    private static void CopyAssetTree(string sourceDir, string destDir)
-    {
-        if (!Directory.Exists(sourceDir)) return;
-        Directory.CreateDirectory(destDir);
-        foreach (var file in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
-        {
-            var rel = Path.GetRelativePath(sourceDir, file);
-            var dest = Path.Combine(destDir, rel);
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            File.Copy(file, dest, overwrite: true);
-        }
     }
 
     /// <summary>

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportPlugin/ImportLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportPlugin/ImportLogicTests.cs
@@ -1,6 +1,9 @@
 using Gum.DataTypes;
 using Gum.Managers;
 using Gum.Plugins.ImportPlugin.Manager;
+using Gum.ProjectServices;
+using Gum.Services.Dialogs;
+using Moq;
 using Moq.AutoMock;
 using Shouldly;
 using System;
@@ -171,5 +174,41 @@ public class ImportLogicTests : BaseTestClass
         result.Instances[0].Name.ShouldBe("Background");
         result.Instances[1].Name.ShouldBe("TextInstance");
         result.Instances[2].Name.ShouldBe("FocusedIndicator");
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldReturnScreen_WhenScreenImportServiceSucceeds()
+    {
+        // Arrange
+        var screenSave = new ScreenSave { Name = "NewScreen" };
+        _mocker.GetMock<IScreenImportService>()
+            .Setup(x => x.ImportScreen(It.IsAny<GumProjectSave>(), screenSave))
+            .Returns(ScreenImportResult.Ok(screenSave));
+
+        // Act
+        var result = _importLogic.ImportScreen(screenSave, saveProject: false);
+
+        // Assert
+        result.ShouldBeSameAs(screenSave);
+    }
+
+    [Fact]
+    public void ImportScreen_ShouldShowDialogAndReturnNull_WhenScreenImportServiceReportsConflict()
+    {
+        // Arrange
+        var screenSave = new ScreenSave { Name = "Dupe" };
+        _mocker.GetMock<IScreenImportService>()
+            .Setup(x => x.ImportScreen(It.IsAny<GumProjectSave>(), screenSave))
+            .Returns(ScreenImportResult.Conflict("Dupe"));
+
+        // Act
+        var result = _importLogic.ImportScreen(screenSave, saveProject: false);
+
+        // Assert
+        result.ShouldBeNull();
+        _mocker.GetMock<IDialogService>()
+            .Verify(x => x.ShowMessage(
+                It.Is<string>(msg => msg.Contains("Dupe")), It.IsAny<string>(), It.IsAny<MessageDialogStyle?>()),
+                Times.Once);
     }
 }

--- a/Tools/Gum.Cli/Commands/ImportScreenCommand.cs
+++ b/Tools/Gum.Cli/Commands/ImportScreenCommand.cs
@@ -1,0 +1,134 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.ProjectServices;
+
+namespace Gum.Cli.Commands;
+
+/// <summary>
+/// Defines the <c>gumcli import-screen</c> command, which performs headlessly the merge step
+/// that Content → Import → HTML… otherwise only exercises from inside the running tool: qualify
+/// the screen name against a destination subfolder (resolving conflicts), copy staged
+/// Images/Fonts/FontCache into the project, add the ScreenReference, and write the screen file.
+/// </summary>
+public static class ImportScreenCommand
+{
+    public static Command Create()
+    {
+        var projectArgument = new Argument<string>(
+            "project",
+            "Path to the .gumx project file.");
+
+        var screenArgument = new Argument<string>(
+            "screen",
+            "Path to the .gusx (or .gusj) screen file to import.");
+
+        var subfolderOption = new Option<string?>(
+            "--subfolder",
+            getDefaultValue: () => null,
+            description: "Destination subfolder under Screens/. Avoids name conflicts by importing under Screens/<subfolder>/.");
+
+        var assetsOption = new Option<string?>(
+            "--assets",
+            getDefaultValue: () => null,
+            description: "Staging directory containing Images/, Fonts/, and/or FontCache/ to copy into the project. Omit to skip asset copying.");
+
+        var command = new Command(
+            "import-screen",
+            "Import a .gusx screen file into a project: qualify/uniquify its name, copy staged assets, add the ScreenReference, and write the screen file.")
+        {
+            projectArgument,
+            screenArgument,
+            subfolderOption,
+            assetsOption
+        };
+
+        command.SetHandler((InvocationContext context) =>
+        {
+            string projectPath = context.ParseResult.GetValueForArgument(projectArgument);
+            string screenPath = context.ParseResult.GetValueForArgument(screenArgument);
+            string? subfolder = context.ParseResult.GetValueForOption(subfolderOption);
+            string? assetsDirectory = context.ParseResult.GetValueForOption(assetsOption);
+            context.ExitCode = Execute(projectPath, screenPath, subfolder, assetsDirectory);
+        });
+
+        return command;
+    }
+
+    private static int Execute(string projectPath, string screenPath, string? subfolderOption, string? assetsOption)
+    {
+        string fullProjectPath = Path.GetFullPath(projectPath);
+        string fullScreenPath = Path.GetFullPath(screenPath);
+
+        if (!File.Exists(fullScreenPath))
+        {
+            Console.Error.WriteLine($"Screen file not found: {fullScreenPath}");
+            return 2;
+        }
+
+        IProjectLoader loader = new ProjectLoader();
+        ProjectLoadResult loadResult = loader.Load(fullProjectPath);
+
+        if (!loadResult.Success)
+        {
+            Console.Error.WriteLine(loadResult.ErrorMessage);
+            return 2;
+        }
+
+        GumProjectSave project = loadResult.Project!;
+
+        // Conflict checks (ScreenImportService, and the uniquify loop below) go through
+        // ObjectFinder.Self, same as the tool's own import paths — see CheckReferencesCommand.
+        ObjectFinder.Self.GumProjectSave = project;
+
+        string? subfolder = string.IsNullOrWhiteSpace(subfolderOption) ? null : subfolderOption.Trim();
+
+        ScreenSave screenSave;
+        try
+        {
+            screenSave = ElementReference.DeserializeElement<ScreenSave>(fullScreenPath, GumProjectSave.NativeVersion);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to deserialize screen: {ex.Message}");
+            return 2;
+        }
+
+        // Headless equivalent of the dialog the tool would show on conflict — auto-uniquify
+        // instead, mirroring MainHtmlToGumPlugin.HandleImportHtml's screen-name resolution.
+        string uniqueBaseName = HtmlImportNaming.ResolveUniqueScreenName(
+            screenSave.Name, subfolder, name => ObjectFinder.Self.GetElementSave(name) != null);
+        screenSave.Name = HtmlImportNaming.QualifyScreenName(uniqueBaseName, subfolder);
+
+        IScreenImportService importService = new ScreenImportService();
+        ScreenImportResult result = importService.ImportScreen(project, screenSave);
+
+        if (!result.Success)
+        {
+            Console.Error.WriteLine($"A screen or component named \"{result.ConflictingScreenName}\" already exists.");
+            return 1;
+        }
+
+        string projectDirectory = Path.GetDirectoryName(fullProjectPath) ?? "";
+
+        if (!string.IsNullOrWhiteSpace(assetsOption))
+        {
+            AssetTreeCopier.CopyStagedAssets(Path.GetFullPath(assetsOption), projectDirectory);
+        }
+
+        project.Save(fullProjectPath, saveElements: false);
+
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(fullProjectPath);
+        bool useCompact = project.Version >= (int)GumProjectSave.GumxVersions.AttributeVersion;
+        string screenExtension = isJsonFormat ? GumProjectSave.ScreenJsonExtension : GumProjectSave.ScreenExtension;
+        string screenFilePath = Path.Combine(
+            projectDirectory, ElementReference.ScreenSubfolder, result.ImportedScreen!.Name + "." + screenExtension);
+        result.ImportedScreen.Save(screenFilePath, useCompact);
+
+        Console.WriteLine($"Imported screen \"{result.ImportedScreen.Name}\".");
+        return 0;
+    }
+}

--- a/Tools/Gum.Cli/Program.cs
+++ b/Tools/Gum.Cli/Program.cs
@@ -30,6 +30,7 @@ public class Program
         rootCommand.AddCommand(ConvertToJsonCommand.Create());
         rootCommand.AddCommand(StageFormsBehaviorsCommand.Create());
         rootCommand.AddCommand(PackCommand.Create());
+        rootCommand.AddCommand(ImportScreenCommand.Create());
         rootCommand.AddCommand(CodegenCommand.Create());
         rootCommand.AddCommand(CodegenInitCommand.Create());
         rootCommand.AddCommand(FontsCommand.Create());

--- a/Tools/Gum.Presentation/Plugins/ImportPlugin/Manager/ImportLogic.cs
+++ b/Tools/Gum.Presentation/Plugins/ImportPlugin/Manager/ImportLogic.cs
@@ -1,6 +1,7 @@
 ﻿using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.Managers;
+using Gum.ProjectServices;
 using Gum.Services;
 using Gum.ToolStates;
 using System;
@@ -22,8 +23,9 @@ public class ImportLogic : IImportLogic
     private readonly IProjectManager _projectManager;
     private readonly IPluginManager _pluginManager;
     private readonly IStandardElementsManagerGumTool _standardElementsManagerGumTool;
+    private readonly IScreenImportService _screenImportService;
 
-    public ImportLogic(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands, IDialogService dialogService, IProjectManager projectManager, IPluginManager pluginManager, IStandardElementsManagerGumTool standardElementsManagerGumTool)
+    public ImportLogic(ISelectedState selectedState, IGuiCommands guiCommands, IFileCommands fileCommands, IDialogService dialogService, IProjectManager projectManager, IPluginManager pluginManager, IStandardElementsManagerGumTool standardElementsManagerGumTool, IScreenImportService screenImportService)
     {
         _selectedState = selectedState;
         _guiCommands = guiCommands;
@@ -32,6 +34,7 @@ public class ImportLogic : IImportLogic
         _projectManager = projectManager;
         _pluginManager = pluginManager;
         _standardElementsManagerGumTool = standardElementsManagerGumTool;
+        _screenImportService = screenImportService;
     }
 
     public ScreenSave? ImportScreen(FilePath filePath, string? desiredDirectory = null, bool saveProject = true)
@@ -45,24 +48,15 @@ public class ImportLogic : IImportLogic
 
     public ScreenSave? ImportScreen(ScreenSave screenSave, bool saveProject = true)
     {
-        if (ObjectFinder.Self.GetElementSave(screenSave.Name) != null)
+        var result = _screenImportService.ImportScreen(_projectManager.GumProjectSave, screenSave);
+        if (!result.Success)
         {
-            _dialogService.ShowMessage($"This project already a screen named {screenSave.Name} in this project");
+            _dialogService.ShowMessage($"This project already a screen named {result.ConflictingScreenName} in this project");
             return null;
         }
 
-        var elementReferences = _projectManager.GumProjectSave.ScreenReferences;
-        elementReferences.Add(new ElementReference { Name = screenSave.Name, ElementType = ElementType.Screen });
-        elementReferences.Sort((first, second) => first.Name.CompareTo(second.Name));
-
-        var screens = _projectManager.GumProjectSave.Screens;
-        screens.Add(screenSave);
-        screens.Sort((first, second) => first.Name.CompareTo(second.Name));
-
-        screenSave.Initialize(null);
-
-        DoAfterImportLogic(saveProject, screenSave);
-        return screenSave;
+        DoAfterImportLogic(saveProject, result.ImportedScreen!);
+        return result.ImportedScreen;
     }
 
     public ComponentSave? ImportComponent(FilePath filePath, string? desiredDirectory = null, bool saveProject = true)

--- a/Tools/Gum.ProjectServices/AssetTreeCopier.cs
+++ b/Tools/Gum.ProjectServices/AssetTreeCopier.cs
@@ -1,0 +1,39 @@
+using System.IO;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Copies the Images/Fonts/FontCache trees a Screen import stages alongside its element file into
+/// a project directory. Shared by HtmlToGumPlugin's Content → Import → HTML… merge step and
+/// gumcli import-screen so both copy staged assets identically.
+/// </summary>
+public static class AssetTreeCopier
+{
+    private static readonly string[] AssetFolders = ["Images", "Fonts", "FontCache"];
+
+    /// <summary>
+    /// Copies each of Images/Fonts/FontCache found under <paramref name="stagedAssetsDirectory"/>
+    /// into the matching subfolder of <paramref name="projectDirectory"/>, overwriting existing
+    /// files. A missing source subfolder is skipped, not an error.
+    /// </summary>
+    public static void CopyStagedAssets(string stagedAssetsDirectory, string projectDirectory)
+    {
+        foreach (string folder in AssetFolders)
+        {
+            CopyTree(Path.Combine(stagedAssetsDirectory, folder), Path.Combine(projectDirectory, folder));
+        }
+    }
+
+    private static void CopyTree(string sourceDir, string destDir)
+    {
+        if (!Directory.Exists(sourceDir)) return;
+        Directory.CreateDirectory(destDir);
+        foreach (string file in Directory.EnumerateFiles(sourceDir, "*", SearchOption.AllDirectories))
+        {
+            string rel = Path.GetRelativePath(sourceDir, file);
+            string dest = Path.Combine(destDir, rel);
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            File.Copy(file, dest, overwrite: true);
+        }
+    }
+}

--- a/Tools/Gum.ProjectServices/HtmlImportNaming.cs
+++ b/Tools/Gum.ProjectServices/HtmlImportNaming.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Text.RegularExpressions;
 
-namespace HtmlToGumPlugin;
+namespace Gum.ProjectServices;
 
 /// <summary>
-/// Pure naming/conflict-resolution helpers for HTML import, kept separate from
-/// <see cref="MainHtmlToGumPlugin"/> so they can be unit tested without a WinForms/MEF host.
+/// Pure naming/conflict-resolution helpers for importing a Screen into a project. Shared by
+/// HtmlToGumPlugin's Content → Import → HTML… merge step and gumcli import-screen so the two
+/// import paths qualify/uniquify names identically.
 /// </summary>
 public static class HtmlImportNaming
 {

--- a/Tools/Gum.ProjectServices/IScreenImportService.cs
+++ b/Tools/Gum.ProjectServices/IScreenImportService.cs
@@ -1,0 +1,21 @@
+using Gum.DataTypes;
+
+namespace Gum.ProjectServices;
+
+/// <summary>
+/// Headless core of adding a deserialized Screen into a loaded Gum project: conflict-checks by
+/// name, adds the <see cref="ElementReference"/> and <see cref="ScreenSave"/>, sorts both lists,
+/// and initializes the screen. Shared by the tool's Content → Import → Screen path (which layers
+/// a conflict dialog, selection, and autosave on top — see
+/// <c>Gum.Plugins.ImportPlugin.Manager.ImportLogic</c>) and <c>gumcli import-screen</c> (headless).
+/// </summary>
+public interface IScreenImportService
+{
+    /// <summary>
+    /// Adds <paramref name="screenSave"/> to <paramref name="project"/>. Returns a failed result
+    /// with <see cref="ScreenImportResult.ConflictingScreenName"/> set if a screen or component
+    /// already exists under that name — checked via <c>ObjectFinder.Self</c>, so callers must
+    /// point it at <paramref name="project"/> before calling.
+    /// </summary>
+    ScreenImportResult ImportScreen(GumProjectSave project, ScreenSave screenSave);
+}

--- a/Tools/Gum.ProjectServices/ScreenImportResult.cs
+++ b/Tools/Gum.ProjectServices/ScreenImportResult.cs
@@ -1,0 +1,21 @@
+using Gum.DataTypes;
+
+namespace Gum.ProjectServices;
+
+/// <summary>Outcome of <see cref="IScreenImportService.ImportScreen"/>.</summary>
+public class ScreenImportResult
+{
+    public bool Success { get; private init; }
+
+    /// <summary>Set when <see cref="Success"/> is false: the name that already exists in the project.</summary>
+    public string? ConflictingScreenName { get; private init; }
+
+    /// <summary>Set when <see cref="Success"/> is true: the screen that was added.</summary>
+    public ScreenSave? ImportedScreen { get; private init; }
+
+    public static ScreenImportResult Conflict(string screenName) =>
+        new() { Success = false, ConflictingScreenName = screenName };
+
+    public static ScreenImportResult Ok(ScreenSave screenSave) =>
+        new() { Success = true, ImportedScreen = screenSave };
+}

--- a/Tools/Gum.ProjectServices/ScreenImportService.cs
+++ b/Tools/Gum.ProjectServices/ScreenImportService.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.Managers;
+
+namespace Gum.ProjectServices;
+
+/// <inheritdoc/>
+public class ScreenImportService : IScreenImportService
+{
+    /// <inheritdoc/>
+    public ScreenImportResult ImportScreen(GumProjectSave project, ScreenSave screenSave)
+    {
+        if (ObjectFinder.Self.GetElementSave(screenSave.Name) != null)
+        {
+            return ScreenImportResult.Conflict(screenSave.Name);
+        }
+
+        List<ElementReference> elementReferences = project.ScreenReferences;
+        elementReferences.Add(new ElementReference { Name = screenSave.Name, ElementType = ElementType.Screen });
+        elementReferences.Sort((first, second) => first.Name.CompareTo(second.Name));
+
+        List<ScreenSave> screens = project.Screens;
+        screens.Add(screenSave);
+        screens.Sort((first, second) => first.Name.CompareTo(second.Name));
+
+        screenSave.Initialize(null);
+
+        return ScreenImportResult.Ok(screenSave);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `gumcli import-screen <project.gumx> <screen.gusx> [--subfolder <name>] [--assets <dir>]`, running the merge step Content → Import → HTML… only exercised from inside the running tool: qualify/uniquify the screen name, copy staged Images/Fonts/FontCache, add the `ScreenReference`, write the screen file.
- Extracted the core "add screen to project" logic (conflict check, add reference, add screen, sort, initialize) out of `Tools/Gum.Presentation/.../ImportLogic.ImportScreen(ScreenSave, bool)` into `Gum.ProjectServices.ScreenImportService`, returning a conflict result instead of a dialog. `ImportLogic` now layers the dialog/selection/autosave on top; the tool's plain Content → Import → Screen path gets this coverage for free.
- Moved `HtmlImportNaming` (pure qualify/uniquify helpers) and a new `AssetTreeCopier` (Images/Fonts/FontCache tree copy) from the WPF-only `HtmlToGumPlugin` project into `Gum.ProjectServices`, so both the CLI and `MainHtmlToGumPlugin` share one implementation instead of duplicating it.

## Test plan
- [x] `Tests/Gum.ProjectServices.Tests`: `ScreenImportServiceTests`, `AssetTreeCopierTests`, moved `HtmlImportNamingTests` — all pass (536 total, 3 pre-existing skips)
- [x] `Tests/Gum.Cli.Tests`: new `ImportScreenCommandTests` (happy path, uniquify-on-conflict, subfolder qualification, asset copy, missing project/screen exit codes) — 78 total pass
- [x] `Tool/Tests/GumToolUnitTests`: pinning tests added to `ImportLogicTests` for the delegated `ImportScreen(ScreenSave, bool)`; full suite (1287 tests) + `AllPluginsCompositionTests` + `ServiceProviderCompositionSpikeTests` green — confirms the new `IScreenImportService` DI wiring doesn't break MEF composition or the DI graph
- [x] `dotnet build GumFull.sln` — 0 errors
- [x] Manual end-to-end smoke test via built `gumcli.dll`: created a project, imported a staged `.gusx` with `--subfolder`/`--assets`, verified the `ScreenReference`, screen file, and copied asset landed on disk, then re-ran to confirm `_2` uniquify suffixing

Manual test: not needed for the `ImportLogic` refactor (behavior-preserving extraction, covered by pinning tests + the full green tool suite + composition tests). The new CLI command's actual behavior was manually verified end-to-end above.

FRB canary: not needed — no FRB1-shared source touched.

Closes #4524
