### PR TITLE
Cache unresolvable font signatures to avoid repeated slow fallback retries

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -155,12 +155,28 @@ public partial class CustomSetPropertyOnRenderable
     }
 
 #if !FRB
+    private static IRuntimeFontService? _fontService;
+
     /// <summary>
     /// Optional font service used for on-demand font creation. In the Gum tool this is
     /// assigned at startup; game runtimes can assign their own implementation.
     /// </summary>
-    public static IRuntimeFontService? FontService { get; set; }
+    public static IRuntimeFontService? FontService
+    {
+        get => _fontService;
+        set
+        {
+            _fontService = value;
+#if !RAYLIB
+            // #4563: a signature cached as unresolvable was only unresolvable against the *previous*
+            // FontService -- swapping it in (or clearing it) is a "try again" signal, not a no-op.
+            _knownUnresolvableFontKeys.Clear();
 #endif
+        }
+    }
+#endif
+
+    private static FontCreatorType? _inMemoryFontCreator;
 
     /// <summary>
     /// Optional in-memory font creator. When set, font generation bypasses disk entirely. On the
@@ -170,7 +186,19 @@ public partial class CustomSetPropertyOnRenderable
     /// null or if creation fails, falls back to the disk-based <see cref="FontService"/> path (or
     /// the existing disk / system-font path on Raylib).
     /// </summary>
-    public static FontCreatorType? InMemoryFontCreator { get; set; }
+    public static FontCreatorType? InMemoryFontCreator
+    {
+        get => _inMemoryFontCreator;
+        set
+        {
+            _inMemoryFontCreator = value;
+#if !RAYLIB
+            // #4563: same reasoning as FontService's setter above -- a new (or removed) creator gets
+            // a fresh attempt at any signature previously marked unresolvable.
+            _knownUnresolvableFontKeys.Clear();
+#endif
+        }
+    }
 
     public static event Action<string>? PropertyAssignmentError;
 
@@ -2271,6 +2299,16 @@ public partial class CustomSetPropertyOnRenderable
     public static HashSet<string> Tags => BbCodeParser.KnownTags;
 
 #if !RAYLIB
+    // #4563: signatures (GetOrCreateBakedFont's `fullFileName` cache key) for which every resolution
+    // tier has already failed. Checked up front so a repeated request for the identical signature
+    // short-circuits instead of re-running the in-memory-creator/FontService/disk cascade -- which can
+    // be slow to fail (e.g. a rasterizer backend unsupported on the current platform). This can't be
+    // folded into LoaderManager's own font cache: a `null` GetDisposable result there is indistinguishable
+    // from "never attempted", and Text.DefaultBitmapFont -- the fallback a naive fix might cache instead
+    // -- is itself null on most real hosts (SystemManagers/LoaderManager only populate it when the
+    // default font is a .fnt bitmap font, not the far more common SpriteFont/"hudFont" default).
+    private static readonly HashSet<string> _knownUnresolvableFontKeys = new();
+
     /// <summary>
     /// Resolves (loading/generating as needed) a <see cref="BitmapFont"/> for <paramref name="fontFilePath"/>
     /// (a .ttf/.otf source, or null to resolve by family name) combined with <paramref name="textRuntime"/>'s
@@ -2292,6 +2330,11 @@ public partial class CustomSetPropertyOnRenderable
         string fontName = textRuntime.GetFontCacheFileName(fontFilePath);
 
         string fullFileName = ToolsUtilities.FileManager.Standardize(fontName, preserveCase: true, makeAbsolute: true);
+
+        if (_knownUnresolvableFontKeys.Contains(fullFileName))
+        {
+            return null;
+        }
 
         font = loaderManager.GetDisposable(fullFileName) as BitmapFont;
 
@@ -2400,6 +2443,11 @@ public partial class CustomSetPropertyOnRenderable
         {
             PropertyAssignmentError?.Invoke(
                 $"No usable font could be resolved for '{fontName}' (in-memory creator, disk cache, and font service all failed) - falling back to the default font.");
+
+            // #4563: remember this signature is unresolvable so a repeated request (e.g. every other
+            // Text-bearing control sharing a broken/unsupported font) short-circuits at the
+            // top-of-function check above instead of re-running the whole cascade.
+            _knownUnresolvableFontKeys.Add(fullFileName);
         }
 
         return font;

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -208,7 +208,21 @@ public partial class CustomSetPropertyOnRenderable
     /// failures on its own render-time path) can surface a failure the same way the property-assignment
     /// cascade in this class does, instead of letting the exception propagate.
     /// </summary>
