### PR TITLE
Compute and reset RenderStateChangeStatistics/LastFrameDrawStates for the GumBatch immediate-mode path

### DIFF
--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -137,6 +137,8 @@ Mid-walk `End()` from `SpriteBatchRenderableBase.EndBatch` does NOT pop the stac
 
 This cross-cycle leakage is the single biggest source of "draw order looks weird across N renderables" bugs. Any fix to flushing must end the custom batch at `Renderer.End` so cycle boundaries are clean.
 
+`RenderStateChangeStatistics` and `SpriteRenderer.LastFrameDrawStates` follow the same rule. `Renderer.Begin` resets both once per host frame, gated by `_perfStatsResetForHostFrame` (cleared in `NotifyHostFrameAdvanced`/`EndFrame`, same as `_allLayersPreRenderedForHostFrame`). `Renderer.End` then adds that cycle's `GraphicsDevice.Metrics.DrawCount` delta. Multiple `Begin`/`End` cycles in one host frame accumulate into one total instead of overwriting each other (FRB2's per-camera-plus-overlay shape). A host that never advances `SystemManagers.Activity`/`GumUI.Update` never resets past the first frame (#4571).
+
 ## SpriteBatchStack: Begin(false) must re-apply currentParameters
 
 `Begin(createNewParameters=false)` runs whenever the BatchOrchestrator transitions back to SpriteBatch from a custom batch (Apos.Shapes, future custom batches). It's reached via `SpriteBatchRenderableBase.StartBatch`, which sequences:
@@ -283,3 +285,4 @@ When changing batch logic:
 8. If you touch `RenderableShapeBase.StartBatch` or `ShapeBatch.Begin` plumbing, does the active scissor state still flow to the shape batch? Empirical canary: rounded shape bodies inside a `ScrollViewer` / `ListBox` clip to the container. Setting `GraphicsDevice.ScissorRectangle` is not sufficient — `ShapeBatch.Begin` must also receive a `rasterizerState` with `ScissorTestEnable=true`.
 9. If you touch `Renderer.AdjustRenderStates` or the clip-change paths in `Renderer.Draw`, does a clip change (entry OR exit) flush the orchestrator (`_batchOrchestrator.FlushAndReset`) BEFORE `BeginSpriteBatch`? Empirical canary: the first item's shape background inside a `ScrollViewer` clips when scrolled past the top edge (not just the second item and beyond).
 10. Investigating draw-call/batching cost? Check `Renderer.SiblingOrdering`, not just `BatchOrchestrator` — they're separate layers (see "Draw Order Is a Separate, Pluggable Layer" above).
+11. Reset immediate-mode perf stats once per host frame, not on every `Begin`. Per-`Begin` reset wipes out an earlier camera pass's stats instead of accumulating them within the frame.

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -87,7 +87,14 @@ public class Renderer : IRenderer
     private bool _renderTargetSweepCompletedForHostFrame;
     private bool _allLayersPreRenderedForHostFrame;
     private bool _referencedRenderTargetsCollectedForHostFrame;
+    private bool _perfStatsResetForHostFrame;
     private readonly HashSet<IRenderableIpso> _referencedRenderTargetOwners = new();
+#if !FNA
+    // Set at the start of each immediate-mode Begin/End cycle (Renderer.Begin/Draw/End, the path
+    // GumBatch wraps) so End can take the same before/after GraphicsDevice.Metrics.DrawCount delta
+    // that Draw(SystemManagers) takes for the layered path. See RenderStateChangeStatistics.DrawCallCount remarks.
+    private long _immediateModeDrawCountBeforeCycle;
+#endif
     Camera mCamera;
 
     Texture2D mSinglePixelTexture;
@@ -460,6 +467,7 @@ public class Renderer : IRenderer
             _renderTargetSweepCompletedForHostFrame = false;
             _allLayersPreRenderedForHostFrame = false;
             _referencedRenderTargetsCollectedForHostFrame = false;
+            _perfStatsResetForHostFrame = false;
         }
     }
 
@@ -470,7 +478,25 @@ public class Renderer : IRenderer
             _renderTargetSweepCompletedForHostFrame = false;
             _allLayersPreRenderedForHostFrame = false;
             _referencedRenderTargetsCollectedForHostFrame = false;
+            _perfStatsResetForHostFrame = false;
         }
