### PR TITLE
RaylibGum: automatic font glyph growth (#4546)

### DIFF
--- a/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
+++ b/Integrations/KernSmith/KernSmith.RaylibGum/KernSmithRaylibFontCreator.cs
@@ -1,11 +1,14 @@
 using KernSmith.Atlas;
 using KernSmith.Output;
+using KernSmith.Output.Model;
 using KernSmith.Rasterizer;
 using Raylib_cs;
 using RaylibGum.Renderables;
 using RenderingLibrary;
 using RenderingLibrary.Content;
 using RenderingLibrary.Graphics.Fonts;
+using System.Collections.Generic;
+using System.Linq;
 using ToolsUtilities;
 
 namespace KernSmith.Gum;
@@ -19,8 +22,50 @@ namespace KernSmith.Gum;
 /// <code>CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithRaylibFontCreator();</code>
 /// This is the raylib counterpart to KernSmith.MonoGameGum's <c>KernSmithFontCreator</c>.
 /// </remarks>
-public class KernSmithRaylibFontCreator : IRaylibFontCreator
+public class KernSmithRaylibFontCreator : IRaylibFontCreator, IGrowableRaylibFontCreator
 {
+    /// <summary>
+    /// Tracks a font identity this creator has grown at least once (issue #4546). <see cref="Raylib_cs.Font"/>
+    /// is a value type -- unlike KernSmith.MonoGameGum's <c>BitmapFont</c>, which every <c>Text</c>
+    /// sharing it sees mutate through a shared reference -- so growth here never frees or replaces
+    /// resources a font it has already handed out still points at; the alternative would be a real
+    /// use-after-free/stale-GPU-texture-id risk, since nothing else in the game can safely be told "the
+    /// old struct copy you're holding is no longer valid."
+    /// </summary>
+    /// <remarks>
+    /// <see cref="GlyphCapacity"/> reserves headroom in <see cref="CanonicalFont"/>'s Recs/Glyphs
+    /// arrays, doubled whenever it's exceeded, so most growth calls write new entries into
+    /// already-allocated space instead of allocating (and orphaning the previous) array every time --
+    /// bounding the number of orphaned generations to O(log(final glyph count)) rather than one per
+    /// growth call. The GPU texture gets the same treatment for free: <see cref="ApplyGrowth"/> only
+    /// replaces it when KernSmith's own atlas actually had to resize
+    /// (<see cref="GlyphAdditionResult.PageGrown"/>); otherwise it patches the new glyph pixels
+    /// directly into the still-live texture via <c>UpdateTextureRec</c>, which is safe for the SAME
+    /// reason writing into reserved array headroom is -- the identity (Texture.Id) never changes, so
+    /// no struct copy anywhere is left pointing at something that got freed or replaced.
+    /// </remarks>
+    private sealed class GrowableFontState
+    {
+        public Raylib_cs.Font CanonicalFont;
+        public int GlyphCapacity;
+        public readonly int LineHeight;
+        public readonly int BaselineY;
+
+        public GrowableFontState(Raylib_cs.Font font, int lineHeight, int baselineY)
+        {
+            CanonicalFont = font;
+            GlyphCapacity = font.GlyphCount;
+            LineHeight = lineHeight;
+            BaselineY = baselineY;
+        }
+    }
+
+    // Keyed by BmfcSave.FontCacheFileName, the same identity TryCreateFont already names its textures
+    // after -- mirrors KernSmith.MonoGameGum's KernSmithFontCreator._growableModels/_activeSessions.
+    private readonly Dictionary<string, BmFontModel> _growableModels = new();
+    private readonly Dictionary<string, GrowableFontState> _growableFonts = new();
+    private readonly Dictionary<string, BmFontIncrementalSession> _activeSessions = new();
+
     // Atlas ceiling handed to KernSmith. KernSmith sizes each page to the smallest power-of-two
     // that fits, UP TO this max — so a generous ceiling collapses the whole glyph set onto one page
     // (sized to need, not to the ceiling) for any size this is used with, while staying within the
@@ -155,7 +200,188 @@ public class KernSmithRaylibFontCreator : IRaylibFontCreator
             RaylibFontShadowRegistry.Register(font.Texture.Id, shadowFont);
         }
 
+        // Issue #4546: remember this font's model so a later TryAddGlyphs call can resume an
+        // incremental session against it. Mirrors KernSmith.MonoGameGum's KernSmithFontCreator, with
+        // one extra restriction: only a font that came back as a SINGLE page is tracked as growable.
+        // KernSmith's incremental sessions grow a single atlas (AdditionOverflowPolicy.Grow, never
+        // NewPage -- see TextRuntime.MaxInMemoryFontAtlasSize's own doc comment on why growth
+        // standardized on that policy), so there's no defined way to resume growth against a font that
+        // was already multi-page at creation time -- a large enough initial Ranges character set to
+        // exceed SingleAtlasMaxSize on its own, which is rare in practice. Dropshadow fonts are also
+        // skipped: KernSmith's incremental sessions reject Variants outright.
+        if (!string.IsNullOrEmpty(bmfcSave.FontFile) && !bmfcSave.HasDropshadow && result.Pages.Count == 1)
+        {
+            RaylibFontMetricsRegistry.TryGet(font.Texture.Id, out RaylibFontMetricsRegistry.FontLineMetrics metrics);
+            _growableModels[bmfcSave.FontCacheFileName] = result.Model;
+            _growableFonts[bmfcSave.FontCacheFileName] = new GrowableFontState(font, metrics.LineHeight, metrics.BaselineY);
+        }
+
         return font;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<char>? TryAddGlyphs(ref Raylib_cs.Font font, BmfcSave bmfcSave, string characters)
+    {
+        string key = bmfcSave.FontCacheFileName;
+        if (!_growableModels.TryGetValue(key, out BmFontModel? model)
+            || !_growableFonts.TryGetValue(key, out GrowableFontState? state))
+        {
+            return null;
+        }
+
+        if (!_activeSessions.TryGetValue(key, out BmFontIncrementalSession? session))
+        {
+            session = GumFontGenerator.ResumeIncremental(bmfcSave, model, backend: _backend);
+            _activeSessions[key] = session;
+        }
+
+        GlyphAdditionResult result = session.AddGlyphs(characters);
+
+        if (result.Added.Count > 0)
+        {
+            ApplyGrowth(state, result);
+        }
+
+        font = state.CanonicalFont;
+        return result.FailedCodepoints.Select(cp => (char)cp).ToArray();
+    }
+
+    /// <summary>
+    /// Applies <paramref name="result"/>'s newly-added glyphs onto <paramref name="state"/>'s canonical
+    /// font, amortizing the cost per <see cref="GrowableFontState"/>'s own doc comment: the texture is
+    /// only rebuilt when the atlas itself had to resize (<see cref="GlyphAdditionResult.PageGrown"/>),
+    /// and the Recs/Glyphs arrays are only reallocated (geometrically) when
+    /// <see cref="GrowableFontState.GlyphCapacity"/> is exhausted.
+    /// </summary>
+    private static unsafe void ApplyGrowth(GrowableFontState state, GlyphAdditionResult result)
+    {
+        Texture2D texture = state.CanonicalFont.Texture;
+        if (result.PageGrown)
+        {
+            // The live atlas no longer fits its own previous size -- rebuild it as a full CPU-side
+            // composite (read back the current atlas, blit the new glyphs into it, reupload) into a
+            // brand-new texture. The superseded Texture is deliberately never unloaded here; see
+            // GrowableFontState's own doc comment.
+            Image oldImage = Raylib.LoadImageFromTexture(texture);
+            byte[] buffer = new byte[result.PageWidth * result.PageHeight * 4];
+            CopyImageInto(oldImage, buffer, result.PageWidth);
+            Raylib.UnloadImage(oldImage);
+
+            foreach (AddedGlyph glyph in result.Added)
+            {
+                WriteGlyphPixels(buffer, result.PageWidth, glyph);
+            }
+
+            texture = UploadTexture(buffer, result.PageWidth, result.PageHeight);
+            ContentLoader.TextureFilterApplier(texture, ContentLoader.DefaultTextureFilter);
+            RaylibFontMetricsRegistry.Register(texture.Id, state.LineHeight, state.BaselineY);
+        }
+        else
+        {
+            // The new glyphs fit in the atlas's current size -- patch their pixels directly into the
+            // STILL-LIVE texture instead of rebuilding it. Safe for the same reason writing into
+            // reserved Recs/Glyphs headroom below is: the texture's identity (Texture.Id) never
+            // changes, so every struct copy of this font -- old or new -- keeps sampling the same GPU
+            // resource, just with more of it filled in once its own copy's GlyphCount catches up.
+            foreach (AddedGlyph glyph in result.Added)
+            {
+                UpdateTextureRegion(texture, glyph);
+            }
+        }
+
+        int oldGlyphCount = state.CanonicalFont.GlyphCount;
+        int newGlyphCount = oldGlyphCount + result.Added.Count;
+
+        Rectangle* recs;
+        GlyphInfo* glyphs;
+        if (newGlyphCount <= state.GlyphCapacity)
+        {
+            // Room already reserved from an earlier growth -- write the new entries into the existing
+            // arrays' unused tail. Older struct copies of this font have their own (smaller) GlyphCount
+            // and never index past it, so they're unaffected by entries appended beyond it.
+            recs = state.CanonicalFont.Recs;
+            glyphs = state.CanonicalFont.Glyphs;
+        }
+        else
+        {
+            int newCapacity = System.Math.Max(newGlyphCount, state.GlyphCapacity * 2);
+            recs = (Rectangle*)Raylib.MemAlloc((uint)(newCapacity * sizeof(Rectangle)));
+            glyphs = (GlyphInfo*)Raylib.MemAlloc((uint)(newCapacity * sizeof(GlyphInfo)));
+
+            Buffer.MemoryCopy(state.CanonicalFont.Recs, recs,
+                (long)newCapacity * sizeof(Rectangle), (long)oldGlyphCount * sizeof(Rectangle));
+            Buffer.MemoryCopy(state.CanonicalFont.Glyphs, glyphs,
+                (long)newCapacity * sizeof(GlyphInfo), (long)oldGlyphCount * sizeof(GlyphInfo));
+
+            state.GlyphCapacity = newCapacity;
+        }
+
+        int index = oldGlyphCount;
+        foreach (AddedGlyph glyph in result.Added)
+        {
+            recs[index] = new Rectangle(glyph.X, glyph.Y, glyph.Width, glyph.Height);
+            glyphs[index] = new GlyphInfo
+            {
+                Value = glyph.Char.Id,
+                OffsetX = glyph.Char.XOffset,
+                OffsetY = glyph.Char.YOffset,
+                AdvanceX = glyph.Char.XAdvance,
+            };
+            index++;
+        }
+
+        state.CanonicalFont = new Raylib_cs.Font
+        {
+            BaseSize = state.CanonicalFont.BaseSize,
+            GlyphCount = newGlyphCount,
+            GlyphPadding = 0,
+            Texture = texture,
+            Recs = recs,
+            Glyphs = glyphs,
+        };
+    }
+
+    /// <summary>
+    /// Blits one newly-added glyph's tightly-packed RGBA32 pixels directly into the live GPU texture at
+    /// its placed (X, Y) position, without reallocating or otherwise touching the rest of the texture.
+    /// </summary>
+    private static unsafe void UpdateTextureRegion(Texture2D texture, AddedGlyph glyph)
+    {
+        fixed (byte* p = glyph.Pixels)
+        {
+            Raylib.UpdateTextureRec(texture, new Rectangle(glyph.X, glyph.Y, glyph.Width, glyph.Height), p);
+        }
+    }
+
+    /// <summary>
+    /// Copies <paramref name="source"/>'s full pixel content into <paramref name="destination"/> at
+    /// (0, 0), respecting the row stride when <paramref name="destinationWidth"/> differs from the
+    /// source's own width (the atlas grew wider). Assumes both are tightly-packed RGBA32.
+    /// </summary>
+    private static unsafe void CopyImageInto(Image source, byte[] destination, int destinationWidth)
+    {
+        byte* src = (byte*)source.Data;
+        int rowBytes = source.Width * 4;
+        for (int y = 0; y < source.Height; y++)
+        {
+            int destinationOffset = y * destinationWidth * 4;
+            System.Runtime.InteropServices.Marshal.Copy((System.IntPtr)(src + (long)y * rowBytes), destination, destinationOffset, rowBytes);
+        }
+    }
+
+    /// <summary>
+    /// Blits one newly-added glyph's tightly-packed RGBA32 pixels into <paramref name="buffer"/> at its
+    /// placed (X, Y) position.
+    /// </summary>
+    private static void WriteGlyphPixels(byte[] buffer, int bufferWidth, AddedGlyph glyph)
+    {
+        int rowBytes = glyph.Width * 4;
+        for (int row = 0; row < glyph.Height; row++)
+        {
+            int sourceOffset = row * rowBytes;
+            int destinationOffset = ((glyph.Y + row) * bufferWidth + glyph.X) * 4;
+            System.Buffer.BlockCopy(glyph.Pixels, sourceOffset, buffer, destinationOffset, rowBytes);
+        }
     }
 
     private static unsafe Texture2D UploadTexture(byte[] pixels, int width, int height)

--- a/MonoGameGum/GueDeriving/TextRuntime.cs
+++ b/MonoGameGum/GueDeriving/TextRuntime.cs
@@ -2,6 +2,7 @@
 #if RAYLIB
 using Gum.Renderables;
 using RaylibGum.Helpers;
+using RaylibGum.Renderables;
 // This file (via Gum/Wireframe/CustomSetPropertyOnRenderable.cs, RAYLIB-namespaced) is the same
 // shared dispatcher source XNALIKE compiles, just under a different namespace -- see that file's
 // own #if RAYLIB/#else namespace switch.
@@ -55,8 +56,6 @@ public class TextRuntime : InteractiveGue
                 _containedText = (Text)this.RenderableComponent;
 #if XNALIKE || RAYLIB
                 _containedText.OnPreRender = UpdateAutomaticFontOversampling;
-#endif
-#if XNALIKE
                 _containedText.OnGlyphGrowthCheck = CheckAndGrowFont;
 #endif
             }
