### PR TITLE
Add Expander to the Add Forms component set

### DIFF
--- a/GumDataTypes/Behaviors/StandardFormsBehaviorNames.cs
+++ b/GumDataTypes/Behaviors/StandardFormsBehaviorNames.cs
@@ -8,6 +8,7 @@ public static class StandardFormsBehaviorNames
     public const string CheckBoxBehaviorName = "CheckBoxBehavior";
     public const string ColorPickerBehaviorName = "ColorPickerBehavior";
     public const string ComboBoxBehaviorName = "ComboBoxBehavior";
+    public const string ExpanderBehaviorName = "ExpanderBehavior";
     public const string ItemsControlBehaviorName = "ItemsControlBehavior";
     public const string LabelBehaviorName = "LabelBehavior";
     public const string ListBoxBehaviorName = "ListBoxBehavior";
@@ -32,6 +33,7 @@ public static class StandardFormsBehaviorNames
         CheckBoxBehaviorName,
         ColorPickerBehaviorName,
         ComboBoxBehaviorName,
+        ExpanderBehaviorName,
         ItemsControlBehaviorName,
         LabelBehaviorName,
         ListBoxBehaviorName,

--- a/MonoGameGum.Tests/Forms/ExpanderTests.cs
+++ b/MonoGameGum.Tests/Forms/ExpanderTests.cs
@@ -1,0 +1,30 @@
+using Gum.DataTypes;
+using Gum.Managers;
+using Gum.Forms.DefaultFromFileVisuals;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Forms;
+
+public class ExpanderTests : BaseTestClass
+{
+    [Fact]
+    public void ToGraphicalUiElement_ShouldCreateFromFileExpander_IfElementExists()
+    {
+        GumProjectSave gumProject = new GumProjectSave();
+        var expanderComponent = new ComponentSave();
+        expanderComponent.States.Add(new Gum.DataTypes.Variables.StateSave() { Name = "Default" });
+        gumProject.Components.Add(expanderComponent);
+        expanderComponent.Name = "TestExpanderComponent";
+        expanderComponent.Behaviors.Add(new Gum.DataTypes.Behaviors.ElementBehaviorReference
+        { BehaviorName = "ExpanderBehavior" });
+
+        ObjectFinder.Self.GumProjectSave = gumProject;
+
+        Gum.Forms.FormsUtilities.RegisterFromFileFormRuntimeDefaults();
+
+        var gue = expanderComponent.ToGraphicalUiElement();
+
+        (gue is DefaultFromFileExpanderRuntime).ShouldBeTrue();
+    }
+}

--- a/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileExpanderRuntime.cs
+++ b/MonoGameGum/Forms/DefaultFromFileVisuals/DefaultFromFileExpanderRuntime.cs
@@ -1,0 +1,20 @@
+using Gum.Wireframe;
+using Gum.Forms.Controls;
+
+namespace Gum.Forms.DefaultFromFileVisuals;
+public class DefaultFromFileExpanderRuntime : InteractiveGue
+{
+    public DefaultFromFileExpanderRuntime(bool fullInstantiation = true, bool tryCreateFormsObject = true) :
+        base()
+    {
+    }
+    public override void AfterFullCreation()
+    {
+        base.AfterFullCreation();
+        if (FormsControl == null)
+        {
+            FormsControlAsObject = new Expander(this);
+        }
+    }
+    public Expander FormsControl => FormsControlAsObject as Expander;
+}

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -648,6 +648,12 @@ public class FormsUtilities
                     component.Name,
                     typeof(DefaultFromFileColorPickerRuntime), overwriteIfAlreadyExists: false);
             }