-    internal static void RaisePropertyAssignmentError(string message) => PropertyAssignmentError?.Invoke(message);
+    /// <remarks>
+    /// Also writes <paramref name="message"/> to <see cref="Console.Error"/> unconditionally -- #4565:
+    /// <see cref="PropertyAssignmentError"/> has no default subscriber (only the Gum tool's editor
+    /// plugin and tests subscribe), so a consumer that never wires the event up got these failures
+    /// completely silently. This is the single choke point every <c>PropertyAssignmentError?.Invoke</c>
+    /// call site in this class routes through, so the console write covers all of them without each
+    /// site needing its own logging call. <c>Console.Error</c> (not <see cref="System.Diagnostics.Debug"/>,
+    /// which no-ops in a Release-configuration NuGet package) because it works in every build
+    /// configuration and is forwarded to the browser console on Blazor WASM.
+    /// </remarks>
+    internal static void RaisePropertyAssignmentError(string message)
+    {
+        Console.Error.WriteLine($"[Gum] {message}");
+        PropertyAssignmentError?.Invoke(message);
+    }
 
     /// <summary>
     /// Optional resolver that turns a render-target shader file reference (e.g. an <c>.fx</c> path on
@@ -493,7 +507,7 @@ public partial class CustomSetPropertyOnRenderable
                 throw new System.IO.FileNotFoundException(message, resolveException);
             }
             effectOwner.RenderTargetEffect = null;
-            PropertyAssignmentError?.Invoke(resolveException != null ? message + "\n" + resolveException.ToString() : message);
+            RaisePropertyAssignmentError(resolveException != null ? message + "\n" + resolveException.ToString() : message);
             return;
         }
 