@@ -780,6 +779,14 @@ public class TextRuntime : InteractiveGue
             return false;
         }
 
+        // Issue #4546: mirrors the XNALIKE ReplayGrownCharacters call above -- this freshly-generated
+        // font was built from BmfcSave.Ranges alone, so replay this Text's own growth history into it
+        // before it becomes live, or continuous zooming would silently drop previously-grown
+        // characters on every regenerate.
+        Font replayedFont = font.Value;
+        ReplayGrownCharacters(ref replayedFont, bmfcSave);
+        font = replayedFont;
+
         ContainedText.SetOversampledDisplayFont(font.Value);
 
         Raylib_cs.Font? pinnedFont = ContainedText.MeasurementFont;
@@ -900,14 +907,17 @@ public class TextRuntime : InteractiveGue
 #endif
 #endif
 
-#if XNALIKE
-    // Issue #4542: characters this Text has ever asked to grow into a font, at any raster size --
-    // survives a RegenerateOversampledFont building a brand-new BitmapFont (replayed via
+#if XNALIKE || RAYLIB
+    // Issue #4542 (#4546 for Raylib): characters this Text has ever asked to grow into a font, at any
+    // raster size -- survives a RegenerateOversampledFont building a brand-new font (replayed via
     // ReplayGrownCharacters below). Kept per-instance, not per-font-identity: each Text only needs to