+            else if (behaviorNames.Contains(StandardFormsBehaviorNames.ExpanderBehaviorName))
+            {
+                ElementSaveExtensions.RegisterGueInstantiationType(
+                    component.Name,
+                    typeof(DefaultFromFileExpanderRuntime), overwriteIfAlreadyExists: false);
+            }
             else if (behaviorNames.Contains(StandardFormsBehaviorNames.StackPanelBehaviorName))
             {
                 ElementSaveExtensions.RegisterGueInstantiationType(

--- a/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/CodeGeneratorGetInheritanceTests.cs
@@ -211,4 +211,23 @@ public class CodeGeneratorGetInheritanceTests
 
         result.ShouldBe("global::Gum.Forms.Controls.ColorPicker");
     }
+
+    [Fact]
+    public void GetInheritance_MonoGameForms_ComponentWithExpanderBehavior_ReturnsExpander()
+    {
+        ComponentSave component = new ComponentSave();
+        component.Name = "Components/MyExpander";
+        component.BaseType = "Container";
+        component.Behaviors.Add(new Gum.DataTypes.Behaviors.ElementBehaviorReference
+        { BehaviorName = "ExpanderBehavior" });
+
+        CodeOutputProjectSettings settings = new CodeOutputProjectSettings
+        {
+            OutputLibrary = OutputLibrary.MonoGameForms
+        };
+
+        string? result = CodeGenerator.GetInheritance(component, settings);
+
+        result.ShouldBe("global::Gum.Forms.Controls.Expander");
+    }
 }

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1797,6 +1797,7 @@ public class CodeGenerator
         { StandardFormsBehaviorNames.CheckBoxBehaviorName, "global::Gum.Forms.Controls.CheckBox" },
         { StandardFormsBehaviorNames.ColorPickerBehaviorName, "global::Gum.Forms.Controls.ColorPicker" },
         { StandardFormsBehaviorNames.ComboBoxBehaviorName, "global::Gum.Forms.Controls.ComboBox" },
+        { StandardFormsBehaviorNames.ExpanderBehaviorName, "global::Gum.Forms.Controls.Expander" },
         { StandardFormsBehaviorNames.ItemsControlBehaviorName, "global::Gum.Forms.Controls.ItemsControl" },
         { StandardFormsBehaviorNames.LabelBehaviorName, "global::Gum.Forms.Controls.Label" },
         { StandardFormsBehaviorNames.ListBoxBehaviorName, "global::Gum.Forms.Controls.ListBox" },

--- a/Tools/Gum.ProjectServices/Templates/FormsBehaviors/ExpanderBehavior.behx
+++ b/Tools/Gum.ProjectServices/Templates/FormsBehaviors/ExpanderBehavior.behx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<BehaviorSave xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>ExpanderBehavior</Name>
+  <RequiredVariables />
+  <FormsProperty Type="string" Name="ToolTip" />
+  <FormsProperty Type="bool" Name="IsEnabled">
+    <Value xsi:type="xsd:boolean">true</Value>
+  </FormsProperty>
+  <FormsProperty Type="bool" Name="IsExpanded">
+    <Value xsi:type="xsd:boolean">false</Value>
+  </FormsProperty>
+  <ToolOnlyVariableReference>ExpanderCategoryState = IsEnabled ? (IsExpanded ? "Expanded" : "Collapsed") : (IsExpanded ? "DisabledExpanded" : "DisabledCollapsed")</ToolOnlyVariableReference>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+    </State>
+  </Category>
+  <RequiredInstances />
+  <RequiredAnimations />
+  <DefaultImplementation>Controls/ExpanderStandard</DefaultImplementation>
+</BehaviorSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ExpanderStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ExpanderStandard.gucx
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Controls/ExpanderStandard</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="ColorCategory" Name="ArrowIndicator.ColorCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">DarkGray</Value>
+    </Variable>
+    <Variable Type="IconCategory" Name="ArrowIndicator.IconCategoryState" SetsValue="true">
+      <Value xsi:type="xsd:string">Arrow2</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Rotation" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">211</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">211</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">211</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">80</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Arial</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">70</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Styles.DarkGray.FillColor</string>
+        <string>Font = Components/Styles.Normal.Font</string>
+        <string>FontSize = Components/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="float" Name="ArrowIndicator.Rotation" SetsValue="true">
+        <Value xsi:type="xsd:float">0</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="float" Name="ArrowIndicator.Rotation" SetsValue="true">
+        <Value xsi:type="xsd:float">90</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.ColorCategoryState" SetsValue="true">
+        <Value xsi:type="xsd:string">Gray</Value>
+      </Variable>
+      <Variable Type="float" Name="ArrowIndicator.Rotation" SetsValue="true">
+        <Value xsi:type="xsd:float">0</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Styles.Gray.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.ColorCategoryState" SetsValue="true">
+        <Value xsi:type="xsd:string">Gray</Value>
+      </Variable>
+      <Variable Type="float" Name="ArrowIndicator.Rotation" SetsValue="true">
+        <Value xsi:type="xsd:float">90</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">130</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Styles.Gray.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Elements/Icon" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ExpanderStandard.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/Components/Controls/ExpanderStandard.gucx
@@ -52,6 +52,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
       <Value xsi:type="xsd:int">211</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/GumProject.gumx
