### PR TITLE
Add incremental KernSmith font atlas growth (0.21.0)

### DIFF
--- a/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
+++ b/Integrations/KernSmith/KernSmith.GumCommon/GumFontGenerator.cs
@@ -1,5 +1,6 @@
 using KernSmith;
 using KernSmith.Output;
+using KernSmith.Output.Model;
 using KernSmith.Rasterizer;
 using RenderingLibrary.Graphics.Fonts;
 using ToolsUtilities;
@@ -40,6 +41,69 @@ public static class GumFontGenerator
     /// </exception>
     public static BmFontResult Generate(BmfcSave bmfcSave, RasterizerBackend? backend = null)
     {
+        GuardBrowserBackend(backend);
+        FontGeneratorOptions options = BuildOptionsWithBackend(bmfcSave, backend);
+        return string.IsNullOrEmpty(bmfcSave.FontFile)
+            ? BmFont.GenerateFromSystem(bmfcSave.FontName, options)
+            : BmFont.Generate(ReadFontFileBytes(bmfcSave.FontFile!), options);
+    }
+
+    /// <summary>
+    /// Starts an empty incremental glyph-addition session (KernSmith 0.21.0) for
+    /// <paramref name="bmfcSave"/>'s font: the atlas builds up as callers call
+    /// <see cref="BmFontIncrementalSession.AddGlyphs(string)"/>, instead of generating the whole
+    /// <see cref="BmfcSave.Ranges"/> character set up front. See KernSmith's
+    /// incremental-glyph-addition docs for the full session contract (stable packing, overflow
+    /// policies, the v1 unsupported-options list -- notably <see cref="BmfcSave.HasDropshadow"/>,
+    /// which throws <see cref="NotSupportedException"/> here via KernSmith's own validation).
+    /// </summary>
+    /// <param name="bmfcSave">The Gum font descriptor to start the session from.</param>
+    /// <param name="overflowPolicy">What to do when a glyph doesn't fit the current atlas.</param>
+    /// <param name="backend">Optional rasterizer backend override; see <see cref="Generate"/>.</param>
+    /// <exception cref="NotSupportedException">
+    /// <paramref name="bmfcSave"/> has no <see cref="BmfcSave.FontFile"/> -- incremental sessions
+    /// require font file bytes; KernSmith has no system-font overload for them.
+    /// </exception>
+    public static BmFontIncrementalSession BeginIncremental(BmfcSave bmfcSave,
+        AdditionOverflowPolicy overflowPolicy = AdditionOverflowPolicy.Grow, RasterizerBackend? backend = null)
+    {
+        GuardBrowserBackend(backend);
+        FontGeneratorOptions options = BuildOptionsWithBackend(bmfcSave, backend);
+        return BmFont.BeginIncremental(ReadRequiredFontFileBytes(bmfcSave), options, overflowPolicy);
+    }
+
+    /// <summary>
+    /// Resumes an incremental glyph-addition session (KernSmith 0.21.0) from a previously generated
+    /// <paramref name="existing"/> model -- e.g. <see cref="Generate"/>'s <see cref="BmFontResult.Model"/>,
+    /// or a loaded <c>.fnt</c> -- so new glyphs pack alongside what's already placed without moving it.
+    /// <paramref name="bmfcSave"/> must map to the same options <paramref name="existing"/> was
+    /// generated with (padding, spacing, size, outline); a mismatch throws <see cref="ArgumentException"/>.
+    /// </summary>
+    /// <param name="bmfcSave">The Gum font descriptor the session resumes -- must match how <paramref name="existing"/> was generated.</param>
+    /// <param name="existing">The model providing the atlas's current occupancy, characters, and kerning.</param>
+    /// <param name="overflowPolicy">What to do when a glyph doesn't fit the current atlas.</param>
+    /// <param name="backend">Optional rasterizer backend override; see <see cref="Generate"/>.</param>
+    /// <exception cref="NotSupportedException">
+    /// <paramref name="bmfcSave"/> has no <see cref="BmfcSave.FontFile"/> -- incremental sessions
+    /// require font file bytes; KernSmith has no system-font overload for them.
+    /// </exception>
+    public static BmFontIncrementalSession ResumeIncremental(BmfcSave bmfcSave, BmFontModel existing,
+        AdditionOverflowPolicy overflowPolicy = AdditionOverflowPolicy.Grow, RasterizerBackend? backend = null)
+    {
+        GuardBrowserBackend(backend);
+        FontGeneratorOptions options = BuildOptionsWithBackend(bmfcSave, backend);
+        return BmFont.ResumeIncremental(ReadRequiredFontFileBytes(bmfcSave), options, existing, overflowPolicy);
+    }
+
+    /// <summary>
+    /// <paramref name="backend"/> is null and this is running on browser-wasm. FreeType (the default
+    /// backend) is native code and cannot run there -- a silent fallback or an opaque KernSmith-internal
+    /// failure is worse than failing fast with the fix (found via a BlazorGL repro where the consumer
+    /// forgot the explicit backend argument; see also the render-time try/catch this bug motivated
+    /// around <c>TextRuntime.RegenerateOversampledFont</c>'s <c>TryCreateFont</c> calls).
+    /// </summary>
+    private static void GuardBrowserBackend(RasterizerBackend? backend)
+    {
         if (backend is null && IsBrowserPlatform())
         {
             throw new PlatformNotSupportedException(
@@ -49,13 +113,29 @@ public static class GumFontGenerator
                 "and reference the KernSmith.Rasterizers.StbTrueType package -- see " +
                 "docs/code/files-and-fonts/font-oversampling.md.");
         }
+    }
 