@@ -2070,7 +2084,7 @@ public partial class CustomSetPropertyOnRenderable
                     {
                         // Fall through to disk-based path, but surface the failure instead of leaving it
                         // completely silent (previously: catch { } with zero diagnostics anywhere - #4464).
-                        PropertyAssignmentError?.Invoke(
+                        RaisePropertyAssignmentError(
                             $"Error creating in-memory font '{fontNameStack.Peek()}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
                     }
                 }
@@ -2213,7 +2227,7 @@ public partial class CustomSetPropertyOnRenderable
             {
                 // Fall through to null - the caller uses the base font / base-atlas scale fallback -
                 // but surface the failure instead of leaving it completely silent.
-                PropertyAssignmentError?.Invoke(
+                RaisePropertyAssignmentError(
                     $"Error creating in-memory font '{fontNameStack.Peek()}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
             }
 
@@ -2362,7 +2376,7 @@ public partial class CustomSetPropertyOnRenderable
             {
                 // Fall through to disk-based path, but surface the failure instead of leaving it
                 // completely silent (previously: catch { } with zero diagnostics anywhere - #4464).
-                PropertyAssignmentError?.Invoke(
+                RaisePropertyAssignmentError(
                     $"Error creating in-memory font '{fontName}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
             }
         }
@@ -2441,7 +2455,7 @@ public partial class CustomSetPropertyOnRenderable
         // configured) used to fall back to the default font with zero diagnostics anywhere - #4553.
         if (font == null)
         {
-            PropertyAssignmentError?.Invoke(
+            RaisePropertyAssignmentError(
                 $"No usable font could be resolved for '{fontName}' (in-memory creator, disk cache, and font service all failed) - falling back to the default font.");
 
             // #4563: remember this signature is unresolvable so a repeated request (e.g. every other
@@ -2516,7 +2530,7 @@ public partial class CustomSetPropertyOnRenderable
                 // Fall through to the disk / system-font path, but surface the failure - previously
                 // silent, leaving Raylib's default font on screen with no indication the in-memory
                 // creator failed.
-                PropertyAssignmentError?.Invoke(
+                RaisePropertyAssignmentError(
                     $"Error creating in-memory font '{fontName}' via {InMemoryFontCreator.GetType().Name}:\n{ex}");
             }
         }
@@ -2534,7 +2548,7 @@ public partial class CustomSetPropertyOnRenderable
         // either - #4553.
         if (fontFromGum.BaseSize == 0)
         {
-            PropertyAssignmentError?.Invoke(
+            RaisePropertyAssignmentError(
                 $"No usable font could be resolved for '{fontName}' (in-memory creator, disk cache, and system font all failed) - falling back to raylib's default font.");
         }
 
@@ -3142,7 +3156,7 @@ public partial class CustomSetPropertyOnRenderable
                 }
                 sprite.AnimationChains = null;
 
-                PropertyAssignmentError?.Invoke(message + "\n" + ex.ToString());
+                RaisePropertyAssignmentError(message + "\n" + ex.ToString());
             }
 
 
@@ -3204,7 +3218,7 @@ public partial class CustomSetPropertyOnRenderable
                 }
                 sprite.Texture = null;
 
-                PropertyAssignmentError?.Invoke(loadException != null ? message + "\n" + loadException.ToString() : message);
+                RaisePropertyAssignmentError(loadException != null ? message + "\n" + loadException.ToString() : message);
             }
             else
             {

--- a/MonoGameGum.Tests/Runtimes/InMemoryFontCreatorPropertyAssignmentErrorTests.cs
+++ b/MonoGameGum.Tests/Runtimes/InMemoryFontCreatorPropertyAssignmentErrorTests.cs
@@ -7,6 +7,7 @@ using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using ToolsUtilities;
 using Xunit;
@@ -114,6 +115,38 @@ public class InMemoryFontCreatorPropertyAssignmentErrorTests : BaseTestClass
         {
             CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
             CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+        }
+    }
+
+    // #4565: PropertyAssignmentError has no default subscriber -- only the Gum tool's editor plugin
+    // and tests subscribe -- so a consumer that never wires the event up got these failures
+    // completely silently. That's exactly what happened investigating #4563/#4564 on Blazor WASM: the
+    // real font-creator failure never surfaced anywhere visible, only its downstream symptom (repeated
+    // 404s probing a FontCache path that was never going to exist). Every raise now also goes to
+    // Console.Error so it's visible without opting in, on every platform and build configuration.
+    [Fact]
+    public void GetOrCreateBakedFont_WhenCreatorDeclinesAndNoFallbackResolves_ShouldWriteToConsoleError()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        TextWriter originalError = Console.Error;
+        StringWriter capturedError = new StringWriter();
+        Console.SetError(capturedError);
+        try
+        {
+            DecliningFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            string fontName = UniqueFontName();
+            TextRuntime textRuntime = new();
+            textRuntime.Font = fontName;
+            textRuntime.FontSize = 12;
+
+            capturedError.ToString().ShouldContain(fontName);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
         }
     }
 

--- a/MonoGameGum.Tests/Runtimes/InMemoryFontCreatorPropertyAssignmentErrorTests.cs
+++ b/MonoGameGum.Tests/Runtimes/InMemoryFontCreatorPropertyAssignmentErrorTests.cs
@@ -6,6 +6,8 @@ using RenderingLibrary.Graphics;
 using RenderingLibrary.Graphics.Fonts;
 using Shouldly;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using ToolsUtilities;
 using Xunit;
 
@@ -112,6 +114,46 @@ public class InMemoryFontCreatorPropertyAssignmentErrorTests : BaseTestClass
         {
             CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
             CustomSetPropertyOnRenderable.PropertyAssignmentError -= Handler;
+        }
+    }
+
+    // #4563: a font signature that fails to resolve (creator declines/throws, nothing else resolves
+    // it either) previously wasn't cached, so every Text-bearing control requesting that same
+    // signature re-ran the whole creator/FontService/disk cascade from scratch -- costly when the
+    // creator is slow to fail (e.g. a rasterizer backend that isn't supported on the current
+    // platform). GetAndCreateFontIfNecessary (the inline [Font=...] BBCode path) already caches its
+    // failure; this pins GetOrCreateBakedFont doing the same for the base Font/CustomFontFile path.
+    //
+    // Counts only calls whose cache name contains our GUID-unique fontName, not raw CallCount --
+    // constructing a TextRuntime can itself trigger a resolution for its construction-time default
+    // font ("Arial"), which is incidental noise unrelated to the signature under test here.
+    [Fact]
+    public void GetOrCreateBakedFont_WhenCreatorDeclinesAndSameSignatureIsRequestedAgain_ShouldNotReinvokeCreator()
+    {
+        IInMemoryFontCreator? savedCreator = CustomSetPropertyOnRenderable.InMemoryFontCreator;
+        try
+        {
+            DecliningFontCreator creator = new();
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = creator;
+
+            string fontName = UniqueFontName();
+
+            TextRuntime first = new();
+            first.Font = fontName;
+
+            // A second, unrelated TextRuntime requesting the exact same signature (same family at
+            // the same default FontSize) should hit the cached failure instead of consulting the
+            // creator again.
+            TextRuntime second = new();
+            second.Font = fontName;
+
+            int callsForOurSignature = creator.SeenCacheNames.Count(name => name.Contains(fontName));
+            callsForOurSignature.ShouldBe(1,
+                "seen names: " + string.Join(" | ", creator.SeenCacheNames));
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.InMemoryFontCreator = savedCreator;
         }
     }
 
