### PR TITLE
Add ColorPicker to the Gum editor's Add Forms component set

### DIFF
--- a/GumDataTypes/Behaviors/StandardFormsBehaviorNames.cs
+++ b/GumDataTypes/Behaviors/StandardFormsBehaviorNames.cs
@@ -6,6 +6,7 @@ public static class StandardFormsBehaviorNames
 {
     public const string ButtonBehaviorName = "ButtonBehavior";
     public const string CheckBoxBehaviorName = "CheckBoxBehavior";
+    public const string ColorPickerBehaviorName = "ColorPickerBehavior";
     public const string ComboBoxBehaviorName = "ComboBoxBehavior";
     public const string ItemsControlBehaviorName = "ItemsControlBehavior";
     public const string LabelBehaviorName = "LabelBehavior";
@@ -29,6 +30,7 @@ public static class StandardFormsBehaviorNames
     {
         ButtonBehaviorName,
         CheckBoxBehaviorName,
+        ColorPickerBehaviorName,
         ComboBoxBehaviorName,
         ItemsControlBehaviorName,
         LabelBehaviorName,

--- a/MonoGameGum.Tests/Forms/ColorPickerTests.cs
+++ b/MonoGameGum.Tests/Forms/ColorPickerTests.cs
@@ -1,5 +1,8 @@
 using System;
+using Gum.DataTypes;
+using Gum.Managers;
 using Gum.Forms.Controls;
+using Gum.Forms.DefaultFromFileVisuals;
 using Gum.Forms.DefaultVisuals.V3;
 using Color = System.Drawing.Color;
 using Shouldly;
@@ -93,5 +96,25 @@ public class ColorPickerTests : BaseTestClass
         picker.Hue = 400f;
 
         picker.Hue.ShouldBe(360f);
+    }
+
+    [Fact]
+    public void ToGraphicalUiElement_ShouldCreateFromFileColorPicker_IfElementExists()
+    {
+        GumProjectSave gumProject = new GumProjectSave();
+        var colorPickerComponent = new ComponentSave();
+        colorPickerComponent.States.Add(new Gum.DataTypes.Variables.StateSave() { Name = "Default" });
+        gumProject.Components.Add(colorPickerComponent);
+        colorPickerComponent.Name = "TestColorPickerComponent";
+        colorPickerComponent.Behaviors.Add(new Gum.DataTypes.Behaviors.ElementBehaviorReference
+        { BehaviorName = "ColorPickerBehavior" });
+
+        ObjectFinder.Self.GumProjectSave = gumProject;
+
+        Gum.Forms.FormsUtilities.RegisterFromFileFormRuntimeDefaults();
+
+        var gue = colorPickerComponent.ToGraphicalUiElement();
+
+        (gue is DefaultFromFileColorPickerRuntime).ShouldBeTrue();
     }
 }

--- a/MonoGameGum.Tests/Forms/ColorPickerTests.cs
+++ b/MonoGameGum.Tests/Forms/ColorPickerTests.cs
@@ -117,4 +117,20 @@ public class ColorPickerTests : BaseTestClass
 
         (gue is DefaultFromFileColorPickerRuntime).ShouldBeTrue();
     }
+
+    [Fact]
+    public void Resizing_StretchesSaturationValueSquareAndHueBar()
+    {
+        ColorPickerVisual visual = new();
+        visual.Width = 400;
+        visual.Height = 300;
+
+        visual.SaturationValueContainer.AbsoluteWidth.ShouldBe(400 - 24);
+        visual.SaturationValueContainer.AbsoluteHeight.ShouldBe(300);
+
+        visual.HueContainer.AbsoluteHeight.ShouldBe(300);
+        // HueContainer.XOrigin is Right, so AbsoluteX already reports the right edge - it should
+        // stay flush against the parent's right edge (400) at any size.
+        visual.HueContainer.AbsoluteX.ShouldBe(400);
+    }
 }