+    private static FontGeneratorOptions BuildOptionsWithBackend(BmfcSave bmfcSave, RasterizerBackend? backend)
+    {
         FontGeneratorOptions options = BuildOptions(bmfcSave);
         if (backend.HasValue)
             options.Backend = backend.Value;
-        return string.IsNullOrEmpty(bmfcSave.FontFile)
-            ? BmFont.GenerateFromSystem(bmfcSave.FontName, options)
-            : BmFont.Generate(ReadFontFileBytes(bmfcSave.FontFile!), options);
+        return options;
+    }
+
+    /// <summary>
+    /// Reads <see cref="BmfcSave.FontFile"/>'s bytes for a session entry point, which -- unlike
+    /// <see cref="Generate"/> -- has no system-font overload in KernSmith.
+    /// </summary>
+    private static byte[] ReadRequiredFontFileBytes(BmfcSave bmfcSave)
+    {
+        if (string.IsNullOrEmpty(bmfcSave.FontFile))
+        {
+            throw new NotSupportedException(
+                "Incremental glyph sessions require a font file (BmfcSave.FontFile) -- KernSmith's " +
+                "BeginIncremental/ResumeIncremental only accept font file bytes, not a system font name.");
+        }
+        return ReadFontFileBytes(bmfcSave.FontFile!);
     }
 
     /// <summary>

--- a/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
+++ b/Integrations/KernSmith/KernSmith.GumCommon/KernSmith.GumCommon.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KernSmith" Version="0.20.0" />
-    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.20.0" />
+    <PackageReference Include="KernSmith" Version="0.21.0" />
+    <PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.MonoGameGum/KernSmithFontCreator.cs
@@ -1,9 +1,11 @@
 using KernSmith.Atlas;
 using KernSmith.Output;
+using KernSmith.Output.Model;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Fonts;
+using System.Collections.Generic;
 using ToolsUtilities;
 
 namespace KernSmith.Gum;
@@ -16,6 +18,17 @@ public class KernSmithFontCreator : IInMemoryFontCreator
 {
     private readonly GraphicsDevice _graphicsDevice;
     private readonly RasterizerBackend? _backend;
+
+    // Growth bookkeeping (issue #4535 Phase 2), keyed by BmfcSave.FontCacheFileName -- the same
+    // identity TryCreateFont already names its textures after. Populated by TryCreateFont so
+    // TryAddGlyphs can resume growth against the exact font this creator generated. A font with no
+    // FontFile (a system font) never gets an entry: incremental sessions require font file bytes.
+    private readonly Dictionary<string, BmFontModel> _growableModels = new();
+
+    // Sessions are created lazily on first TryAddGlyphs call per font identity, not eagerly in
+    // TryCreateFont -- matches KernSmith's documented usage (create on first miss, keep for the
+    // rest of the run) and avoids paying a session's rasterizer/parse cost for fonts that never grow.
+    private readonly Dictionary<string, BmFontIncrementalSession> _activeSessions = new();
 
     /// <summary>
     /// Initializes a new instance of <see cref="KernSmithFontCreator"/>.
@@ -156,6 +169,142 @@ public class KernSmithFontCreator : IInMemoryFontCreator
             bitmapFont.ShadowFont = new BitmapFont(textures, result.GetVariantFntText("shadow"));
         }
 
+        // Issue #4535: remember this font's model so a later TryAddGlyphs call can resume an
+        // incremental session against it. Dropshadow fonts (Variants set) are skipped -- KernSmith's
+        // incremental sessions reject Variants outright (ValidateIncrementalOptions), so there is
+        // nothing growable to remember for them.
+        if (!string.IsNullOrEmpty(bmfcSave.FontFile) && !bmfcSave.HasDropshadow)
+        {
+            _growableModels[bmfcSave.FontCacheFileName] = result.Model;
+        }
+
         return bitmapFont;
     }