@@ -228,10 +270,12 @@ char id=67 x=0 y=0 width=9 height=13 xoffset=0 yoffset=4 xadvance=9 page=0 chnl=
     private sealed class DecliningFontCreator : IInMemoryFontCreator
     {
         public int CallCount { get; private set; }
+        public List<string> SeenCacheNames { get; } = new();
 
         public BitmapFont? TryCreateFont(BmfcSave bmfcSave)
         {
             CallCount++;
+            SeenCacheNames.Add(bmfcSave.FontCacheFileName);
             return null;
         }
     }

--- a/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
+++ b/Tests/Gum.Themes.Tests/Gum.Themes.Tests.csproj
@@ -21,7 +21,11 @@
   <ItemGroup>
     <ProjectReference Include="..\MonoGameGum.TestsCommon\MonoGameGum.TestsCommon.csproj" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.DarkPro.MonoGame\Gum.Themes.DarkPro.MonoGame.csproj" />
-    <ProjectReference Include="..\..\Themes\Gum.Themes.Bubblegum.MonoGame\Gum.Themes.Bubblegum.MonoGame.csproj" />
+    <!-- Aliased (in addition to the default global alias) so ThemePlatformSelectBackendTests can
+         reference this assembly's copy of the internal ThemePlatform type unambiguously. Every
+         theme .MonoGame project links the same Themes/Shared/ThemePlatform.cs source file, so without
+         an alias the compiler can't tell which assembly's ThemePlatform an unqualified reference means. -->
+    <ProjectReference Include="..\..\Themes\Gum.Themes.Bubblegum.MonoGame\Gum.Themes.Bubblegum.MonoGame.csproj" Aliases="global,ThemePlatformHost" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.Editor.MonoGame\Gum.Themes.Editor.MonoGame.csproj" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.Retro95.MonoGame\Gum.Themes.Retro95.MonoGame.csproj" />
     <ProjectReference Include="..\..\Themes\Gum.Themes.ForestGlade.MonoGame\Gum.Themes.ForestGlade.MonoGame.csproj" />