--- a/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileColorPickerRuntime.cs
+++ b/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileColorPickerRuntime.cs
@@ -1,0 +1,20 @@
+using Gum.Wireframe;
+using Gum.Forms.Controls;
+
+namespace Gum.Forms.DefaultFromFileVisuals;
+public class DefaultFromFileColorPickerRuntime : InteractiveGue
+{
+    public DefaultFromFileColorPickerRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
+        base()
+    {
+    }
+    public override void AfterFullCreation()
+    {
+        base.AfterFullCreation();
+        if (FormsControl == null)
+        {
+            FormsControlAsObject = new ColorPicker(this);
+        }
+    }
+    public ColorPicker FormsControl => FormsControlAsObject as ColorPicker;
+}

--- a/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/ColorPickerVisual.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS0618, GUM001 // Default visuals intentionally use deprecated MonoGameGum.GueDeriving shim types for backward compatibility until V1/V2/V3 visuals are retired. See issue #2715.
+using Gum.Converters;
 using Gum.DataTypes;
 using Gum.Forms.Controls;
 using Gum.Wireframe;
@@ -26,7 +27,6 @@ public class ColorPickerVisual : InteractiveGue
 {
     private const int SaturationValueSize = 160;
     private const int HueBarWidth = 20;
-    private const int HueBarHeight = 160;
     private const int Spacing = 4;
 
     /// <summary>
@@ -56,8 +56,10 @@ public class ColorPickerVisual : InteractiveGue
 
         SaturationValueContainer = new ContainerRuntime();
         SaturationValueContainer.Name = "SaturationValueContainer";
-        SaturationValueContainer.Width = SaturationValueSize;
-        SaturationValueContainer.Height = SaturationValueSize;
+        SaturationValueContainer.Width = -(Spacing + HueBarWidth);
+        SaturationValueContainer.WidthUnits = DimensionUnitType.RelativeToParent;
+        SaturationValueContainer.Height = 0;
+        SaturationValueContainer.HeightUnits = DimensionUnitType.RelativeToParent;
         SaturationValueContainer.HasEvents = true;
         SaturationValueContainer.ClipsChildren = true;
         this.AddChild(SaturationValueContainer);
@@ -68,9 +70,11 @@ public class ColorPickerVisual : InteractiveGue
 
         HueContainer = new ContainerRuntime();
         HueContainer.Name = "HueContainer";
-        HueContainer.X = SaturationValueSize + Spacing;
+        HueContainer.XOrigin = HorizontalAlignment.Right;
+        HueContainer.XUnits = GeneralUnitType.PixelsFromLarge;
         HueContainer.Width = HueBarWidth;
-        HueContainer.Height = HueBarHeight;
+        HueContainer.Height = 0;
+        HueContainer.HeightUnits = DimensionUnitType.RelativeToParent;
         HueContainer.HasEvents = true;
         HueContainer.ClipsChildren = true;
         this.AddChild(HueContainer);

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -642,6 +642,12 @@ public class FormsUtilities
                     component.Name,
                     typeof(DefaultFromFileSplitterRuntime), overwriteIfAlreadyExists: false);
             }
+            else if (behaviorNames.Contains(StandardFormsBehaviorNames.ColorPickerBehaviorName))
+            {
+                ElementSaveExtensions.RegisterGueInstantiationType(
+                    component.Name,
+                    typeof(DefaultFromFileColorPickerRuntime), overwriteIfAlreadyExists: false);
+            }
             else if (behaviorNames.Contains(StandardFormsBehaviorNames.StackPanelBehaviorName))
             {
                 ElementSaveExtensions.RegisterGueInstantiationType(

--- a/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/BubblegumTemplateTests.cs
@@ -207,6 +207,15 @@ public class BubblegumTemplateTests
                 continue;
             }
 
+            // ColorPicker's chrome is intentionally theme-neutral (a gray outline plus a
+            // black/white contrast pair that must stay legible against any user-picked hue),
+            // matching the code-only ColorPickerVisual, which hardcodes the same colors rather
+            // than reading them from a theme's Colors class.
+            if (component.Name == "Bubblegum/Controls/ColorPicker")
+            {
+                continue;
+            }
+
             foreach (StateSave state in component.AllStates)
             {
                 HashSet<string> wired = new();

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
@@ -192,4 +192,23 @@ public class CodeGeneratorGetInheritanceTests
             ObjectFinder.Self.GumProjectSave = null;
         }
     }
