### PR TITLE
Document texture-level batch sorting (BatchSortKey, DrawCallCount)

### DIFF
--- a/docs/code/performance-and-optimization/batchkeygroupedorderer.md
+++ b/docs/code/performance-and-optimization/batchkeygroupedorderer.md
@@ -2,18 +2,26 @@
 
 ### Introduction
 
-Gum's default renderer walks the visual tree in depth-first order and emits one draw per renderable. When two adjacent renderables go through different batchers — for example, a `SpriteRuntime` (which uses `SpriteBatch`) followed by a Gum.Shapes shape (which uses Apos.Shapes) — the renderer must end one batch and begin another. A scene that alternates between these types ends up with a batch transition on nearly every draw.
+Gum's default renderer walks the visual tree in depth-first order and emits one draw per renderable. Two kinds of alternation force extra work when adjacent renderables don't match:
 
-`BatchKeyGroupedOrderer` is an opt-in alternative ordering strategy that reorders draws within layer- and clip-bounded windows so that runs of the same `BatchKey` become contiguous. This collapses the per-alternation transitions to roughly one per distinct batch type in the scene.
+* **Different batcher.** A `SpriteRuntime` (which uses `SpriteBatch`) next to a Gum.Shapes shape (which uses Apos.Shapes) forces the renderer to end one batch and begin another. A scene that alternates between these types ends up with a batch transition on nearly every draw.
+* **Same batcher, different texture.** A `NineSliceRuntime` frame next to a `TextRuntime` label both use `SpriteBatch`, so no batch transition happens, but they draw from different textures. `SpriteBatch` only merges *consecutive* draws that share a texture, so alternating frame-then-text-then-frame still costs one GPU draw call per element.
+
+`BatchKeyGroupedOrderer` is an opt-in alternative ordering strategy that reorders draws within layer- and clip-bounded windows so that runs sharing the same batcher, and within that the same texture, become contiguous. This collapses both kinds of alternation down to roughly one draw call per distinct batcher/texture combination in the scene.
+
+{% hint style="info" %}
+The batcher-level grouping described here has been available for a while. The texture-level grouping (the "How it groups draws" section below, `BatchSortKey`, and `RenderStateChangeStatistics.DrawCallCount`) is available in September 2026, or now if building Gum from source.
+{% endhint %}
 
 ### When to use it
 
 The default `HierarchicalOrderer` is correct and fast. The grouped orderer helps when:
 
-* Your scene mixes batch types the user can't unify with atlas tricks — most commonly `SpriteBatch` (sprite/text/nineslice/solid rectangle) combined with Gum.Shapes shapes (`CircleRuntime`, `RectangleRuntime`, etc.).
+* Your scene mixes batch types the user can't unify with atlas tricks, most commonly `SpriteBatch` (sprite/text/nineslice/solid rectangle) combined with Gum.Shapes shapes (`CircleRuntime`, `RectangleRuntime`, etc.).
 * You're seeing a `SpriteBatch.Begin` count that scales with the number of items in a list or grid rather than with the number of distinct textures.
+* You have a list or grid whose rows mix textures under a single batcher, such as a `NineSliceRuntime` frame with a `TextRuntime` label on top, and the GPU draw-call count scales with the row count instead of the number of distinct textures on screen.
 
-Within `SpriteBatch` alone, you can usually reduce flushes yourself by packing fonts and sprites into one atlas (see [SinglePixelTexture](singlepixeltexture.md)). Cross-batcher alternation has no such workaround — that's the case this orderer exists to fix.
+Within `SpriteBatch` alone, you can also reduce draw calls by packing fonts and sprites into one atlas (see [SinglePixelTexture](singlepixeltexture.md)); an atlas removes the alternation entirely, so it wins over grouping when it's practical. Reach for the grouped orderer when an atlas isn't practical (mixed art sources, dynamically loaded textures) or when the alternation crosses batchers, which no atlas can fix.
 
 ### Choosing an orderer
 
@@ -21,10 +29,10 @@ Within `SpriteBatch` alone, you can usually reduce flushes yourself by packing f
 
 | Set `Renderer.SiblingOrdering` to | What it does |
 |---|---|
-| `HierarchicalOrderer.Instance` *(default)* | Depth-first walk, one draw per renderable in tree order. No reordering — this is the order Gum has always used. |
-| `BatchKeyGroupedOrderer.Instance` | Reorders draws within layer- and clip-bounded windows so same-`BatchKey` runs become contiguous, cutting batch flushes. Output is pixel-identical to the default. |
+| `HierarchicalOrderer.Instance` *(default)* | Depth-first walk, one draw per renderable in tree order. No reordering, this is the order Gum has always used. |
+| `BatchKeyGroupedOrderer.Instance` | Reorders draws within layer- and clip-bounded windows so matching draws become contiguous, cutting both batch flushes and GPU draw calls. Output is pixel-identical to the default. |
 
