### PR TITLE
Let New Project pick a Forms theme; share the picker UI with Add Forms

### DIFF
--- a/Gum/Controls/ThemeSelectionControl.xaml
+++ b/Gum/Controls/ThemeSelectionControl.xaml
@@ -1,0 +1,45 @@
+<UserControl
+    x:Class="Gum.Controls.ThemeSelectionControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+    </UserControl.Resources>
+    <StackPanel Orientation="Vertical">
+        <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
+            <Label
+                MinWidth="56"
+                VerticalAlignment="Center"
+                Content="Theme" />
+            <ComboBox
+                MinWidth="160"
+                VerticalAlignment="Center"
+                ItemsSource="{Binding AvailableThemes}"
+                SelectedItem="{Binding SelectedTheme}" />
+        </StackPanel>
+        <Border
+            Margin="0,4,0,0"
+            Padding="8"
+            Background="{DynamicResource Frb.Brushes.Contrast.Subtle}"
+            BorderBrush="{DynamicResource Frb.Brushes.Border}"
+            BorderThickness="1"
+            CornerRadius="4"
+            Visibility="{Binding HasRequirements, Converter={StaticResource BooleanToVisibility}}">
+            <StackPanel>
+                <TextBlock
+                    FontWeight="SemiBold"
+                    Foreground="{DynamicResource Frb.Brushes.Foreground}"
+                    Text="Clicking OK will also apply these project changes:"
+                    TextWrapping="Wrap" />
+                <TextBlock
+                    Margin="0,4,0,0"
+                    Foreground="{DynamicResource Frb.Brushes.Foreground}"
+                    Text="{Binding RequirementsDescription}"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/Gum/Controls/ThemeSelectionControl.xaml.cs
+++ b/Gum/Controls/ThemeSelectionControl.xaml.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using GumFormsPlugin.ViewModels;
+
+namespace Gum.Controls
+{
+    /// <summary>
+    /// Theme picker (combo box + project-change requirements panel), shared between the Add Forms
+    /// dialog and the New Project dialog. Bind this control's own DataContext to a
+    /// <see cref="ThemeSelectionViewModel"/> (e.g. <c>DataContext="{Binding ThemeSelection}"</c>);
+    /// its own bindings are relative to that.
+    /// </summary>
+    public partial class ThemeSelectionControl : UserControl
+    {
+        public ThemeSelectionControl()
+        {
+            InitializeComponent();
+
+            // The host DialogWindow locks SizeToContent to Manual once loaded, so subsequent
+            // visibility changes on the requirements panel don't grow the window. Listen for
+            // HasRequirements changing and re-fit the window's size to its content for one frame
+            // each time.
+            DataContextChanged += (_, e) =>
+            {
+                if (e.OldValue is INotifyPropertyChanged oldVm)
+                {
+                    oldVm.PropertyChanged -= OnViewModelPropertyChanged;
+                }
+                if (e.NewValue is INotifyPropertyChanged newVm)
+                {
+                    newVm.PropertyChanged += OnViewModelPropertyChanged;
+                }
+            };
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ThemeSelectionViewModel.HasRequirements))
+            {
+                RefitHostWindow();
+            }
+        }
+
+        private void RefitHostWindow()
+        {
+            // Defer to Loaded priority so the new visibility has been laid out before we resize.
+            // Then snap back to Manual so the user can still drag the window edges afterwards if
+            // they want.
+            Dispatcher.BeginInvoke(() =>
+            {
+                if (Window.GetWindow(this) is { } window)
+                {
+                    window.SizeToContent = SizeToContent.WidthAndHeight;
+                    Dispatcher.BeginInvoke(
+                        () => window.SizeToContent = SizeToContent.Manual,
+                        DispatcherPriority.Loaded);
+                }
+            }, DispatcherPriority.Loaded);
+        }
+    }
+}

--- a/Gum/Dialogs/NewProjectDialogView.xaml
+++ b/Gum/Dialogs/NewProjectDialogView.xaml
@@ -16,8 +16,9 @@
             Foreground="{DynamicResource Frb.Brushes.Foreground.Subtle}"
             Text="Adds buttons, text boxes, list boxes and other standard controls to the project."
             TextWrapping="Wrap" />