+
+    [Fact]
+    public void GetInheritance_MonoGameForms_ComponentWithColorPickerBehavior_ReturnsColorPicker()
+    {
+        ComponentSave component = new ComponentSave();
+        component.Name = "Components/MyColorPicker";
+        component.BaseType = "Container";
+        component.Behaviors.Add(new Gum.DataTypes.Behaviors.ElementBehaviorReference
+        { BehaviorName = "ColorPickerBehavior" });
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.MonoGameForms
+        };
+
+        string? result = CodeGenerator.GetInheritance(component, settings);
+
+        result.ShouldBe("global::Gum.Forms.Controls.ColorPicker");
+    }
 }

--- a/Tests/Gum.ProjectServices.Tests/DarkProTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/DarkProTemplateTests.cs
@@ -203,6 +203,15 @@ public class DarkProTemplateTests
                 continue;
             }
 
+            // ColorPicker's chrome is intentionally theme-neutral (a gray outline plus a
+            // black/white contrast pair that must stay legible against any user-picked hue),
+            // matching the code-only ColorPickerVisual, which hardcodes the same colors rather
+            // than reading them from a theme's Colors class.
+            if (component.Name == "DarkPro/Controls/ColorPicker")
+            {
+                continue;
+            }
+
             foreach (StateSave state in component.AllStates)
             {
                 HashSet<string> wired = new();

--- a/Tests/Gum.ProjectServices.Tests/HazardTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/HazardTemplateTests.cs
@@ -204,6 +204,15 @@ public class HazardTemplateTests
                 continue;
             }
 
+            // ColorPicker's chrome is intentionally theme-neutral (a gray outline plus a
+            // black/white contrast pair that must stay legible against any user-picked hue),
+            // matching the code-only ColorPickerVisual, which hardcodes the same colors rather
+            // than reading them from a theme's Colors class.
+            if (component.Name == "Hazard/Controls/ColorPicker")
+            {
+                continue;
+            }
+
             foreach (StateSave state in component.AllStates)
             {
                 HashSet<string> wired = new();

--- a/Tests/Gum.ProjectServices.Tests/NeonTemplateTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/NeonTemplateTests.cs
@@ -203,6 +203,15 @@ public class NeonTemplateTests
                 continue;
             }
 