+    }
+
+    // Immediate-mode counterpart to Draw(SystemManagers)'s unconditional
+    // ClearPerformanceRecordingVariables() call: Begin/Draw/End (what GumBatch wraps) can run
+    // multiple cycles per host frame (one per camera, plus a screen-level overlay pass is a real
+    // shape - see FRB2's GumRenderBatch), so resetting on every Begin would wipe out earlier
+    // cycles' stats instead of accumulating them across the frame. Reset once, on the first Begin
+    // after a host frame boundary, then let AddDrawCalls/RecordShapeBatchBegin accumulate normally.
+    private void TryResetPerformanceStatsForHostFrame()
+    {
+        if (_perfStatsResetForHostFrame)
+        {
+            return;
+        }
+
+        ClearPerformanceRecordingVariables();
+        _perfStatsResetForHostFrame = true;
     }
 
     private void TrySweepUnusedRenderTargetsAtFrameBoundary()
@@ -695,6 +721,11 @@ public class Renderer : IRenderer
     // Immediate mode calls:
     public void Begin(Microsoft.Xna.Framework.Matrix? spriteBatchMatrix = null)
     {
+        TryResetPerformanceStatsForHostFrame();
+#if !FNA
+        _immediateModeDrawCountBeforeCycle = GraphicsDevice?.Metrics.DrawCount ?? 0;
+#endif
+
         SpriteBatchStack.PerformStartOfLayerRenderingLogic();
         spriteRenderer.ForcedMatrix = spriteBatchMatrix;
         spriteRenderer.BeginSpriteBatch(mRenderStateVariables, _layers[0], BeginType.Push, mCamera, null);
@@ -756,6 +787,14 @@ public class Renderer : IRenderer
         _batchOrchestrator.FlushAndReset(SystemManagers.Default);
 
         spriteRenderer.EndSpriteBatch();
+
+#if !FNA
+        if (GraphicsDevice != null)
+        {
+            RenderStateChangeStatistics.AddDrawCalls(
+                (int)(GraphicsDevice.Metrics.DrawCount - _immediateModeDrawCountBeforeCycle));
+        }
+#endif
     }
 
 

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/ImmediateModeDrawCallStatisticsTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/ImmediateModeDrawCallStatisticsTests.cs
@@ -1,0 +1,208 @@
+using System.Linq;
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins the immediate-mode entry point (<see cref="Renderer.Begin"/> / <see cref="Renderer.Draw(IRenderableIpso)"/> /
+/// <see cref="Renderer.End"/> — what <c>GumBatch</c> wraps) for two bugs reported against it:
+/// <see cref="RenderStateChangeStatistics.DrawCallCount"/> was never computed on this path at all
+/// (only <see cref="Renderer.Draw(SystemManagers)"/> took the <c>GraphicsDevice.Metrics.DrawCount</c>
+/// delta), and both it and <see cref="SpriteRenderer.LastFrameDrawStates"/> were never reset on this
+/// path either, so they grew for the life of the process instead of describing one frame. Both are
+/// now driven off the same once-per-host-frame boundary <see cref="SystemManagers.Activity"/> already
+/// uses for other bookkeeping (<c>NotifyHostFrameAdvanced</c>), so multiple <c>Begin</c>/<c>End</c>
+/// cycles in one host frame (one per camera, plus a screen-level overlay pass — the reported FRB2
+/// shape) accumulate into one frame's total instead of resetting mid-frame or leaking across frames.
+/// </summary>
+public class ImmediateModeDrawCallStatisticsTests : BaseTestClass
+{
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0 / 60.0;
+        managers.Activity(hostTime);
+    }
+
+    private static RectangleRuntime CreateRectangle()
+    {
+        RectangleRuntime rectangle = new();
+        rectangle.IsFilled = true;
+        rectangle.Width = 50;
+        rectangle.Height = 50;
+        return rectangle;
+    }
+
+    /// <summary>
+    /// Draws an equivalent rectangle through both entry points and asserts they report the same
+    /// draw-call count. This is what pins the "never computed" bug: before the fix, the
+    /// immediate-mode side of this comparison was always 0 regardless of what was drawn, while the
+    /// layered side (<see cref="Renderer.Draw(SystemManagers)"/>, already pinned by
+    /// <c>RendererDrawCallCountTests</c>) reported the real cost. The exact per-rectangle cost is
+    /// intentionally not hardcoded here — it's an incidental detail of <see cref="RectangleRuntime"/>'s
+    /// fill+stroke rendering, not part of the contract under test.
+    /// </summary>
+    [Fact]
+    public void Begin_Draw_End_ReportsSameDrawCallCountAsLayeredPathForEquivalentContent()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        // Layered-path measurement: a rectangle added to the root, drawn through the existing,
+        // already-pinned GumService.Draw() -> Renderer.Draw(SystemManagers) contract.
+        RectangleRuntime layeredRectangle = CreateRectangle();
+        layeredRectangle.AddToRoot();
+        global::Gum.GumService.Default.Root.UpdateLayout();
+        global::Gum.GumService.Default.Draw(); // warm-up: discard first-time costs
+        global::Gum.GumService.Default.Draw();
+        int layeredCount = renderer.RenderStateChangeStatistics.DrawCallCount;
+
+        // Immediate-mode measurement: an equivalent, unparented rectangle drawn directly through
+        // Renderer.Begin/Draw/End - the path GumBatch wraps, and the one under test here.
+        RectangleRuntime immediateRectangle = CreateRectangle();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin();
+        renderer.End(); // warm-up: discard first-time costs
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin();
+        renderer.Draw(immediateRectangle);
+        renderer.End();
+        int immediateModeCount = renderer.RenderStateChangeStatistics.DrawCallCount;
+
+        immediateModeCount.ShouldBe(layeredCount);
+    }
+
+    [Fact]
+    public void MultipleBeginEndCyclesInSameHostFrame_AccumulateDrawCallCount()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+        RectangleRuntime rectangle = CreateRectangle();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin();
+        renderer.Draw(rectangle);
+        renderer.End();
+        int afterFirstCycle = renderer.RenderStateChangeStatistics.DrawCallCount;
+        afterFirstCycle.ShouldBeGreaterThan(0);
+
+        // A second Begin/End cycle in the SAME host frame (no AdvanceHostFrame call) — the FRB2
+        // shape of one cycle per camera plus a screen-level overlay pass, all within one frame.
+        renderer.Begin();
+        renderer.Draw(rectangle);
+        renderer.End();
+        int afterSecondCycle = renderer.RenderStateChangeStatistics.DrawCallCount;
+
+        afterSecondCycle.ShouldBe(afterFirstCycle * 2);
+    }
+
+    [Fact]
+    public void NextHostFrame_ResetsDrawCallCount()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+        RectangleRuntime rectangle = CreateRectangle();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin();
+        renderer.Draw(rectangle);
+        renderer.End();
+        int firstFrameCount = renderer.RenderStateChangeStatistics.DrawCallCount;
+        firstFrameCount.ShouldBeGreaterThan(0);
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin();
+        renderer.Draw(rectangle);
+        renderer.End();
+        int secondFrameCount = renderer.RenderStateChangeStatistics.DrawCallCount;
+
+        secondFrameCount.ShouldBe(firstFrameCount);
+    }
+
+    [Fact]
+    public void LastFrameDrawStates_DoesNotGrowAcrossHostFrames_OnImmediateModePath()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+        RectangleRuntime rectangle = CreateRectangle();
+
+        // Warm-up: discard the first few cycles' one-time costs before measuring.
+        for (int i = 0; i < 5; i++)
+        {
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Begin();
+            renderer.Draw(rectangle);
+            renderer.End();
+        }
+
+        int earlyCount = renderer.SpriteRenderer.LastFrameDrawStates.Count();
+
+        const int measuredFrames = 200;
+        for (int i = 0; i < measuredFrames; i++)
+        {
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Begin();
+            renderer.Draw(rectangle);
+            renderer.End();
+        }
+
+        int lateCount = renderer.SpriteRenderer.LastFrameDrawStates.Count();
+
+        // Without a per-host-frame reset this list would grow by one entry per measured frame
+        // instead of describing just the latest one.
+        lateCount.ShouldBe(earlyCount);
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, global::Gum.Forms.DefaultVisualsVersion.V3);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/docs/code/performance-and-optimization/lastframedrawstates.md
+++ b/docs/code/performance-and-optimization/lastframedrawstates.md
@@ -17,6 +17,12 @@ Internally Gum uses a SpriteBatch for rendering. It attempts to use as few Begin
 
 Gum provides a list of changes which can be inspected to spot where render problems might be occurring.
 