@@ -67,6 +67,7 @@
   <ComponentReference Name="Controls/ColorPickerStandard" />
   <ComponentReference Name="Controls/ComboBox" />
   <ComponentReference Name="Controls/DialogBox" />
+  <ComponentReference Name="Controls/ExpanderStandard" />
   <ComponentReference Name="Controls/ItemsControl" />
   <ComponentReference Name="Controls/Keyboard" />
   <ComponentReference Name="Controls/KeyboardKey" />
@@ -112,6 +113,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../FormsBehaviors/ColorPickerBehavior.behx" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../FormsBehaviors/ComboBoxBehavior.behx" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../FormsBehaviors/DialogBoxBehavior.behx" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../FormsBehaviors/ExpanderBehavior.behx" />
   <BehaviorReference Name="InputDeviceSelectionItemBehavior" />
   <BehaviorReference Name="InputDeviceSelectorBehavior" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../FormsBehaviors/ItemsControlBehavior.behx" />

--- a/Tools/Gum.ProjectServices/Templates/FormsTemplate/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsTemplate/manifest.txt
@@ -4,6 +4,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/InputDeviceSelectionItemBehavior.behx
 Behaviors/InputDeviceSelectorBehavior.behx
 Behaviors/ItemsControlBehavior.behx
@@ -42,6 +43,7 @@ Components/Controls/CheckBox.gucx
 Components/Controls/ColorPickerStandard.gucx
 Components/Controls/ComboBox.gucx
 Components/Controls/DialogBox.gucx
+Components/Controls/ExpanderStandard.gucx
 Components/Controls/ItemsControl.gucx
 Components/Controls/ItemsControlAnimations.ganx
 Components/Controls/Keyboard.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Bubblegum/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">85</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">17</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">61</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">8</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">85</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">17</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">61</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/Bubblegum/Styles.Surface1.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
+        <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
+        <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Bubblegum/Styles.Text.FillColor</string>
+        <string>Font = Components/Bubblegum/Styles.Normal.Font</string>
+        <string>FontSize = Components/Bubblegum/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">217</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">168</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">217</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">168</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">217</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">168</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">217</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">168</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">201</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Bubblegum/Styles.Placeholder.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/Components/Bubblegum/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="Bubblegum/Controls/ColorPicker" />
   <ComponentReference Name="Bubblegum/Controls/ComboBox" />
   <ComponentReference Name="Bubblegum/Controls/DialogBox" />
+  <ComponentReference Name="Bubblegum/Controls/Expander" />
   <ComponentReference Name="Bubblegum/Controls/ItemsControl" />
   <ComponentReference Name="Bubblegum/Controls/Label" />
   <ComponentReference Name="Bubblegum/Controls/ListBox" />
@@ -95,6 +96,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="Bubblegum/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Bubblegum/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/Bubblegum/Controls/CheckBox.gucx
 Components/Bubblegum/Controls/ColorPicker.gucx
 Components/Bubblegum/Controls/ComboBox.gucx
 Components/Bubblegum/Controls/DialogBox.gucx
