### PR TITLE
Fix double Content/ prefix loading screens on Android/iOS

### DIFF
--- a/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
+++ b/MonoGameGum.Tests/DataTypes/GumProjectSaveTests.cs
@@ -1,4 +1,5 @@
-﻿using Gum.DataTypes;
+﻿using Gum.Bundle;
+using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using RenderingLibrary;
 using Shouldly;
@@ -304,6 +305,81 @@ public class GumProjectSaveTests : BaseTestClass
         finally
         {
             FileManager.RelativeDirectory = originalRelativeDirectory;
+        }
+    }
+
+    // Repro for #4548: on Android/iOS, FileManager has no filesystem root to detect an
+    // already-resolved path, so it marks one by a leading "./" instead. GumBundleLoader.Resolve
+    // absolutizes the project path once and hands GumProjectSave.Load a "./Content/..."-marked
+    // path; per-screen loads inherit that same marker through projectRootDirectory. But
+    // FileManager.XmlDeserialize strips the "./" marker (TitleContainer rejects it) *before*
+    // calling GetStreamForFile, which then sees an unmarked, "looks relative again" path and
+    // re-prepends RelativeDirectory - doubling the Content/ prefix.
+    [Fact]
+    public void Load_OnMobilePlatform_DoesNotDoublePrefixRelativeDirectoryForScreenReferences()
+    {
+        bool? originalIsMobileOverride = FileManager.IsMobileOverride;
+        string originalRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream> originalCustomGetStreamFromFile = FileManager.CustomGetStreamFromFile;
+
+        FileManager.IsMobileOverride = true;
+        FileManager.RelativeDirectory = "Content/";
+
+        const string projectXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <GumProjectSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <ScreenReference>
+                <ElementType>Screen</ElementType>
+                <LinkType>ReferenceOriginal</LinkType>
+                <Name>OpeningScreen</Name>
+              </ScreenReference>
+            </GumProjectSave>
+            """;
+        const string screenXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <ScreenSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>OpeningScreen</Name>
+            </ScreenSave>
+            """;
+
+        // Keyed exactly like real Android asset paths (no leading "./"), matching how
+        // RenderingLibrary.SystemManagers' real CustomGetStreamFromFile hook strips "./"
+        // immediately before calling TitleContainer.OpenStream.
+        Dictionary<string, string> files = new Dictionary<string, string>
+        {
+            ["Content/GumProject/Gum.gumx"] = projectXml,
+            ["Content/GumProject/Screens/OpeningScreen.gusx"] = screenXml,
+        };
+
+        FileManager.CustomGetStreamFromFile = path =>
+        {
+            // Real Android/iOS always use forward slashes; normalize here purely because this test
+            // forces IsMobileOverride while still running on a Windows/Unix desktop CLR, where
+            // Path.DirectorySeparatorChar (used internally by FileManager) can still be '\'.
+            string normalized = path.Replace('\\', '/');
+            string stripped = normalized.StartsWith("./") ? normalized.Substring(2) : normalized;
+            if (!files.TryGetValue(stripped, out string content))
+            {
+                throw new FileNotFoundException(path);
+            }
+            return new MemoryStream(Encoding.UTF8.GetBytes(content));
+        };
+
+        try
+        {
+            ProjectResolution resolution = GumBundleLoader.Resolve("GumProject/Gum.gumx");
+            GumProjectSave project = GumProjectSave.Load(resolution.ResolvedGumxPath, out GumLoadResult loadResult);
+
+            loadResult.ErrorMessage.ShouldBeNullOrEmpty();
+            loadResult.MissingFiles.ShouldBeEmpty();
+            project.ShouldNotBeNull();
+            project!.Screens.ShouldContain(s => s.Name == "OpeningScreen");
+        }
+        finally
+        {
+            FileManager.IsMobileOverride = originalIsMobileOverride;
+            FileManager.RelativeDirectory = originalRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = originalCustomGetStreamFromFile;
         }
     }
 

--- a/ToolsUtilities/FileManager.cs
+++ b/ToolsUtilities/FileManager.cs
@@ -27,10 +27,19 @@ namespace ToolsUtilities
         public const char DefaultSlash = '\\';
         #region Fields
 
+        /// <summary>
+        /// Test-only override for <see cref="IsMobile"/>. Android/iOS are the only platforms with no
+        /// filesystem root to detect, so their "already resolved" signal is a fragile "starts with
+        /// ./" string marker instead - a real device is otherwise the only way to exercise that path.
+        /// Null (the default) falls back to the real <see cref="System.OperatingSystem"/> check.
+        /// </summary>
+        public static bool? IsMobileOverride { get; set; }
+
         static bool IsMobile =>
+            IsMobileOverride ??
 #if NET6_0_OR_GREATER
-            System.OperatingSystem.IsAndroid() ||
-                System.OperatingSystem.IsIOS() ;
+            (System.OperatingSystem.IsAndroid() ||
+                System.OperatingSystem.IsIOS());
 #else
         false;
 #endif