-    // guarantee ITS OWN previously-required glyphs survive ITS OWN regenerate. A shared BitmapFont's
-    // in-place mutation (KernSmithFontCreator.TryAddGlyphs -> BitmapFont.AddOrUpdateCharacter) already
-    // makes growth visible to every other Text sharing that same font object -- no cross-instance
+    // guarantee ITS OWN previously-required glyphs survive ITS OWN regenerate. On XNALIKE, a shared
+    // BitmapFont's in-place mutation (KernSmithFontCreator.TryAddGlyphs -> BitmapFont.AddOrUpdateCharacter)
+    // already makes growth visible to every other Text sharing that same font OBJECT -- no cross-instance
     // ledger is needed for that case, only for "a fresh font object was just built from Ranges alone".
+    // Raylib_cs.Font is a value type, not a shared object, so this ledger additionally carries growth
+    // across the per-instance struct copies GrowIfNeeded/CheckAndGrowFont reassign below -- see
+    // IGrowableRaylibFontCreator's own remarks.
     readonly HashSet<char> _grownCharacters = new();
 
     // Characters already reported as unrenderable for this Text (design decision #4's warning fired at
@@ -919,14 +929,14 @@ public class TextRuntime : InteractiveGue
     readonly HashSet<char> _failedGrowthCharacters = new();
 
     /// <summary>
-    /// Issue #4542: when <see cref="UseAutomaticFontGrowth"/> is on, checks this Text's current
-    /// <see cref="Text.RawText"/> against its live font(s) for characters they don't have yet, and
-    /// grows them in place via <see cref="CustomSetPropertyOnRenderableType.InMemoryFontCreator"/> cast
-    /// to <see cref="IGrowableFontCreator"/>. Wired to <see cref="Text.OnGlyphGrowthCheck"/>, invoked
-    /// synchronously at the top of every <see cref="Text.UpdateWrappedText"/> call so wrap measurement
-    /// sees the grown glyph's real metrics immediately -- unlike oversampling regeneration, this can't
-    /// be deferred to the next frame's PreRender: a property setter like <see cref="Text"/> wraps
-    /// before it returns (e.g. a TextBox keystroke).
+    /// Issue #4542 (#4546 for Raylib): when <see cref="UseAutomaticFontGrowth"/> is on, checks this
+    /// Text's current <see cref="Text.RawText"/> against its live font(s) for characters they don't
+    /// have yet, and grows them in place via <see cref="CustomSetPropertyOnRenderableType.InMemoryFontCreator"/>
+    /// cast to the platform's growable-creator interface. Wired to <see cref="Text.OnGlyphGrowthCheck"/>,
+    /// invoked synchronously at the top of every <see cref="Text.UpdateWrappedText"/> call so wrap
+    /// measurement sees the grown glyph's real metrics immediately -- unlike oversampling regeneration,
+    /// this can't be deferred to the next frame's PreRender: a property setter like <see cref="Text"/>
+    /// wraps before it returns (e.g. a TextBox keystroke).
     /// </summary>
     void CheckAndGrowFont()
     {
@@ -935,6 +945,7 @@ public class TextRuntime : InteractiveGue
             return;
         }
 
+#if XNALIKE
         if (CustomSetPropertyOnRenderableType.InMemoryFontCreator is not IGrowableFontCreator growCreator)
         {
             return;
@@ -965,8 +976,53 @@ public class TextRuntime : InteractiveGue
         {
             GrowIfNeeded(growCreator, displayFont, FontSize * _lastAutoOversampleRatio, text);
         }
+#else
+        if (CustomSetPropertyOnRenderableType.InMemoryFontCreator is not IGrowableRaylibFontCreator growCreator)
+        {
+            return;
+        }
+
+        string? text = ContainedText.RawText;
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        // MeasurementFont is only pinned once oversampling has actually fired at least once (see
+        // Text.SetOversampledDisplayFont); before that, Font itself is the effective measurement font,
+        // matching Text.EffectiveMeasurementFont's own fallback order.
+        Font? measurementFont = ContainedText.MeasurementFont;
+        Font displayFont = ContainedText.Font;
+        Font primaryFont = measurementFont ?? displayFont;
+
+        // Font is a value type (see IGrowableRaylibFontCreator's own remarks) -- GrowIfNeeded returns
+        // the (possibly replaced) font via ref, so a successful grow must be written back onto
+        // whichever of MeasurementFont/Font this Text's own copy actually came from.
+        if (GrowIfNeeded(growCreator, ref primaryFont, FontSize, text))
+        {
+            if (measurementFont != null)
+            {
+                ContainedText.MeasurementFont = primaryFont;
+            }
+            else
+            {
+                ContainedText.Font = primaryFont;
+            }
+        }
+
+        // Oversampling active: the separately-rasterized display font also needs the character, or
+        // drawing would disagree with wrapping about whether it exists (design decision #3).
+        if (measurementFont != null && displayFont.Texture.Id != measurementFont.Value.Texture.Id)
+        {
+            if (GrowIfNeeded(growCreator, ref displayFont, FontSize * _lastAutoOversampleRatio, text))
+            {
+                ContainedText.Font = displayFont;
+            }
+        }
+#endif
     }
 
+#if XNALIKE
     void GrowIfNeeded(IGrowableFontCreator growCreator, BitmapFont font, float fontSize, string text)
     {
         string missing = font.GetMissingCharacters(text);
@@ -1039,7 +1095,98 @@ public class TextRuntime : InteractiveGue
                 $"Error growing font via {growCreator.GetType().Name}:\n{ex}");
         }
     }