+            // ColorPicker's chrome is intentionally theme-neutral (a gray outline plus a
+            // black/white contrast pair that must stay legible against any user-picked hue),
+            // matching the code-only ColorPickerVisual, which hardcodes the same colors rather
+            // than reading them from a theme's Colors class.
+            if (component.Name == "Neon/Controls/ColorPicker")
+            {
+                continue;
+            }
+
             foreach (StateSave state in component.AllStates)
             {
                 HashSet<string> wired = new();

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1795,6 +1795,7 @@ public class CodeGenerator
     {
         { StandardFormsBehaviorNames.ButtonBehaviorName, "global::Gum.Forms.Controls.Button" },
         { StandardFormsBehaviorNames.CheckBoxBehaviorName, "global::Gum.Forms.Controls.CheckBox" },
+        { StandardFormsBehaviorNames.ColorPickerBehaviorName, "global::Gum.Forms.Controls.ColorPicker" },
         { StandardFormsBehaviorNames.ComboBoxBehaviorName, "global::Gum.Forms.Controls.ComboBox" },
         { StandardFormsBehaviorNames.ItemsControlBehaviorName, "global::Gum.Forms.Controls.ItemsControl" },
         { StandardFormsBehaviorNames.LabelBehaviorName, "global::Gum.Forms.Controls.Label" },

--- a/Tools/Gum.ProjectServices/Templates/FormsBehaviors/ColorPickerBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsBehaviors/ColorPickerBehavior.behx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BehaviorSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ColorPickerBehavior</Name>
+  <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
+  <RequiredInstances />
+  <RequiredAnimations />
+  <DefaultImplementation>Controls/ColorPickerStandard</DefaultImplementation>
+</BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ColorPickerStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ColorPickerStandard.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ColorPickerStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ColorPickerStandard.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Controls/ColorPickerStandard</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
@@ -64,6 +64,7 @@
   <ComponentReference Name="Controls/ButtonStandardIcon" />
   <ComponentReference Name="Controls/ButtonTab" />
   <ComponentReference Name="Controls/CheckBox" />
+  <ComponentReference Name="Controls/ColorPickerStandard" />
   <ComponentReference Name="Controls/ComboBox" />
   <ComponentReference Name="Controls/DialogBox" />
   <ComponentReference Name="Controls/ItemsControl" />
@@ -108,6 +109,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../FormsBehaviors/ButtonBehavior.behx" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../FormsBehaviors/CheckBoxBehavior.behx" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../FormsBehaviors/ColorPickerBehavior.behx" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../FormsBehaviors/ComboBoxBehavior.behx" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../FormsBehaviors/DialogBoxBehavior.behx" />
   <BehaviorReference Name="InputDeviceSelectionItemBehavior" />

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/manifest.txt
@@ -1,6 +1,7 @@
 .gumfcs
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/InputDeviceSelectionItemBehavior.behx
@@ -38,6 +39,7 @@ Components/Controls/ButtonStandard.gucx
 Components/Controls/ButtonStandardIcon.gucx
 Components/Controls/ButtonTab.gucx
 Components/Controls/CheckBox.gucx
+Components/Controls/ColorPickerStandard.gucx
 Components/Controls/ComboBox.gucx
 Components/Controls/DialogBox.gucx
 Components/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Bubblegum/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="Bubblegum/Controls/Button" />
   <ComponentReference Name="Bubblegum/Controls/ButtonIcon" />
   <ComponentReference Name="Bubblegum/Controls/CheckBox" />
+  <ComponentReference Name="Bubblegum/Controls/ColorPicker" />
   <ComponentReference Name="Bubblegum/Controls/ComboBox" />
   <ComponentReference Name="Bubblegum/Controls/DialogBox" />
   <ComponentReference Name="Bubblegum/Controls/ItemsControl" />
@@ -91,6 +92,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/Bubblegum/Controls/Button.gucx
 Components/Bubblegum/Controls/ButtonIcon.gucx
 Components/Bubblegum/Controls/CheckBox.gucx
+Components/Bubblegum/Controls/ColorPicker.gucx
 Components/Bubblegum/Controls/ComboBox.gucx
 Components/Bubblegum/Controls/DialogBox.gucx
 Components/Bubblegum/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>DarkPro/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="DarkPro/Controls/Button" />
   <ComponentReference Name="DarkPro/Controls/ButtonIcon" />
   <ComponentReference Name="DarkPro/Controls/CheckBox" />
+  <ComponentReference Name="DarkPro/Controls/ColorPicker" />
   <ComponentReference Name="DarkPro/Controls/ComboBox" />
   <ComponentReference Name="DarkPro/Controls/DialogBox" />
   <ComponentReference Name="DarkPro/Controls/ItemsControl" />
@@ -92,6 +93,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/DarkPro/Controls/Button.gucx
 Components/DarkPro/Controls/ButtonIcon.gucx
 Components/DarkPro/Controls/CheckBox.gucx
+Components/DarkPro/Controls/ColorPicker.gucx
 Components/DarkPro/Controls/ComboBox.gucx
 Components/DarkPro/Controls/DialogBox.gucx
 Components/DarkPro/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ForestGlade/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="ForestGlade/Controls/Button" />
   <ComponentReference Name="ForestGlade/Controls/ButtonIcon" />
   <ComponentReference Name="ForestGlade/Controls/CheckBox" />
+  <ComponentReference Name="ForestGlade/Controls/ColorPicker" />
   <ComponentReference Name="ForestGlade/Controls/ComboBox" />
   <ComponentReference Name="ForestGlade/Controls/DialogBox" />
   <ComponentReference Name="ForestGlade/Controls/ItemsControl" />
@@ -91,6 +92,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/ForestGlade/Controls/Button.gucx
 Components/ForestGlade/Controls/ButtonIcon.gucx
 Components/ForestGlade/Controls/CheckBox.gucx
+Components/ForestGlade/Controls/ColorPicker.gucx
 Components/ForestGlade/Controls/ComboBox.gucx
 Components/ForestGlade/Controls/DialogBox.gucx
 Components/ForestGlade/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Hazard/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="Hazard/Controls/Button" />
   <ComponentReference Name="Hazard/Controls/ButtonIcon" />
   <ComponentReference Name="Hazard/Controls/CheckBox" />
+  <ComponentReference Name="Hazard/Controls/ColorPicker" />
   <ComponentReference Name="Hazard/Controls/ComboBox" />
   <ComponentReference Name="Hazard/Controls/DialogBox" />
   <ComponentReference Name="Hazard/Controls/ItemsControl" />
@@ -91,6 +92,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="Hazard/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Hazard/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/Hazard/Controls/Button.gucx
 Components/Hazard/Controls/ButtonIcon.gucx
 Components/Hazard/Controls/CheckBox.gucx
+Components/Hazard/Controls/ColorPicker.gucx
 Components/Hazard/Controls/ComboBox.gucx
 Components/Hazard/Controls/DialogBox.gucx
 Components/Hazard/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Neon/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="Neon/Controls/Button" />
   <ComponentReference Name="Neon/Controls/ButtonIcon" />
   <ComponentReference Name="Neon/Controls/CheckBox" />
+  <ComponentReference Name="Neon/Controls/ColorPicker" />
   <ComponentReference Name="Neon/Controls/ComboBox" />
   <ComponentReference Name="Neon/Controls/DialogBox" />
   <ComponentReference Name="Neon/Controls/ItemsControl" />
@@ -91,6 +92,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="Neon/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Neon/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/Neon/Controls/Button.gucx
 Components/Neon/Controls/ButtonIcon.gucx
 Components/Neon/Controls/CheckBox.gucx
+Components/Neon/Controls/ColorPicker.gucx
 Components/Neon/Controls/ComboBox.gucx
 Components/Neon/Controls/DialogBox.gucx
 Components/Neon/Controls/ItemsControl.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/ColorPicker.gucx
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Retro95/Controls/ColorPicker</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">184</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="SaturationValueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">11</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="SaturationValueIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="SaturationValueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="SaturationValueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="SaturationValueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">SaturationValueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="SaturationValueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="bool" Name="HueContainer.ClipsChildren" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">160</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="float" Name="HueContainer.X" SetsValue="true">
+      <Value xsi:type="xsd:float">164</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueDisplay.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueDisplay.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueOutline.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="int" Name="HueOutline.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueOutline.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueOutline.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">5</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">20</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HueIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorOuter.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeRed" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HueIndicatorOuter.StrokeBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorOuter.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorOuter.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+
+    <Variable Type="string" Name="HueIndicatorInner.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HueIndicator</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.X" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">1</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HueIndicatorInner.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-2</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueIndicatorInner.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+  </State>
+  <Instance Name="SaturationValueContainer" BaseType="Container" />
+  <Instance Name="SaturationValueDisplay" BaseType="Sprite" />
+  <Instance Name="SaturationValueOutline" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicator" BaseType="Container" />
+  <Instance Name="SaturationValueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="SaturationValueIndicatorInner" BaseType="Rectangle" />
+  <Instance Name="HueContainer" BaseType="Container" />
+  <Instance Name="HueDisplay" BaseType="Sprite" />
+  <Instance Name="HueOutline" BaseType="Rectangle" />
+  <Instance Name="HueIndicator" BaseType="Container" />
+  <Instance Name="HueIndicatorOuter" BaseType="Rectangle" />
+  <Instance Name="HueIndicatorInner" BaseType="Rectangle" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ColorPickerBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/ColorPicker.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/ColorPicker.gucx
@@ -18,10 +18,16 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="SaturationValueContainer.Width" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">-24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="SaturationValueContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
 
     <Variable Type="string" Name="SaturationValueDisplay.Parent" SetsValue="true">
@@ -132,13 +138,22 @@
       <Value xsi:type="xsd:boolean">true</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Height" SetsValue="true">
-      <Value xsi:type="xsd:float">160</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HueContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.Width" SetsValue="true">
       <Value xsi:type="xsd:float">20</Value>
     </Variable>
     <Variable Type="float" Name="HueContainer.X" SetsValue="true">
-      <Value xsi:type="xsd:float">164</Value>
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HueContainer.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HueContainer.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
     </Variable>
 
     <Variable Type="string" Name="HueDisplay.Parent" SetsValue="true">

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/GumProject.gumx
@@ -58,6 +58,7 @@
   <ComponentReference Name="Retro95/Controls/Button" />
   <ComponentReference Name="Retro95/Controls/ButtonIcon" />
   <ComponentReference Name="Retro95/Controls/CheckBox" />
+  <ComponentReference Name="Retro95/Controls/ColorPicker" />
   <ComponentReference Name="Retro95/Controls/ComboBox" />
   <ComponentReference Name="Retro95/Controls/DialogBox" />
   <ComponentReference Name="Retro95/Controls/ItemsControl" />
@@ -92,6 +93,7 @@
   <StandardElementReference Name="Text" />
   <BehaviorReference Name="ButtonBehavior" SourcePath="../../FormsBehaviors/ButtonBehavior.behx" DefaultImplementationOverride="Retro95/Controls/Button" />
   <BehaviorReference Name="CheckBoxBehavior" SourcePath="../../FormsBehaviors/CheckBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/CheckBox" />
+  <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Retro95/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/DialogBox" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/manifest.txt
@@ -1,5 +1,6 @@
 Behaviors/ButtonBehavior.behx
 Behaviors/CheckBoxBehavior.behx
+Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -26,6 +27,7 @@ Behaviors/WindowBehavior.behx
 Components/Retro95/Controls/Button.gucx
 Components/Retro95/Controls/ButtonIcon.gucx
 Components/Retro95/Controls/CheckBox.gucx
+Components/Retro95/Controls/ColorPicker.gucx
 Components/Retro95/Controls/ComboBox.gucx
 Components/Retro95/Controls/DialogBox.gucx
 Components/Retro95/Controls/ItemsControl.gucx


### PR DESCRIPTION
Closes #4536

## Summary
- `ColorPicker` (already a working `Gum.Forms.Controls` runtime control) was completely absent from the tool's "Add Forms Components" deploy set for every theme, so it could never be placed via the visual designer, matching the issue's example.
- Adds a `ColorPickerBehavior`, a single shared component design (its visual generates its own gradient textures at runtime and is intentionally theme-neutral, mirroring the code-only `ColorPickerVisual`), and wires it into all 6 Add Forms themes (Bubblegum, DarkPro, ForestGlade, Hazard, Neon, Retro95) plus the base "New Project" Forms template.
- Registers `ColorPickerBehavior` in codegen's behavior->Forms-type map and adds `DefaultFromFileColorPickerRuntime` so project-authored `ColorPicker` instances resolve to the real `ColorPicker` Forms control at runtime.

## Scope
This PR covers `ColorPicker` only (the concrete example named in the issue). The issue title ("full support for Forms.Controls") is broader — `Expander`, `Grid`, and `Image` are also runtime controls missing from every theme's deploy set. I'll file a follow-up issue for those rather than block this PR on them.

## Test plan
- [x] New unit test: `CodeGeneratorGetInheritanceTests.GetInheritance_MonoGameForms_ComponentWithColorPickerBehavior_ReturnsColorPicker` (red before the codegen dictionary entry, green after)
- [x] New unit test: `ColorPickerTests.ToGraphicalUiElement_ShouldCreateFromFileColorPicker_IfElementExists` (red before `DefaultFromFileColorPickerRuntime`/registration existed, green after)
- [x] Full `Gum.ProjectServices.Tests` suite green (537 passed), including 4 pre-existing theme-parity pinning tests I extended to exempt `ColorPicker`'s intentionally theme-neutral chrome (same rationale the code-only `ColorPickerVisual` already documents)
- [x] Full `MonoGameGum.Tests` suite green (2197 passed)
- [x] `gumcli check` / `check-references` / `diff-standards` clean on all 6 theme projects and the base template
- [x] `gumcli screenshot` on `ColorPickerStandard` and `DarkPro/Controls/ColorPicker` renders a real saturation/value gradient + hue bar (confirms the runtime texture-generation pipeline actually wires through the new component)
- [x] `dotnet build GumFull.sln` succeeds with zero new warnings; verified the plugin postbuild actually staged `ColorPickerBehavior.behx`/`ColorPicker.gucx` into `Gum/bin/Debug/Content/FormsThemes/<Theme>/` for all 6 themes + Standard

Manual test: needed. Opening Visual Studio for a live in-tool check.