+
+    /// <summary>
+    /// Adds <paramref name="characters"/> to <paramref name="font"/>, a font this creator previously
+    /// built via <see cref="TryCreateFont"/>, growing its live atlas texture(s) in place (KernSmith
+    /// 0.21.0 incremental sessions, issue #4535) instead of a full regenerate.
+    /// </summary>
+    /// <param name="font">The font to grow, as returned by an earlier <see cref="TryCreateFont"/> call.</param>
+    /// <param name="bmfcSave">
+    /// The same descriptor <paramref name="font"/> was created from. Must match -- padding, spacing,
+    /// size and outline are verified against the font's original generation and a mismatch throws.
+    /// </param>
+    /// <param name="characters">The characters to add. Already-present characters are a no-op; codepoints the font cannot render are reported in the result, not thrown.</param>
+    /// <returns>
+    /// The addition result, or null when <paramref name="font"/> was not created by this creator's
+    /// <see cref="TryCreateFont"/> (or was generated from a system font / with a dropshadow, neither
+    /// of which this creator tracks as growable).
+    /// </returns>
+    public GlyphAdditionResult? TryAddGlyphs(BitmapFont font, BmfcSave bmfcSave, string characters)
+    {
+        string key = bmfcSave.FontCacheFileName;
+        if (!_growableModels.TryGetValue(key, out BmFontModel? model))
+        {
+            return null;
+        }
+
+        if (!_activeSessions.TryGetValue(key, out BmFontIncrementalSession? session))
+        {
+            session = GumFontGenerator.ResumeIncremental(bmfcSave, model, backend: _backend);
+            _activeSessions[key] = session;
+        }
+
+        GlyphAdditionResult result = session.AddGlyphs(characters);
+
+        if (result.Added.Count > 0)
+        {
+            ApplyGrowth(font, result);
+        }
+
+        return result;
+    }
+
+    private void ApplyGrowth(BitmapFont font, GlyphAdditionResult result)
+    {
+        if (result.PageGrown || result.PageCount > font.Textures.Length)
+        {
+            GrowTexturePages(font, result);
+        }
+
+        foreach (AddedGlyph glyph in result.Added)
+        {
+            Texture2D page = font.Textures[glyph.PageIndex];
+            Rectangle destRect = new Rectangle(glyph.X, glyph.Y, glyph.Width, glyph.Height);
+            // Pixels is tightly-packed straight-alpha RGBA32 -- reinterpret as Color[] rather than
+            // handing SetData the raw byte[] (which would need elementCount in bytes, not pixels).
+            Color[] glyphPixels = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, Color>(glyph.Pixels).ToArray();
+            page.SetData(0, destRect, glyphPixels, 0, glyph.Width * glyph.Height);
+
+            font.AddOrUpdateCharacter(ToFontFileCharLine(glyph.Char), page.Width, page.Height);
+        }
+
+        foreach (KerningEntry kerning in result.NewKerning)
+        {
+            font.AddKerningPair(kerning.First, kerning.Second, kerning.Amount);
+        }
+    }
+
+    /// <summary>
+    /// Reallocates <paramref name="font"/>'s texture pages to match <paramref name="result"/>'s
+    /// current page geometry. A width/height change (<see cref="GlyphAdditionResult.PageGrown"/>)
+    /// replaces every page (copying old pixel content to (0,0), per KernSmith's grow contract) and
+    /// rescales every already-placed character's UVs against the new size, since their pixel
+    /// positions do not move but the denominator they were computed against did. A page-count-only
+    /// change (<see cref="AdditionOverflowPolicy.NewPage"/>) reuses existing page instances untouched
+    /// and only appends new, empty pages.
+    /// </summary>
+    private void GrowTexturePages(BitmapFont font, GlyphAdditionResult result)
+    {
+        Texture2D[] oldTextures = font.Textures;
+        Texture2D[] newTextures = new Texture2D[result.PageCount];
+
+        for (int i = 0; i < result.PageCount; i++)
+        {
+            if (!result.PageGrown && i < oldTextures.Length)
+            {
+                newTextures[i] = oldTextures[i];
+                continue;
+            }
+
+            Texture2D newPage = new Texture2D(_graphicsDevice, result.PageWidth, result.PageHeight,
+                false, SurfaceFormat.Color);
+            newPage.Name = i < oldTextures.Length ? oldTextures[i].Name : $"{oldTextures[0].Name}_{i}";
+
+            if (i < oldTextures.Length)
+            {
+                Texture2D oldPage = oldTextures[i];
+                Color[] oldPixels = new Color[oldPage.Width * oldPage.Height];
+                oldPage.GetData(oldPixels);
+                newPage.SetData(0, new Rectangle(0, 0, oldPage.Width, oldPage.Height), oldPixels, 0, oldPixels.Length);
+            }
+
+            newTextures[i] = newPage;
+        }
+
+        if (result.PageGrown)
+        {
+            foreach (Texture2D oldPage in oldTextures)
+            {
+                oldPage?.Dispose();
+            }
+            font.RescaleTextureCoordinates(result.PageWidth, result.PageHeight);
+        }
+
+        font.ReplaceTexturePages(newTextures);
+    }
+
+    private static FontFileCharLine ToFontFileCharLine(CharEntry charEntry) => new FontFileCharLine
+    {
+        Id = charEntry.Id,
+        X = charEntry.X,
+        Y = charEntry.Y,
+        Width = charEntry.Width,
+        Height = charEntry.Height,
+        XOffset = charEntry.XOffset,
+        YOffset = charEntry.YOffset,
+        XAdvance = charEntry.XAdvance,
+        Page = charEntry.Page,
+    };
 }

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -305,6 +305,27 @@ char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xad
     }
 
     [Fact]