-Note that the default and the opt-in are **different** types — `HierarchicalOrderer` versus `BatchKeyGroupedOrderer`. Assign the grouped one to turn the optimization on:
+Note that the default and the opt-in are **different** types, `HierarchicalOrderer` versus `BatchKeyGroupedOrderer`. Assign the grouped one to turn the optimization on:
 
 ```csharp
 // Initialize
@@ -33,6 +41,17 @@ RenderingLibrary.Graphics.Renderer.SiblingOrdering =
 ```
 
 To switch back, assign `HierarchicalOrderer.Instance`. You can flip the property at any time; no teardown is required, and the next frame uses the new orderer.
+
+### How it groups draws
+
+The orderer sorts on two levels:
+
+1. **Batcher first.** Every renderable reports a `BatchKey` string identifying which batcher it draws with (`"SpriteBatch"` or the Apos.Shapes key). The orderer keeps same-`BatchKey` draws together first, so `SpriteBatch` work and shape work each land in one contiguous run.
+2. **Texture within that.** Renderables that draw from a texture also report a `BatchSortKey`, typically the `Texture2D` they use. Within a `BatchKey` run, the orderer further groups draws that share the same `BatchSortKey`, so all the frame draws land together and all the text draws land together.
+
+`Sprite` and `NineSlice` report their texture as their `BatchSortKey`. `Text` reports its font's texture when it renders character-by-character (the default text rendering mode); text rendered through a cached render target or an XNA `SpriteFont` has no exposed texture reference and falls back to no finer grouping. A renderable with no `BatchSortKey` still groups correctly by `BatchKey`, it just doesn't get the finer texture-level pass.
+
+You don't need to set `BatchSortKey` yourself. It's a read-only hint the built-in renderables already provide; it exists for the orderer to read, not for game code to assign.
 
 ### What it preserves
 
@@ -45,15 +64,22 @@ The grouped orderer is pixel-correct for any scene the default orderer renders c
 
 ### Trade-offs
 
-* The orderer runs per layer per frame and builds an overlap graph between renderables in each reorder window. The cost is `O(n²)` in the number of renderables in the window. For typical UI scenes this is negligible; for windows with thousands of renderables, profile before assuming it's free.
-* The first-pass scope keys only on the existing `BatchKey` string. Finer texture-level grouping inside a single batch type is a possible future optimization.
+The orderer runs per layer per frame and builds an overlap graph between renderables in each reorder window. The cost is `O(n²)` in the number of renderables in the window. For typical UI scenes this is negligible; for windows with thousands of renderables, profile before assuming it's free.
 
 ### Measuring the win
 
-Use [LastFrameDrawStates](lastframedrawstates.md) to count `SpriteBatch.Begin` calls before and after enabling the orderer. The grouped orderer should reduce the count substantially on any scene that mixes `SpriteBatch` and Apos.Shapes work; it should leave a single-batcher scene unchanged.
+The two cases the orderer targets show up in different diagnostics, because only one of them changes how many times `SpriteBatch.Begin` is called:
 