+Components/Bubblegum/Controls/Expander.gucx
 Components/Bubblegum/Controls/ItemsControl.gucx
 Components/Bubblegum/Controls/Label.gucx
 Components/Bubblegum/Controls/ListBox.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/Components/DarkPro/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>DarkPro/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/DMMono-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">8</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">38</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">37</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">37</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/DMMono-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">212</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/DarkPro/Styles.Surface1.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/DarkPro/Styles.Text.FillColor</string>
+        <string>Font = Components/DarkPro/Styles.Normal.Font</string>
+        <string>FontSize = Components/DarkPro/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/DarkPro/Styles.Text.FillColor</string>
+        <string>Font = Components/DarkPro/Styles.Normal.Font</string>
+        <string>FontSize = Components/DarkPro/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/DarkPro/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/DarkPro/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/DarkPro/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/DarkPro/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="DarkPro/Controls/ColorPicker" />
   <ComponentReference Name="DarkPro/Controls/ComboBox" />
   <ComponentReference Name="DarkPro/Controls/DialogBox" />
+  <ComponentReference Name="DarkPro/Controls/Expander" />
   <ComponentReference Name="DarkPro/Controls/ItemsControl" />
   <ComponentReference Name="DarkPro/Controls/Label" />
   <ComponentReference Name="DarkPro/Controls/ListBox" />
@@ -96,6 +97,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="DarkPro/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/DarkPro/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/DarkPro/Controls/CheckBox.gucx
 Components/DarkPro/Controls/ColorPicker.gucx
 Components/DarkPro/Controls/ComboBox.gucx
 Components/DarkPro/Controls/DialogBox.gucx
+Components/DarkPro/Controls/Expander.gucx
 Components/DarkPro/Controls/ItemsControl.gucx
 Components/DarkPro/Controls/Label.gucx
 Components/DarkPro/Controls/ListBox.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/Components/ForestGlade/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ForestGlade/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">240</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">241</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">8</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">22</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">37</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">74</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">240</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">14</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">241</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/ForestGlade/Styles.WindowTitleBar.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/ForestGlade/Styles.Text.FillColor</string>
+        <string>Font = Components/ForestGlade/Styles.Normal.Font</string>
+        <string>FontSize = Components/ForestGlade/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/ForestGlade/Styles.Text.FillColor</string>
+        <string>Font = Components/ForestGlade/Styles.Normal.Font</string>
+        <string>FontSize = Components/ForestGlade/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">88</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">106</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">74</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">88</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">106</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">74</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/ForestGlade/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/ForestGlade/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">88</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">106</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">74</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">88</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">106</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">74</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/ForestGlade/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/ForestGlade/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="ForestGlade/Controls/ColorPicker" />
   <ComponentReference Name="ForestGlade/Controls/ComboBox" />
   <ComponentReference Name="ForestGlade/Controls/DialogBox" />
+  <ComponentReference Name="ForestGlade/Controls/Expander" />
   <ComponentReference Name="ForestGlade/Controls/ItemsControl" />
   <ComponentReference Name="ForestGlade/Controls/Label" />
   <ComponentReference Name="ForestGlade/Controls/ListBox" />
@@ -95,6 +96,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="ForestGlade/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/ForestGlade/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/ForestGlade/Controls/CheckBox.gucx
 Components/ForestGlade/Controls/ColorPicker.gucx
 Components/ForestGlade/Controls/ComboBox.gucx
 Components/ForestGlade/Controls/DialogBox.gucx
+Components/ForestGlade/Controls/Expander.gucx
 Components/ForestGlade/Controls/ItemsControl.gucx
 Components/ForestGlade/Controls/Label.gucx
 Components/ForestGlade/Controls/ListBox.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/Components/Hazard/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Hazard/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">40</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/SairaCondensed-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">15</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">181</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">227</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">8</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">16</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">18</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">40</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/SairaCondensed-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">15</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">181</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">227</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/Hazard/Styles.Surface1.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