+### Immediate-mode (GumBatch) callers
+
+Everything on this page also works when Gum is driven through [GumBatch](../rendering/gumbatch.md)'s `Begin`/`Draw`/`End` instead of `GumUI.Draw()`. `LastFrameDrawStates`, `GetDrawStateSummary`, and `DrawCallCount` are all populated on that path too, and they reset once per **host frame** rather than once per `Begin`/`End` cycle. This lets a host that runs several cycles in one frame (for example one per camera, plus a screen-level overlay pass) accumulate them into one frame's total, instead of the last cycle wiping out the earlier ones.
+
+That per-frame reset is tied to the same signal `SystemManagers.Activity`/`GumUI.Update` already uses for other once-per-frame bookkeeping. A host that calls `Activity`/`Update` once per frame before drawing, the normal MonoGame `Update` then `Draw` shape, gets a correct per-frame snapshot automatically, with no extra call needed. A host that never advances Activity time never gets a second reset, so these numbers only reflect the very first frame and then keep growing for the life of the process. Call `Renderer.Self.EndFrame()` once per frame yourself if your host draws through GumBatch without ever calling Activity/Update.
+
 ### Code Example: Checking Performance
 
 The following code shows how to check the performance of a simple project. Note that this code creates visuals instead of Forms controls to intentionally create render breaks.