--- a/Tests/Gum.Themes.Tests/ThemePlatformSelectBackendTests.cs
+++ b/Tests/Gum.Themes.Tests/ThemePlatformSelectBackendTests.cs
@@ -1,0 +1,98 @@
+// ThemePlatform (internal) is linked from the same Themes/Shared/ThemePlatform.cs source file into
+// every theme .MonoGame assembly this project references, so an unaliased reference is ambiguous --
+// see the Aliases="global,ThemePlatformHost" on the Bubblegum ProjectReference in this project's
+// .csproj. Any one theme assembly's copy is equally valid to test against; Bubblegum is arbitrary.
+extern alias ThemePlatformHost;
+
+using KernSmith;
+using Shouldly;
+using ThemePlatform = ThemePlatformHost::Gum.Themes.ThemePlatform;
+
+// Deliberately NOT namespace Gum.Themes.Tests (this project's usual convention): a namespace nested
+// under Gum.Themes makes the compiler search that enclosing namespace across EVERY referenced
+// assembly for an unqualified name -- reintroducing the exact CS0433 ambiguity the extern alias
+// above exists to avoid.
+namespace GumThemePlatformTests;
+
+/// <summary>
+/// Pins #4564: on browser-wasm, <c>ThemePlatform.WireInMemoryFontCreator</c> must select the
+/// StbTrueType rasterizer backend instead of the native-only FreeType default, or every theme font
+/// fails to bake (KernSmith throws, and -- before #4563's caching fix -- the failure retried on every
+/// request, freezing the page on theme switch). <c>SelectBackend</c> is the extracted, pure decision
+/// so this is testable without a real browser host or GraphicsDevice.
+/// </summary>
+public class ThemePlatformSelectBackendTests
+{
+    [Fact]
+    public void SelectBackend_WhenNotBrowser_ReturnsNull()
+    {
+        var (savedIsBrowser, savedResolve, savedForce) = SaveSeams();
+        try
+        {
+            ThemePlatform.IsBrowserPlatform = () => false;
+            ThemePlatform.ResolveStbTrueTypeRasterizerType = () =>
+                throw new System.InvalidOperationException("Should not be consulted off-browser.");
+
+            ThemePlatform.SelectBackend().ShouldBeNull();
+        }
+        finally
+        {
+            RestoreSeams(savedIsBrowser, savedResolve, savedForce);
+        }
+    }
+
+    [Fact]
+    public void SelectBackend_WhenBrowserAndStbTrueTypeIsAvailable_ReturnsStbTrueTypeAndForcesRegistration()
+    {
+        var (savedIsBrowser, savedResolve, savedForce) = SaveSeams();
+        System.Type? forcedType = null;
+        try
+        {
+            ThemePlatform.IsBrowserPlatform = () => true;
+            ThemePlatform.ResolveStbTrueTypeRasterizerType = () => typeof(ThemePlatformSelectBackendTests);
+            ThemePlatform.ForceStaticConstructor = type => forcedType = type;
+
+            RasterizerBackend? backend = ThemePlatform.SelectBackend();
+
+            backend.ShouldBe(RasterizerBackend.StbTrueType);
+            forcedType.ShouldBe(typeof(ThemePlatformSelectBackendTests));
+        }
+        finally
+        {
+            RestoreSeams(savedIsBrowser, savedResolve, savedForce);
+        }
+    }
+
+    [Fact]
+    public void SelectBackend_WhenBrowserAndStbTrueTypeIsNotReferenced_ReturnsNull()
+    {
+        var (savedIsBrowser, savedResolve, savedForce) = SaveSeams();
+        bool forceCalled = false;
+        try
+        {
+            ThemePlatform.IsBrowserPlatform = () => true;
+            ThemePlatform.ResolveStbTrueTypeRasterizerType = () => null;
+            ThemePlatform.ForceStaticConstructor = _ => forceCalled = true;
+
+            ThemePlatform.SelectBackend().ShouldBeNull(
+                "so the existing PlatformNotSupportedException from GumFontGenerator.Generate still " +
+                "fires and names the missing package, instead of silently misbehaving");
+            forceCalled.ShouldBeFalse();
+        }
+        finally
+        {
+            RestoreSeams(savedIsBrowser, savedResolve, savedForce);
+        }
+    }
+
+    private static (System.Func<bool>, System.Func<System.Type?>, System.Action<System.Type>) SaveSeams() =>
+        (ThemePlatform.IsBrowserPlatform, ThemePlatform.ResolveStbTrueTypeRasterizerType, ThemePlatform.ForceStaticConstructor);
+
+    private static void RestoreSeams(
+        System.Func<bool> isBrowser, System.Func<System.Type?> resolve, System.Action<System.Type> force)
+    {
+        ThemePlatform.IsBrowserPlatform = isBrowser;
+        ThemePlatform.ResolveStbTrueTypeRasterizerType = resolve;
+        ThemePlatform.ForceStaticConstructor = force;
+    }
+}