+        <string>Font = Components/Hazard/Styles.Normal.Font</string>
+        <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Hazard/Styles.Text.FillColor</string>
+        <string>Font = Components/Hazard/Styles.Normal.Font</string>
+        <string>FontSize = Components/Hazard/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">57</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">57</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">57</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">26</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">57</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">69</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Hazard/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="Hazard/Controls/ColorPicker" />
   <ComponentReference Name="Hazard/Controls/ComboBox" />
   <ComponentReference Name="Hazard/Controls/DialogBox" />
+  <ComponentReference Name="Hazard/Controls/Expander" />
   <ComponentReference Name="Hazard/Controls/ItemsControl" />
   <ComponentReference Name="Hazard/Controls/Label" />
   <ComponentReference Name="Hazard/Controls/ListBox" />
@@ -95,6 +96,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Hazard/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="Hazard/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="Hazard/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Hazard/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/Hazard/Controls/CheckBox.gucx
 Components/Hazard/Controls/ColorPicker.gucx
 Components/Hazard/Controls/ComboBox.gucx
 Components/Hazard/Controls/DialogBox.gucx
+Components/Hazard/Controls/Expander.gucx
 Components/Hazard/Controls/ItemsControl.gucx
 Components/Hazard/Controls/Label.gucx
 Components/Hazard/Controls/ListBox.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">8</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/Components/Neon/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Neon/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/ShareTechMono-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">250</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">200</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">8</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">34</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">255</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/ShareTechMono-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">250</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">200</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/Neon/Styles.Surface1.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Neon/Styles.Text.FillColor</string>
+        <string>Font = Components/Neon/Styles.Normal.Font</string>
+        <string>FontSize = Components/Neon/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Neon/Styles.Text.FillColor</string>
+        <string>Font = Components/Neon/Styles.Normal.Font</string>
+        <string>FontSize = Components/Neon/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">48</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">48</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Neon/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Neon/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">48</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">48</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">21</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Neon/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Neon/Styles.Disabled.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="Neon/Controls/ColorPicker" />
   <ComponentReference Name="Neon/Controls/ComboBox" />
   <ComponentReference Name="Neon/Controls/DialogBox" />
+  <ComponentReference Name="Neon/Controls/Expander" />
   <ComponentReference Name="Neon/Controls/ItemsControl" />
   <ComponentReference Name="Neon/Controls/Label" />
   <ComponentReference Name="Neon/Controls/ListBox" />
@@ -95,6 +96,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Neon/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="Neon/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="Neon/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Neon/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/Neon/Controls/CheckBox.gucx
 Components/Neon/Controls/ColorPicker.gucx
 Components/Neon/Controls/ComboBox.gucx
 Components/Neon/Controls/DialogBox.gucx