+    public void RescaleTextureCoordinates_ShouldRecomputeUVsFromStoredPixelCoordinates_ForAllCharacters()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        // Simulates a page-grow: pixel positions (where each glyph already lives in the atlas)
+        // never move, but the atlas got bigger, so UVs computed against the old 256x256 denominator
+        // are now wrong until recomputed against the new size.
+        font.RescaleTextureCoordinates(newTextureWidth: 512, newTextureHeight: 512);
+
+        font.Characters[32].TULeft.ShouldBe(206f / 512f);
+        font.Characters[32].TVTop.ShouldBe(102f / 512f);
+        font.Characters[32].TURight.ShouldBe(209f / 512f);
+        font.Characters[32].TVBottom.ShouldBe(103f / 512f);
+        font.Characters[32].PixelLeft.ShouldBe(206, "because pixel coordinates must stay the same -- only UVs change on a grow");
+
+        font.Characters[37].TULeft.ShouldBe(161f / 512f);
+        font.Characters[37].TVTop.ShouldBe(0f / 512f);
+    }
+
+    [Fact]
     public void MeasureString_ShouldIgnoreTrailingNewlines()
     {
 

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -202,6 +202,109 @@ char id=5   x=0   y=0   width=3     height=1     xoffset=-1    yoffset=20    xad
     }
 
     [Fact]