-Before reaching for the orderer, confirm it can actually help: call `Renderer.GetDrawStateSummary` (see [Summarizing by cause](lastframedrawstates.md#summarizing-by-cause)) and look at the `Apos.Shapes ShapeBatch.Begin(s)` row. The orderer only collapses alternation between the `SpriteBatch` and Apos.Shapes batchers, so if that row is near zero, your begins come from clipping or texture sets instead — and the orderer will leave the count unchanged no matter what. In that case, reduce `ClipsChildren` usage or atlas your textures rather than switching orderers.
+* **Cross-batcher alternation** (`SpriteBatch` next to Apos.Shapes) reduces the `SpriteBatch.Begin` count. Use [LastFrameDrawStates](lastframedrawstates.md) or `Renderer.GetDrawStateSummary` to count begins before and after enabling the orderer.
+* **Same-batcher, different-texture alternation** never changes the `SpriteBatch.Begin` count, since both renderables already share the `SpriteBatch` batch. The win is fewer actual GPU draw calls inside that one batch. Measure it with `RenderStateChangeStatistics.DrawCallCount` (see [Measuring GPU draw calls](lastframedrawstates.md#measuring-gpu-draw-calls-drawcallcount)), or watch `GetDrawStateSummary`'s `TextureSetCount` drop.
+
+Before reaching for the orderer, confirm it can actually help. Call `Renderer.GetDrawStateSummary` (see [Summarizing by cause](lastframedrawstates.md#summarizing-by-cause)) and check two rows:
+
+* **`Apos.Shapes ShapeBatch.Begin(s)`:** if this is near zero, your scene has no cross-batcher alternation to collapse.
+* **Texture sets within batches:** if this is near zero, your scene has no same-batcher texture alternation to collapse either.
+
+If both rows are low, your begins come from clipping instead, and the orderer will leave your draw-call count unchanged no matter what. In that case, reduce `ClipsChildren` usage rather than switching orderers.
 
 {% hint style="info" %}
-`LastFrameDrawStates` only sees `SpriteBatch.Begin` calls. Apos.Shapes batch starts are not counted, so the total batch count is higher than the reported number. The orderer's effect on `SpriteBatch.Begin` is still a useful proxy for the overall trend.
+`LastFrameDrawStates` only sees `SpriteBatch.Begin` calls. Apos.Shapes batch starts are not counted there, so the total batch count is higher than the reported number. `RenderStateChangeStatistics.DrawCallCount` is backend-neutral and counts every actual GPU draw call, including Apos.Shapes ones, so prefer it when you want a single before/after number.
 {% endhint %}

--- a/docs/code/performance-and-optimization/lastframedrawstates.md
+++ b/docs/code/performance-and-optimization/lastframedrawstates.md
@@ -114,10 +114,26 @@ Draw State Summary: 120 SpriteBatch.Begin(s)
 
 Use the breakdown to decide where to spend effort:
 
-* **Clip changes dominate** — each `ClipsChildren` container forces a begin on entry and another on exit. Forms controls add clipping containers freely, so a list or grid with many clipping items drives this number up. Reduce it by removing `ClipsChildren` where it isn't needed.
-* **Texture sets are high** — pack sprites, fonts, and the single-pixel texture onto shared PNGs (see [SinglePixelTexture](singlepixeltexture.md)).
-* **`Apos.Shapes` is high** — your scene mixes the `SpriteBatch` and Apos.Shapes batchers, which is the case [BatchKeyGroupedOrderer](batchkeygroupedorderer.md) targets. `SpriteBatch.Begin` counts (the other rows, and the total reported by `LastFrameDrawStates`) do not include Apos.Shapes begins, so this row is the only one the grouped orderer can reduce.
+* **Clip changes dominate:** each `ClipsChildren` container forces a begin on entry and another on exit. Forms controls add clipping containers freely, so a list or grid with many clipping items drives this number up. Reduce it by removing `ClipsChildren` where it isn't needed.
+* **Texture sets are high:** pack sprites, fonts, and the single-pixel texture onto shared PNGs (see [SinglePixelTexture](singlepixeltexture.md)). When an atlas isn't practical, opt into [BatchKeyGroupedOrderer](batchkeygroupedorderer.md) instead: it reorders draws so same-texture items become contiguous, which lets `SpriteBatch`'s own batching merge them without lowering the `SpriteBatch.Begin` count.
+* **`Apos.Shapes` is high:** your scene mixes the `SpriteBatch` and Apos.Shapes batchers, which is the other case [BatchKeyGroupedOrderer](batchkeygroupedorderer.md) targets. `SpriteBatch.Begin` counts (the other rows, and the total reported by `LastFrameDrawStates`) do not include Apos.Shapes begins, so this row is the only one that reflects cross-batcher cost.
 
 {% hint style="info" %}
 The clip-versus-state split is a heuristic. Clip-exit begins are identified exactly; clip-enter begins are inferred from whether the begin's renderable clips its children. A renderable that both clips and changes a non-clip state in the same begin is counted as a clip change. The totals are exact; only the clip/state attribution is approximate.
+{% endhint %}
+
+### Measuring GPU draw calls (DrawCallCount)
+
+`SpriteBatch.Begin` counts and texture-set counts are both proxies for cost. `Renderer.RenderStateChangeStatistics.DrawCallCount` is the actual number, a backend-neutral count of GPU draw calls for the frame, covering `SpriteBatch` and Apos.Shapes work alike. Use it when you want one number to compare before and after a change, such as toggling `BatchKeyGroupedOrderer` on a scene where the alternating renderables already share a `BatchKey` and won't move the begin count at all.
+
+```csharp
+// Draw
+int drawCalls = SystemManagers.Default.Renderer.RenderStateChangeStatistics.DrawCallCount;
+System.Diagnostics.Debug.WriteLine($"Draw calls last frame: {drawCalls}");
+```
+
+`DrawCallCount` resets at the start of every `Draw` call, so read it after `GumUI.Draw()` to see the count for the frame that just rendered.
+
+{% hint style="info" %}
+`DrawCallCount` is wired for MonoGame, KNI, and raylib. It stays at `0` on FNA and Skia until those backends wire up the same counter. It's available in September 2026, or now if building Gum from source.
 {% endhint %}


### PR DESCRIPTION
#4543 added texture-level grouping to BatchKeyGroupedOrderer (BatchSortKey) and RenderStateChangeStatistics.DrawCallCount, but only touched the AI-facing gum-monogame-rendering skill, not the published docs. Updates batchkeygroupedorderer.md and lastframedrawstates.md to cover the same-batcher/different-texture case and how to measure it (DrawCallCount, since SpriteBatch.Begin count doesn't move for this case). Flagged as September 2026/build-from-source in a hint block per the docs-writing skill's release-status convention.

Manual test: not needed, docs-only change.