+Components/Neon/Controls/Expander.gucx
 Components/Neon/Controls/ItemsControl.gucx
 Components/Neon/Controls/Label.gucx
 Components/Neon/Controls/ListBox.gucx

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/Expander.gucx
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ComponentSave xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Retro95/Controls/Expander</Name>
+  <BaseType>Container</BaseType>
+  <State>
+    <Name>Default</Name>
+    <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="ArrowIndicator.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+      <Value xsi:type="xsd:string">+</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">24</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ArrowIndicator.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.X" SetsValue="true">
+      <Value xsi:type="xsd:float">4</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="ArrowIndicator.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="ArrowIndicator.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="ArrowIndicator.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="ArrowIndicator.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="ChildrenLayout" Name="ChildrenLayout" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+      <Value xsi:type="xsd:boolean">false</Value>
+    </Variable>
+    <Variable Type="float" Name="ContentContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
+    <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillBlue" SetsValue="true">
+      <Value xsi:type="xsd:int">192</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillGreen" SetsValue="true">
+      <Value xsi:type="xsd:int">192</Value>
+    </Variable>
+    <Variable Type="int" Name="HeaderBackground.FillRed" SetsValue="true">
+      <Value xsi:type="xsd:int">192</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderBackground.IsFilled" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="string" Name="HeaderBackground.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.StrokeWidth" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderBackground.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.X" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="HeaderBackground.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">6</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderBackground.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="HeaderBackground.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="HeaderBackground.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="bool" Name="HeaderContainer.HasEvents" SetsValue="true">
+      <Value xsi:type="xsd:boolean">true</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">32</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="HeaderContainer.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeaderContainer.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">4</Value>
+    </Variable>
+    <Variable Type="State" Name="State" Category="States and Visibility" SetsValue="false">
+      <Value xsi:type="xsd:string">Default</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable IsFont="true" Type="string" Name="TextInstance.Font" SetsValue="true">
+      <Value xsi:type="xsd:string">Fonts/Nunito-Regular.ttf</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.FontSize" SetsValue="true">
+      <Value xsi:type="xsd:int">13</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Height" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.HeightUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.HorizontalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Parent" SetsValue="true">
+      <Value xsi:type="xsd:string">HeaderContainer</Value>
+    </Variable>
+    <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="string" Name="TextInstance.Text" ExposedAsName="Header" SetsValue="true">
+      <Value xsi:type="xsd:string">Expander</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.VerticalAlignment" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Width" SetsValue="true">
+      <Value xsi:type="xsd:float">-48</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="TextInstance.WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.X" SetsValue="true">
+      <Value xsi:type="xsd:float">40</Value>
+    </Variable>
+    <Variable Type="HorizontalAlignment" Name="TextInstance.XOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.XUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">0</Value>
+    </Variable>
+    <Variable Type="float" Name="TextInstance.Y" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="VerticalAlignment" Name="TextInstance.YOrigin" SetsValue="true">
+      <Value xsi:type="xsd:int">1</Value>
+    </Variable>
+    <Variable Type="PositionUnitType" Name="TextInstance.YUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">7</Value>
+    </Variable>
+    <Variable Type="float" Name="Width" SetsValue="true">
+      <Value xsi:type="xsd:float">0</Value>
+    </Variable>
+    <Variable Type="DimensionUnitType" Name="WidthUnits" SetsValue="true">
+      <Value xsi:type="xsd:int">2</Value>
+    </Variable>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>HeaderBackground.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>FillColor = Components/Retro95/Styles.Surface.FillColor</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>TextInstance.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Retro95/Styles.Text.FillColor</string>
+        <string>Font = Components/Retro95/Styles.Normal.Font</string>
+        <string>FontSize = Components/Retro95/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+    <VariableList xsi:type="VariableListSaveOfString">
+      <Type>string</Type>
+      <Name>ArrowIndicator.VariableReferences</Name>
+      <Category>References</Category>
+      <IsFile>false</IsFile>
+      <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+      <Value>
+        <string>Color = Components/Retro95/Styles.Text.FillColor</string>
+        <string>Font = Components/Retro95/Styles.Normal.Font</string>
+        <string>FontSize = Components/Retro95/Styles.Normal.FontSize</string>
+      </Value>
+    </VariableList>
+  </State>
+  <Category>
+    <Name>ExpanderCategory</Name>
+    <State>
+      <Name>Collapsed</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>Expanded</Name>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+    </State>
+    <State>
+      <Name>DisabledCollapsed</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">+</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">false</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Retro95/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Retro95/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+    <State>
+      <Name>DisabledExpanded</Name>
+      <Variable Type="int" Name="ArrowIndicator.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="ArrowIndicator.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="string" Name="ArrowIndicator.Text" SetsValue="true">
+        <Value xsi:type="xsd:string">-</Value>
+      </Variable>
+      <Variable Type="bool" Name="ContentContainer.Visible" SetsValue="true">
+        <Value xsi:type="xsd:boolean">true</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Blue" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Green" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <Variable Type="int" Name="TextInstance.Red" SetsValue="true">
+        <Value xsi:type="xsd:int">128</Value>
+      </Variable>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>TextInstance.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Retro95/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+      <VariableList xsi:type="VariableListSaveOfString">
+        <Type>string</Type>
+        <Name>ArrowIndicator.VariableReferences</Name>
+        <Category>References</Category>
+        <IsFile>false</IsFile>
+        <IsHiddenInPropertyGrid>false</IsHiddenInPropertyGrid>
+        <Value>
+          <string>Color = Components/Retro95/Styles.DisabledText.FillColor</string>
+        </Value>
+      </VariableList>
+    </State>
+  </Category>
+  <Instance Name="HeaderContainer" BaseType="Container" />
+  <Instance Name="HeaderBackground" BaseType="Rectangle" />
+  <Instance Name="ArrowIndicator" BaseType="Text" />
+  <Instance Name="TextInstance" BaseType="Text" />
+  <Instance Name="ContentContainer" BaseType="Container" />
+  <Behaviors>
+    <ElementBehaviorReference>
+      <BehaviorName>ExpanderBehavior</BehaviorName>
+    </ElementBehaviorReference>
+  </Behaviors>
+  <VariablesHiddenFromInstances>
+    <string>ExpanderCategoryState</string>
+    <string>ContainedType</string>
+    <string>ChildrenLayout</string>
+    <string>ClipsChildren</string>
+    <string>IsRenderTarget</string>
+    <string>ExposeChildrenEvents</string>
+  </VariablesHiddenFromInstances>
+</ComponentSave>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/Expander.gucx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/Components/Retro95/Controls/Expander.gucx
@@ -79,6 +79,9 @@
     <Variable Type="DimensionUnitType" Name="ContentContainer.WidthUnits" SetsValue="true">
       <Value xsi:type="xsd:int">2</Value>
     </Variable>