+    public void AddOrUpdateCharacter_ShouldGrowCharacterArray_AndPreserveExistingCharacters()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, smallCharSetFontData);
+        font.SetFontPattern(256, 256);
+
+        int originalLength = font.Characters.Length;
+
+        FontFileCharLine newChar = new FontFileCharLine
+        {
+            Id = 65, // 'A'
+            X = 32,
+            Y = 64,
+            Width = 8,
+            Height = 12,
+            XOffset = 1,
+            YOffset = 2,
+            XAdvance = 9,
+            Page = 0,
+        };
+
+        font.AddOrUpdateCharacter(newChar, textureWidth: 256, textureHeight: 256);
+
+        font.Characters.Length.ShouldBe(66, "because AddOrUpdateCharacter must grow the array to hold the new id");
+        originalLength.ShouldBeLessThan(66);
+
+        BitmapCharacterInfo added = font.Characters[65];
+        added.TULeft.ShouldBe(32f / 256f);
+        added.TVTop.ShouldBe(64f / 256f);
+        added.TURight.ShouldBe((32f + 8f) / 256f);
+        added.TVBottom.ShouldBe((64f + 12f) / 256f);
+        added.XAdvance.ShouldBe(9);
+        added.XOffsetInPixels.ShouldBe(1);
+        added.PageNumber.ShouldBe(0);
+
+        // The original character (id 5) must survive the growth untouched.
+        font.Characters[5].XAdvance.ShouldBe(5);
+    }
+
+    [Fact]
+    public void AddOrUpdateCharacter_ShouldUpdateExistingCharacter_WithoutGrowingArray()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        int originalLength = font.Characters.Length;
+
+        FontFileCharLine updatedChar = new FontFileCharLine
+        {
+            Id = 33, // '!'
+            X = 1,
+            Y = 2,
+            Width = 3,
+            Height = 4,
+            XOffset = 0,
+            YOffset = 0,
+            XAdvance = 20,
+            Page = 0,
+        };
+
+        font.AddOrUpdateCharacter(updatedChar, textureWidth: 256, textureHeight: 256);
+
+        font.Characters.Length.ShouldBe(originalLength);
+        font.Characters[33].XAdvance.ShouldBe(20);
+    }
+
+    [Fact]
+    public void AddKerningPair_ShouldAddPairToExistingCharacter()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        font.AddKerningPair(first: 33, second: 34, amount: 5);
+
+        font.Characters[33].SecondLetterKearning[34].ShouldBe(5);
+    }
+
+    [Fact]
+    public void AddKerningPair_ShouldNotOverwriteExistingPair()
+    {
+        BitmapFont font = new BitmapFont((Texture2D)null!, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        font.AddKerningPair(first: 33, second: 34, amount: 5);
+        font.AddKerningPair(first: 33, second: 34, amount: 99);
+
+        font.Characters[33].SecondLetterKearning[34].ShouldBe(5);
+    }
+
+    [Fact]
+    public void ReplaceTexturePages_ShouldUpdateTexturesAndNames()
+    {
+        BitmapFont font = new BitmapFont(new Texture2D[] { null! }, basicBMFontFileData);
+        font.SetFontPattern(256, 256);
+
+        Texture2D[] grownPages = new Texture2D[] { null!, null! };
+
+        font.ReplaceTexturePages(grownPages);
+
+        font.Textures.Length.ShouldBe(2);
+        font.Textures.ShouldBe(grownPages);
+    }
+
+    [Fact]
     public void MeasureString_ShouldIgnoreTrailingNewlines()
     {
 

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -630,6 +630,31 @@ public class BitmapFont : IDisposable
     }
 
     /// <summary>
+    /// Recomputes every character's UV coordinates (<see cref="BitmapCharacterInfo.TULeft"/>/
+    /// <see cref="BitmapCharacterInfo.TVTop"/>/<see cref="BitmapCharacterInfo.TURight"/>/
+    /// <see cref="BitmapCharacterInfo.TVBottom"/>) from its already-stored pixel coordinates, against
+    /// a new texture size. Used after incremental atlas growth reallocates the texture pages at a
+    /// larger size: existing glyphs' pixel positions never move (KernSmith's "stable packing"), but
+    /// their UVs were computed against the old, smaller denominator and are wrong until rescaled here.
+    /// Pair with <see cref="ReplaceTexturePages"/> using the same new dimensions.
+    /// </summary>
+    public void RescaleTextureCoordinates(int newTextureWidth, int newTextureHeight)
+    {
+        foreach (BitmapCharacterInfo info in mCharacterInfo)
+        {
+            if (info == null)
+            {
+                continue;
+            }
+
+            info.TULeft = info.PixelLeft / (float)newTextureWidth;
+            info.TVTop = info.PixelTop / (float)newTextureHeight;
+            info.TURight = info.PixelRight / (float)newTextureWidth;
+            info.TVBottom = info.PixelBottom / (float)newTextureHeight;
+        }
+    }
+
+    /// <summary>
     /// Replaces this font's atlas texture pages, e.g. after incremental atlas growth reallocates
     /// them at a larger size or with an added page. Does not dispose the previous pages -- the
     /// caller owns their lifetime, matching the <see cref="Texture"/> setter.

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -578,6 +578,74 @@ public class BitmapFont : IDisposable
     }
 
     /// <summary>