+#else
+    /// <returns>
+    /// True if <paramref name="font"/> was replaced with the creator's current canonical font for this
+    /// identity (growth supported and attempted) -- the caller must write it back onto whichever of
+    /// its own Font/MeasurementFont properties it came from. False if growth isn't supported for this
+    /// font (nothing to write back) or nothing was missing.
+    /// </returns>
+    bool GrowIfNeeded(IGrowableRaylibFontCreator growCreator, ref Font font, float fontSize, string text)
+    {
+        string missing = font.GetMissingCharacters(text);
+        if (missing.Length == 0)
+        {
+            return false;
+        }
 
+        if (_failedGrowthCharacters.Count > 0)
+        {
+            missing = new string(missing.Where(c => !_failedGrowthCharacters.Contains(c)).ToArray());
+            if (missing.Length == 0)
+            {
+                return false;
+            }
+        }
+
+        var fontFilePath = BmfcSave.ResolveTtfSourcePath(UseCustomFont, CustomFontFile, Font);
+        var bmfcSave = new BmfcSave();
+        CopyFontGenerationFieldsTo(bmfcSave, fontFilePath);
+        bmfcSave.FontSize = fontSize;
+        // See MaxInMemoryFontAtlasSize's doc comment -- BmfcSave's own 512x256 disk-cache default
+        // would cap growth at a handful of glyphs.
+        bmfcSave.OutputWidth = MaxInMemoryFontAtlasSize;
+        bmfcSave.OutputHeight = MaxInMemoryFontAtlasSize;
+
+        try
+        {
+            IReadOnlyList<char>? failed = growCreator.TryAddGlyphs(ref font, bmfcSave, missing);
+            if (failed == null)
+            {
+                // Not created by this creator (or growth otherwise unsupported for it, e.g. a system
+                // font with no backing file) -- font was left untouched, nothing to write back.
+                return false;
+            }
+
+            if (failed.Count > 0)
+            {
+                // Design decision #4: a glyph the font genuinely cannot render (no glyph in the source
+                // font file) surfaces as a warning, matching PropertyAssignmentError's existing
+                // pattern -- never a silent fallback to the space glyph. Remembered so it isn't
+                // re-attempted (and re-warned) on every subsequent wrap.
+                foreach (char c in failed)
+                {
+                    _failedGrowthCharacters.Add(c);
+                }
+                // fontFilePath is null for a family-name-resolved system font (UseCustomFont false);
+                // Font is the only identity that applies there. When UseCustomFont is true, Font
+                // still holds whatever unrelated default/last value it was constructed or last set
+                // to (e.g. "Arial") -- CustomFontFile/fontFilePath is the actual font in that case.
+                string fontIdentity = fontFilePath ?? Font;
+                CustomSetPropertyOnRenderableType.RaisePropertyAssignmentError(
+                    $"Font '{fontIdentity}' cannot render character(s) \"{new string(failed.ToArray())}\" -- " +
+                    "no glyph for them exists in the font file.");
+            }
+
+            foreach (char c in missing)
+            {
+                if (!failed.Contains(c))
+                {
+                    _grownCharacters.Add(c);
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Mirrors the try/catch around InMemoryFontCreator.TryCreateFont elsewhere in this file --
+            // this can run synchronously from inside a property setter (Text=), so an uncaught
+            // exception here would escape into arbitrary game code instead of a render-time hook. The
+            // whole batch is remembered as failed too (can't tell which characters caused it, e.g. the
+            // atlas hit its max size), so it isn't retried (and re-warned) on every subsequent wrap.
+            foreach (char c in missing)
+            {
+                _failedGrowthCharacters.Add(c);
+            }
+            CustomSetPropertyOnRenderableType.RaisePropertyAssignmentError(
+                $"Error growing font via {growCreator.GetType().Name}:\n{ex}");
+            return false;
+        }
+    }
+#endif
+
+#if XNALIKE
     /// <summary>
     /// Replays <see cref="_grownCharacters"/> into <paramref name="font"/>, a brand-new BitmapFont
     /// <see cref="RegenerateOversampledFont"/> just built from <see cref="BmfcSave.Ranges"/> alone --
@@ -1068,6 +1215,36 @@ public class TextRuntime : InteractiveGue
                 $"Error replaying grown characters into oversampled font via {growCreator.GetType().Name}:\n{ex}");
         }
     }
+#else
+    /// <summary>
+    /// Replays <see cref="_grownCharacters"/> into <paramref name="font"/>, a brand-new font
+    /// <see cref="RegenerateOversampledFont"/> just built from <see cref="BmfcSave.Ranges"/> alone --
+    /// see design decision #3. A no-op when nothing has ever been grown, or growth isn't supported.
+    /// </summary>
+    void ReplayGrownCharacters(ref Font font, BmfcSave bmfcSave)
+    {
+        if (_grownCharacters.Count == 0)
+        {
+            return;
+        }
+
+        if (CustomSetPropertyOnRenderableType.InMemoryFontCreator is not IGrowableRaylibFontCreator growCreator)
+        {
+            return;
+        }
+
+        string replay = new string(_grownCharacters.ToArray());
+        try
+        {
+            growCreator.TryAddGlyphs(ref font, bmfcSave, replay);
+        }
+        catch (Exception ex)
+        {
+            CustomSetPropertyOnRenderableType.RaisePropertyAssignmentError(
+                $"Error replaying grown characters into oversampled font via {growCreator.GetType().Name}:\n{ex}");
+        }
+    }
+#endif
 #endif
 
     public TextOverflowHorizontalMode TextOverflowHorizontalMode
@@ -1315,11 +1492,11 @@ public class TextRuntime : InteractiveGue
     /// <see cref="Text"/> is assigned a character the font doesn't have yet (issue #4542), instead of
     /// silently falling back to the space glyph. Off by default, mirroring <see cref="UseFontOversampling"/>'s
     /// shape: games that never need it pay zero per-Text cost, and whether a project wants dynamic
-    /// glyph growth at all is a project-wide decision. Requires an
-    /// <c>RenderingLibrary.Graphics.Fonts.IGrowableFontCreator</c> registered via
-    /// <c>CustomSetPropertyOnRenderable.InMemoryFontCreator</c> (KernSmith implements it) -- MonoGame,
-    /// KniGum, and FnaGum only in this pass; RaylibGum uses a separate, non-BitmapFont font
-    /// representation and does not yet support growth (tracked as a follow-up).
+    /// glyph growth at all is a project-wide decision. Requires an in-memory font creator that also
+    /// implements the platform's growable-creator interface, registered via
+    /// <c>CustomSetPropertyOnRenderable.InMemoryFontCreator</c> (KernSmith implements both) --
+    /// <c>RenderingLibrary.Graphics.Fonts.IGrowableFontCreator</c> on MonoGame/KniGum/FnaGum,
+    /// <c>RaylibGum.Renderables.IGrowableRaylibFontCreator</c> on Raylib (issue #4546).
     /// </summary>
     public static bool UseAutomaticFontGrowth = false;
 