--- a/Tests/MonoGameGum.Tests.V3/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/GueDeriving/TextRuntimeDropshadowPlumbingTests.cs
@@ -22,10 +22,15 @@ public class TextRuntimeDropshadowPlumbingTests
 
         try
         {
+            // #4563: a font signature the creator has already declined for is now cached, so the
+            // property that actually changes the font-cache key (HasDropshadow, which adds "_ds" --
+            // see GetFontCacheFileName_WhenHasDropshadowDiffersFromPlainKey below) is set LAST. That
+            // guarantees the one un-cached creator call captures every shadow field below, which are
+            // draw-time-only (not part of the font-cache key, see GumFontGenerator.ApplyShadowOptions)
+            // and were already live on the instance by the time HasDropshadow flips the key.
             TextRuntime text = new TextRuntime();
             text.Font = "Arial";
             text.FontSize = 24;
-            text.HasDropshadow = true;
             text.DropshadowOffsetX = 2f;
             text.DropshadowOffsetY = 3f;
             text.DropshadowBlur = 4f;
@@ -33,6 +38,7 @@ public class TextRuntimeDropshadowPlumbingTests
             text.DropshadowGreen = 20;
             text.DropshadowBlue = 30;
             text.DropshadowAlpha = 128;
+            text.HasDropshadow = true;
 
             creator.LastBmfcSave.ShouldNotBeNull();
             creator.LastBmfcSave!.HasDropshadow.ShouldBeTrue();

--- a/Themes/Shared/ThemePlatform.cs
+++ b/Themes/Shared/ThemePlatform.cs
@@ -6,6 +6,7 @@ using SkiaGum.Content.Fonts;
 #else
 using Gum.Wireframe;
 using RenderingLibrary;
+using KernSmith;
 using KernSmith.Gum;
 #endif
 using System;
@@ -20,6 +21,50 @@ namespace Gum.Themes;
 /// </summary>
 internal static class ThemePlatform
 {
+#if !RAYLIB && !SKIA
+    // Test seams for SelectBackend() below -- swappable so its logic is unit-testable without a real
+    // browser host or a compile-time reference to KernSmith.Rasterizers.StbTrueType. Mirrors the
+    // established IsBrowserPlatform seam pattern in GumFontGenerator (KernSmith.GumCommon).
+    internal static Func<bool> IsBrowserPlatform = OperatingSystem.IsBrowser;
+    internal static Func<Type?> ResolveStbTrueTypeRasterizerType = () =>
+        Type.GetType("KernSmith.Rasterizers.StbTrueType.StbTrueTypeRasterizer, KernSmith.Rasterizers.StbTrueType");
+    internal static Action<Type> ForceStaticConstructor = type =>
+        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type.TypeHandle);
+
+    /// <summary>
+    /// Picks the KernSmith rasterizer backend a theme's font creator should use. FreeType (the
+    /// default, <c>null</c> here) is native code and cannot run on browser-wasm (#4564) -- there,
+    /// StbTrueType (the sole pure-C# backend) is required instead. Resolved by name via reflection
+    /// rather than a compile-time reference, so desktop/Raylib/SilkNet theme consumers never have to
+    /// carry the <c>KernSmith.Rasterizers.StbTrueType</c> package just because it exists (see the
+    /// <c>gum-kernsmith-integrations</c> skill's "per-backend package split"). Also force-runs the
+    /// backend's static constructor: KernSmith's reflection-based backend auto-discovery is trimmed
+    /// away under wasm/AOT publish and would otherwise silently fail to register it.
+    /// </summary>
+    /// <returns>
+    /// <see cref="RasterizerBackend.StbTrueType"/> on browser-wasm when the package is referenced;
+    /// otherwise <c>null</c>, which keeps the existing FreeType default -- and, on browser-wasm
+    /// without the package, the existing actionable <c>PlatformNotSupportedException</c> from
+    /// <c>GumFontGenerator.Generate</c> that names the missing package.
+    /// </returns>
+    internal static RasterizerBackend? SelectBackend()
+    {
+        if (!IsBrowserPlatform())
+        {
+            return null;
+        }
+
+        Type? stbType = ResolveStbTrueTypeRasterizerType();
+        if (stbType == null)
+        {
+            return null;
+        }
+
+        ForceStaticConstructor(stbType);
+        return RasterizerBackend.StbTrueType;
+    }
+#endif
+
     /// <summary>
     /// Assigns the backend-appropriate KernSmith in-memory font creator so themed controls can
     /// rasterize their fonts (system or embedded) at runtime without shipping <c>.fnt</c> files.
@@ -39,7 +84,7 @@ internal static class ThemePlatform
         var graphicsDevice = SystemManagers.Default?.Renderer?.GraphicsDevice
             ?? throw new InvalidOperationException(
                 "Gum must be initialized (GumService.Initialize) before applying a theme.");
-        CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(graphicsDevice);
+        CustomSetPropertyOnRenderable.InMemoryFontCreator = new KernSmithFontCreator(graphicsDevice, SelectBackend());
 #endif
     }
 


### PR DESCRIPTION
## Summary