+    /// Adds a new character to the font, or updates an existing one, without re-parsing the whole
+    /// .fnt content. Used by incremental atlas growth (e.g. KernSmith's <c>AddGlyphs</c>), where a
+    /// glyph is placed into an already-live atlas and the font's character table must reflect it
+    /// without disturbing every other character already parsed.
+    /// </summary>
+    /// <param name="charInfo">The character's atlas position and rendering metrics.</param>
+    /// <param name="textureWidth">The pixel width of the atlas page <paramref name="charInfo"/> was placed on.</param>
+    /// <param name="textureHeight">The pixel height of the atlas page <paramref name="charInfo"/> was placed on.</param>
+    public void AddOrUpdateCharacter(FontFileCharLine charInfo, int textureWidth, int textureHeight)
+    {
+        if (charInfo.Id >= mCharacterInfo.Length)
+        {
+            BitmapCharacterInfo[] grown = new BitmapCharacterInfo[charInfo.Id + 1];
+            Array.Copy(mCharacterInfo, grown, mCharacterInfo.Length);
+            for (int i = mCharacterInfo.Length; i < grown.Length; i++)
+            {
+                grown[i] = _defaultCharacterInfo;
+            }
+            mCharacterInfo = grown;
+        }
+
+        BitmapCharacterInfo filled = FillBitmapCharacterInfo(charInfo, textureWidth, textureHeight, mLineHeightInPixels);
+        mCharacterInfo[charInfo.Id] = filled;
+
+        if (charInfo.Id == (int)' ')
+        {
+            _defaultCharacterInfo = filled;
+        }
+    }
+
+    /// <summary>
+    /// Adds a kerning adjustment between two characters already present in this font. Used by
+    /// incremental atlas growth to merge in the kerning delta a glyph addition introduces. A pair
+    /// that already exists for <paramref name="first"/>/<paramref name="second"/> is left unchanged,
+    /// matching <see cref="SetFontPattern"/>'s parse-time kerning behavior.
+    /// </summary>
+    /// <param name="first">The character id that precedes <paramref name="second"/>.</param>
+    /// <param name="second">The character id that follows <paramref name="first"/>.</param>
+    /// <param name="amount">The pixel adjustment applied when <paramref name="second"/> follows <paramref name="first"/>.</param>
+    public void AddKerningPair(int first, int second, int amount)
+    {
+        if (first < mCharacterInfo.Length)
+        {
+            BitmapCharacterInfo character = mCharacterInfo[first];
+            if (!character.SecondLetterKearning.ContainsKey(second))
+            {
+                character.SecondLetterKearning.Add(second, amount);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces this font's atlas texture pages, e.g. after incremental atlas growth reallocates
+    /// them at a larger size or with an added page. Does not dispose the previous pages -- the
+    /// caller owns their lifetime, matching the <see cref="Texture"/> setter.
+    /// </summary>
+    public void ReplaceTexturePages(Texture2D[] textures)
+    {
+        mTextures = textures;
+
+        mTextureNames = new string[textures.Length];
+        for (int i = 0; i < textures.Length; i++)
+        {
+            mTextureNames[i] = textures[i]?.Name;
+        }
+    }
+
+    /// <summary>
     /// Loads a .fnt file from disk and re-parses the font data, replacing the current character layout.
     /// Does not reload textures.
     /// </summary>

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorGrowthTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Fonts/KernSmithFontCreatorGrowthTests.cs
@@ -1,0 +1,155 @@
+using KernSmith.Gum;
+using KernSmith.Output;
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Fonts;
+
+/// <summary>
+/// Issue #4535 Phase 2 -- <see cref="KernSmithFontCreator.TryAddGlyphs"/> grows a font this creator
+/// already built via <see cref="KernSmithFontCreator.TryCreateFont"/>, blitting new glyph pixels into
+/// the live <see cref="Texture2D"/> instead of a full regenerate. Uses a real <see cref="GraphicsDevice"/>
+/// (mirrors <see cref="KernSmithFontCreatorTests"/>) since this exercises actual texture uploads/reads.
+/// </summary>
+public class KernSmithFontCreatorGrowthTests : BaseTestClass
+{
+    [Fact]
+    public void TryAddGlyphs_AddsANewCharacter_UpdatesMetricsAndBlitsPixels()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+        KernSmithFontCreator creator = new(game.GraphicsDevice);
+
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65"); // just 'A'
+        BitmapFont? font = creator.TryCreateFont(bmfcSave);
+        font.ShouldNotBeNull();
+
+        GlyphAdditionResult? result = creator.TryAddGlyphs(font!, bmfcSave, "B");
+
+        result.ShouldNotBeNull();
+        result!.Added.Select(g => g.Codepoint).ShouldContain((int)'B');
+
+        BitmapCharacterInfo bInfo = font!.GetCharacterInfo('B');
+        bInfo.ShouldNotBeNull();
+        (bInfo.PixelRight - bInfo.PixelLeft).ShouldBeGreaterThan(0, "because 'B' must have real, non-fallback glyph dimensions after growth");
+
+        Texture2D page = font.Textures[0];
+        Color[] pixels = new Color[page.Width * page.Height];
+        page.GetData(pixels);
+        bool anyOpaquePixelInGlyphRegion = false;
+        for (int y = bInfo.PixelTop; y < bInfo.PixelBottom && !anyOpaquePixelInGlyphRegion; y++)
+        {
+            for (int x = bInfo.PixelLeft; x < bInfo.PixelRight; x++)
+            {
+                if (pixels[y * page.Width + x].A > 0)
+                {
+                    anyOpaquePixelInGlyphRegion = true;
+                    break;
+                }
+            }
+        }
+        anyOpaquePixelInGlyphRegion.ShouldBeTrue("because the new glyph's pixel bytes must actually be blitted into the live texture");
+    }
+
+    [Fact]
+    public void TryAddGlyphs_WhenFontWasNotCreatedByThisCreator_ReturnsNull()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+        KernSmithFontCreator creator = new(game.GraphicsDevice);
+
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65");
+        BitmapFont untrackedFont = new BitmapFont((Texture2D)null!, MinimalFontData);
+        untrackedFont.SetFontPattern(256, 256);
+
+        GlyphAdditionResult? result = creator.TryAddGlyphs(untrackedFont, bmfcSave, "B");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryAddGlyphs_WhenAtlasGrows_ReallocatesTextureAndKeepsExistingGlyphPixelPositions()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+        KernSmithFontCreator creator = new(game.GraphicsDevice);
+
+        // A generous font size against a tiny max atlas ceiling forces a Grow on the second add.
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65", fontSize: 48);
+        bmfcSave.OutputWidth = 64;
+        bmfcSave.OutputHeight = 64;
+        BitmapFont? font = creator.TryCreateFont(bmfcSave);
+        font.ShouldNotBeNull();
+
+        BitmapCharacterInfo originalAInfo = font!.GetCharacterInfo('A');
+        int originalPixelLeft = originalAInfo.PixelLeft;
+        int originalPixelTop = originalAInfo.PixelTop;
+        int originalTextureWidth = font.Textures[0].Width;
+
+        bmfcSave.OutputWidth = 4096;
+        bmfcSave.OutputHeight = 4096;
+        GlyphAdditionResult? result = creator.TryAddGlyphs(font, bmfcSave, "WWWWWWWWWWWWWWWW");
+
+        result.ShouldNotBeNull();
+
+        BitmapCharacterInfo rescaledAInfo = font.GetCharacterInfo('A');
+        rescaledAInfo.PixelLeft.ShouldBe(originalPixelLeft, "because a grow must never move an already-placed glyph's pixel position");
+        rescaledAInfo.PixelTop.ShouldBe(originalPixelTop);
+
+        int newTextureWidth = font.Textures[0].Width;
+        newTextureWidth.ShouldBeGreaterThan(originalTextureWidth, "because the atlas must actually have grown to fit the new batch");
+        rescaledAInfo.TULeft.ShouldBe(originalPixelLeft / (float)newTextureWidth, tolerance: 0.0001f,
+            "because 'A's UV must be rescaled against the NEW texture width, not left stale from the old one");
+    }
+
+    // Incremental sessions require font file bytes -- KernSmith's BeginIncremental/ResumeIncremental
+    // have no system-font overload, so growth needs a real .ttf, not a FontName-only system font.
+    private static string FixtureFontPath =>
+        Path.Combine(AppContext.BaseDirectory, "Content", "Fonts", "Orbitron-Black.ttf");
+
+    private static BmfcSave BuildBmfcSave(string ranges, float fontSize = 24) => new BmfcSave
+    {
+        FontName = "Orbitron-Black",
+        FontFile = FixtureFontPath,
+        FontSize = fontSize,
+        UseSmoothing = true,
+        Ranges = ranges,
+    };
+
+    private const string MinimalFontData =
+@"info face=""Arial"" size=-18 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=21 base=17 scaleW=256 scaleH=256 pages=1 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+page id=0 file=""Font18Arial_0.png""
+chars count=1
+char id=65   x=0   y=0   width=10     height=10    xoffset=0    yoffset=0    xadvance=10     page=0  chnl=15
+";
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorIncrementalTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/GumFontGeneratorIncrementalTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Linq;
+using KernSmith;
+using KernSmith.Gum;
+using KernSmith.Output;
+using KernSmith.Output.Model;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Issue #4535 -- KernSmith 0.21.0's <see cref="BmFontIncrementalSession"/> (<see cref="BmFont.BeginIncremental"/>/
+/// <see cref="BmFont.ResumeIncremental"/>) adds glyphs to a live atlas without moving existing ones. These tests
+/// cover <see cref="GumFontGenerator.BeginIncremental"/>/<see cref="GumFontGenerator.ResumeIncremental"/>, the
+/// thin wrappers that map a Gum <see cref="BmfcSave"/> to KernSmith's session entry points the same way
+/// <see cref="GumFontGenerator.Generate"/> maps it for a one-shot atlas.
+/// </summary>
+public class GumFontGeneratorIncrementalTests
+{
+    private static string FixtureFontPath =>
+        Path.Combine(AppContext.BaseDirectory, "Content", "Fonts", "Orbitron-Black.ttf");
+
+    private static BmfcSave BuildBmfcSave(string ranges) => new BmfcSave
+    {
+        FontName = "Orbitron-Black",
+        FontFile = FixtureFontPath,
+        FontSize = 24,
+        UseSmoothing = true,
+        Ranges = ranges,
+    };
+
+    [Fact]
+    public void BeginIncremental_ThenAddGlyphs_ReturnsThePlacedGlyph()
+    {
+        BmfcSave bmfcSave = BuildBmfcSave("65");
+
+        using BmFontIncrementalSession session = GumFontGenerator.BeginIncremental(bmfcSave);
+        GlyphAdditionResult result = session.AddGlyphs("A");
+
+        result.Added.Select(glyph => glyph.Codepoint).ShouldContain((int)'A');
+    }
+
+    [Fact]
+    public void BeginIncremental_WithNoFontFile_ThrowsNotSupportedException()
+    {
+        BmfcSave bmfcSave = new BmfcSave { FontName = "Arial", FontSize = 18, Ranges = "65" };
+
+        Should.Throw<NotSupportedException>(() => GumFontGenerator.BeginIncremental(bmfcSave));
+    }
+
+    [Fact]
+    public void ResumeIncremental_AddsAGlyphNotInTheOriginalGeneration_WithoutMovingExistingGlyphs()
+    {
+        BmfcSave bmfcSave = BuildBmfcSave("65"); // just 'A'
+        BmFontResult generated = GumFontGenerator.Generate(bmfcSave);
+        CharEntry originalA = generated.Model.Characters.Single(character => character.Id == (int)'A');
+
+        using BmFontIncrementalSession session = GumFontGenerator.ResumeIncremental(bmfcSave, generated.Model);
+        GlyphAdditionResult result = session.AddGlyphs("B");
+
+        result.Added.Select(glyph => glyph.Codepoint).ShouldContain((int)'B');
+        session.CurrentModel.Characters.Single(character => character.Id == (int)'A').ShouldBe(originalA,
+            "because resuming and adding a new glyph must not move a glyph already placed (stable packing)");
+    }
+}

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -28,8 +28,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="KernSmith" Version="0.18.2" />
-		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.18.2" />
+		<PackageReference Include="KernSmith" Version="0.21.0" />
+		<PackageReference Include="KernSmith.Rasterizers.FreeType" Version="0.21.0" />
 		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.5" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
Incremental KernSmith bitmap-font atlas growth for #4535 — building blocks plus a working MonoGame implementation, so a font can grow at runtime instead of always baking the full character set upfront. One PR for the whole issue (not split by phase).

- Bumps `KernSmith`/`KernSmith.Rasterizers.FreeType` to 0.21.0 (adds `BmFontIncrementalSession`, kaltinril/Kernsmith#212).
- `GumFontGenerator.BeginIncremental`/`ResumeIncremental` — thin wrappers mapping `BmfcSave` to KernSmith's session entry points, mirroring `Generate`'s option-mapping and browser-wasm guard.
- `BitmapFont.AddOrUpdateCharacter`/`AddKerningPair`/`ReplaceTexturePages`/`RescaleTextureCoordinates` — lets a platform font creator merge a session's `GlyphAdditionResult` into a live `BitmapFont` without a full re-parse, including correctly rescaling existing glyphs' UVs after a page grow (their pixel positions don't move, but the texture-size denominator does).
- `KernSmithFontCreator.TryAddGlyphs` (MonoGame) — resumes an incremental session against a font it previously built, blits new glyph pixels into the live `Texture2D` via `SetData` sub-rectangle writes, reallocates the texture array on a page grow (copying old content), and merges the new character/kerning data into the `BitmapFont` in place.

Nothing calls `TryAddGlyphs` yet — there's no on-demand "grow when a glyph is missing" trigger in `TextRuntime`, and no growth support for `KniGum`/`FnaGum`/`RaylibGum`. That's real, undone scope, so it's split into a follow-up issue rather than left implicit: #4542. It needs its own design pass (opt-in shape, detection timing, oversampling interaction) before building — the design notes gathered while planning this work are carried over there.

## Test plan
- [x] New tests: `BitmapFontTests` (7 new), `GumFontGeneratorIncrementalTests` (3 new, real fixture font through KernSmith 0.21.0), `KernSmithFontCreatorGrowthTests` (3 new, real `GraphicsDevice` — verifies actual pixel bytes land in the texture and a page grow preserves existing glyph pixel positions while rescaling UVs)
- [x] `MonoGameGum.Tests` full suite: 2202 passed
- [x] `MonoGameGum.IntegrationTests` full suite: 94 passed
- [x] `RaylibGum.Tests` full suite: 617 passed
- [x] `GumFull.sln` builds clean, no new warnings
- [x] FRB1 canary (`GumCore.DesktopGlNet6.csproj`) — 0 errors, no new warnings (touches `RenderingLibrary/Graphics/Fonts/BitmapFont.cs`, FRB1-shared source)

Manual test: not needed — nothing in this PR is reachable from a running app yet (no `TextRuntime` trigger exists); it's pure API surface fully covered by the integration tests above, including real GPU texture reads/writes.

Closes #4535 (this PR covers everything currently in scope on it). Remaining work split to #4542.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K6eZaceEZos4GN88Rp5JBc