-        <controls:ThemeSelectionControl
-            DataContext="{Binding ThemeSelection}"
-            IsEnabled="{Binding DataContext.IsIncludeFormsControls, ElementName=Root}" />
+        <StackPanel IsEnabled="{Binding DataContext.IsIncludeFormsControls, ElementName=Root}">
+            <controls:ThemeSelectionControl DataContext="{Binding ThemeSelection}" />
+            <CheckBox Margin="0,8,0,0" IsChecked="{Binding IsIncludeDemoScreenGum}">Include DemoScreenGum</CheckBox>
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/Gum/Dialogs/NewProjectDialogView.xaml
+++ b/Gum/Dialogs/NewProjectDialogView.xaml
@@ -1,18 +1,23 @@
-﻿<UserControl
+<UserControl
     x:Class="Gum.Dialogs.NewProjectDialogView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Gum.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dialogs="clr-namespace:Gum.Services.Dialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Name="Root"
     dialogs:Dialog.DialogTitle="New Project"
     mc:Ignorable="d">
     <StackPanel MaxWidth="420" Orientation="Vertical">
         <CheckBox IsChecked="{Binding IsIncludeFormsControls}">Include Forms controls</CheckBox>
         <TextBlock
-            Margin="0,4,0,0"
+            Margin="0,4,0,8"
             Foreground="{DynamicResource Frb.Brushes.Foreground.Subtle}"
             Text="Adds buttons, text boxes, list boxes and other standard controls to the project."
             TextWrapping="Wrap" />
+        <controls:ThemeSelectionControl
+            DataContext="{Binding ThemeSelection}"
+            IsEnabled="{Binding DataContext.IsIncludeFormsControls, ElementName=Root}" />
     </StackPanel>
 </UserControl>

--- a/Gum/GumFormsPlugin/Views/AddFormsWindow.xaml
+++ b/Gum/GumFormsPlugin/Views/AddFormsWindow.xaml
@@ -2,48 +2,15 @@
     x:Class="GumFormsPlugin.Views.AddFormsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="clr-namespace:Gum.Controls;assembly=Gum"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dialogs="clr-namespace:Gum.Services.Dialogs;assembly=Gum"
     xmlns:local="clr-namespace:GumFormsPlugin.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     dialogs:Dialog.DialogTitle="Add Forms"
     mc:Ignorable="d">
-    <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
-    </UserControl.Resources>
     <StackPanel MaxWidth="420" Orientation="Vertical">
-        <StackPanel Margin="0,0,0,8" Orientation="Horizontal">
-            <Label
-                MinWidth="56"
-                VerticalAlignment="Center"
-                Content="Theme" />
-            <ComboBox
-                MinWidth="160"
-                VerticalAlignment="Center"
-                ItemsSource="{Binding AvailableThemes}"
-                SelectedItem="{Binding SelectedTheme}" />
-        </StackPanel>
+        <controls:ThemeSelectionControl Margin="0,0,0,8" DataContext="{Binding ThemeSelection}" />
         <CheckBox IsChecked="{Binding IsIncludeDemoScreenGum}">Include DemoScreenGum</CheckBox>
-        <Border
-            Margin="0,12,0,0"
-            Padding="8"
-            Background="{DynamicResource Frb.Brushes.Contrast.Subtle}"
-            BorderBrush="{DynamicResource Frb.Brushes.Border}"
-            BorderThickness="1"
-            CornerRadius="4"
-            Visibility="{Binding HasRequirements, Converter={StaticResource BooleanToVisibility}}">
-            <StackPanel>
-                <TextBlock
-                    FontWeight="SemiBold"
-                    Foreground="{DynamicResource Frb.Brushes.Foreground}"
-                    Text="Clicking OK will also apply these project changes:"
-                    TextWrapping="Wrap" />
-                <TextBlock
-                    Margin="0,4,0,0"
-                    Foreground="{DynamicResource Frb.Brushes.Foreground}"
-                    Text="{Binding RequirementsDescription}"
-                    TextWrapping="Wrap" />
-            </StackPanel>
-        </Border>
     </StackPanel>
 </UserControl>

--- a/Gum/GumFormsPlugin/Views/AddFormsWindow.xaml.cs
+++ b/Gum/GumFormsPlugin/Views/AddFormsWindow.xaml.cs
@@ -1,7 +1,4 @@
-using System.ComponentModel;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
 using Gum.Services.Dialogs;
 using GumFormsPlugin.ViewModels;
 