@@ -1394,12 +1571,10 @@ public class TextRuntime : InteractiveGue
             // TextRuntime is constructed, and the automatic per-frame oversampling trigger (#4317)
             // silently never engages for any normally-constructed instance.
             textRenderable.OnPreRender = UpdateAutomaticFontOversampling;
-#endif
-#if XNALIKE
-            // Same landmine as OnPreRender above (issue #4542): must be wired here too, or the
-            // automatic glyph-growth trigger silently never engages for any normally-constructed
-            // TextRuntime, since ContainedText's lazy-init getter never runs again once _containedText
-            // is assigned directly below.
+            // Same landmine as OnPreRender above (issue #4542, Raylib parity #4546): must be wired
+            // here too, or the automatic glyph-growth trigger silently never engages for any
+            // normally-constructed TextRuntime, since ContainedText's lazy-init getter never runs
+            // again once _containedText is assigned directly below.
             textRenderable.OnGlyphGrowthCheck = CheckAndGrowFont;
 #endif
             _containedText = textRenderable;

--- a/Runtimes/RaylibGum/Helpers/RaylibFontExtensions.cs
+++ b/Runtimes/RaylibGum/Helpers/RaylibFontExtensions.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace RaylibGum.Helpers;
+
+/// <summary>
+/// Missing-character detection for <see cref="Raylib_cs.Font"/> (issue #4546), mirroring
+/// <c>RenderingLibrary.Graphics.Fonts.BitmapFont.HasCharacter</c>/<c>GetMissingCharacters</c> for the
+/// MonoGame/KniGum/FnaGum side. A raylib <see cref="Raylib_cs.Font"/> has no lookup table -- character
+/// presence is a linear scan of its own <see cref="Raylib_cs.Font.Glyphs"/> array.
+/// </summary>
+public static class RaylibFontExtensions
+{
+    /// <summary>
+    /// Whether <paramref name="font"/> has real glyph data for <paramref name="character"/>, as
+    /// opposed to falling back to raylib's own default-glyph behavior for an unknown codepoint.
+    /// </summary>
+    public static unsafe bool HasCharacter(this Raylib_cs.Font font, char character)
+    {
+        for (int i = 0; i < font.GlyphCount; i++)
+        {
+            if (font.Glyphs[i].Value == character)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the atlas pixel rectangle <paramref name="font"/> placed <paramref name="character"/>'s
+    /// glyph at, or <c>null</c> when the font has no real glyph data for it (see
+    /// <see cref="HasCharacter"/>).
+    /// </summary>
+    public static unsafe Raylib_cs.Rectangle? TryGetGlyphRectangle(this Raylib_cs.Font font, char character)
+    {
+        for (int i = 0; i < font.GlyphCount; i++)
+        {
+            if (font.Glyphs[i].Value == character)
+            {
+                return font.Recs[i];
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the distinct characters in <paramref name="text"/> that <paramref name="font"/> has no
+    /// real glyph data for (see <see cref="HasCharacter"/>), in first-encounter order, or an empty
+    /// string when every character is already present. A one-shot pre-pass over the whole string, not
+    /// a per-character check in the hot wrap/measure loop.
+    /// </summary>
+    public static string GetMissingCharacters(this Raylib_cs.Font font, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        StringBuilder? missing = null;
+        HashSet<char>? seen = null;
+        foreach (char c in text)
+        {
+            if (!font.HasCharacter(c))
+            {
+                seen ??= new HashSet<char>();
+                if (seen.Add(c))
+                {
+                    missing ??= new StringBuilder();
+                    missing.Append(c);
+                }
+            }
+        }
+
+        return missing?.ToString() ?? string.Empty;
+    }
+}

--- a/Runtimes/RaylibGum/Renderables/IGrowableRaylibFontCreator.cs
+++ b/Runtimes/RaylibGum/Renderables/IGrowableRaylibFontCreator.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using RenderingLibrary.Graphics.Fonts;
+
+namespace RaylibGum.Renderables;
+
+/// <summary>
+/// Optional companion to <see cref="IRaylibFontCreator"/> (issue #4546, raylib parity for #4542):
+/// implemented by an in-memory raylib font creator that can grow a font it previously produced with
+/// new characters, in place, without a full regenerate. Consumers (<c>TextRuntime</c>'s automatic
+/// glyph-growth trigger) check <c>CustomSetPropertyOnRenderable.InMemoryFontCreator</c> for this
+/// interface at the point they need to grow a font -- an <see cref="IRaylibFontCreator"/> that
+/// doesn't implement it simply doesn't support growth, the same "not applicable" signal
+/// <see cref="IRaylibFontCreator.TryCreateFont"/> itself uses for a null return.
+/// </summary>
+/// <remarks>
+/// Unlike <c>RenderingLibrary.Graphics.Fonts.IGrowableFontCreator</c> (the MonoGame/KniGum/FnaGum
+/// equivalent), <paramref name="font"/> below is passed by <c>ref</c> rather than mutated through a
+/// held reference: <c>BitmapFont</c> is a class, so every <c>Text</c> sharing one automatically sees
+/// growth through that shared reference, but <see cref="Raylib_cs.Font"/> is a value type -- each
+/// <c>Text</c> holds its own independent copy. A creator that supports growth returns the CURRENT
+/// canonical font for this identity (which the caller assigns back onto its own copy via
+/// <paramref name="font"/>), and never frees or replaces the resources behind any font it has already
+/// handed out -- another <c>Text</c> instance holding an older copy of the same identity keeps
+/// rendering it safely until (if ever) its own growth check catches it up to the latest characters.
+/// </remarks>
+public interface IGrowableRaylibFontCreator
+{
+    /// <summary>
+    /// Attempts to add <paramref name="characters"/> to the font identified by <paramref name="bmfcSave"/>,
+    /// growing it in place (via an incremental atlas session) instead of a full regenerate.
+    /// </summary>
+    /// <param name="font">
+    /// In: the caller's own copy of a font this creator previously produced via
+    /// <see cref="IRaylibFontCreator.TryCreateFont"/>. Out: replaced with the creator's current
+    /// canonical font for this identity when growth is supported (whether or not this specific call
+    /// added anything new); left untouched when it returns <c>null</c>.
+    /// </param>
+    /// <param name="bmfcSave">The same descriptor <paramref name="font"/> was created from.</param>
+    /// <param name="characters">The characters to add. Already-present characters are a silent no-op.</param>
+    /// <returns>
+    /// <c>null</c> when <paramref name="font"/> was not created by this creator, or growth is not
+    /// supported for it (e.g. it was generated from a system font with no backing file). Otherwise, a
+    /// possibly-empty list of the requested characters this font cannot render at all -- e.g. no glyph
+    /// for them exists in the source font file.
+    /// </returns>
+    IReadOnlyList<char>? TryAddGlyphs(ref Raylib_cs.Font font, BmfcSave bmfcSave, string characters);
+}

--- a/Runtimes/RaylibGum/Renderables/Text.cs
+++ b/Runtimes/RaylibGum/Renderables/Text.cs
@@ -384,6 +384,15 @@ public class Text : IVisible, IRenderableIpso,
     internal Action? OnPreRender;
 
     /// <summary>
+    /// Runs synchronously at the top of every <see cref="UpdateWrappedText"/> call, before wrapping.
+    /// Used by <c>TextRuntime</c> (issue #4546, Raylib parity for #4542) to detect a character this
+    /// Text's live font is missing and grow it in place -- unlike <see cref="OnPreRender"/>'s
+    /// once-per-frame cadence, this can't be deferred: a property setter like <c>Text</c> wraps before
+    /// it returns (e.g. a TextBox keystroke), so wrap measurement must already see the grown glyph.
+    /// </summary>
+    internal Action? OnGlyphGrowthCheck;
+
+    /// <summary>
     /// The scale applied when drawing plain (non-BBCode) text: composes the public <see cref="FontScale"/>
     /// with <see cref="OversampleCompensationScale"/>.
     /// </summary>
@@ -963,6 +972,8 @@ public class Text : IVisible, IRenderableIpso,
     /// </summary>
     public void UpdateWrappedText()
     {
+        OnGlyphGrowthCheck?.Invoke();
+
         mWrappedText.Clear();
         this.UpdateLines(mWrappedText);
     }

--- a/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
+++ b/Tests/RaylibGum.Tests/RaylibGum.Tests.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Issue #4546: growth tests read a Raylib_cs.Font's native Recs/Glyphs pointer arrays and an
+         Image's raw pixel data to verify glyph placement/pixel content. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorGrowthTests.cs
+++ b/Tests/RaylibGum.Tests/Renderables/KernSmithRaylibFontCreatorGrowthTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.Linq;
+using KernSmith.Gum;
+using RaylibGum.Helpers;
+using RaylibGum.Renderables;
+using RenderingLibrary;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Renderables;
+
+/// <summary>
+/// Issue #4546 -- <see cref="KernSmithRaylibFontCreator.TryAddGlyphs(ref Raylib_cs.Font, BmfcSave, string)"/>
+/// grows a font this creator already built via <see cref="KernSmithRaylibFontCreator.TryCreateFont"/>.
+/// Uses a real GPU/GL context (RaylibGum.Tests runs headless via llvmpipe in CI) and a real font file,
+/// mirroring <see cref="KernSmithRaylibFontCreatorTests"/> and the MonoGame-side growth tests --
+/// hand-crafting a fake Raylib_cs.Font (native Recs/Glyphs pointer arrays) is impractical from managed
+/// test code.
+/// </summary>
+public class KernSmithRaylibFontCreatorGrowthTests : BaseTestClass
+{
+    private static string FixtureFontPath =>
+        Path.Combine(AppContext.BaseDirectory, "Content", "Fonts", "Orbitron-Black.ttf");
+
+    private static BmfcSave BuildBmfcSave(string ranges, float fontSize = 24) => new BmfcSave
+    {
+        FontName = "Orbitron-Black",
+        FontFile = FixtureFontPath,
+        FontSize = fontSize,
+        UseSmoothing = true,
+        Ranges = ranges,
+    };
+
+    [Fact]
+    public void TryAddGlyphs_AddsANewCharacter_GrowsGlyphCountAndBlitsPixels()
+    {
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65"); // just 'A'
+        Raylib_cs.Font? created = creator.TryCreateFont(bmfcSave);
+        created.ShouldNotBeNull();
+        Raylib_cs.Font font = created!.Value;
+        int originalGlyphCount = font.GlyphCount;
+        font.HasCharacter('B').ShouldBeFalse();
+
+        var failed = growable.TryAddGlyphs(ref font, bmfcSave, "B");
+
+        failed.ShouldNotBeNull();
+        failed.ShouldBeEmpty();
+        font.GlyphCount.ShouldBe(originalGlyphCount + 1);
+        font.HasCharacter('B').ShouldBeTrue();
+
+        Raylib_cs.Rectangle bRect = font.TryGetGlyphRectangle('B')!.Value;
+        (bRect.Width * bRect.Height).ShouldBeGreaterThan(0,
+            "because 'B' must have real, non-fallback glyph dimensions after growth");
+
+        Raylib_cs.Image image = Raylib_cs.Raylib.LoadImageFromTexture(font.Texture);
+        try
+        {
+            bool anyOpaquePixelInGlyphRegion = false;
+            unsafe
+            {
+                byte* pixels = (byte*)image.Data;
+                for (int y = (int)bRect.Y; y < bRect.Y + bRect.Height && !anyOpaquePixelInGlyphRegion; y++)
+                {
+                    for (int x = (int)bRect.X; x < bRect.X + bRect.Width; x++)
+                    {
+                        byte alpha = pixels[(y * image.Width + x) * 4 + 3];
+                        if (alpha > 0)
+                        {
+                            anyOpaquePixelInGlyphRegion = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            anyOpaquePixelInGlyphRegion.ShouldBeTrue("because the new glyph's pixel bytes must actually be blitted into the live texture");
+        }
+        finally
+        {
+            Raylib_cs.Raylib.UnloadImage(image);
+        }
+    }
+
+    [Fact]
+    public void TryAddGlyphs_WhenFontWasNotCreatedByThisCreator_ReturnsNull()
+    {
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        Raylib_cs.Font untrackedFont = Raylib_cs.Raylib.GetFontDefault();
+
+        var result = growable.TryAddGlyphs(ref untrackedFont, BuildBmfcSave(ranges: "65"), "B");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryAddGlyphs_WhenACharacterHasNoGlyphInTheFontFile_ListsItAsFailed()
+    {
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        // Same fixture/codepoint choice as the MonoGame-side growth tests: U+2192 ('->') is confirmed
+        // absent from Orbitron-Black.ttf's cmap.
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65");
+        Raylib_cs.Font? created = creator.TryCreateFont(bmfcSave);
+        created.ShouldNotBeNull();
+        Raylib_cs.Font font = created!.Value;
+
+        var failed = growable.TryAddGlyphs(ref font, bmfcSave, "B→");
+
+        failed.ShouldNotBeNull();
+        failed.ShouldBe(new[] { '→' });
+        font.HasCharacter('B').ShouldBeTrue("because a failure for one requested character must not block the others in the same batch");
+        font.HasCharacter('→').ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryAddGlyphs_WhenAtlasGrows_ReallocatesTextureAndKeepsExistingGlyphPixelPositions()
+    {
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        // A generous font size against a tiny max atlas ceiling forces a Grow on the second add.
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65", fontSize: 48);
+        bmfcSave.OutputWidth = 64;
+        bmfcSave.OutputHeight = 64;
+        Raylib_cs.Font? created = creator.TryCreateFont(bmfcSave);
+        created.ShouldNotBeNull();
+        Raylib_cs.Font font = created!.Value;
+
+        Raylib_cs.Rectangle originalARect = font.TryGetGlyphRectangle('A')!.Value;
+        int originalTextureWidth = font.Texture.Width;
+
+        bmfcSave.OutputWidth = 4096;
+        bmfcSave.OutputHeight = 4096;
+        var failed = growable.TryAddGlyphs(ref font, bmfcSave, "WWWWWWWWWWWWWWWW");
+
+        failed.ShouldNotBeNull();
+
+        Raylib_cs.Rectangle rescaledARect = font.TryGetGlyphRectangle('A')!.Value;
+        rescaledARect.X.ShouldBe(originalARect.X, "because a grow must never move an already-placed glyph's pixel position");
+        rescaledARect.Y.ShouldBe(originalARect.Y);
+
+        font.Texture.Width.ShouldBeGreaterThan(originalTextureWidth, "because the atlas must actually have grown to fit the new batch");
+    }
+
+    // Issue #4546 review finding: growth must not fork (rebuild the texture + Recs/Glyphs arrays) on
+    // every call. A generous atlas ceiling means the first growth's own atlas resize already reserves
+    // headroom well beyond what one extra character needs, so a second, unrelated character added
+    // afterward must land in that same reserved room -- patched into the STILL-LIVE texture rather
+    // than forcing another full rebuild.
+    [Fact]
+    public void TryAddGlyphs_SecondUnrelatedCharacter_ReusesTheSameTextureInsteadOfRebuilding()
+    {
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65"); // just 'A'
+        Raylib_cs.Font font = creator.TryCreateFont(bmfcSave)!.Value;
+
+        growable.TryAddGlyphs(ref font, bmfcSave, "B").ShouldNotBeNull();
+        uint textureIdAfterFirstGrowth = font.Texture.Id;
+        int glyphCountAfterFirstGrowth = font.GlyphCount;
+
+        growable.TryAddGlyphs(ref font, bmfcSave, "C").ShouldNotBeNull();
+
+        font.Texture.Id.ShouldBe(textureIdAfterFirstGrowth,
+            "because the second character must be patched into the atlas the first growth already reserved, not force a whole new texture");
+        font.GlyphCount.ShouldBe(glyphCountAfterFirstGrowth + 1);
+        font.HasCharacter('C').ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryAddGlyphs_TwoStructCopiesOfTheSameFont_BothConvergeOnTheSameCanonicalGeneration()
+    {
+        // Issue #4546: Raylib_cs.Font is a value type, so two Texts that resolved the same font
+        // identity (e.g. both hit the same LoaderManager cache entry, mirroring the real runtime path
+        // in CustomSetPropertyOnRenderable) each hold their OWN struct copy. Growing through one
+        // Text's copy must not strand the other -- once IT ALSO calls TryAddGlyphs (because it, too,
+        // is missing some character), it must land on the SAME canonical generation, not a second,
+        // independent one.
+        KernSmithRaylibFontCreator creator = new();
+        IGrowableRaylibFontCreator growable = creator;
+
+        BmfcSave bmfcSave = BuildBmfcSave(ranges: "65"); // just 'A'
+        Raylib_cs.Font created = creator.TryCreateFont(bmfcSave)!.Value;
+        Raylib_cs.Font firstCopy = created;
+        Raylib_cs.Font secondCopy = created; // both Texts resolved the SAME cached value
+
+        growable.TryAddGlyphs(ref firstCopy, bmfcSave, "B").ShouldNotBeNull();
+        var result = growable.TryAddGlyphs(ref secondCopy, bmfcSave, "B");
+
+        result.ShouldNotBeNull();
+        secondCopy.Texture.Id.ShouldBe(firstCopy.Texture.Id);
+        secondCopy.GlyphCount.ShouldBe(firstCopy.GlyphCount);
+    }
+}

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeAutomaticFontGrowthTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeAutomaticFontGrowthTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Gum.GueDeriving;
+using Gum.Renderables;
+using KernSmith.Gum;
+using RaylibGum.Helpers;
+using RaylibGum.Renderables;
+using RenderingLibrary;
+using RenderingLibrary.Graphics.Fonts;
+using Shouldly;
+using Xunit;
+
+namespace RaylibGum.Tests.Runtimes;
+
+// Issue #4546 -- Raylib parity for #4542 (TextRuntime.UseAutomaticFontGrowth). Uses the real
+// KernSmithRaylibFontCreator (wrapped by a recording spy, not a synthetic fake), same rationale as
+// TextRuntimeFontOversamplingTests: hand-crafting a fake Raylib_cs.Font (native Recs/Glyphs pointer
+// arrays) is impractical from managed test code. Growth requires a real font FILE (KernSmith's
+// incremental sessions have no system-font overload), so these assign Font directly to a .ttf path
+// (BmfcSave.ResolveTtfSourcePath's "Font-as-path" branch) rather than a family name like "Arial".
+public class TextRuntimeAutomaticFontGrowthTests : BaseTestClass
+{
+    private static string FixtureFontPath =>
+        Path.Combine(AppContext.BaseDirectory, "Content", "Fonts", "Orbitron-Black.ttf");
+
+    [Fact]
+    public void Text_WhenAutomaticFontGrowthDisabled_MissingCharacterStaysUngrown()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = false;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            // U+20AC ('€') is confirmed present in Orbitron-Black.ttf's cmap but outside the default
+            // Ranges (32-126,160-255), so it's only reachable via growth -- with growth disabled it
+            // must stay ungrown.
+            textRuntime.Text = "€";
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            text.Font.HasCharacter('€').ShouldBeFalse();
+            creator.TryAddGlyphsCalls.ShouldBeEmpty();
+        }
+        finally
+        {
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WhenAutomaticFontGrowthEnabled_MissingCharacterIsGrownSynchronously()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = true;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            textRuntime.Text = "€"; // present in the font but outside the default Ranges -- see test above
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            text.Font.HasCharacter('€').ShouldBeTrue(
+                "because the missing character must be grown synchronously, in the same Text assignment that discovered it");
+            creator.TryAddGlyphsCalls.ShouldContain("€");
+        }
+        finally
+        {
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WhenAutomaticFontGrowthEnabled_AllCharactersAlreadyPresent_NeverCallsGrowth()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = true;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            textRuntime.Text = "€"; // grows it once
+            creator.TryAddGlyphsCalls.Clear();
+
+            textRuntime.Text = "€€"; // same character again -- already grown, nothing left missing
+
+            creator.TryAddGlyphsCalls.ShouldBeEmpty(
+                "because a font that already has every requested character must never be asked to grow");
+        }
+        finally
+        {
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WhenACharacterCannotBeRendered_RaisesPropertyAssignmentError_AndDoesNotGrowIt()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        List<string> reportedMessages = new();
+        Action<string> handler = reportedMessages.Add;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = true;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+            CustomSetPropertyOnRenderable.PropertyAssignmentError += handler;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            reportedMessages.Clear(); // isolate from whatever the Font/constructor cascade already reported
+
+            // U+2192 ('->') is confirmed absent from Orbitron-Black.ttf's cmap.
+            textRuntime.Text = "→";
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            text.Font.HasCharacter('→').ShouldBeFalse();
+            reportedMessages.ShouldHaveSingleItem();
+            reportedMessages[0].ShouldContain("→");
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.PropertyAssignmentError -= handler;
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // BmfcSave.OutputWidth/OutputHeight default to 512x256 -- sized for a small, disk-persisted
+    // .fnt/.png cache file. Reused verbatim as a growth ceiling, that fills after only a handful of
+    // glyphs at any real FontSize and throws a KernSmith atlas-packing exception. Growth must raise
+    // the ceiling to TextRuntime.MaxInMemoryFontAtlasSize.
+    [Fact]
+    public void Text_WhenGrowing_UsesMaxInMemoryFontAtlasSize_NotBmfcSavesSmallDiskCacheDefault()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = true;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            textRuntime.Text = "€";
+
+            creator.LastBmfcSave.ShouldNotBeNull();
+            creator.LastBmfcSave!.OutputWidth.ShouldBe(TextRuntime.MaxInMemoryFontAtlasSize);
+            creator.LastBmfcSave.OutputHeight.ShouldBe(TextRuntime.MaxInMemoryFontAtlasSize);
+        }
+        finally
+        {
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    [Fact]
+    public void Text_WhenInMemoryFontCreatorDoesNotSupportGrowth_DoesNothingSilently()
+    {
+        bool savedFlag = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseAutomaticFontGrowth = true;
+            // Implements IRaylibFontCreator only -- no IGrowableRaylibFontCreator, same as any
+            // existing custom creator written before this feature existed.
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = new NonGrowableRaylibFontCreator();
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+
+            Should.NotThrow(() => textRuntime.Text = "€");
+        }
+        finally
+        {
+            TextRuntime.UseAutomaticFontGrowth = savedFlag;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Issue #4542 design decision #3 (Raylib parity): oversampling keeps two live fonts (pinned
+    // MeasurementFont, regenerated display font). A full RegenerateOversampledFont builds a brand-new
+    // font from BmfcSave.Ranges alone -- it has no idea about characters grown in at runtime, so
+    // continuous zooming would silently drop them on every regenerate unless growth history is
+    // replayed into each freshly-generated font.
+    [Fact]
+    public void RegenerateOversampledFont_ReplaysPreviouslyGrownCharacters_IntoTheFreshOversampledFont()
+    {
+        bool savedOversampling = TextRuntime.UseFontOversampling;
+        bool savedGrowth = TextRuntime.UseAutomaticFontGrowth;
+        IRaylibFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            TextRuntime.UseFontOversampling = true;
+            TextRuntime.UseAutomaticFontGrowth = true;
+            SpyGrowableRaylibFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            TextRuntime textRuntime = new();
+            textRuntime.Font = FixtureFontPath;
+            textRuntime.FontSize = 20;
+            // U+2026 ('…') is confirmed present in Orbitron-Black.ttf's cmap but outside the default
+            // Ranges, so assigning it forces a real growth event on the native font.
+            textRuntime.Text = "…";
+
+            Text text = (Text)textRuntime.RenderableComponent;
+            text.Font.HasCharacter('…').ShouldBeTrue("because the native font must have grown first");
+
+            bool result = textRuntime.RegenerateOversampledFont(2.5f);
+
+            result.ShouldBeTrue();
+            text.Font.HasCharacter('…').ShouldBeTrue(
+                "because previously-grown characters must be replayed into every freshly-regenerated oversampled font");
+        }
+        finally
+        {
+            TextRuntime.UseFontOversampling = savedOversampling;
+            TextRuntime.UseAutomaticFontGrowth = savedGrowth;
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
+        }
+    }
+
+    // Wraps the real KernSmithRaylibFontCreator (not a synthetic fake, per this file's own header
+    // comment) so tests can observe/count TryAddGlyphs calls the way MonoGame's stub fakes do.
+    private sealed class SpyGrowableRaylibFontCreator : IRaylibFontCreator, IGrowableRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public List<string> TryAddGlyphsCalls { get; } = new();
+        public BmfcSave? LastBmfcSave { get; private set; }
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave) => _inner.TryCreateFont(bmfcSave);
+
+        public IReadOnlyList<char>? TryAddGlyphs(ref Raylib_cs.Font font, BmfcSave bmfcSave, string characters)
+        {
+            LastBmfcSave = bmfcSave;
+            TryAddGlyphsCalls.Add(characters);
+            return ((IGrowableRaylibFontCreator)_inner).TryAddGlyphs(ref font, bmfcSave, characters);
+        }
+    }
+
+    private sealed class NonGrowableRaylibFontCreator : IRaylibFontCreator
+    {
+        private readonly KernSmithRaylibFontCreator _inner = new();
+
+        public Raylib_cs.Font? TryCreateFont(BmfcSave bmfcSave) => _inner.TryCreateFont(bmfcSave);
+    }
+}


### PR DESCRIPTION
Closes #4546

## Summary

Raylib parity for `TextRuntime.UseAutomaticFontGrowth` (#4542): a `Text`/`TextNoTranslate` assignment that introduces a character missing from the live font now grows the `Raylib_cs.Font`'s glyph atlas in place instead of silently falling back to the default glyph.

- New `IGrowableRaylibFontCreator` interface (Raylib analog of `IGrowableFontCreator`), implemented by `KernSmithRaylibFontCreator`.
- `TextRuntime`'s existing `CheckAndGrowFont`/`GrowIfNeeded`/`ReplayGrownCharacters` logic widened from `#if XNALIKE` to `#if XNALIKE || RAYLIB`, with a Raylib-specific branch.
- `Raylib_cs.Font` is a value type (unlike MonoGame's shared-by-reference `BitmapFont`), so growth can't safely free/replace resources a `Text` struct copy may already be pointing at. `KernSmithRaylibFontCreator` tracks one canonical generation per font identity; growth never frees a superseded generation, and amortizes cost via geometric Recs/Glyphs capacity growth plus in-place `UpdateTextureRec` texture patches, only doing a full atlas rebuild when the atlas itself has to resize.

## Testing

- 12 new tests (`KernSmithRaylibFontCreatorGrowthTests`, `TextRuntimeAutomaticFontGrowthTests`) against the real `KernSmithRaylibFontCreator` + a real font file, including pixel-level blit verification and atlas-resize/capacity-reuse assertions.
- Confirmed 4/7 `TextRuntimeAutomaticFontGrowthTests` go red when the constructor wiring is disabled (not tautological).
- Full `RaylibGum.Tests` suite: 630/630 pass. Relevant `MonoGameGum.Tests` slice: 32/32 pass (XNALIKE branch unaffected).
- Zero new build warnings.

Manual test: verified in a scratch raylib+Gum project against this branch (typed text growing new glyphs live, atlas texture preview updating, unrenderable-character warning firing).

FRB canary: not needed — `TextRuntime.cs` is in the FRB1-excluded `GueDeriving/*Runtime.cs` set; the rest of the changed files are Raylib-only, never compiled by FRB1.