+    <Variable Type="string" Name="DefaultChildContainer" SetsValue="true">
+      <Value xsi:type="xsd:string">ContentContainer</Value>
+    </Variable>
     <Variable Type="ExpanderCategory" Name="ExpanderCategoryState" SetsValue="false" />
     <Variable Type="float" Name="HeaderBackground.CornerRadius" SetsValue="true">
       <Value xsi:type="xsd:float">0</Value>

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/GumProject.gumx
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/GumProject.gumx
@@ -61,6 +61,7 @@
   <ComponentReference Name="Retro95/Controls/ColorPicker" />
   <ComponentReference Name="Retro95/Controls/ComboBox" />
   <ComponentReference Name="Retro95/Controls/DialogBox" />
+  <ComponentReference Name="Retro95/Controls/Expander" />
   <ComponentReference Name="Retro95/Controls/ItemsControl" />
   <ComponentReference Name="Retro95/Controls/Label" />
   <ComponentReference Name="Retro95/Controls/ListBox" />
@@ -96,6 +97,7 @@
   <BehaviorReference Name="ColorPickerBehavior" SourcePath="../../FormsBehaviors/ColorPickerBehavior.behx" DefaultImplementationOverride="Retro95/Controls/ColorPicker" />
   <BehaviorReference Name="ComboBoxBehavior" SourcePath="../../FormsBehaviors/ComboBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/ComboBox" />
   <BehaviorReference Name="DialogBoxBehavior" SourcePath="../../FormsBehaviors/DialogBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/DialogBox" />
+  <BehaviorReference Name="ExpanderBehavior" SourcePath="../../FormsBehaviors/ExpanderBehavior.behx" DefaultImplementationOverride="Retro95/Controls/Expander" />
   <BehaviorReference Name="ItemsControlBehavior" SourcePath="../../FormsBehaviors/ItemsControlBehavior.behx" />
   <BehaviorReference Name="LabelBehavior" SourcePath="../../FormsBehaviors/LabelBehavior.behx" />
   <BehaviorReference Name="ListBoxBehavior" SourcePath="../../FormsBehaviors/ListBoxBehavior.behx" DefaultImplementationOverride="Retro95/Controls/ListBox" />

--- a/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/manifest.txt
+++ b/Tools/Gum.ProjectServices/Templates/FormsThemes/Retro95/manifest.txt
@@ -3,6 +3,7 @@ Behaviors/CheckBoxBehavior.behx
 Behaviors/ColorPickerBehavior.behx
 Behaviors/ComboBoxBehavior.behx
 Behaviors/DialogBoxBehavior.behx