@@ -16,47 +13,6 @@ namespace GumFormsPlugin.Views
         public AddFormsWindow()
         {
             InitializeComponent();
-
-            // The host DialogWindow locks SizeToContent to Manual once loaded,
-            // so subsequent visibility changes on the requirements panel don't
-            // grow the window. Listen for HasRequirements changing and re-fit
-            // the window's size to its content for one frame each time.
-            DataContextChanged += (_, e) =>
-            {
-                if (e.OldValue is INotifyPropertyChanged oldVm)
-                {
-                    oldVm.PropertyChanged -= OnViewModelPropertyChanged;
-                }
-                if (e.NewValue is INotifyPropertyChanged newVm)
-                {
-                    newVm.PropertyChanged += OnViewModelPropertyChanged;
-                }
-            };
-        }
-
-        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(AddFormsViewModel.HasRequirements))
-            {
-                RefitHostWindow();
-            }
-        }
-
-        private void RefitHostWindow()
-        {
-            // Defer to Loaded priority so the new visibility has been laid out
-            // before we resize. Then snap back to Manual so the user can still
-            // drag the window edges afterwards if they want.
-            Dispatcher.BeginInvoke(() =>
-            {
-                if (Window.GetWindow(this) is { } window)
-                {
-                    window.SizeToContent = SizeToContent.WidthAndHeight;
-                    Dispatcher.BeginInvoke(
-                        () => window.SizeToContent = SizeToContent.Manual,
-                        DispatcherPriority.Loaded);
-                }
-            }, DispatcherPriority.Loaded);
         }
     }
 }

--- a/Tests/Gum.Presentation.Tests/AddFormsViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AddFormsViewModelTests.cs
@@ -13,6 +13,8 @@ namespace Gum.Presentation.Tests;
 /// IFormsFileService (which unblocked the VM's move into the headless Gum.Presentation assembly,
 /// ADR-0005 Phase 3, #3754) so DefaultThemeName went from a static const on the concrete
 /// FormsFileService to an instance member reachable through the interface.
+/// Theme picking itself moved into ThemeSelectionViewModel (shared with NewProjectDialogViewModel);
+/// see ThemeSelectionViewModelTests for that behavior's coverage.
 /// </summary>
 public class AddFormsViewModelTests
 {
@@ -31,32 +33,10 @@ public class AddFormsViewModelTests
         _projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave());
     }
 
-    private AddFormsViewModel CreateSut() => new(
-        _formsFileService.Object,
-        _themeImporter.Object,
-        _projectState.Object);
+    private ThemeSelectionViewModel CreateThemeSelection() =>
+        new(_formsFileService.Object, _projectState.Object);
 
-    [Fact]
-    public void Constructor_SelectsDefaultTheme_WhenPresentAmongAvailableThemes()
-    {
-        _formsFileService.Setup(x => x.GetAvailableThemes())
-            .Returns(new List<string> { "Bubblegum", "Standard" });
-
-        AddFormsViewModel sut = CreateSut();
-
-        sut.SelectedTheme.ShouldBe("Standard");
-    }
-
-    [Fact]
-    public void Constructor_FallsBackToFirstAvailableTheme_WhenDefaultThemeIsNotPresent()
-    {
-        _formsFileService.Setup(x => x.GetAvailableThemes())
-            .Returns(new List<string> { "Bubblegum" });
-
-        AddFormsViewModel sut = CreateSut();
-
-        sut.SelectedTheme.ShouldBe("Bubblegum");
-    }
+    private AddFormsViewModel CreateSut() => new(CreateThemeSelection(), _themeImporter.Object);
 
     [Fact]
     public void OnAffirmative_ImportsTheSelectedTheme()
@@ -65,7 +45,7 @@ public class AddFormsViewModelTests
             .Returns(new List<string> { "Standard", "Bubblegum" });
 
         AddFormsViewModel sut = CreateSut();
-        sut.SelectedTheme = "Bubblegum";
+        sut.ThemeSelection.SelectedTheme = "Bubblegum";
         sut.IsIncludeDemoScreenGum = true;
 
         bool? affirmativeResult = null;

--- a/Tests/Gum.Presentation.Tests/NewProjectLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/NewProjectLogicTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Dialogs;
@@ -8,6 +9,7 @@ using Gum.Services.Dialogs;
 using Gum.ToolCommands;
 using Gum.ToolStates;
 using GumFormsPlugin.Services;