- `GetOrCreateBakedFont` (the resolution path for `TextRuntime.Font`/`CustomFontFile`) now caches a signature that every resolution tier declined/threw on, so a repeated request for the identical font signature short-circuits instead of re-running the in-memory-creator/FontService/disk cascade.
- The cache is a `HashSet<string>` of known-unresolvable signatures (`_knownUnresolvableFontKeys`), not a reuse of `LoaderManager`'s font cache — `Text.DefaultBitmapFont` (what a naive fix would cache as the "resolved" value) is itself `null` on most real hosts, so it can't double as a sentinel.
- `InMemoryFontCreator`/`FontService`'s setters now clear that cache on reassignment, since a signature that failed against the old creator/service deserves a fresh attempt against a new one.
- `PropertyAssignmentError` (previously silent — no default subscriber outside the Gum tool/tests) now also writes to `Console.Error` from its one choke point (`RaisePropertyAssignmentError`), so a failure like the one below is visible without a consumer opting in.
- `ThemePlatform.SelectBackend` picks `RasterizerBackend.StbTrueType` on browser-wasm (resolved by name via reflection, never a compile-time package reference, plus force-running its static constructor to counter wasm/AOT trimming of KernSmith's backend auto-discovery) instead of the native-only FreeType default that can never run there.

Closes #4563. Closes #4564.

## Test plan
- [x] New test pins the #4563 caching behavior (`GetOrCreateBakedFont_WhenCreatorDeclinesAndSameSignatureIsRequestedAgain_ShouldNotReinvokeCreator`), confirmed red before the fix, green after.
- [x] New test pins the console-logging behavior (`GetOrCreateBakedFont_WhenCreatorDeclinesAndNoFallbackResolves_ShouldWriteToConsoleError`), confirmed red/green.
- [x] New tests pin `ThemePlatform.SelectBackend`'s three branches (not-browser / browser+package-present / browser+package-absent) in `Tests/Gum.Themes.Tests`, confirmed red/green.
- [x] `MonoGameGum.Tests` full suite: 2235/2235 passed.
- [x] `Tests/MonoGameGum.Tests.V3`: 154/154 passed (one pre-existing test reordered — see below).
- [x] `Tests/RaylibGum.Tests`: 632/632 passed (unaffected — RAYLIB uses a separate resolution path).
- [x] `Tests/Gum.Themes.Tests`: 33/33 passed.
- [x] `GumFull.sln`: 0 errors.
- [x] Kni/Raylib/SilkNet theme package variants build clean (0 errors) individually.
- FRB canary: pass (0 errors on baseline and branch; `GumCore.DesktopGlNet6.csproj`). `Themes/Shared/ThemePlatform.cs` is not FRB-shared (not in `GumCoreShared.projitems`), so no canary needed for the #4564 portion.
- Manual test: built the reporting user's own external Blazor/KNI theme-picker app against this worktree via `ProjectReference`, plus added `KernSmith.Rasterizers.StbTrueType` to it — compiles clean, 0 errors, and the built output confirms the StbTrueType assembly is present. Confirmed by the reporting user in-browser: theme switching is fast and fonts render correctly.

## Note on `TextRuntimeDropshadowPlumbingTests.cs`
`SettingHasDropshadow_PassesShadowFieldsToInMemoryFontCreator` set 7 dropshadow fields (offset/color/alpha) that don't affect the font-cache key (only `HasDropshadow`+`Blur` do — see `GumFontGenerator.ApplyShadowOptions`), then read the creator's *last* captured call. With caching, only key-changing calls reach the creator, so most of those assignments were correctly skipped and the assertion saw a stale capture. Reordered so `HasDropshadow = true` (the key-changing assignment) runs last, guaranteeing the one live call captures the fully-configured state — no change to the underlying plumbing being tested.

## Note on `Tests/Gum.Themes.Tests/ThemePlatformSelectBackendTests.cs`
Every theme `.MonoGame` project links the identical `Themes/Shared/ThemePlatform.cs` source file, so `Gum.Themes.Tests` (which references all 9 for their public `*Colors` types) sees 9 different assemblies each defining internal `Gum.Themes.ThemePlatform` — an unqualified reference is ambiguous (`CS0433`). Fixed with an `extern alias` on the Bubblegum reference (arbitrary pick) plus keeping the new test class out of the `Gum.Themes.*` namespace tree (a nested namespace auto-searches enclosing namespaces across every referenced assembly, reintroducing the same ambiguity even with the alias in scope).