@@ -265,7 +274,12 @@ namespace ToolsUtilities
                 fileName = RelativeDirectory + fileName;
             }
 
-            fileName = TryRemoveLeadingDotSlash(fileName);
+            // Don't strip a leading "./" here: on mobile that's the only signal that fileName is
+            // already resolved. GetStreamForFile does its own IsRelative check, so stripping it
+            // first makes an already-resolved path look relative again and re-prepends
+            // RelativeDirectory, doubling it (#4548). GetStreamForFile hands the "./"-marked path
+            // to CustomGetStreamFromFile unchanged; the host-installed hook is what strips it,
+            // immediately before the real OS call.
 
             // Creating a filestream then using that enables us to open files that are open by other apps.
             using (var fileStream = GetStreamForFile(fileName))
@@ -816,12 +830,12 @@ namespace ToolsUtilities
             //ThrowExceptionIfFileDoesntExist(fileName);
 
 
-            if (IsMobile)
-            {
-                // Mobile platforms don't like ./ at the start of the file name, but that's what we use to identify an absolute path
-                fileName = TryRemoveLeadingDotSlash(fileName);
-            }
-
+            // Don't strip a leading "./" here: on mobile that's the only signal that fileName is
+            // already resolved. GetStreamForFile does its own IsRelative check, so stripping it
+            // first makes an already-resolved path look relative again and re-prepends
+            // RelativeDirectory, doubling it (#4548). GetStreamForFile hands the "./"-marked path
+            // to CustomGetStreamFromFile unchanged; the host-installed hook is what strips it,
+            // immediately before the real OS call.
 
             using (Stream stream = GetStreamForFile(fileName))
             {
@@ -838,15 +852,6 @@ namespace ToolsUtilities
             }
 
             return objectToReturn;
-        }
-
-        static string TryRemoveLeadingDotSlash(string fileName)
-        {
-            if (fileName != null && fileName.Length > 1 && fileName[0] == '.' && (fileName[1] == '/' || fileName[1] == '\\'))
-            {
-                fileName = fileName.Substring(2);
-            }
-            return fileName;
         }
 
         public static Stream GetStreamForFile(string fileName)
@@ -1513,10 +1518,12 @@ namespace ToolsUtilities
 #endif
         public static T XmlDeserialize<T>(string fileName, XmlSerializer serializer)
         {
-            if (IsMobile)
-            {
-                fileName = TryRemoveLeadingDotSlash(fileName);
-            }
+            // Don't strip a leading "./" here: on mobile that's the only signal that fileName is
+            // already resolved. GetStreamForFile does its own IsRelative check, so stripping it
+            // first makes an already-resolved path look relative again and re-prepends
+            // RelativeDirectory, doubling it (#4548). GetStreamForFile hands the "./"-marked path
+            // to CustomGetStreamFromFile unchanged; the host-installed hook is what strips it,
+            // immediately before the real OS call.
 
             using (Stream stream = GetStreamForFile(fileName))
             {


### PR DESCRIPTION
Closes #4548

## Summary
`FileManager.XmlDeserialize`/`FromFileText` stripped the leading `./` marker (mobile's substitute for a filesystem root, used to mean "already resolved") before calling `GetStreamForFile`, which independently re-checks `IsRelative` and re-prepends `RelativeDirectory` — doubling `Content/` for every screen/component/standard element load on Android/iOS. `GetStreamForFile` already hands the `./`-marked path to `CustomGetStreamFromFile` unchanged, and the host-installed hook (`RenderingLibrary/SystemManagers.cs`) is what strips it right before the real `TitleContainer.OpenStream` call — the early strip was redundant and the actual bug. `GumBundleLoader.Resolve()` (flagged in the reporter's follow-up) was not at fault; verified via the regression test below.

Added `FileManager.IsMobileOverride` as a test seam, since `IsMobile` is a real `OperatingSystem.IsAndroid()/IsIOS()` check otherwise unreachable in unit tests. The regression test reproduces the exact reported error end-to-end through `GumBundleLoader.Resolve -> GumProjectSave.Load`.

## Test plan
- [x] New unit test (`Load_OnMobilePlatform_DoesNotDoublePrefixRelativeDirectoryForScreenReferences`) reproduces the exact reported error message before the fix, passes after.
- [x] `MonoGameGum.Tests` (2199), `RaylibGum.Tests` (614), `SkiaGum.Tests` (437), `Gum.ProjectServices.Tests` (536) all green, zero new warnings.
- [x] FRB1 canary (`GumCore.DesktopGlNet6.csproj`) builds clean — `FileManager.cs` is shared into FRB1.

Manual test: not needed — mobile-only path-resolution fix with no visual/runtime-observable effect on any platform this environment can run (desktop `IsMobile` is always false), proven end-to-end by the regression test instead.