+using GumFormsPlugin.ViewModels;
 using Moq;
 using Shouldly;
 
@@ -23,6 +25,7 @@ public class NewProjectLogicTests
     private readonly Mock<IDialogService> _dialogService = new();
     private readonly Mock<IFileCommands> _fileCommands = new();
     private readonly Mock<IFormsFileService> _formsFileService = new();
+    private readonly Mock<IProjectState> _projectState = new();
     private readonly Mock<IFormsThemeImporter> _themeImporter = new();
     private readonly Mock<ICopyPasteProjectCommands> _projectCommands = new();
     private readonly Mock<ISelectedState> _selectedState = new();
@@ -31,25 +34,36 @@ public class NewProjectLogicTests
     public NewProjectLogicTests()
     {
         _formsFileService.Setup(x => x.DefaultThemeName).Returns("Standard");
+        _formsFileService.Setup(x => x.GetAvailableThemes()).Returns(new List<string> { "Standard", "Bubblegum" });
+        _formsFileService.Setup(x => x.GetThemeDirectory(It.IsAny<string>())).Returns("C:/nonexistent-theme/");
+        _projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave());
         _fileCommands.Setup(x => x.TryAutoSaveProject(It.IsAny<bool>())).Returns(true);
 
         _logic = new NewProjectLogic(
             _projectManager.Object,
             _dialogService.Object,
             _fileCommands.Object,
-            _formsFileService.Object,
             _themeImporter.Object,
             _projectCommands.Object,
             _selectedState.Object);
     }
 
+    private ThemeSelectionViewModel CreateThemeSelection() => new(_formsFileService.Object, _projectState.Object);
+
     /// <summary>
     /// Sets up the options dialog to return <paramref name="accepted"/>, with Forms inclusion set
-    /// to <paramref name="isIncludeFormsControls"/>.
+    /// to <paramref name="isIncludeFormsControls"/> and, when given, a specific theme selected.
     /// </summary>
-    private void SetUpDialog(bool accepted, bool isIncludeFormsControls = true)
+    private void SetUpDialog(bool accepted, bool isIncludeFormsControls = true, string? selectedTheme = null)
     {
-        NewProjectDialogViewModel viewModel = new() { IsIncludeFormsControls = isIncludeFormsControls };
+        ThemeSelectionViewModel themeSelection = CreateThemeSelection();
+        if (selectedTheme != null)
+        {
+            themeSelection.SelectedTheme = selectedTheme;
+        }
+
+        NewProjectDialogViewModel viewModel =
+            new(themeSelection) { IsIncludeFormsControls = isIncludeFormsControls };
         _dialogService
             .Setup(x => x.Show(It.IsAny<Action<NewProjectDialogViewModel>?>(), out viewModel))
             .Returns(accepted);
@@ -123,6 +137,17 @@ public class NewProjectLogicTests
         _projectCommands.Verify(
             x => x.AddScreen(It.Is<ScreenSave>(s => s.Name == NewProjectLogic.StartingScreenName)),
             Times.Once);
+    }
+
+    [Fact]
+    public void CreateNewProject_ImportsTheThemePickedInTheDialog_WhenItDiffersFromTheDefault()
+    {
+        SetUpDialog(accepted: true, isIncludeFormsControls: true, selectedTheme: "Bubblegum");
+        SetUpSaveLocationPrompt(accepted: true);
+
+        _logic.CreateNewProject();
+
+        _themeImporter.Verify(x => x.ImportTheme("Bubblegum", false), Times.Once);
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/NewProjectLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/NewProjectLogicTests.cs
@@ -54,7 +54,11 @@ public class NewProjectLogicTests
     /// Sets up the options dialog to return <paramref name="accepted"/>, with Forms inclusion set
     /// to <paramref name="isIncludeFormsControls"/> and, when given, a specific theme selected.
     /// </summary>
-    private void SetUpDialog(bool accepted, bool isIncludeFormsControls = true, string? selectedTheme = null)
+    private void SetUpDialog(
+        bool accepted,
+        bool isIncludeFormsControls = true,
+        string? selectedTheme = null,
+        bool isIncludeDemoScreenGum = false)
     {
         ThemeSelectionViewModel themeSelection = CreateThemeSelection();
         if (selectedTheme != null)
@@ -62,8 +66,11 @@ public class NewProjectLogicTests
             themeSelection.SelectedTheme = selectedTheme;
         }
 
-        NewProjectDialogViewModel viewModel =
-            new(themeSelection) { IsIncludeFormsControls = isIncludeFormsControls };
+        NewProjectDialogViewModel viewModel = new(themeSelection)
+        {
+            IsIncludeFormsControls = isIncludeFormsControls,
+            IsIncludeDemoScreenGum = isIncludeDemoScreenGum,
+        };
         _dialogService
             .Setup(x => x.Show(It.IsAny<Action<NewProjectDialogViewModel>?>(), out viewModel))
             .Returns(accepted);
@@ -148,6 +155,17 @@ public class NewProjectLogicTests
         _logic.CreateNewProject();
 
         _themeImporter.Verify(x => x.ImportTheme("Bubblegum", false), Times.Once);
+    }
+
+    [Fact]
+    public void CreateNewProject_ImportsTheDemoScreenGum_WhenCheckedInTheDialog()
+    {
+        SetUpDialog(accepted: true, isIncludeFormsControls: true, isIncludeDemoScreenGum: true);
+        SetUpSaveLocationPrompt(accepted: true);
+
+        _logic.CreateNewProject();
+
+        _themeImporter.Verify(x => x.ImportTheme("Standard", true), Times.Once);
     }
 
     [Fact]