@@ -132,8 +138,8 @@ int drawCalls = SystemManagers.Default.Renderer.RenderStateChangeStatistics.Draw
 System.Diagnostics.Debug.WriteLine($"Draw calls last frame: {drawCalls}");
 ```
 
-`DrawCallCount` resets at the start of every `Draw` call, so read it after `GumUI.Draw()` to see the count for the frame that just rendered.
+`DrawCallCount` resets once per frame, so read it after `GumUI.Draw()` to see the count for the frame that just rendered. See [Immediate-mode (GumBatch) callers](#immediate-mode-gumbatch-callers) above for exactly when that reset happens on the `GumBatch` path.
 
 {% hint style="info" %}
-`DrawCallCount` is wired for MonoGame, KNI, and raylib. It stays at `0` on FNA and Skia until those backends wire up the same counter. It's available in September 2026, or now if building Gum from source.
+`DrawCallCount` is wired for MonoGame, KNI, and raylib, on both the `GumUI.Draw()` path and the `GumBatch` immediate-mode path. It stays at `0` on FNA and Skia until those backends wire up the same counter. It's available in September 2026, or now if building Gum from source.
 {% endhint %}

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -275,3 +275,7 @@ For a runnable example, see the `RenderTarget` screen in the Gum immediate-mode 
 {% embed url="https://github.com/vchelaru/Gum/tree/main/Samples/MonoGameGumImmediateMode" %}
 
 If you are rendering multiple translucent objects onto the render target, see [Render Targets](render-targets.md) for the `BlendState` needed to accumulate alpha correctly (the default `BlendState` can "remove" alpha from the render target when new instances are drawn on top of existing content). That page also covers the equivalent raylib pattern.
+
+### Performance diagnostics
+
+`Begin`/`Draw`/`End` supports the same draw-call diagnostics as `GumUI.Draw()`. Reading `SystemManagers.Default.Renderer.GetDrawStateSummary()` or `RenderStateChangeStatistics.DrawCallCount` after an `End` call reports the cost for that frame, including across multiple `Begin`/`End` cycles run in the same frame (for example one per camera, plus a screen-level overlay pass). See [Measuring Draw Calls](../performance-and-optimization/lastframedrawstates.md#immediate-mode-gumbatch-callers) for the full detail on when these reset and what to do if your host never calls `SystemManagers.Activity`/`GumUI.Update`.


### PR DESCRIPTION
## Summary

Two bugs against the `GumBatch`/immediate-mode entry point (`Renderer.Begin`/`Draw`/`End`), both reported by an FRB2 agent:

- `RenderStateChangeStatistics.DrawCallCount` was never computed on this path at all (only `Draw(SystemManagers)` took the `GraphicsDevice.Metrics.DrawCount` delta), so it read `0` forever for a `GumBatch`-only host.
- Neither `DrawCallCount` nor `SpriteRenderer.LastFrameDrawStates` were ever reset on this path, so once fixed they'd grow for the life of the process instead of describing one frame.

Fix: `Renderer.Begin`/`End` now take the same `Metrics.DrawCount` delta `Draw(SystemManagers)` takes, and reset both stats once per **host frame** (via the existing `NotifyHostFrameAdvanced`/`EndFrame` mechanism) instead of once per `Begin`/`End` cycle. This lets multiple cycles in one frame (one per camera, plus a screen-level overlay pass, FRB2's shape) accumulate into one frame's total instead of the reset wiping out earlier cycles mid-frame.

Docs (`lastframedrawstates.md`, `gumbatch.md`) and the `gum-monogame-rendering` skill are updated to describe the new behavior and the host-frame-advance requirement.

Closes #4571

## Test plan

- [x] New tests in `ImmediateModeDrawCallStatisticsTests.cs`: red before the fix (0/computed-nothing, then unbounded growth), green after.
- [x] Existing pinned tests unaffected: `RendererDrawCallCountTests`, `RenderStateChangeStatisticsResetTests`, `RenderStateStackGrowthTests`.
- [x] Full `MonoGameGum.IntegrationTests` suite green (108/108).
- [x] `KniGum`, `FnaGum` (both target frameworks), `RaylibGum`, `SkiaGum` all build clean (0 new warnings/errors).
- [x] FRB1 canary (`GumCore.DesktopGlNet6.csproj`, net6.0 + net8.0): pass, matches baseline.
- Manual test: not needed — diagnostic counters only, no rendering/visual change; covered by integration tests against a real `GraphicsDevice`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nmz8Kz9gJyiP64APB87czb
