### PR TITLE
Split September migration doc, tighten release-notes brevity rules

### DIFF
--- a/.claude/skills/gum-monthly-release/SKILL.md
+++ b/.claude/skills/gum-monthly-release/SKILL.md
@@ -99,11 +99,16 @@ gh release view <prior-release-tag> --repo vchelaru/Gum
 
 > You are expanding Gum PRs into release-notes bullets. For each PR number in this batch — [N1, N2, …] — run `gh pr view <N> --repo vchelaru/Gum --json number,title,author,files,commits`. If the commit list is sparse or the intent is unclear, also read `gh pr diff <N> --repo vchelaru/Gum`, and for PRs whose title references an issue number, `gh issue view <issue-num> --repo vchelaru/Gum` for the user-facing symptom. Standalone `jq`/`python` are not installed; use `gh --jq` only.
 >
-> The style is **user-impact-first, not mechanical**: the reader is a Gum customer deciding whether this release matters to them. Translate, e.g. *"Refactored TextRuntime font loading"* → *"Better error messages when fonts fail to load because Gum wasn't initialized"*; *"Added IsTilingMiddleSections to NineSlice"* → *"NineSlices can now optionally tile the middle section in tool and at runtime."* Keep bullets to one line unless a feature genuinely needs more; link docs (`https://docs.flatredball.com/gum/...`) when relevant.
+> The style is **user-impact-first, not mechanical**: the reader is a Gum customer deciding whether this release matters to them. Translate, e.g. *"Refactored TextRuntime font loading"* → *"Better error messages when fonts fail to load because Gum wasn't initialized"*; *"Added IsTilingMiddleSections to NineSlice"* → *"NineSlices can now optionally tile the middle section in tool and at runtime."*
+>
+> **Humans are lazy. One short sentence per bullet, no exceptions.** State the change and stop — cut every qualifying clause ("this only affects you if...", "instead of the old behavior of...", "note that...") unless deleting it would make the bullet actively wrong. A bullet with a semicolon or a second sentence is a compression failure, not thoroughness. If detail matters (who's affected by a breaking change, how to migrate), that detail belongs in the linked doc, not the bullet — link docs (`https://docs.flatredball.com/gum/...`) instead of inlining them.
+>
+> Bad: *"V1 and V2 default Forms visuals are removed. DefaultVisualsVersion.V1/.V2 and their backing classes no longer exist. Passing either value, or referencing a V1/V2 class directly, is now a compile error instead of a CS0618 warning. This only affects you if you explicitly requested V1/V2 or subclassed a V1/V2 visual directly; every backend already defaulted to V3 in practice."*
+> Good: *"V1 and V2 default Forms visuals removed, replaced by V3."*
 >
 > **Expand roll-ups — this is the single most important instruction.** A PR titled "Styling improvements" / "Font improvements" / "FRB fixes" / "Apos Shapes work" / "More work on X" almost always contains *several* distinct user-visible changes in its commit list. Emit **one bullet per distinct change**, never one bullet for the PR. The PR title is never the only signal; the per-commit changelog is. ("Bump version", `GITBOOK-NNN`, `Merge pull request` commits add nothing — for those, trust the title.)
 >
-> **Skip entirely** (return nothing): GitBook auto-syncs (`GITBOOK-NNN`), FRB-integration fix PRs ("FRB fixes" / "Oops fixed FRB" — FlatRedBall-1 patches the maintainer never wants in notes), internal-only first-party plugin/code-organization renames (e.g. `InternalPlugin` → `PriorityPlugin`), and **documentation-only PRs** (new or updated docs pages, troubleshooting sections, doc reorganization, broken-link fixes) — the maintainer does not include documentation in the release notes. For a *mixed* PR that also changes code, still surface the non-documentation user-facing change; only the documentation portion is dropped.
+> **Skip entirely** (return nothing): GitBook auto-syncs (`GITBOOK-NNN`), FRB-integration fix PRs ("FRB fixes" / "Oops fixed FRB" — FlatRedBall-1 patches the maintainer never wants in notes), internal-only first-party plugin/code-organization renames (e.g. `InternalPlugin` → `PriorityPlugin`), **documentation-only PRs** (new or updated docs pages, troubleshooting sections, doc reorganization, broken-link fixes) — the maintainer does not include documentation in the release notes, and **internal diagnostic logging** (e.g. per-phase timing added to the Output window, debug instrumentation) — not a user-visible capability change, so skip it without routing to Open Questions. For a *mixed* PR that also changes code, still surface the non-documentation user-facing change; only the documentation/diagnostic portion is dropped.
 >
 > **Clarity bar** — every bullet must answer "what changed and why do I care?" without opening the PR or knowing the codebase:
 > - No dangling internal class/method names. *"Property paths shared via the relocated `PropertyPathObserver`"* is unacceptable — name the user scenario or drop the class name.
@@ -129,9 +134,11 @@ Work from the **combined bullet list the Step 3 subagents returned**, not the ra
 
 **Documentation-only changes are excluded from the curated sections** — the maintainer does not want docs called out in the highlight bullets. The Step 3 subagents already drop them, but double-check that none slipped through as a Gum Tool or Gum Runtimes bullet. (Documentation PRs are *only* excluded from the curated highlights — they still appear in the complete What's Changed list per Step 7.5.)
 
+**One bullet = one change, one short sentence — never stitch bullets together to save space.** Each Step 3 subagent already returns one bullet per distinct change. When filing them into a section, keep them as separate list items, and keep each to a single short sentence — no semicolons chaining a second fact, no "this only affects you if..." caveats, no parenthetical PR-number lists like "(#4426, #4436, #4498)" tacked onto a combined sentence. A bullet that names more than one PR, or that runs past one sentence, is a compression failure — split it back into separate bullets, even when the changes are thematically related (a shared intro sentence is fine; the fixes below it still get one bullet each). No em dashes — use a period or comma instead. This is the single most common way a draft goes wrong: it's easy to re-merge Step 3's already-good short bullets into a longer "complete" paragraph while filing them, and that's exactly the failure to avoid.
+
 Sections, in order:
 
-1. **Breaking Changes** — bullets + a "For more information... see <migration-doc-url>" line. Omit the section entirely if the user said no breaking changes this month.
+1. **Breaking Changes** — one short sentence per change, naming what was removed/changed and its replacement (e.g. "X removed, replaced by Y"), plus a "See the upgrade guide for who's affected and how to fix it: <migration-doc-url>" line. Who's affected, why, and how to migrate are the doc's job, not the bullet's — do not restate them inline. Omit the section entirely if the user said no breaking changes this month.
 2. **Biggest Changes** — see Step 5.
 3. **Gum Tool** — anything affecting the Gum WPF tool (paths under `Tool/`, `Gum/`, plugins, tool-side projects).
 4. **Gum Runtimes** — anything affecting shipped runtime libraries (`MonoGameGum`, `KniGum`, `FnaGum`, `SkiaGum`, `RaylibGum`, `GumCommon`'s runtime-facing pieces).
@@ -155,7 +162,7 @@ The user picks the spotlight features by gut feel: coolest / most impactful for 
 - Identify **up to 4 additional candidates** — also strong but didn't make your top 4.
 - Place the Top 4 in the **Biggest Changes** section in the markdown, each with:
   - `### <Feature name>` heading
-  - 1–3 sentence user-impact description
+  - 1–2 short sentences of user-impact description, same "cut every caveat" bar as regular bullets (see Step 3) — a spotlight section earns a heading and an image, not extra words
   - Doc link if available
   - `PLACEHOLDER!!!! IMAGE/GIF for <feature name>` line where the image goes
 - Put the additional candidates in the **Open Questions** block at the bottom (see Step 9) so the user can swap or re-rank.
@@ -209,7 +216,7 @@ Rules for the list:
 - **Order newest-first** (git log default) — matches GitHub's auto-generated "What's Changed".
 - **Exclude** GitBook auto-syncs and FRB-integration PRs (same filters as Step 2). These never appear, not even here.
 - **Keep everything else by default** — this list's job is completeness. Internal refactors **and documentation PRs** that were omitted from the curated sections still belong here. (Documentation is excluded from the curated highlights but retained in this complete list.)
-- **Repo-housekeeping is the one trim the user may request** (CLAUDE.md edits, skill-file changes, CI-only PRs, GitBook asset renames, stub-doc adds). Leave them in by default but offer to strip them (see Step 11). Remove with `grep -vxF -e "<exact line>" …` (exact, fixed-string match) — note `grep -P` fails in this environment's locale, and `/`-containing titles break naive `sed /…/d` because `/` is the sed delimiter.
+- **Repo-housekeeping is excluded from What's Changed by default, without asking** (CLAUDE.md edits, skill-file changes, CI-only PRs, GitBook asset renames, stub-doc adds). Filter with `grep -vxF -e "<exact line>" …` (exact, fixed-string match) — note `grep -P` fails in this environment's locale, and `/`-containing titles break naive `sed /…/d` because `/` is the sed delimiter.
 
 Sanity-check the count against the canonical set (`git log` PR count minus the FRB/GitBook exclusions) before moving on.
 
@@ -269,6 +276,16 @@ Critically: do not let the *presence* of a class name lull you into thinking a b
 
 If you find yourself producing a bullet you wouldn't be able to defend in a code review, that's the signal to investigate or OQ rather than ship.
 
+## Step 9.6: Compression audit (mandatory before writing)
+
+This is where the "it's SOOOOOOOO WORDY" failure actually happens: not in Step 3's per-PR bullets, but in Step 4's merge, when multiple already-good short bullets get stitched into one dense paragraph, or a single bullet grows a string of "this only affects you if..." caveats, to save space. Before writing the file, re-scan every bullet in Breaking Changes, Biggest Changes, Gum Tool, Gum Runtimes, and Tutorials and Templates:
+
+- Is it one short sentence? A bullet naming more than one PR number, or containing a semicolon or a second sentence, is almost always two bullets wearing one, or a caveat that belongs in a linked doc instead.
+- Does it state the change and stop, with no "this only affects you if..." / "instead of the old behavior of..." qualifier tacked on?
+- Does it avoid an em dash?
+
+Any "no" means split or cut it per the rule in Step 4.
+
 ## Step 10: Write the file and open it
 
 Write to `temp/release-notes-YYYY-MM-DD.md` at the repo root, where the date is parsed from the release tag from Step 1 question 1.
@@ -283,7 +300,7 @@ Confirm the path in chat so the user can find it again.
 
 ## Step 11: Walk through Open Questions
 
-After the file is open, work through the Open Questions block with the user **one question at a time**. As each is resolved, edit the file directly (move bullets between sections, swap Biggest Changes entries, fill in clarified user-impact descriptions). Among the questions to raise here: **offer to trim repo-housekeeping from the What's Changed list** (CLAUDE.md/skill-file/CI/stub-doc/GitBook-asset-rename PRs) — list the specific candidate lines so the user can say yes/no in one go. Once all are resolved, delete the Open Questions block.
+After the file is open, work through the Open Questions block with the user **one question at a time**. As each is resolved, edit the file directly (move bullets between sections, swap Biggest Changes entries, fill in clarified user-impact descriptions). Once all are resolved, delete the Open Questions block.
 
 The skill is done when the markdown file contains only the release notes — curated highlights + the What's Changed list + the two intentional placeholders (per-spotlight images and the Full Changelog compare link), no Open Questions — and the user is satisfied.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -154,6 +154,7 @@
   * [Upgrading File (GUMX) Version](gum-tool/upgrading/upgrading-file-gumx-version.md)
   * [Syntax Versions](gum-tool/upgrading/syntax-versions.md)
     * [Syntax Version 1](gum-tool/upgrading/syntax-version-1.md)
+  * [Migrating to 2026 September](gum-tool/upgrading/migrating-to-2026-september.md)
   * [Migrating to 2026 August](gum-tool/upgrading/migrating-to-2026-august.md)
   * [Migrating to 2026 July - 2nd Release](gum-tool/upgrading/migrating-to-2026-july-2nd-release.md)
   * [Migrating to 2026 July](gum-tool/upgrading/migrating-to-2026-july.md)

--- a/docs/gum-tool/upgrading/migrating-to-2026-august.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-august.md
@@ -6,12 +6,10 @@ This page discusses breaking changes and other considerations when migrating fro
 
 ## What Changed at a Glance
 
-Four changes need your attention:
+Two changes need your attention:
 
 * `GraphicalUiElement`'s `GetAbsoluteWidth()` and `GetAbsoluteHeight()` methods are renamed to the `AbsoluteWidth` and `AbsoluteHeight` properties, matching the existing `AbsoluteLeft`/`AbsoluteTop`/`AbsoluteRight`/`AbsoluteBottom` properties. This is a **soft break**: the old methods still compile and work, but now emit a `CS0618` obsolete warning.
 * `MonoGameGum.csproj`'s iOS and Android target frameworks changed from opt-out to opt-in. This affects you only if you reference the MonoGameGum **source project** directly. If you use the `Gum.MonoGame` NuGet package, nothing changes.
-* The V1 and V2 default Forms visuals are removed. This is a **hard break**: `DefaultVisualsVersion.V1`/`.V2` and their backing classes no longer exist. This only affects you if you explicitly requested V1 or V2; everyone else was already on V3.
-* `Gum.SkiaSharp` now compiles `GumService` (and its new `GumServiceSkiaBase`) directly instead of requiring host projects to file-link `GumService.cs`. This affects you only if you previously file-linked `Runtimes/SkiaGum.Standalone/GumService.cs` into your own project.
 
 ## Upgrading the Gum Tool
 
@@ -90,58 +88,3 @@ dotnet build MonoGameGum/MonoGameGum.csproj -p:IncludeIOS=true -p:IncludeAndroid
 ```
 
 Setting them inside your own `.csproj` does not work. Only real global properties propagate through a `ProjectReference`.
-
-### V1 and V2 Default Forms Visuals Are Removed
-
-The 2026 July release (see [Migrating to 2026 July](migrating-to-2026-july.md)) marked the V1 (`Default*Runtime`) and V2 (non-V3 `*Visual`) Forms default visuals `[Obsolete]`. This release removes them outright: `DefaultVisualsVersion.V1`/`.V2` and their backing classes no longer exist. Passing either value, or referencing a V1/V2 class directly, is now a compile error rather than a `CS0618` warning.
-
-This only affects you if you explicitly passed `DefaultVisualsVersion.V1` or `.V2` to `GumService.Initialize` / `FormsUtilities.InitializeDefaults`, or referenced a V1/V2 visual class (e.g. `DefaultButtonRuntime`, the non-V3 `ButtonVisual`) directly, for example to build a custom visual around one. Every backend already defaulted to V3 in practice, so most projects need no changes.
-
-To migrate, pass `DefaultVisualsVersion.V3` (or `.Newest`):
-
-❌ Old:
-```csharp
-// Initialize
-GumService.Default.Initialize(
-    this,
-    defaultVisualsVersion: DefaultVisualsVersion.V2);
-```
-
-✅ New:
-```csharp
-// Initialize
-GumService.Default.Initialize(
-    this,
-    defaultVisualsVersion: DefaultVisualsVersion.V3);
-```
-
-If you subclassed a V1/V2 visual (e.g. `internal class MyButton : DefaultButtonRuntime`), switch to its V3 equivalent under `Gum.Forms.DefaultVisuals.V3` (e.g. `Gum.Forms.DefaultVisuals.V3.ButtonVisual`). V3's visual tree and state system are not identical to V1/V2's: V3 drives per-state appearance through a `StateSave.Apply` lambda rather than a `Variables` list, so a subclass that customized state behavior against V1/V2 internals needs more than a type swap.
-
-{% hint style="info" %}
-`FormsUtilities.InitializeDefaults`'s XNA-only `Game` overload also dropped its unused `game` parameter as part of this change. This only affects direct callers of `FormsUtilities.InitializeDefaults` that passed `game`; `GumService.Initialize` callers are unaffected.
-{% endhint %}
-
-### `GumService` Is Now Compiled Directly Into `Gum.SkiaSharp`
-
-The render-only `Gum.GumService` used by WPF, MAUI, and any bring-your-own-`SKCanvas` project (Silk.NET has its own, separate `GumService` and is unaffected) used to live as shared **source** (`Runtimes/SkiaGum.Standalone/GumService.cs`), file-linked into each host project. It is now a real, compiled member of the `Gum.SkiaSharp` package (`SkiaGum.csproj`), reached through the `ProjectReference`/NuGet reference every host already has. The public API is unchanged: `GumService.Default.Initialize(canvas, ...)`, `.Update(...)`, `.Draw()`, and `.HandleResize(...)` all work exactly as before.
-
-If you never file-linked `GumService.cs` yourself, this affects you only through a real behavior fix: `GumService.Initialize` now calls `FormsUtilities.InitializeDefaults()` unconditionally, matching every other backend. Previously, a code-only Forms control (`Button`, etc.) got no default `Visual` on this render-only path unless a `.gumx` project happened to be loaded; now it does.
-
-If you did file-link `Runtimes/SkiaGum.Standalone/GumService.cs` into your own project (for example, following an older version of the [SkiaSharp (General Canvas)](../../code/getting-started/setup/adding-initializing-gum/skiasharp-general-canvas.md) setup, or mirroring how `SkiaGum.Wpf`/`SkiaGum.Maui` used to do it), you'll get a duplicate-type build error once you upgrade to a `Gum.SkiaSharp` version that includes the type natively:
-
-```
-error CS0433: The type 'GumService' exists in both 'YourProject' and 'Gum.SkiaSharp'
-```
-
-To fix it, delete the file-link from your `.csproj`:
-
-❌ Old:
-```xml
-<ItemGroup>
-  <Compile Include="..\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
-</ItemGroup>
-```
-
-✅ New: delete the `ItemGroup` above entirely. `GumService` now comes from your existing `Gum.SkiaSharp` reference.
-
-`Runtimes/SkiaGum.Standalone/` itself is removed from the Gum repository; there is no longer a file to link.

--- a/docs/gum-tool/upgrading/migrating-to-2026-september.md
+++ b/docs/gum-tool/upgrading/migrating-to-2026-september.md
@@ -1,0 +1,100 @@
+# Migrating to 2026 September
+
+## Introduction
+
+This page discusses breaking changes and other considerations when migrating from `2026 August` to `2026 September`.
+
+## What Changed at a Glance
+
+Two changes need your attention:
+
+* The V1 and V2 default Forms visuals are removed. This is a **hard break**: `DefaultVisualsVersion.V1`/`.V2` and their backing classes no longer exist. This only affects you if you explicitly requested V1 or V2; everyone else was already on V3.
+* `Gum.SkiaSharp` now compiles `GumService` (and its new `GumServiceSkiaBase`) directly instead of requiring host projects to file-link `GumService.cs`. This affects you only if you previously file-linked `Runtimes/SkiaGum.Standalone/GumService.cs` into your own project.
+
+## Upgrading the Gum Tool
+
+{% tabs %}
+{% tab title="Windows" %}
+To upgrade the Gum tool:
+
+1. Download Gum.zip from the [September 2, 2026 release on GitHub](https://github.com/vchelaru/Gum/releases/tag/Release_September_02_2026)
+2. Delete the old tool from your machine
+3. Unzip the gum tool to the same location as to not break any file associations
+{% endtab %}
+
+{% tab title="Linux" %}
+Run the upgrade `gum upgrade` or `~/bin/gum upgrade`
+{% endtab %}
+{% endtabs %}
+
+## Upgrading the Runtime
+
+This release's runtime ships as NuGet version **`PLACEHOLDER!!!! NuGet version`**. Upgrade your Gum NuGet packages to this version. For more information, see the NuGet packages for your particular platform:
+
+* MonoGame - [https://www.nuget.org/packages/Gum.MonoGame/](https://www.nuget.org/packages/Gum.MonoGame/)
+* KNI - [https://www.nuget.org/packages/Gum.KNI/](https://www.nuget.org/packages/Gum.KNI/)
+* FNA - [https://www.nuget.org/packages/Gum.FNA/](https://www.nuget.org/packages/Gum.FNA/)
+* raylib - [https://www.nuget.org/packages/Gum.raylib](https://www.nuget.org/packages/Gum.raylib)
+* .NET MAUI - [https://www.nuget.org/packages/Gum.SkiaSharp.Maui](https://www.nuget.org/packages/Gum.SkiaSharp.Maui)
+* SkiaSharp - [https://www.nuget.org/packages/Gum.SkiaSharp/](https://www.nuget.org/packages/Gum.SkiaSharp/)
+
+If using GumCommon directly, you can update the GumCommon NuGet:
+
+* GumCommon - [https://www.nuget.org/packages/FlatRedBall.GumCommon](https://www.nuget.org/packages/FlatRedBall.GumCommon)
+
+## Breaking Changes and Migrations
+
+### V1 and V2 Default Forms Visuals Are Removed
+
+The 2026 July release (see [Migrating to 2026 July](migrating-to-2026-july.md)) marked the V1 (`Default*Runtime`) and V2 (non-V3 `*Visual`) Forms default visuals `[Obsolete]`. This release removes them outright: `DefaultVisualsVersion.V1`/`.V2` and their backing classes no longer exist. Passing either value, or referencing a V1/V2 class directly, is now a compile error rather than a `CS0618` warning.
+
+This only affects you if you explicitly passed `DefaultVisualsVersion.V1` or `.V2` to `GumService.Initialize` / `FormsUtilities.InitializeDefaults`, or referenced a V1/V2 visual class (e.g. `DefaultButtonRuntime`, the non-V3 `ButtonVisual`) directly, for example to build a custom visual around one. Every backend already defaulted to V3 in practice, so most projects need no changes.
+
+To migrate, pass `DefaultVisualsVersion.V3` (or `.Newest`):
+
+❌ Old:
+```csharp
+// Initialize
+GumService.Default.Initialize(
+    this,
+    defaultVisualsVersion: DefaultVisualsVersion.V2);
+```
+
+✅ New:
+```csharp
+// Initialize
+GumService.Default.Initialize(
+    this,
+    defaultVisualsVersion: DefaultVisualsVersion.V3);
+```
+
+If you subclassed a V1/V2 visual (e.g. `internal class MyButton : DefaultButtonRuntime`), switch to its V3 equivalent under `Gum.Forms.DefaultVisuals.V3` (e.g. `Gum.Forms.DefaultVisuals.V3.ButtonVisual`). V3's visual tree and state system are not identical to V1/V2's: V3 drives per-state appearance through a `StateSave.Apply` lambda rather than a `Variables` list, so a subclass that customized state behavior against V1/V2 internals needs more than a type swap.
+
+{% hint style="info" %}
+`FormsUtilities.InitializeDefaults`'s XNA-only `Game` overload also dropped its unused `game` parameter as part of this change. This only affects direct callers of `FormsUtilities.InitializeDefaults` that passed `game`; `GumService.Initialize` callers are unaffected.
+{% endhint %}
+
+### `GumService` Is Now Compiled Directly Into `Gum.SkiaSharp`
+
+The render-only `Gum.GumService` used by WPF, MAUI, and any bring-your-own-`SKCanvas` project (Silk.NET has its own, separate `GumService` and is unaffected) used to live as shared **source** (`Runtimes/SkiaGum.Standalone/GumService.cs`), file-linked into each host project. It is now a real, compiled member of the `Gum.SkiaSharp` package (`SkiaGum.csproj`), reached through the `ProjectReference`/NuGet reference every host already has. The public API is unchanged: `GumService.Default.Initialize(canvas, ...)`, `.Update(...)`, `.Draw()`, and `.HandleResize(...)` all work exactly as before.
+
+If you never file-linked `GumService.cs` yourself, this affects you only through a real behavior fix: `GumService.Initialize` now calls `FormsUtilities.InitializeDefaults()` unconditionally, matching every other backend. Previously, a code-only Forms control (`Button`, etc.) got no default `Visual` on this render-only path unless a `.gumx` project happened to be loaded; now it does.
+
+If you did file-link `Runtimes/SkiaGum.Standalone/GumService.cs` into your own project (for example, following an older version of the [SkiaSharp (General Canvas)](../../code/getting-started/setup/adding-initializing-gum/skiasharp-general-canvas.md) setup, or mirroring how `SkiaGum.Wpf`/`SkiaGum.Maui` used to do it), you'll get a duplicate-type build error once you upgrade to a `Gum.SkiaSharp` version that includes the type natively:
+
+```
+error CS0433: The type 'GumService' exists in both 'YourProject' and 'Gum.SkiaSharp'
+```
+
+To fix it, delete the file-link from your `.csproj`:
+
+❌ Old:
+```xml
+<ItemGroup>
+  <Compile Include="..\SkiaGum.Standalone\GumService.cs" Link="GumService.cs" />
+</ItemGroup>
+```
+
+✅ New: delete the `ItemGroup` above entirely. `GumService` now comes from your existing `Gum.SkiaSharp` reference.
+
+`Runtimes/SkiaGum.Standalone/` itself is removed from the Gum repository; there is no longer a file to link.


### PR DESCRIPTION
## Summary
- Split the two breaking changes that shipped after Aug 5 (V1/V2 visuals removed, GumService relocated) out of `migrating-to-2026-august.md` into a new `migrating-to-2026-september.md`, so a release's migration doc only covers changes since the prior release.
- `gum-monthly-release`'s draft came out far too wordy for the Sept 2 release. Added a one-short-sentence-per-change rule with a concrete good/bad example, a mandatory pre-write compression audit, and made repo-housekeeping/internal-diagnostic-logging exclusion from What's Changed the default (previously offered as an ask).

## Test plan
- [x] `Release_September_02_2026` GitHub release notes rewritten to the new standard and published live.
- N/A for automated tests — doc/skill content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw9uqrBMwEsKoD2mirb5L3