--- a/Tests/Gum.Presentation.Tests/ThemeSelectionViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/ThemeSelectionViewModelTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using Gum.DataTypes;
+using Gum.ToolStates;
+using GumFormsPlugin.Services;
+using GumFormsPlugin.ViewModels;
+using Moq;
+using Shouldly;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Theme picker extracted out of AddFormsViewModel (#4536) so the New Project dialog can offer the
+/// same theme choice instead of always importing the default theme.
+/// </summary>
+public class ThemeSelectionViewModelTests
+{
+    private readonly Mock<IFormsFileService> _formsFileService;
+    private readonly Mock<IProjectState> _projectState;
+
+    public ThemeSelectionViewModelTests()
+    {
+        _formsFileService = new Mock<IFormsFileService>();
+        _projectState = new Mock<IProjectState>();
+
+        _formsFileService.Setup(x => x.DefaultThemeName).Returns("Standard");
+        _formsFileService.Setup(x => x.GetThemeDirectory(It.IsAny<string>())).Returns("C:/nonexistent-theme/");
+        _projectState.Setup(x => x.GumProjectSave).Returns(new GumProjectSave());
+    }
+
+    private ThemeSelectionViewModel CreateSut() => new(_formsFileService.Object, _projectState.Object);
+
+    [Fact]
+    public void Constructor_SelectsDefaultTheme_WhenPresentAmongAvailableThemes()
+    {
+        _formsFileService.Setup(x => x.GetAvailableThemes())
+            .Returns(new List<string> { "Bubblegum", "Standard" });
+
+        ThemeSelectionViewModel sut = CreateSut();
+
+        sut.SelectedTheme.ShouldBe("Standard");
+    }
+
+    [Fact]
+    public void Constructor_FallsBackToFirstAvailableTheme_WhenDefaultThemeIsNotPresent()
+    {
+        _formsFileService.Setup(x => x.GetAvailableThemes())
+            .Returns(new List<string> { "Bubblegum" });
+
+        ThemeSelectionViewModel sut = CreateSut();
+
+        sut.SelectedTheme.ShouldBe("Bubblegum");
+    }
+
+    [Fact]
+    public void GetSelectedThemeOrDefault_ReturnsSelectedTheme_WhenOneIsSelected()
+    {
+        _formsFileService.Setup(x => x.GetAvailableThemes())
+            .Returns(new List<string> { "Standard", "Bubblegum" });
+
+        ThemeSelectionViewModel sut = CreateSut();
+        sut.SelectedTheme = "Bubblegum";
+
+        sut.GetSelectedThemeOrDefault().ShouldBe("Bubblegum");
+    }
+
+    [Fact]
+    public void GetSelectedThemeOrDefault_FallsBackToDefaultThemeName_WhenNoThemeIsSelected()
+    {
+        _formsFileService.Setup(x => x.GetAvailableThemes()).Returns(new List<string>());
+
+        ThemeSelectionViewModel sut = CreateSut();
+
+        sut.GetSelectedThemeOrDefault().ShouldBe("Standard");
+    }
+}

--- a/Tools/Gum.Presentation/Dialogs/NewProjectDialogViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/NewProjectDialogViewModel.cs
@@ -31,4 +31,14 @@ public class NewProjectDialogViewModel : DialogViewModel
         get => Get<bool>();
         set => Set(value);
     }