+Behaviors/ExpanderBehavior.behx
 Behaviors/ItemsControlBehavior.behx
 Behaviors/LabelBehavior.behx
 Behaviors/ListBoxBehavior.behx
@@ -30,6 +31,7 @@ Components/Retro95/Controls/CheckBox.gucx
 Components/Retro95/Controls/ColorPicker.gucx
 Components/Retro95/Controls/ComboBox.gucx
 Components/Retro95/Controls/DialogBox.gucx
+Components/Retro95/Controls/Expander.gucx
 Components/Retro95/Controls/ItemsControl.gucx
 Components/Retro95/Controls/Label.gucx
 Components/Retro95/Controls/ListBox.gucx


### PR DESCRIPTION
Closes #4539 (Expander only — see Scope below)

## Summary
- `Expander` was completely absent from the tool's "Add Forms Components" deploy set for every theme, so it couldn't be placed via the visual designer, matching the issue.
- Adds an `ExpanderBehavior` (Collapsed/Expanded/DisabledCollapsed/DisabledExpanded category, `IsExpanded`/`IsEnabled` FormsProperties), a real per-theme styled component (a clickable header row with a `+`/`-` indicator and text, plus a collapsible content area) for all 6 Add Forms themes (Bubblegum, DarkPro, ForestGlade, Hazard, Neon, Retro95) and the base Standard template.
- Registers `ExpanderBehavior` in codegen's behavior→Forms-type map and adds `DefaultFromFileExpanderRuntime` + `FormsUtilities` registration so project-authored `Expander` instances resolve to the real `Expander` Forms control at runtime.
- Standard's indicator uses the shared `Elements/Icon` sprite (`Arrow2`, rotated 0°/90°); themes use a plain `+`/`-` glyph on the theme's own `Normal` style font, after discovering `Fonts/DejaVuSansMono.ttf` silently fails to generate in several themes (filed as #4553).

## Scope
This PR covers `Expander` only, per the user's explicit instruction. `Grid` and `Image` (the other two controls named in #4539) are left for a follow-up.

## Test plan
- [x] New unit test: `CodeGeneratorGetInheritanceTests.GetInheritance_MonoGameForms_ComponentWithExpanderBehavior_ReturnsExpander`
- [x] New unit test: `ExpanderTests.ToGraphicalUiElement_ShouldCreateFromFileExpander_IfElementExists`
- [x] Full `Gum.ProjectServices.Tests` suite green (538 passed), including the generic `AllColorVariables_ShouldBeStylesWired` pinning test in Bubblegum/DarkPro/Hazard/Neon's own template test files
- [x] Full `MonoGameGum.Tests` suite green (2207 passed)
- [x] `gumcli check` / `check-references` / `diff-standards` clean on all 6 theme projects and the Standard template
- [x] `gumcli screenshot` on all 7 variants, confirming visible header text + collapse indicator with each theme's real palette
- [x] `dotnet build GumFull.sln` succeeds with zero new warnings; verified the plugin postbuild staged `ExpanderBehavior.behx`/`Expander(Standard).gucx` into `Gum/bin/Debug/Content/FormsThemes/<Theme>/` for all 6 themes + Standard
- [x] FRB canary: not needed — none of the touched `.cs` files are included in `GumCoreShared.projitems` or `FlatRedBall.Forms.Shared.projitems`; `DefaultFromFileExpanderRuntime` is in the explicitly-excluded `DefaultFromFileVisuals`/runtime-registration family

Manual test: needed. Opening Visual Studio for a live in-tool check.

## Filed while working
Found two pre-existing, unrelated bugs while researching the Icon/font pipeline for this control:
- #4552 — Bubblegum/DarkPro/Hazard's `Elements/Icon` references a `UISpriteSheet.png` that doesn't exist in the theme.
- #4553 — ComboBox/CheckBox glyph icons render invisible in Bubblegum/DarkPro/ForestGlade because `DejaVuSansMono.ttf` silently fails to generate.