+
+    /// <summary>
+    /// Whether the selected theme's DemoScreenGum is imported alongside its controls. Only
+    /// relevant when <see cref="IsIncludeFormsControls"/> is checked.
+    /// </summary>
+    public bool IsIncludeDemoScreenGum
+    {
+        get => Get<bool>();
+        set => Set(value);
+    }
 }

--- a/Tools/Gum.Presentation/Dialogs/NewProjectDialogViewModel.cs
+++ b/Tools/Gum.Presentation/Dialogs/NewProjectDialogViewModel.cs
@@ -1,4 +1,5 @@
 using Gum.Services.Dialogs;
+using GumFormsPlugin.ViewModels;
 
 namespace Gum.Dialogs;
 
@@ -9,13 +10,21 @@ namespace Gum.Dialogs;
 /// </summary>
 public class NewProjectDialogViewModel : DialogViewModel
 {
-    public NewProjectDialogViewModel()
+    /// <summary>
+    /// Theme picker, shared with the Add Forms dialog. Only relevant when
+    /// <see cref="IsIncludeFormsControls"/> is checked.
+    /// </summary>
+    public ThemeSelectionViewModel ThemeSelection { get; }
+
+    public NewProjectDialogViewModel(ThemeSelectionViewModel themeSelection)
     {
+        ThemeSelection = themeSelection;
         IsIncludeFormsControls = true;
     }
 
     /// <summary>
-    /// Whether the default Forms theme is imported into the new project.
+    /// Whether the selected Forms theme (<see cref="ThemeSelection"/>) is imported into the new
+    /// project.
     /// </summary>
     public bool IsIncludeFormsControls
     {

--- a/Tools/Gum.Presentation/GumForms/GumFormsLogic.cs
+++ b/Tools/Gum.Presentation/GumForms/GumFormsLogic.cs
@@ -73,7 +73,7 @@ public class GumFormsLogic
             return false;
         }
 
-        viewModel = new AddFormsViewModel(_formsFileService, _themeImporter, _projectState);
+        viewModel = new AddFormsViewModel(new ThemeSelectionViewModel(_formsFileService, _projectState), _themeImporter);
         blockedMessage = null;
         return true;
     }

--- a/Tools/Gum.Presentation/GumForms/ViewModels/AddFormsViewModel.cs
+++ b/Tools/Gum.Presentation/GumForms/ViewModels/AddFormsViewModel.cs
@@ -1,7 +1,3 @@
-using Gum.ToolStates;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using GumFormsPlugin.Services;
 using Gum.Services.Dialogs;
 
@@ -11,9 +7,9 @@ public class AddFormsViewModel : DialogViewModel
 {
     #region Fields/Properties
 
-    private readonly IFormsFileService _formsFileService;
     private readonly IFormsThemeImporter _themeImporter;
-    private readonly IProjectState _projectState;
+
+    public ThemeSelectionViewModel ThemeSelection { get; }
 
     public bool IsIncludeDemoScreenGum
     {
@@ -21,80 +17,17 @@ public class AddFormsViewModel : DialogViewModel
         set => Set(value);
     }
 
-    public IReadOnlyList<string> AvailableThemes
-    {
-        get => Get<IReadOnlyList<string>>() ?? Array.Empty<string>();
-        private set => Set(value);
-    }
-
-    public string? SelectedTheme
-    {
-        get => Get<string?>();
-        set
-        {
-            if (Set(value))
-            {
-                RefreshRequirementsDescription();
-                NotifyPropertyChanged(nameof(HasRequirements));
-            }
-        }
-    }
-
-    public bool HasMultipleThemes => AvailableThemes.Count > 1;
-
-    /// <summary>
-    /// Bullet-formatted description of the project-level changes the import
-    /// will apply for the currently-selected theme. Empty when the theme has
-    /// no prerequisites that affect this project. Bound inline in the dialog
-    /// so the user sees what's going to happen before clicking OK — no
-    /// confirmation popup.
-    /// </summary>
-    public string RequirementsDescription
-    {
-        get => Get<string>() ?? string.Empty;
-        private set => Set(value);
-    }
-
-    public bool HasRequirements => !string.IsNullOrEmpty(RequirementsDescription);
-
     #endregion
 
-    public AddFormsViewModel(IFormsFileService formsFileService,
-        IFormsThemeImporter themeImporter,
-        IProjectState projectState)
+    public AddFormsViewModel(ThemeSelectionViewModel themeSelection, IFormsThemeImporter themeImporter)
     {
-        _formsFileService = formsFileService;
+        ThemeSelection = themeSelection;
         _themeImporter = themeImporter;
-        _projectState = projectState;
-
-        AvailableThemes = _formsFileService.GetAvailableThemes();
-        SelectedTheme = AvailableThemes.FirstOrDefault(t =>
-                            string.Equals(t, _formsFileService.DefaultThemeName, StringComparison.OrdinalIgnoreCase))
-                        ?? AvailableThemes.FirstOrDefault();
-
-        RefreshRequirementsDescription();
-    }
-
-    private void RefreshRequirementsDescription()
-    {
-        string? theme = SelectedTheme;
-        if (string.IsNullOrEmpty(theme))
-        {
-            RequirementsDescription = string.Empty;
-            return;
-        }
-
-        ThemeRequirements requirements =
-            ThemeRequirements.LoadFromThemeDirectory(_formsFileService.GetThemeDirectory(theme));
-        ThemeRequirementsDiff diff = requirements.Diff(_projectState.GumProjectSave);
-        RequirementsDescription = diff.HasChanges
-            ? string.Join(Environment.NewLine, diff.DescribeChanges().Select(c => "• " + c))
-            : string.Empty;
     }
 
     public override void OnAffirmative()
     {
-        _themeImporter.ImportTheme(SelectedTheme ?? _formsFileService.DefaultThemeName, IsIncludeDemoScreenGum);
+        _themeImporter.ImportTheme(ThemeSelection.GetSelectedThemeOrDefault(), IsIncludeDemoScreenGum);
 
         base.OnAffirmative();
     }

--- a/Tools/Gum.Presentation/GumForms/ViewModels/ThemeSelectionViewModel.cs
+++ b/Tools/Gum.Presentation/GumForms/ViewModels/ThemeSelectionViewModel.cs
@@ -1,0 +1,90 @@
+using Gum.Mvvm;
+using Gum.ToolStates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GumFormsPlugin.Services;
+
+namespace GumFormsPlugin.ViewModels;
+
+/// <summary>
+/// Theme picker (available themes, selected theme, and the project-change requirements panel for
+/// the current selection). Shared between the Add Forms dialog and the New Project dialog so both
+/// present the same picking UI.
+/// </summary>
+public class ThemeSelectionViewModel : ViewModel
+{
+    private readonly IFormsFileService _formsFileService;
+    private readonly IProjectState _projectState;
+
+    public IReadOnlyList<string> AvailableThemes
+    {
+        get => Get<IReadOnlyList<string>>() ?? Array.Empty<string>();
+        private set => Set(value);
+    }
+
+    public string? SelectedTheme
+    {
+        get => Get<string?>();
+        set
+        {
+            if (Set(value))
+            {
+                RefreshRequirementsDescription();
+                NotifyPropertyChanged(nameof(HasRequirements));
+            }
+        }
+    }
+
+    public bool HasMultipleThemes => AvailableThemes.Count > 1;
+
+    /// <summary>
+    /// Bullet-formatted description of the project-level changes the import will apply for the
+    /// currently-selected theme. Empty when the theme has no prerequisites that affect this
+    /// project. Bound inline in the dialog so the user sees what's going to happen before clicking
+    /// OK — no confirmation popup.
+    /// </summary>
+    public string RequirementsDescription
+    {
+        get => Get<string>() ?? string.Empty;
+        private set => Set(value);
+    }
+
+    public bool HasRequirements => !string.IsNullOrEmpty(RequirementsDescription);
+
+    public ThemeSelectionViewModel(IFormsFileService formsFileService, IProjectState projectState)
+    {
+        _formsFileService = formsFileService;
+        _projectState = projectState;
+
+        AvailableThemes = _formsFileService.GetAvailableThemes();
+        SelectedTheme = AvailableThemes.FirstOrDefault(t =>
+                            string.Equals(t, _formsFileService.DefaultThemeName, StringComparison.OrdinalIgnoreCase))
+                        ?? AvailableThemes.FirstOrDefault();
+
+        RefreshRequirementsDescription();
+    }
+
+    /// <summary>
+    /// The theme to import: <see cref="SelectedTheme"/>, falling back to
+    /// <see cref="IFormsFileService.DefaultThemeName"/> when nothing is selected (no themes shipped).
+    /// </summary>
+    public string GetSelectedThemeOrDefault() => SelectedTheme ?? _formsFileService.DefaultThemeName;
+
+    private void RefreshRequirementsDescription()
+    {
+        string? theme = SelectedTheme;
+        if (string.IsNullOrEmpty(theme))
+        {
+            RequirementsDescription = string.Empty;
+            return;
+        }
+
+        ThemeRequirements requirements =
+            ThemeRequirements.LoadFromThemeDirectory(_formsFileService.GetThemeDirectory(theme));
+        ThemeRequirementsDiff diff = requirements.Diff(_projectState.GumProjectSave);
+        RequirementsDescription = diff.HasChanges
+            ? string.Join(Environment.NewLine, diff.DescribeChanges().Select(c => "• " + c))
+            : string.Empty;
+    }
+}

--- a/Tools/Gum.Presentation/Logic/NewProjectLogic.cs
+++ b/Tools/Gum.Presentation/Logic/NewProjectLogic.cs
@@ -72,7 +72,8 @@ public class NewProjectLogic : INewProjectLogic
 
         if (viewModel.IsIncludeFormsControls)
         {
-            _themeImporter.ImportTheme(viewModel.ThemeSelection.GetSelectedThemeOrDefault(), isIncludeDemoScreenGum: false);
+            _themeImporter.ImportTheme(
+                viewModel.ThemeSelection.GetSelectedThemeOrDefault(), viewModel.IsIncludeDemoScreenGum);
         }
 
         ScreenSave startingScreen = new() { Name = StartingScreenName };

--- a/Tools/Gum.Presentation/Logic/NewProjectLogic.cs
+++ b/Tools/Gum.Presentation/Logic/NewProjectLogic.cs
@@ -21,7 +21,6 @@ public class NewProjectLogic : INewProjectLogic
     private readonly IProjectManager _projectManager;
     private readonly IDialogService _dialogService;
     private readonly IFileCommands _fileCommands;
-    private readonly IFormsFileService _formsFileService;
     private readonly IFormsThemeImporter _themeImporter;
     // Named for its first consumer; AddScreen is the call needed here.
     private readonly ICopyPasteProjectCommands _projectCommands;
@@ -31,7 +30,6 @@ public class NewProjectLogic : INewProjectLogic
         IProjectManager projectManager,
         IDialogService dialogService,
         IFileCommands fileCommands,
-        IFormsFileService formsFileService,
         IFormsThemeImporter themeImporter,
         ICopyPasteProjectCommands projectCommands,
         ISelectedState selectedState)
@@ -39,7 +37,6 @@ public class NewProjectLogic : INewProjectLogic
         _projectManager = projectManager;
         _dialogService = dialogService;
         _fileCommands = fileCommands;
-        _formsFileService = formsFileService;
         _themeImporter = themeImporter;
         _projectCommands = projectCommands;
         _selectedState = selectedState;
@@ -75,7 +72,7 @@ public class NewProjectLogic : INewProjectLogic
 
         if (viewModel.IsIncludeFormsControls)
         {
-            _themeImporter.ImportTheme(_formsFileService.DefaultThemeName, isIncludeDemoScreenGum: false);
+            _themeImporter.ImportTheme(viewModel.ThemeSelection.GetSelectedThemeOrDefault(), isIncludeDemoScreenGum: false);
         }
 
         ScreenSave startingScreen = new() { Name = StartingScreenName };


### PR DESCRIPTION
## Summary
- New Project's "Include Forms controls" always imported the default theme; it now shares the theme picker with Add Forms, so the user can choose a non-default theme.
- Extracted the picker (available themes, selection, project-change requirements panel) out of `AddFormsViewModel` into `ThemeSelectionViewModel` + a shared `ThemeSelectionControl`, composed into both `NewProjectDialogViewModel` and `AddFormsViewModel`. Sets up the planned theme-preview PR to touch one control instead of two.

## Test plan
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings
- [x] `dotnet test Tests/Gum.Presentation.Tests` — 933 passed
- [x] Confirmed the new `NewProjectLogicTests` theme-selection test fails for the right reason when the fix is reverted