### PR TITLE
Add GumBatchDrawMode.Deferred to batch multiple Draw calls in one Begin/End cycle

### DIFF
--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -116,6 +116,8 @@ Three behaviors worth internalizing:
 
 **Landmine:** `BatchOrchestrator` only flushes on a `BatchKey` change, so its granularity caps what it can detect — a coarse key (e.g. one shared across many texture sources) means real per-texture draw-call cost hides inside MonoGame's own SpriteBatch batching over whatever order `SiblingOrdering` produced. Per-texture grouping goes through the separate `BatchSortKey` member instead, read only by `BatchKeyGroupedOrderer` — `BatchOrchestrator` never sees it, so it carries no flush cost under the default orderer.
 
+`BatchKeyGroupedOrderer.Instance` exposes `MergeBlockedByOverlapCount`/`NoCandidateInWindowBreakCount` (issue #4575), reset every `BuildDrawList` call — read them right after a draw to tell an overlap-forced batch break from genuine content alternation, instead of guessing from `GetDrawStateSummary` alone.
+
 ## SpriteBatchStack: Push / Pop / Replace
 
 `SpriteBatchStack` wraps a single `SpriteBatch` instance with a stack of `BeginParameters`:

--- a/.claude/skills/gum-monogame-rendering/SKILL.md
+++ b/.claude/skills/gum-monogame-rendering/SKILL.md
@@ -28,6 +28,8 @@ Key contract difference: each `Renderer.Draw` is one top-level renderable. If a 
 
 `Renderer.End` historically was asymmetric with `RenderLayer`'s end-of-walk: it called `EndSpriteBatch` but **did not** flush the pending custom batch, so draws leaked across cycles. Fixed: `Renderer.End` now calls `_batchOrchestrator.FlushAndReset(...)` before `EndSpriteBatch`. If you change the End logic, preserve that ordering.
 
+`Renderer.GumBatchDrawMode.Deferred` (optional `Begin(mode:)` param, issue #4573) accumulates `Draw()` calls into a scratch list instead of submitting immediately. `End` stable-sorts it by `Z` (`Layer.SortByZ`, extracted out of `Layer.SortRenderables`) and runs it through `SiblingOrdering.BuildDrawList`/`Submit` once, so separate `Draw()` calls can batch together (e.g. under `BatchKeyGroupedOrderer`). `Immediate` (the default) is unchanged.
+
 ## PreRender Walk: Layered Path Has Two Phases, GumBatch Path Has One
 
 The layered path runs a recursive `PreRender` pass on `layer.Renderables` **before** `BeginSpriteBatch`. That pass does two jobs:
@@ -286,3 +288,4 @@ When changing batch logic:
 9. If you touch `Renderer.AdjustRenderStates` or the clip-change paths in `Renderer.Draw`, does a clip change (entry OR exit) flush the orchestrator (`_batchOrchestrator.FlushAndReset`) BEFORE `BeginSpriteBatch`? Empirical canary: the first item's shape background inside a `ScrollViewer` clips when scrolled past the top edge (not just the second item and beyond).
 10. Investigating draw-call/batching cost? Check `Renderer.SiblingOrdering`, not just `BatchOrchestrator` — they're separate layers (see "Draw Order Is a Separate, Pluggable Layer" above).
 11. Reset immediate-mode perf stats once per host frame, not on every `Begin`. Per-`Begin` reset wipes out an earlier camera pass's stats instead of accumulating them within the frame.
+12. Touching the `Deferred` flush? It owns its own scratch buffers (`_deferredImmediateModeRoots`/`_deferredImmediateModeCommands`), not `_scratchCommands`/`_bakeCommands` — those are already claimed by `RenderLayer`/the render-target bake.

--- a/GumCommon/Collections/GraphicalUiElementCollection.cs
+++ b/GumCommon/Collections/GraphicalUiElementCollection.cs
@@ -79,13 +79,18 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
                 case NotifyCollectionChangedAction.Add:
                     if (e.NewItems != null)
                     {
-                        int index = e.NewStartingIndex;
+                        // e.NewStartingIndex is a RAW inner-collection index, which may also hold
+                        // non-GraphicalUiElement items this wrapper doesn't mirror (see
+                        // ToInnerIndex) - translate to the logical position among mirrored items
+                        // rather than assuming they line up.
+                        int rawIndex = e.NewStartingIndex;
                         foreach (var item in e.NewItems)
                         {
                             if (item is GraphicalUiElement gue)
                             {
-                                base.InsertItem(index++, gue);
+                                base.InsertItem(LogicalIndexOf(rawIndex), gue);
                             }
+                            rawIndex++;
                         }
                     }
                     break;
@@ -93,14 +98,29 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
                 case NotifyCollectionChangedAction.Remove:
                     if (e.OldItems != null)
                     {
-                        // Remove items at the specified index
-                        for (int i = 0; i < e.OldItems.Count; i++)
+                        // Key removal off the actual removed object rather than e.OldStartingIndex
+                        // (a raw index) - it may not equal this wrapper's logical index once a
+                        // non-GraphicalUiElement item is interleaved (see ToInnerIndex), and the
+                        // item is already gone from _innerCollection by the time this fires, so a
+                        // raw-index lookup there isn't available anyway.
+                        foreach (var item in e.OldItems)
                         {
-                            base.RemoveAt(e.OldStartingIndex);
+                            if (item is GraphicalUiElement gue)
+                            {
+                                int logicalIndex = base.Items.IndexOf(gue);
+                                if (logicalIndex >= 0)
+                                {
+                                    base.RemoveAt(logicalIndex);
+                                }
+                            }
                         }
                     }
                     break;
 
+                // Replace/Move below still assume a raw index equals this wrapper's logical
+                // index, so they share Add/Remove's latent bug when a non-GraphicalUiElement item
+                // is interleaved - untested and unproven in practice; fix alongside a pinning test
+                // if that changes (see the outer MoveItem's remarks).
                 case NotifyCollectionChangedAction.Replace:
                     if (e.NewItems != null && e.NewItems.Count > 0)
                     {
@@ -155,6 +175,37 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     }
 
     /// <summary>
+    /// Maps a logical index (position among this wrapper's GraphicalUiElement-only items) to the
+    /// corresponding index in <see cref="_innerCollection"/>, which may also hold raw
+    /// non-GraphicalUiElement items this wrapper doesn't mirror (e.g. a shape runtime's
+    /// auto-wired stroke renderable, attached to the inner collection directly via
+    /// <c>RenderableBase.Parent</c>'s own <c>Children.Add</c> before any user-added children
+    /// exist). Inserting at the logical end must land after ALL inner items, mirrored or not -
+    /// "add my new child" means "goes after everything currently there," not "goes right after
+    /// the last mirrored item, ahead of trailing raw ones."
+    /// </summary>
+    private int ToInnerIndex(int logicalIndex) =>
+        logicalIndex >= base.Items.Count ? _innerCollection.Count : _innerCollection.IndexOf(base.Items[logicalIndex]);
+
+    /// <summary>
+    /// The inverse of <see cref="ToInnerIndex"/>: how many of the first <paramref name="innerIndex"/>
+    /// items in <see cref="_innerCollection"/> are GraphicalUiElement (i.e. mirrored) - the logical
+    /// position a newly-added item at that raw index should be mirrored to.
+    /// </summary>
+    private int LogicalIndexOf(int innerIndex)
+    {
+        int logicalIndex = 0;
+        for (int i = 0; i < innerIndex; i++)
+        {
+            if (_innerCollection[i] is GraphicalUiElement)
+            {
+                logicalIndex++;
+            }
+        }
+        return logicalIndex;
+    }
+
+    /// <summary>
     /// Inserts an item into the collection at the specified index.
     /// </summary>
     protected override void InsertItem(int index, GraphicalUiElement item)
@@ -170,13 +221,14 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
+            int innerIndex = ToInnerIndex(index);
             if (_innerNoReset != null)
             {
-                _innerNoReset.InsertWithoutNotification(index, item);
+                _innerNoReset.InsertWithoutNotification(innerIndex, item);
             }
             else
             {
-                _innerCollection.Insert(index, item);
+                _innerCollection.Insert(innerIndex, item);
             }
             base.InsertItem(index, item);
         }
@@ -202,13 +254,16 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
+            // The item at `index` already exists in the inner collection - look up its actual
+            // position rather than assuming logical index == inner index (see ToInnerIndex).
+            int innerIndex = _innerCollection.IndexOf(base.Items[index]);
             if (_innerNoReset != null)
             {
-                _innerNoReset.RemoveAtWithoutNotification(index);
+                _innerNoReset.RemoveAtWithoutNotification(innerIndex);
             }
             else
             {
-                _innerCollection.RemoveAt(index);
+                _innerCollection.RemoveAt(innerIndex);
             }
             base.RemoveItem(index);
         }
@@ -234,13 +289,16 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
+            // The item currently at `index` already exists in the inner collection - look up its
+            // actual position rather than assuming logical index == inner index.
+            int innerIndex = _innerCollection.IndexOf(base.Items[index]);
             if (_innerNoReset != null)
             {
-                _innerNoReset.SetWithoutNotification(index, item);
+                _innerNoReset.SetWithoutNotification(innerIndex, item);
             }
             else
             {
-                _innerCollection[index] = item;
+                _innerCollection[innerIndex] = item;
             }
             base.SetItem(index, item);
         }
@@ -285,6 +343,13 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     /// <summary>
     /// Moves an item from one index to another.
     /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="InsertItem"/>/<see cref="RemoveItem"/>/<see cref="SetItem"/> above, this
+    /// still assumes logical index == inner index and has the same latent bug when a raw
+    /// non-GraphicalUiElement item is interleaved (untested and unproven in practice - nothing
+    /// observed so far calls Move on a collection with such an item present; fix alongside a
+    /// pinning test if that changes).
+    /// </remarks>
     protected override void MoveItem(int oldIndex, int newIndex)
     {
         ThrowIfReadOnly();

--- a/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
+++ b/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.ObjectModel;
+using Gum.Collections;
+using Gum.GueDeriving;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.Collections;
+
+/// <summary>
+/// Unit tests for <see cref="GraphicalUiElementCollection"/>, the wrapper that presents a raw
+/// <c>ObservableCollection&lt;IRenderableIpso&gt;</c> as <c>ObservableCollection&lt;GraphicalUiElement&gt;</c>.
+/// Found while investigating a Gum-batching draw-order discrepancy (a card's fill+stroke shape
+/// pair should have been DFS-adjacent - and mergeable into one batch - but a child text ended up
+/// wedged between them).
+/// </summary>
+public class GraphicalUiElementCollectionTests : BaseTestClass
+{
+    /// <summary>
+    /// Minimal non-<see cref="Gum.Wireframe.GraphicalUiElement"/> <see cref="IRenderableIpso"/> -
+    /// mirrors the shape of e.g. <c>RectangleRuntime</c>'s auto-wired stroke renderable, which is a
+    /// raw renderable object, not a GraphicalUiElement.
+    /// </summary>
+    private sealed class RawRenderable : IRenderableIpso
+    {
+        public RawRenderable(string name) => Name = name;
+        public string Name { get; set; }
+        public bool Visible { get; set; } = true;
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget { get; set; }
+        public ObservableCollection<IRenderableIpso> Children { get; } = new();
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public bool AbsoluteVisible => Visible;
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public object? Tag { get; set; }
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+        public string BatchKey { get; set; } = "";
+        public object? BatchSortKey { get; set; }
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+        public override string ToString() => Name;
+    }
+
+    [Fact]
+    public void Add_AfterARawNonGraphicalUiElementItemWasAlreadyAttached_InsertsAfterIt()
+    {
+        // Reproduces the bug found investigating RectangleRuntime's fill+stroke composite:
+        // SetContainedObject wraps the fill's raw Children in a GraphicalUiElementCollection
+        // BEFORE the stroke (a raw, non-GraphicalUiElement IRenderableIpso) is attached via
+        // RenderableBase.Parent's own Children.Add. The wrapper's CollectionChanged handler
+        // silently drops that raw item from its own bookkeeping (it isn't a GraphicalUiElement),
+        // so a subsequent logical Add computed its insertion index against an undercounted Count
+        // and landed the new item BEFORE the raw one in the real draw list - reordering a user's
+        // AddChild ahead of infrastructure that was attached first.
+        ObservableCollection<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // mirrors RenderableBase.Parent's Children.Add(this)
+
+        ContainerRuntime text = new() { Name = "text" };
+        wrapper.Add(text); // mirrors GraphicalUiElement.AddChild
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { stroke, text });
+    }
+
+    [Fact]
+    public void Remove_WithARawNonGraphicalUiElementItemBeforeIt_RemovesTheCorrectItem()
+    {
+        // Same root cause as the Add test, for RemoveItem: the wrapper's logical index doesn't
+        // match the raw list's index once a non-GraphicalUiElement item is interleaved, so a
+        // naive index passthrough removes the wrong raw entry. Built via direct inner-collection
+        // manipulation (not wrapper.Add) so this test's setup doesn't itself depend on the Add
+        // bug being present or fixed - inner.Add(text) mirrors text into the wrapper through the
+        // (already-correct) from-inner sync path, independent of InsertItem's outer-driven path.
+        ObservableCollection<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // raw index 0, not mirrored into the wrapper
+
+        ContainerRuntime text = new() { Name = "text" };
+        innerCollection.Add(text); // raw index 1; mirrored into the wrapper at logical index 0
+
+        wrapper.Remove(text);
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { stroke });
+    }
+}

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -626,6 +626,50 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void BuildDrawList_FreeContainerChosenAfterAClipExit_DoesNotSwallowTheForcedTransition()
+    {
+        // A free container is exempt from break accounting because it submits nothing - but it
+        // must not CONSUME the pending forced transition a clip exit left behind either. The real
+        // renderable that follows is the one the GPU actually flushes for, so the hard boundary
+        // belongs to it. Without this, HardBoundaryTransitionCount undercounts and the break
+        // groups stop reconciling against the frame's true draw-call count.
+        //
+        // The free-container tier (#4579) is what makes this the likely path rather than a corner
+        // case: after a clip exits, an available wrapper now outranks the smallest-DFS fallback.
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch")
+        {
+            X = 0, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+
+        FakeRenderable container = new FakeRenderable("container", "") { X = 50, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable containerChild = AddChild(container, "containerChild");
+        containerChild.X = 50; containerChild.Y = 0; containerChild.Width = 10; containerChild.Height = 10;
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(clip, container);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:clip",
+            "DrawRenderable:clip",
+            "EndClip:clip",
+            "DrawRenderable:container",
+            "DrawRenderable:containerChild",
+        });
+
+        // The clip entry has nothing running to force away from (NoPredecessor, not a hard
+        // boundary). The clip EXIT is the one that counts, and it must land on containerChild -
+        // note its key matches what the clip left running, so without the forced flag it would be
+        // recorded as no break at all.
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(0);
+    }
+
+    [Fact]
     public void BuildDrawList_RenderUsingHierarchyFalse_DoesNotRecurse()
     {
         bool originalValue = Renderer.RenderUsingHierarchy;
@@ -879,22 +923,18 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
-    public void BuildDrawList_TwoNestedNonOverlappingCardGroups_DoesNotMergeAcrossContainers()
+    public void BuildDrawList_TwoNestedNonOverlappingCardGroups_MergesSameKeyRunsAcrossContainers()
     {
-        // Known limitation - see issue #4579. Two card-shaped groups (2x same-key "rectangle", 2x
-        // same-key "text", 1x "icon" each), each wrapped in its own container (mirroring a real
-        // Gum component instance), placed with zero bounding-box overlap between containers.
-        // Coordinates are the ACTUAL bounds measured from a live 2-card TestScreenFrb run
-        // (Solitaire sample, FlatRedBall2 repo) - not assumed ones.
+        // Issue #4579. Two card-shaped groups (2x same-key "rectangle", 2x same-key "text", 1x
+        // "icon" each), each wrapped in its own container (mirroring a real Gum component
+        // instance), placed with zero bounding-box overlap between containers. Coordinates are the
+        // ACTUAL bounds measured from a live 2-card TestScreenFrb run (Solitaire sample,
+        // FlatRedBall2 repo) - not assumed ones.
         //
-        // A flat (non-nested) version of this same scene merges perfectly (0 extra breaks per
-        // additional group) - the orderer CAN merge same-key items across non-overlapping groups.
-        // But once each group is wrapped in its own container, nothing merges across containers at
-        // all: the container itself never matches the running batch key (it's a transparent
-        // wrapper), so it's only reached via the "smallest DFS index" fallback tier - by which
-        // point the algorithm has already drained the first card's non-matching items instead of
-        // reaching into the second card's container while a same-key run was still active. This
-        // pins the CURRENT (suboptimal) behavior so a future fix has a red-then-green target.
+        // A transparent container is a free choice: it submits no vertices and leaves the running
+        // key alone, so the free-container tier picks both containers up front, which unblocks
+        // both cards' children while each same-key run is still active. The result is one run per
+        // distinct key regardless of how many card instances exist.
         BatchKeyGroupedOrderer.Instance.ResetBreakTally();
         object fontTex = new object();
         object iconTex = new object();
@@ -905,9 +945,7 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
             float dx = card * 100; // card0 Entity.X=0, card1 Entity.X=100 (measured)
             // Real cards are NESTED: each CardGum.Visual is its own container (empty BatchKey,
             // full card bounds), and Background/Border/RankText1/RankText2/SuitIcon are its
-            // CHILDREN - not flat top-level siblings like the previous version of this test
-            // assumed. Testing whether that nesting (not bounds/keys, both already proven fine)
-            // is what defeats cross-card merging.
+            // CHILDREN - not flat top-level siblings.
             FakeRenderable cardContainer = new FakeRenderable($"card{card}", "") { X = 360 + dx, Y = 264, Width = 80, Height = 112 };
             layer.Add(cardContainer);
 
@@ -930,22 +968,61 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         List<DrawCommand> commands = new List<DrawCommand>();
         BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
 
-        // Fully sequential per container - bg1/border1 never get pulled forward to merge with
-        // bg0/border0, even though nothing overlaps and their keys match exactly.
+        // Three runs, not six: both cards' Apos.Shapes rectangles merge, then both cards' font-
+        // texture texts, then both icons. Within a card, DFS order is still preserved wherever
+        // bounds overlap (bg before border, rank1 before rank2, texts before the icon they sit on).
         Describe(commands).ShouldBe(new[]
         {
             "DrawRenderable:card0",
+            "DrawRenderable:card1",
             "DrawRenderable:bg0",
             "DrawRenderable:border0",
-            "DrawRenderable:rank1_0",
-            "DrawRenderable:rank2_0",
-            "DrawRenderable:icon0",
-            "DrawRenderable:card1",
             "DrawRenderable:bg1",
             "DrawRenderable:border1",
+            "DrawRenderable:rank1_0",
+            "DrawRenderable:rank2_0",
             "DrawRenderable:rank1_1",
             "DrawRenderable:rank2_1",
+            "DrawRenderable:icon0",
             "DrawRenderable:icon1",
+        });
+
+        // The only remaining breaks are genuine content alternation (rect -> text -> icon), not
+        // per-instance repetition: adding more cards adds no further breaks.
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildDrawList_FreeContainerOverlappingAnEarlierDraw_StaysBehindItAndBehindAnActiveRun()
+    {
+        // Guards the two ways the free-container tier could break the class's core promise
+        // (#4579). The container is transparent and so a "free" pick, but it must still be the
+        // LOWEST-priority tier above the smallest-DFS fallback:
+        //
+        //  1. It must not jump an overlap edge. The container's bounds cover apos0, so apos0 must
+        //     draw first - if the tier ignored indegree the container (and its child) would be
+        //     hoisted to the front and the child sprite would paint under apos0 instead of over.
+        //  2. It must not preempt a real same-key match. Once apos0 has started an Apos.Shapes
+        //     run, apos1 continues that run; the container waits even though picking it is free.
+        FakeRenderable apos0 = new FakeRenderable("apos0", "Apos.Shapes") { X = 0, Y = 0, Width = 100, Height = 100 };
+
+        FakeRenderable container = new FakeRenderable("container", "") { X = 0, Y = 0, Width = 100, Height = 100 };
+        FakeRenderable containerChild = AddChild(container, "containerChild");
+        containerChild.X = 0; containerChild.Y = 0; containerChild.Width = 100; containerChild.Height = 100;
+
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 200, Y = 0, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(apos0, container, apos1);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:apos0",
+            "DrawRenderable:apos1",
+            "DrawRenderable:container",
+            "DrawRenderable:containerChild",
         });
     }
 

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -434,8 +434,13 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
 
         groups[0].Count.ShouldBe(3);
-        groups.Count(g => g.Count == 3).ShouldBe(2); // sb->apos (blocked) and apos->sb (no candidate)
-        groups.Count(g => g.Count == 1).ShouldBe(2); // the distinct-BatchSortKey row's own pair
+        // sb->apos (blocked), apos->sb (no candidate), and rows 0-2's shared NoPredecessor break
+        // (each row's own "a{row}" starts its own Y-run with nothing before it, but all three
+        // share the same (nothing) -> (SpriteBatch, null) identity, so they merge into one group).
+        groups.Count(g => g.Count == 3).ShouldBe(3);
+        // the distinct-BatchSortKey row's own pair, plus its own NoPredecessor break ("d" has a
+        // distinct BatchSortKey, so it doesn't merge with rows 0-2's).
+        groups.Count(g => g.Count == 1).ShouldBe(3);
     }
 
     [Fact]
@@ -456,7 +461,9 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
 
         BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
         BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(2);
-        BatchKeyGroupedOrderer.Instance.GetBreakGroups().Single().Count.ShouldBe(2);
+        var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
+        groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoCandidateInWindow).Count.ShouldBe(2);
+        groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoPredecessor).Count.ShouldBe(2); // a starts each cycle with nothing before it
     }
 
     [Fact]
@@ -473,7 +480,149 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
 
         var typeGroups = BatchKeyGroupedOrderer.Instance.GetBreakGroupsByType();
 
-        typeGroups.Single().ToString().ShouldBe("FakeRenderable->FakeRenderable (1)");
+        // Two entries: a's own NoPredecessor break (nothing preceded it) and the a->b switch itself.
+        typeGroups.Count.ShouldBe(2);
+        typeGroups.Single(g => g.FromRenderableType == typeof(FakeRenderable)).ToString().ShouldBe("FakeRenderable->FakeRenderable (1)");
+    }
+
+    [Fact]
+    public void BuildDrawList_PlainContainerBetweenSameKeyItems_IsNotCountedAsABreak()
+    {
+        // A plain ContainerRuntime (empty BatchKey, not a render target or clip) is a complete
+        // no-op at the real GPU level - BatchOrchestrator.OnRenderable treats empty BatchKey as
+        // "participates in whatever batch the previous renderable established" (no flush), and
+        // InvisibleRenderable.Render submits no vertices. So a Container physically interposed
+        // between two same-key items (via the overlap chain A-container-B below) must not count
+        // as a break, and must not stop the orderer from recognizing A and B as one contiguous
+        // (sb,null) run once B unblocks.
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable container = new FakeRenderable("container", "") { X = 5, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable b = new FakeRenderable("b", "SpriteBatch") { X = 12, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable c = new FakeRenderable("c", "Apos.Shapes") { X = 100, Y = 0, Width = 10, Height = 10 };
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(a, container, b, c);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1); // only b->c
+        var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
+        groups.Count.ShouldBe(2); // a's own NoPredecessor break, plus b->c
+        var noCandidate = groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoCandidateInWindow);
+        noCandidate.FromBatchKey.ShouldBe("SpriteBatch");
+        noCandidate.ToBatchKey.ShouldBe("Apos.Shapes");
+        groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoPredecessor).ToBatchKey.ShouldBe("SpriteBatch"); // a
+    }
+
+    [Fact]
+    public void BuildDrawList_RenderTargetBetweenSameKeyItems_IsCountedAsABreak()
+    {
+        // Unlike a plain Container, a render target IS a real cost even though it also reports an
+        // empty BatchKey: SubmitDrawRenderable/DrawRenderTargetToScreen give it its own
+        // FlushAndReset + BeginSpriteBatch(effectOverride:) cycle. So (unlike the plain-container
+        // test above) both the entry into it and the exit out of it must count as real breaks.
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable renderTarget = new FakeRenderable("renderTarget", "")
+        {
+            X = 5, Y = 0, Width = 10, Height = 10, IsRenderTarget = true,
+        };
+        FakeRenderable b = new FakeRenderable("b", "SpriteBatch") { X = 12, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable c = new FakeRenderable("c", "Apos.Shapes") { X = 100, Y = 0, Width = 10, Height = 10 };
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(a, renderTarget, b, c);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(2); // a->renderTarget, renderTarget->b
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1); // b->c
+        BatchKeyGroupedOrderer.Instance.GetBreakGroups().Count.ShouldBe(4); // + a's own NoPredecessor break
+    }
+
+    [Fact]
+    public void BuildDrawList_ClipInsideOneRow_DoesNotLeakRunningKeyIntoTheNextRow()
+    {
+        // Regression pin: the running-key state that must persist ACROSS a clip boundary (so
+        // entering/exiting it is counted correctly, see the two clip tests below) must NOT persist
+        // across a SecondarySortOnY row boundary - each row still has to reorder independently.
+        // sbTop (row Y=0) ends the row on a "SpriteBatch" key by clipping; aposBottom (row Y=20)
+        // must not see that leak into its own running state.
+        FakeRenderable sbTop = new FakeRenderable("sbTop", "SpriteBatch") { Y = 0, Width = 10, Height = 10 };
+        FakeRenderable clipTop = new FakeRenderable("clipTop", "SpriteBatch")
+        {
+            X = 50, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+        FakeRenderable aposBottom = new FakeRenderable("aposBottom", "Apos.Shapes") { Y = 20, Width = 10, Height = 10 };
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = new Layer();
+        layer.SecondarySortOnY = true;
+        layer.Add(sbTop);
+        layer.Add(clipTop);
+        layer.Add(aposBottom);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        // aposBottom is the first (and only) item in its own row - if the fix regressed, it would
+        // incorrectly compare against clipTop's "SpriteBatch" key instead of starting fresh.
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1); // sbTop -> clipTop only
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildDrawList_EnteringAClip_IsCountedEvenWhenItsOwnKeyMatchesTheRunningKey()
+    {
+        // The bug this pins: entering a ClipsChildren renderable ALWAYS forces a real flush
+        // (Renderer.AdjustRenderStates restarts SpriteBatch on any clip change), regardless of
+        // whether the clip's own BatchKey happens to equal whatever was running. Before this fix,
+        // clip transitions never reached the break-comparison at all (a clip is always the first
+        // item of a freshly-flushed inner window, and "first emission" is unconditionally
+        // skipped) - so a same-key clip like this one would have been invisible to every counter.
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch")
+        {
+            X = 50, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+        AddChild(clip, "child", "Apos.Shapes");
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(a, clip);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1); // a -> clip, same key
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1); // clip -> child (apos)
+    }
+
+    [Fact]
+    public void BuildDrawList_ExitingAClip_ForcesTheNextItemEvenWhenItsKeyMatches()
+    {
+        // The other half of the same bug: Renderer.Draw's didClipChange exit branch ALSO forces a
+        // flush when leaving a clip - so whatever comes next must count as a break too, even if
+        // its key happens to match whatever was running inside the clip.
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch")
+        {
+            X = 0, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+        FakeRenderable b = new FakeRenderable("b", "SpriteBatch") { X = 50, Y = 0, Width = 10, Height = 10 };
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(clip, b);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1); // clip -> b, same key
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(0);
     }
 
     [Fact]
@@ -673,6 +822,131 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         int backgroundIdx = result.IndexOf("DrawRenderable:background");
         int iconIdx = result.IndexOf("DrawRenderable:icon");
         backgroundIdx.ShouldBeLessThan(iconIdx);
+    }
+
+    [Fact]
+    public void BuildDrawList_FirstItemInAWindow_IsRecordedAsANoPredecessorBreak()
+    {
+        // The very first item of a window has nothing to break from, but it is still a real,
+        // separately-submitted GPU batch - so it must show up in GetBreakGroups() too, or a
+        // caller summing group.Count to reconcile against DrawCallCount silently undercounts by
+        // one per window (the confusion this test exists to prevent).
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        FakeRenderable sb1 = new FakeRenderable("sb1", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 50, Y = 0, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(sb1, apos1);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
+        groups.Count.ShouldBe(2);
+
+        var noPredecessor = groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoPredecessor);
+        noPredecessor.FromRenderableType.ShouldBe(typeof(BatchKeyGroupedOrderer.NoPredecessorMarker));
+        noPredecessor.ToRenderableType.ShouldBe(typeof(FakeRenderable));
+        noPredecessor.ToBatchKey.ShouldBe("SpriteBatch");
+        noPredecessor.Count.ShouldBe(1);
+
+        // Total draws this window = 2 (sb1, apos1). Every draw must now be attributable to
+        // exactly one break group entry (NoPredecessor for the first, NoCandidateInWindow for the
+        // switch to apos1) - the reconciliation the diagnostic exists to provide.
+        groups.Sum(g => g.Count).ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildDrawList_CalledTwiceWithoutReset_SumOfBreakGroupCountsMatchesTotalDrawsAcrossBothCycles()
+    {
+        // Mirrors FRB2's real per-camera + overlay shape: BuildDrawList runs once per cycle, and
+        // Renderer only resets the break tally once per host frame - not per cycle. Each cycle's
+        // own first item is a fresh NoPredecessor break, so the two cycles' single-item draws (2
+        // total) must sum to 2 in GetBreakGroups(), not silently undercount to 0.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        Layer layer = BuildLayer(a);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands); // cycle 1
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands); // cycle 2
+
+        var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
+        var noPredecessor = groups.Single(g => g.Reason == BatchKeyGroupedOrderer.BreakReason.NoPredecessor);
+        noPredecessor.Count.ShouldBe(2);
+        groups.Sum(g => g.Count).ShouldBe(2); // 2 cycles x 1 draw each
+    }
+
+    [Fact]
+    public void BuildDrawList_TwoNestedNonOverlappingCardGroups_DoesNotMergeAcrossContainers()
+    {
+        // Known limitation - see issue #4579. Two card-shaped groups (2x same-key "rectangle", 2x
+        // same-key "text", 1x "icon" each), each wrapped in its own container (mirroring a real
+        // Gum component instance), placed with zero bounding-box overlap between containers.
+        // Coordinates are the ACTUAL bounds measured from a live 2-card TestScreenFrb run
+        // (Solitaire sample, FlatRedBall2 repo) - not assumed ones.
+        //
+        // A flat (non-nested) version of this same scene merges perfectly (0 extra breaks per
+        // additional group) - the orderer CAN merge same-key items across non-overlapping groups.
+        // But once each group is wrapped in its own container, nothing merges across containers at
+        // all: the container itself never matches the running batch key (it's a transparent
+        // wrapper), so it's only reached via the "smallest DFS index" fallback tier - by which
+        // point the algorithm has already drained the first card's non-matching items instead of
+        // reaching into the second card's container while a same-key run was still active. This
+        // pins the CURRENT (suboptimal) behavior so a future fix has a red-then-green target.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        object fontTex = new object();
+        object iconTex = new object();
+
+        Layer layer = BuildLayer();
+        for (int card = 0; card < 2; card++)
+        {
+            float dx = card * 100; // card0 Entity.X=0, card1 Entity.X=100 (measured)
+            // Real cards are NESTED: each CardGum.Visual is its own container (empty BatchKey,
+            // full card bounds), and Background/Border/RankText1/RankText2/SuitIcon are its
+            // CHILDREN - not flat top-level siblings like the previous version of this test
+            // assumed. Testing whether that nesting (not bounds/keys, both already proven fine)
+            // is what defeats cross-card merging.
+            FakeRenderable cardContainer = new FakeRenderable($"card{card}", "") { X = 360 + dx, Y = 264, Width = 80, Height = 112 };
+            layer.Add(cardContainer);
+
+            FakeRenderable bg = AddChild(cardContainer, $"bg{card}", "Apos.Shapes");
+            bg.X = 360 + dx; bg.Y = 264; bg.Width = 80; bg.Height = 112;
+
+            FakeRenderable border = AddChild(cardContainer, $"border{card}", "Apos.Shapes");
+            border.X = 360 + dx; border.Y = 264; border.Width = 80; border.Height = 112;
+
+            FakeRenderable rank1 = AddChild(cardContainer, $"rank1_{card}");
+            rank1.BatchSortKey = fontTex; rank1.X = 369 + dx; rank1.Y = 268; rank1.Width = 14; rank1.Height = 30;
+
+            FakeRenderable rank2 = AddChild(cardContainer, $"rank2_{card}");
+            rank2.BatchSortKey = fontTex; rank2.X = 369 + dx; rank2.Y = 268; rank2.Width = 14; rank2.Height = 30;
+
+            FakeRenderable icon = AddChild(cardContainer, $"icon{card}");
+            icon.BatchSortKey = iconTex; icon.X = 374 + dx; icon.Y = 294; icon.Width = 52; icon.Height = 52;
+        }
+
+        List<DrawCommand> commands = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        // Fully sequential per container - bg1/border1 never get pulled forward to merge with
+        // bg0/border0, even though nothing overlaps and their keys match exactly.
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:card0",
+            "DrawRenderable:bg0",
+            "DrawRenderable:border0",
+            "DrawRenderable:rank1_0",
+            "DrawRenderable:rank2_0",
+            "DrawRenderable:icon0",
+            "DrawRenderable:card1",
+            "DrawRenderable:bg1",
+            "DrawRenderable:border1",
+            "DrawRenderable:rank1_1",
+            "DrawRenderable:rank2_1",
+            "DrawRenderable:icon1",
+        });
     }
 
     [Fact]

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
+using System.Linq;
 using MonoGameGum.TestsCommon;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
@@ -391,6 +392,42 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
 
         BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
         BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetBreakGroups_RanksTheMostFrequentBreakFirst()
+    {
+        // Three identical, non-overlapping-with-each-other overlap chains (rows at Y=0,20,40),
+        // each producing the same pair of breaks: sb->apos (blocked by overlap) and apos->sb (no
+        // candidate). A fourth row uses distinct sb BatchSortKeys, so its breaks are separate,
+        // less-frequent groups. The most frequent groups (count 3) must sort first.
+        // SecondarySortOnY isolates each row into its own reorder window - without it the whole
+        // layer is one window, and Kahn's "stay on the current key" tiebreaker drains every
+        // available same-key item across ALL rows before switching, which mixes the rows' breaks
+        // together instead of keeping each row's chain independent.
+        Layer layer = BuildLayer();
+        layer.SecondarySortOnY = true;
+        for (int row = 0; row < 3; row++)
+        {
+            float y = row * 20;
+            layer.Add(new FakeRenderable($"a{row}", "SpriteBatch") { X = 0, Y = y, Width = 10, Height = 10 });
+            layer.Add(new FakeRenderable($"b{row}", "Apos.Shapes") { X = 5, Y = y, Width = 10, Height = 10 });
+            layer.Add(new FakeRenderable($"c{row}", "SpriteBatch") { X = 12, Y = y, Width = 10, Height = 10 });
+        }
+        // Both d and f need a BatchSortKey distinct from the rows-0-2 default (null) - otherwise
+        // f's break would merge into rows-0-2's apos->sb group (they'd share the same "to" key).
+        layer.Add(new FakeRenderable("d", "SpriteBatch") { X = 0, Y = 100, Width = 10, Height = 10, BatchSortKey = new object() });
+        layer.Add(new FakeRenderable("e", "Apos.Shapes") { X = 5, Y = 100, Width = 10, Height = 10 });
+        layer.Add(new FakeRenderable("f", "SpriteBatch") { X = 12, Y = 100, Width = 10, Height = 10, BatchSortKey = new object() });
+
+        List<DrawCommand> commands = new List<DrawCommand>();
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        var groups = BatchKeyGroupedOrderer.Instance.GetBreakGroups();
+
+        groups[0].Count.ShouldBe(3);
+        groups.Count(g => g.Count == 3).ShouldBe(2); // sb->apos (blocked) and apos->sb (no candidate)
+        groups.Count(g => g.Count == 1).ShouldBe(2); // the distinct-BatchSortKey row's own pair
     }
 
     [Fact]

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -355,6 +355,10 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         // other. Overlap forces the emit order A, B, C - C (sb) can't jump ahead of B to rejoin A's
         // run even though it shares A's key, so switching sb->apos is a real MergeBlockedByOverlap.
         // The following switch apos->sb has no remaining apos candidate at all - NoCandidateInWindow.
+        // BuildDrawList no longer self-resets (issue #4575 follow-up: the tally now accumulates
+        // until Renderer says a frame boundary passed, so it can span multiple Begin/End cycles).
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
         FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
         FakeRenderable b = new FakeRenderable("b", "Apos.Shapes") { X = 5, Y = 0, Width = 10, Height = 10 };
         FakeRenderable c = new FakeRenderable("c", "SpriteBatch") { X = 12, Y = 0, Width = 10, Height = 10 };
@@ -380,6 +384,8 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         // Same non-overlapping scene as BuildDrawList_AlternatingBatchKeys_GroupsSameKeyTogether:
         // the orderer fully collapses to one sb run then one apos run, so the single break between
         // them is a genuine "nothing left to merge with" case, not an overlap block.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
         FakeRenderable sb1 = new FakeRenderable("sb1", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
         FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 50, Y = 0, Width = 10, Height = 10 };
         FakeRenderable sb2 = new FakeRenderable("sb2", "SpriteBatch") { X = 0, Y = 20, Width = 10, Height = 10 };
@@ -405,6 +411,8 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         // layer is one window, and Kahn's "stay on the current key" tiebreaker drains every
         // available same-key item across ALL rows before switching, which mixes the rows' breaks
         // together instead of keeping each row's chain independent.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
         Layer layer = BuildLayer();
         layer.SecondarySortOnY = true;
         for (int row = 0; row < 3; row++)
@@ -428,6 +436,44 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         groups[0].Count.ShouldBe(3);
         groups.Count(g => g.Count == 3).ShouldBe(2); // sb->apos (blocked) and apos->sb (no candidate)
         groups.Count(g => g.Count == 1).ShouldBe(2); // the distinct-BatchSortKey row's own pair
+    }
+
+    [Fact]
+    public void BuildDrawList_CalledTwiceWithoutReset_AccumulatesAcrossBothCalls()
+    {
+        // Renderer calls ResetBreakTally() at frame boundaries, not on every BuildDrawList call,
+        // so multiple cycles in one host frame (FRB2's per-camera + overlay shape) accumulate into
+        // one frame's total instead of the second cycle wiping out the first's tally.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable b = new FakeRenderable("b", "Apos.Shapes") { X = 5, Y = 0, Width = 10, Height = 10 };
+        Layer layer = BuildLayer(a, b);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1);
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(2);
+        BatchKeyGroupedOrderer.Instance.GetBreakGroups().Single().Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetBreakGroupsByType_FormatsAsShortTypeArrowWithCount()
+    {
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable b = new FakeRenderable("b", "Apos.Shapes") { X = 5, Y = 0, Width = 10, Height = 10 };
+        Layer layer = BuildLayer(a, b);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        var typeGroups = BatchKeyGroupedOrderer.Instance.GetBreakGroupsByType();
+
+        typeGroups.Single().ToString().ShouldBe("FakeRenderable->FakeRenderable (1)");
     }
 
     [Fact]

--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -348,6 +348,52 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void BuildDrawList_OverlapChain_RecordsMergeBlockedByOverlapAndNoCandidateBreaks()
+    {
+        // A chain: A(sb) overlaps B(apos), B(apos) overlaps C(sb), but A and C don't overlap each
+        // other. Overlap forces the emit order A, B, C - C (sb) can't jump ahead of B to rejoin A's
+        // run even though it shares A's key, so switching sb->apos is a real MergeBlockedByOverlap.
+        // The following switch apos->sb has no remaining apos candidate at all - NoCandidateInWindow.
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable b = new FakeRenderable("b", "Apos.Shapes") { X = 5, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable c = new FakeRenderable("c", "SpriteBatch") { X = 12, Y = 0, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(a, b, c);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:a",
+            "DrawRenderable:b",
+            "DrawRenderable:c",
+        });
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildDrawList_NonOverlappingAlternation_RecordsOnlyNoCandidateBreaks()
+    {
+        // Same non-overlapping scene as BuildDrawList_AlternatingBatchKeys_GroupsSameKeyTogether:
+        // the orderer fully collapses to one sb run then one apos run, so the single break between
+        // them is a genuine "nothing left to merge with" case, not an overlap block.
+        FakeRenderable sb1 = new FakeRenderable("sb1", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 50, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable sb2 = new FakeRenderable("sb2", "SpriteBatch") { X = 0, Y = 20, Width = 10, Height = 10 };
+        FakeRenderable apos2 = new FakeRenderable("apos2", "Apos.Shapes") { X = 50, Y = 20, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(sb1, apos1, sb2, apos2);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1);
+    }
+
+    [Fact]
     public void BuildDrawList_RenderUsingHierarchyFalse_DoesNotRecurse()
     {
         bool originalValue = Renderer.RenderUsingHierarchy;

--- a/MonoGameGum.Tests/RenderingLibraries/LayerSortByZTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/LayerSortByZTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using RenderingLibrary;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.Tests.RenderingLibraries;
+
+/// <summary>
+/// Pins <see cref="Layer.SortByZ"/>, the stable-Z-sort helper shared by
+/// <see cref="Layer.SortRenderables"/> and <see cref="Renderer"/>'s deferred immediate-mode flush
+/// (issue #4573) so both sort the same way without duplicating the algorithm.
+/// </summary>
+public class LayerSortByZTests : BaseTestClass
+{
+    private sealed class FakeRenderable : IRenderableIpso, IWrappedText
+    {
+        public FakeRenderable(string name, float z)
+        {
+            Name = name;
+            Z = z;
+            Visible = true;
+            Children = new ObservableCollection<IRenderableIpso>();
+        }
+
+        public string Name { get; set; }
+        public bool Visible { get; set; }
+        public bool ClipsChildren { get; set; }
+        public bool IsRenderTarget { get; set; }
+        public ObservableCollection<IRenderableIpso> Children { get; }
+
+        public IRenderableIpso? Parent { get; set; }
+        IVisible? IVisible.Parent => Parent;
+        public bool AbsoluteVisible => Visible;
+
+        public void SetParentDirect(IRenderableIpso? newParent) => Parent = newParent;
+
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float Rotation { get; set; }
+        public bool FlipHorizontal { get; set; }
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public object? Tag { get; set; }
+
+        public int Alpha => 255;
+        public ColorOperation ColorOperation => ColorOperation.Modulate;
+        public Gum.BlendState BlendState => Gum.BlendState.NonPremultiplied;
+        public bool Wrap => false;
+
+        public string BatchKey => string.Empty;
+        public void Render(ISystemManagers managers) { }
+        public void PreRender() { }
+        public void StartBatch(ISystemManagers managers) { }
+        public void EndBatch(ISystemManagers managers) { }
+
+        public float WrappedTextHeight { get; set; }
+        public int? MaxNumberOfLines => null;
+        public int LineHeightInPixels => 0;
+        public bool IsTruncatingWithEllipsisOnLastLine => false;
+        public bool IsHeightDependentOnLines { get; set; }
+        public bool IsMidWordLineBreakEnabled => false;
+        public float MeasureString(string text) => 0;
+        public void SetNeedsRefreshToTrue() { }
+        public void UpdatePreRenderDimensions() { }
+        public float DescenderHeight => 0;
+        public float FontScale => 1;
+        public float WrappedTextWidth => 0;
+        public string? RawText { get; set; }
+        public string? StoredMarkupText => null;
+        float? IText.Width { get => Width; set => Width = value ?? 0; }
+        public TextOverflowVerticalMode TextOverflowVerticalMode { get; set; }
+    }
+
+    [Fact]
+    public void SortByZ_OrdersAscendingByZ()
+    {
+        FakeRenderable low = new("low", 1);
+        FakeRenderable mid = new("mid", 2);
+        FakeRenderable high = new("high", 3);
+        List<IRenderableIpso> renderables = new() { high, low, mid };
+
+        Layer.SortByZ(renderables);
+
+        renderables.ShouldBe(new IRenderableIpso[] { low, mid, high });
+    }
+
+    [Fact]
+    public void SortByZ_IsStableForEqualZ()
+    {
+        // All three share Z=0. A stable sort preserves original relative (insertion/call) order
+        // as the tie-break, matching what Layer.SortRenderables already documents.
+        FakeRenderable first = new("first", 0);
+        FakeRenderable second = new("second", 0);
+        FakeRenderable third = new("third", 0);
+        List<IRenderableIpso> renderables = new() { first, second, third };
+
+        Layer.SortByZ(renderables);
+
+        renderables.ShouldBe(new IRenderableIpso[] { first, second, third });
+    }
+}

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -27,6 +27,25 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     /// <summary>Shared stateless instance.</summary>
     public static readonly BatchKeyGroupedOrderer Instance = new BatchKeyGroupedOrderer();
 
+    /// <summary>
+    /// Number of times <see cref="FlushWindow"/> had to switch away from the running
+    /// (<see cref="IRenderable.BatchKey"/>, <see cref="IRenderable.BatchSortKey"/>) even though
+    /// another item still in the window shared it - the switch happened because overlap forced
+    /// that item to wait behind something else, not because reordering couldn't have merged them.
+    /// Reset at the start of every <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/>
+    /// call, so it reflects only the build that just ran (issue #4575).
+    /// </summary>
+    public int MergeBlockedByOverlapCount { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="FlushWindow"/> had to switch away from the running
+    /// (<see cref="IRenderable.BatchKey"/>, <see cref="IRenderable.BatchSortKey"/>) because no
+    /// remaining window entry shared it at all - genuine content alternation (or the window simply
+    /// ran out), not something reordering could have fixed. Reset at the start of every
+    /// <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/> call (issue #4575).
+    /// </summary>
+    public int NoCandidateInWindowBreakCount { get; private set; }
+
     private struct Entry
     {
         public IRenderableIpso Item;
@@ -52,12 +71,15 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     // single reusable set of buffers serves every call.
     private int[] _indegreeBuffer = Array.Empty<int>();
     private List<int>[] _successorsBuffer = Array.Empty<List<int>>();
+    private bool[] _drawnBuffer = Array.Empty<bool>();
     private readonly List<int> _availableBuffer = new List<int>();
 
     /// <inheritdoc/>
     public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
+        MergeBlockedByOverlapCount = 0;
+        NoCandidateInWindowBreakCount = 0;
 
         ClipBoundsSource clipBounds = camera != null
             ? new ClipBoundsSource(camera, layer)
@@ -73,6 +95,8 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         ClipBoundsSource clipBounds = default)
     {
         destination.Clear();
+        MergeBlockedByOverlapCount = 0;
+        NoCandidateInWindowBreakCount = 0;
         ProcessWindow(roots, clipBounds, destination);
     }
 
@@ -279,6 +303,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         int oldSize = _successorsBuffer.Length;
 
         _indegreeBuffer = new int[newSize];
+        _drawnBuffer = new bool[newSize];
 
         List<int>[] newSuccessors = new List<int>[newSize];
         Array.Copy(_successorsBuffer, newSuccessors, oldSize);
@@ -303,7 +328,9 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         EnsureGraphCapacity(n);
         int[] indegree = _indegreeBuffer;
         List<int>[] successors = _successorsBuffer;
+        bool[] drawn = _drawnBuffer;
         Array.Clear(indegree, 0, n);
+        Array.Clear(drawn, 0, n);
         for (int i = 0; i < n; i++)
         {
             successors[i].Clear();
@@ -381,7 +408,36 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 }
             }
 
+            // #4575 diagnostics: classify a key change (BatchKey and/or BatchSortKey differs from
+            // the last emitted item) as either overlap-blocked (a same-key item is still pending,
+            // just not yet unblocked) or a genuine break (nothing pending shares the old key).
+            // Skipped on the very first emission - there's no prior run to have broken yet.
+            if (currentBatchKey != null &&
+                !(window[chosen].BatchKey == currentBatchKey && Equals(window[chosen].BatchSortKey, currentSortKey)))
+            {
+                bool blockedCandidateExists = false;
+                for (int k = 0; k < n; k++)
+                {
+                    if (!drawn[k] && k != chosen &&
+                        window[k].BatchKey == currentBatchKey && Equals(window[k].BatchSortKey, currentSortKey))
+                    {
+                        blockedCandidateExists = true;
+                        break;
+                    }
+                }
+
+                if (blockedCandidateExists)
+                {
+                    MergeBlockedByOverlapCount++;
+                }
+                else
+                {
+                    NoCandidateInWindowBreakCount++;
+                }
+            }
+
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
+            drawn[chosen] = true;
             currentBatchKey = window[chosen].BatchKey;
             currentSortKey = window[chosen].BatchSortKey;
             available.Remove(chosen);

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -300,6 +300,19 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         public System.Drawing.Rectangle Bounds;
         public string BatchKey;
         public object? BatchSortKey;
+
+        /// <summary>
+        /// True for a plain wrapper (empty <see cref="IRenderable.BatchKey"/>, not a render target,
+        /// not a clip) — the shape a Gum component instance's root takes.
+        /// <see cref="BatchOrchestrator.OnRenderable"/> treats an empty BatchKey as a complete
+        /// no-op (no flush, no StartBatch/EndBatch, running key left alone) and
+        /// <c>InvisibleRenderable.Render</c> submits no vertices, so emitting one costs nothing at
+        /// the GPU level. That makes it both exempt from break accounting and a free choice for
+        /// the topological sort — see the free-container tier in <see cref="FlushWindow"/>.
+        /// Computed once per entry rather than per selection: <see cref="FlushWindow"/>'s tiebreak
+        /// scans it on every pick.
+        /// </summary>
+        public bool IsFreeContainer;
     }
 
     // Scratch state pooled on the instance (#4200) so a build does not allocate after warm-up,
@@ -547,12 +560,14 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
     private static void AddEntry(IRenderableIpso renderable, List<Entry> window)
     {
+        string batchKey = renderable.BatchKey ?? string.Empty;
         window.Add(new Entry
         {
             Item = renderable,
             Bounds = GetEffectiveBounds(renderable),
-            BatchKey = renderable.BatchKey ?? string.Empty,
+            BatchKey = batchKey,
             BatchSortKey = renderable.BatchSortKey,
+            IsFreeContainer = batchKey.Length == 0 && !renderable.IsRenderTarget && !renderable.ClipsChildren,
         });
     }
 
@@ -642,9 +657,20 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         // Among items with indegree 0, prefer one whose (BatchKey, BatchSortKey) matches the
         // last emitted exactly (keeps same-texture runs contiguous); failing that, one whose
         // BatchKey alone matches (keeps the coarser SpriteBatch/Apos.Shapes grouping
-        // BatchOrchestrator relies on, even when BatchSortKey differs or is unset). Ties within
-        // a tier break by smallest DFS index for determinism. No match at all → smallest DFS
-        // overall.
+        // BatchOrchestrator relies on, even when BatchSortKey differs or is unset); failing that,
+        // a free container (Entry.IsFreeContainer) — emitting one submits nothing and leaves the
+        // running key alone, so it is strictly better than committing to a real key change, and
+        // it unblocks the container's children while the running key may still be worth
+        // continuing. Ties within a tier break by smallest DFS index for determinism. No match at
+        // all → smallest DFS overall.
+        //
+        // The free-container tier is what makes same-key runs merge across sibling instances of
+        // the same Gum component (#4579): each instance's root is a transparent wrapper whose
+        // bounds encompass its children, so those children have a precedence edge from it and stay
+        // unavailable until it is chosen. Without this tier a wrapper is only ever reached via the
+        // last-resort smallest-DFS tier — by which point the first instance's non-matching items
+        // have already been drained and the running key has moved on, so nothing merges across
+        // instances no matter how many identical, non-overlapping ones exist.
         List<int> available = _availableBuffer;
         available.Clear();
         for (int i = 0; i < n; i++)
@@ -688,6 +714,20 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 for (int k = 0; k < available.Count; k++)
                 {
                     int idx = available[k];
+                    if (window[idx].IsFreeContainer)
+                    {
+                        if (chosen == -1 || idx < chosen)
+                        {
+                            chosen = idx;
+                        }
+                    }
+                }
+            }
+            if (chosen == -1)
+            {
+                for (int k = 0; k < available.Count; k++)
+                {
+                    int idx = available[k];
                     if (chosen == -1 || idx < chosen)
                     {
                         chosen = idx;
@@ -700,23 +740,27 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             // just not yet unblocked) or a genuine break (nothing pending shares the old key).
             // Skipped on the very first emission - there's no prior run to have broken yet.
             //
-            // Also skipped for a transparent item: empty BatchKey AND not a render target AND not
-            // a clip. BatchOrchestrator.OnRenderable treats empty BatchKey as a complete no-op (no
-            // flush, no StartBatch/EndBatch, _currentBatchKey left unchanged) for a plain
-            // ContainerRuntime, and InvisibleRenderable.Render submits no vertices - free at the
-            // real GPU level, so counting it here would be a false positive.
+            // Also skipped for a free container (Entry.IsFreeContainer) - it is free at the real
+            // GPU level, so counting it here would be a false positive.
             //
             // A render target or a pending forced transition (set when we just entered/exited a
             // clip, or just drew a render target) is UNCONDITIONALLY a break, regardless of
             // whether the key happens to match - HardBoundaryTransitionCount, never
             // MergeBlockedByOverlapCount/NoCandidateInWindowBreakCount, since no reordering could
             // ever have avoided it (issue #4575 follow-up).
-            bool chosenIsTransparentContainer = string.IsNullOrEmpty(window[chosen].BatchKey) &&
-                !window[chosen].Item.IsRenderTarget && !window[chosen].Item.ClipsChildren;
+            bool chosenIsFreeContainer = window[chosen].IsFreeContainer;
             bool forced = _forceNextTransition || window[chosen].Item.IsRenderTarget;
-            _forceNextTransition = false;
 
-            if (!chosenIsTransparentContainer)
+            // A free container is exempt from break accounting, so it must not CONSUME a pending
+            // forced transition either - the real renderable after it is the one the GPU actually
+            // flushes for, and the hard boundary belongs to it. Leaving the flag set keeps the
+            // break groups reconciling against the frame's true draw-call count.
+            if (!chosenIsFreeContainer)
+            {
+                _forceNextTransition = false;
+            }
+
+            if (!chosenIsFreeContainer)
             {
                 Type toRenderableType = window[chosen].Item.GetType();
 
@@ -777,7 +821,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
             drawn[chosen] = true;
-            if (!chosenIsTransparentContainer)
+            if (!chosenIsFreeContainer)
             {
                 _runningBatchKey = window[chosen].BatchKey;
                 _runningSortKey = window[chosen].BatchSortKey;

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -32,8 +32,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     /// (<see cref="IRenderable.BatchKey"/>, <see cref="IRenderable.BatchSortKey"/>) even though
     /// another item still in the window shared it - the switch happened because overlap forced
     /// that item to wait behind something else, not because reordering couldn't have merged them.
-    /// Reset at the start of every <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/>
-    /// call, so it reflects only the build that just ran (issue #4575).
+    /// Accumulates across every <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/> call
+    /// until <see cref="ResetBreakTally"/> runs - <see cref="Renderer"/> calls that once per host
+    /// frame (immediate-mode) or once per <c>Draw(SystemManagers)</c> call (layered), matching
+    /// <see cref="RenderStateChangeStatistics"/>'s own reset cadence on each path. A caller driving
+    /// this orderer directly (outside <see cref="Renderer"/>, e.g. a unit test) must call
+    /// <see cref="ResetBreakTally"/> itself between builds it wants measured independently
+    /// (issue #4575).
     /// </summary>
     public int MergeBlockedByOverlapCount { get; private set; }
 
@@ -41,18 +46,20 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     /// Number of times <see cref="FlushWindow"/> had to switch away from the running
     /// (<see cref="IRenderable.BatchKey"/>, <see cref="IRenderable.BatchSortKey"/>) because no
     /// remaining window entry shared it at all - genuine content alternation (or the window simply
-    /// ran out), not something reordering could have fixed. Reset at the start of every
-    /// <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/> call (issue #4575).
+    /// ran out), not something reordering could have fixed. Same reset cadence as
+    /// <see cref="MergeBlockedByOverlapCount"/> (issue #4575).
     /// </summary>
     public int NoCandidateInWindowBreakCount { get; private set; }
 
     /// <summary>
-    /// One distinct kind of batch break and how many times it happened in the last build - e.g.
-    /// "46 times: SpriteRuntime (SpriteBatch/&lt;texture A&gt;) -&gt; RectangleRuntime
-    /// (Apos.Shapes), blocked by overlap". <see cref="FromSortKey"/>/<see cref="ToSortKey"/> are
-    /// raw <see cref="IRenderable.BatchSortKey"/> values (e.g. a <c>Texture2D</c> reference) -
-    /// Gum core doesn't know the backend type, so a caller that does (FRB2, a sample) formats them
-    /// (e.g. <c>((Texture2D)key)?.Name</c>) rather than Gum guessing a generic description.
+    /// One distinct kind of batch break and how many times it happened since the last
+    /// <see cref="ResetBreakTally"/> - e.g. "46 times: SpriteRuntime (SpriteBatch/&lt;texture
+    /// A&gt;) -&gt; RectangleRuntime (Apos.Shapes), blocked by overlap".
+    /// <see cref="FromSortKey"/>/<see cref="ToSortKey"/> are raw <see cref="IRenderable.BatchSortKey"/>
+    /// values (e.g. a <c>Texture2D</c> reference) - Gum core doesn't know the backend type, so a
+    /// caller that does (FRB2, a sample) formats them (e.g. <c>((Texture2D)key)?.Name</c>) rather
+    /// than Gum guessing a generic description. See <see cref="BatchBreakTypeGroup"/> for a
+    /// coarser, renderable-type-only rollup that needs no such formatting.
     /// </summary>
     public readonly struct BatchBreakGroup
     {
@@ -64,6 +71,86 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         public Type ToRenderableType { get; init; }
         public bool BlockedByOverlap { get; init; }
         public int Count { get; init; }
+    }
+
+    /// <summary>
+    /// A break rollup keyed only by the two renderable types involved - drops <c>BatchKey</c>,
+    /// <c>BatchSortKey</c>, and the overlap/no-candidate distinction that <see cref="BatchBreakGroup"/>
+    /// carries. This is the "what's alternating, at a glance" view: <c>ToString()</c> prints e.g.
+    /// <c>"Sprite-&gt;RoundedRectangle (14)"</c>, trimming the conventional "Runtime" suffix, ready
+    /// to print with no caller-side formatting or aggregation.
+    /// </summary>
+    public readonly struct BatchBreakTypeGroup
+    {
+        public Type FromRenderableType { get; init; }
+        public Type ToRenderableType { get; init; }
+        public int Count { get; init; }
+
+        public override string ToString() =>
+            $"{TrimRuntimeSuffix(FromRenderableType.Name)}->{TrimRuntimeSuffix(ToRenderableType.Name)} ({Count})";
+
+        private static string TrimRuntimeSuffix(string typeName) =>
+            typeName.EndsWith("Runtime", StringComparison.Ordinal)
+                ? typeName.Substring(0, typeName.Length - "Runtime".Length)
+                : typeName;
+    }
+
+    private readonly struct TypeGroupKey : IEquatable<TypeGroupKey>
+    {
+        public readonly Type FromRenderableType;
+        public readonly Type ToRenderableType;
+
+        public TypeGroupKey(Type fromRenderableType, Type toRenderableType)
+        {
+            FromRenderableType = fromRenderableType;
+            ToRenderableType = toRenderableType;
+        }
+
+        public bool Equals(TypeGroupKey other) =>
+            FromRenderableType == other.FromRenderableType && ToRenderableType == other.ToRenderableType;
+
+        public override bool Equals(object? obj) => obj is TypeGroupKey other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(FromRenderableType, ToRenderableType);
+    }
+
+    private readonly Dictionary<TypeGroupKey, int> _breakTypeGroupCounts = new();
+
+    /// <summary>
+    /// Every distinct (fromType, toType) break pair since the last <see cref="ResetBreakTally"/>,
+    /// most-frequent first. Coarser than <see cref="GetBreakGroups"/> - use this for "what's
+    /// alternating" at a glance, and <see cref="GetBreakGroups"/> when you need to know which
+    /// specific texture/key is involved (issue #4575).
+    /// </summary>
+    public IReadOnlyList<BatchBreakTypeGroup> GetBreakGroupsByType()
+    {
+        List<BatchBreakTypeGroup> result = new(_breakTypeGroupCounts.Count);
+        foreach (KeyValuePair<TypeGroupKey, int> pair in _breakTypeGroupCounts)
+        {
+            result.Add(new BatchBreakTypeGroup
+            {
+                FromRenderableType = pair.Key.FromRenderableType,
+                ToRenderableType = pair.Key.ToRenderableType,
+                Count = pair.Value,
+            });
+        }
+        result.Sort((a, b) => b.Count.CompareTo(a.Count));
+        return result;
+    }
+
+    /// <summary>
+    /// Clears <see cref="MergeBlockedByOverlapCount"/>, <see cref="NoCandidateInWindowBreakCount"/>,
+    /// and every tally behind <see cref="GetBreakGroups"/>/<see cref="GetBreakGroupsByType"/>.
+    /// <see cref="Renderer"/> calls this at the same points it resets
+    /// <see cref="RenderStateChangeStatistics"/>; call it yourself if you drive this orderer
+    /// directly (issue #4575).
+    /// </summary>
+    public void ResetBreakTally()
+    {
+        MergeBlockedByOverlapCount = 0;
+        NoCandidateInWindowBreakCount = 0;
+        _breakGroupCounts.Clear();
+        _breakTypeGroupCounts.Clear();
     }
 
     private readonly struct BreakGroupKey : IEquatable<BreakGroupKey>
@@ -160,9 +247,6 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
-        MergeBlockedByOverlapCount = 0;
-        NoCandidateInWindowBreakCount = 0;
-        _breakGroupCounts.Clear();
 
         ClipBoundsSource clipBounds = camera != null
             ? new ClipBoundsSource(camera, layer)
@@ -178,9 +262,6 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         ClipBoundsSource clipBounds = default)
     {
         destination.Clear();
-        MergeBlockedByOverlapCount = 0;
-        NoCandidateInWindowBreakCount = 0;
-        _breakGroupCounts.Clear();
         ProcessWindow(roots, clipBounds, destination);
     }
 
@@ -520,11 +601,15 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                     NoCandidateInWindowBreakCount++;
                 }
 
+                Type toRenderableType = window[chosen].Item.GetType();
                 BreakGroupKey groupKey = new(
                     currentBatchKey, currentSortKey, currentRenderableType!,
-                    window[chosen].BatchKey, window[chosen].BatchSortKey, window[chosen].Item.GetType(),
+                    window[chosen].BatchKey, window[chosen].BatchSortKey, toRenderableType,
                     blockedCandidateExists);
                 _breakGroupCounts[groupKey] = _breakGroupCounts.TryGetValue(groupKey, out int existing) ? existing + 1 : 1;
+
+                TypeGroupKey typeKey = new(currentRenderableType!, toRenderableType);
+                _breakTypeGroupCounts[typeKey] = _breakTypeGroupCounts.TryGetValue(typeKey, out int existingTypeCount) ? existingTypeCount + 1 : 1;
             }
 
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -52,6 +52,60 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     public int NoCandidateInWindowBreakCount { get; private set; }
 
     /// <summary>
+    /// Number of times entering or exiting a <see cref="IRenderableIpso.ClipsChildren"/> renderable
+    /// or a <see cref="IRenderableIpso.IsRenderTarget"/> renderable forced a real flush -
+    /// unconditionally, regardless of whether the surrounding <see cref="IRenderable.BatchKey"/>/
+    /// <see cref="IRenderable.BatchSortKey"/> happened to match. <see cref="Renderer.AdjustRenderStates"/>
+    /// restarts <c>SpriteBatch</c> on every clip change, and <c>SubmitDrawRenderable</c>/
+    /// <c>DrawRenderTargetToScreen</c> give a render target its own flush + bind/restore cycle - no
+    /// amount of reordering can avoid either, so these are never <see cref="MergeBlockedByOverlapCount"/>
+    /// candidates. Same reset cadence as <see cref="MergeBlockedByOverlapCount"/> (issue #4575
+    /// follow-up - the first cut of this diagnostic missed these entirely, since clip/render-target
+    /// boundaries don't flow through the normal same-window key comparison).
+    /// </summary>
+    public int HardBoundaryTransitionCount { get; private set; }
+
+    /// <summary>Why a <see cref="BatchBreakGroup"/> break happened.</summary>
+    public enum BreakReason
+    {
+        /// <summary>A same-key item was still pending, blocked by an overlap edge.</summary>
+        BlockedByOverlap,
+
+        /// <summary>Nothing pending shared the outgoing key at all.</summary>
+        NoCandidateInWindow,
+
+        /// <summary>
+        /// A clip or render-target boundary forced this transition unconditionally - see
+        /// <see cref="HardBoundaryTransitionCount"/>.
+        /// </summary>
+        HardBoundary,
+
+        /// <summary>
+        /// The first non-transparent item this build has emitted with nothing running yet to
+        /// compare it against - no reordering choice was even possible, but it is still a real,
+        /// separately-submitted draw call. Fires at the start of a top-level
+        /// <see cref="BuildDrawList(Layer, List{DrawCommand}, Camera?)"/> call, a
+        /// <see cref="Layer.SecondarySortOnY"/> row, or a clip subtree, whichever comes first -
+        /// there is no single structural concept ("layer", "cycle") this lines up with, only "no
+        /// predecessor existed yet." Without this reason a caller summing
+        /// <see cref="BatchBreakGroup.Count"/> across <see cref="GetBreakGroups"/> to reconcile
+        /// against the frame's total draw-call count would silently undercount by one per reset.
+        /// </summary>
+        NoPredecessor,
+    }
+
+    /// <summary>
+    /// Sentinel <see cref="BatchBreakGroup.FromRenderableType"/>/<see cref="BatchBreakTypeGroup.FromRenderableType"/>
+    /// used for a <see cref="BreakReason.NoPredecessor"/> break, whose "from" side has no real
+    /// predecessor renderable. Named distinctly from <see cref="BreakReason.NoPredecessor"/> itself
+    /// to avoid a same-named type/enum-value pair in this class's public surface.
+    /// </summary>
+    public sealed class NoPredecessorMarker
+    {
+        private NoPredecessorMarker() { }
+    }
+
+    /// <summary>
     /// One distinct kind of batch break and how many times it happened since the last
     /// <see cref="ResetBreakTally"/> - e.g. "46 times: SpriteRuntime (SpriteBatch/&lt;texture
     /// A&gt;) -&gt; RectangleRuntime (Apos.Shapes), blocked by overlap".
@@ -69,7 +123,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         public string ToBatchKey { get; init; }
         public object? ToSortKey { get; init; }
         public Type ToRenderableType { get; init; }
-        public bool BlockedByOverlap { get; init; }
+        public BreakReason Reason { get; init; }
         public int Count { get; init; }
     }
 
@@ -149,6 +203,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     {
         MergeBlockedByOverlapCount = 0;
         NoCandidateInWindowBreakCount = 0;
+        HardBoundaryTransitionCount = 0;
         _breakGroupCounts.Clear();
         _breakTypeGroupCounts.Clear();
     }
@@ -161,10 +216,10 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         public readonly string ToBatchKey;
         public readonly object? ToSortKey;
         public readonly Type ToRenderableType;
-        public readonly bool BlockedByOverlap;
+        public readonly BreakReason Reason;
 
         public BreakGroupKey(string fromBatchKey, object? fromSortKey, Type fromRenderableType,
-            string toBatchKey, object? toSortKey, Type toRenderableType, bool blockedByOverlap)
+            string toBatchKey, object? toSortKey, Type toRenderableType, BreakReason reason)
         {
             FromBatchKey = fromBatchKey;
             FromSortKey = fromSortKey;
@@ -172,22 +227,46 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             ToBatchKey = toBatchKey;
             ToSortKey = toSortKey;
             ToRenderableType = toRenderableType;
-            BlockedByOverlap = blockedByOverlap;
+            Reason = reason;
         }
 
         public bool Equals(BreakGroupKey other) =>
             FromBatchKey == other.FromBatchKey && Equals(FromSortKey, other.FromSortKey) &&
             FromRenderableType == other.FromRenderableType && ToBatchKey == other.ToBatchKey &&
             Equals(ToSortKey, other.ToSortKey) && ToRenderableType == other.ToRenderableType &&
-            BlockedByOverlap == other.BlockedByOverlap;
+            Reason == other.Reason;
 
         public override bool Equals(object? obj) => obj is BreakGroupKey other && Equals(other);
 
         public override int GetHashCode() => HashCode.Combine(
-            FromBatchKey, FromSortKey, FromRenderableType, ToBatchKey, ToSortKey, ToRenderableType, BlockedByOverlap);
+            FromBatchKey, FromSortKey, FromRenderableType, ToBatchKey, ToSortKey, ToRenderableType, Reason);
     }
 
     private readonly Dictionary<BreakGroupKey, int> _breakGroupCounts = new();
+
+    /// <summary>Placeholder "from" batch key for a <see cref="BreakReason.NoPredecessor"/> break.</summary>
+    private const string NoPredecessorBatchKey = "(none)";
+
+    /// <summary>Placeholder "from" renderable type for a <see cref="BreakReason.NoPredecessor"/> break.</summary>
+    private static readonly Type NoPredecessorType = typeof(NoPredecessorMarker);
+
+    /// <summary>
+    /// Tallies one break into both <see cref="_breakGroupCounts"/> (identity-level) and
+    /// <see cref="_breakTypeGroupCounts"/> (type-level rollup) - shared by every call site that
+    /// records a break (<see cref="FlushWindow"/>'s per-item loop and
+    /// <see cref="RecordHardBoundaryTransition"/>) so both dictionaries stay in sync.
+    /// </summary>
+    private void RecordBreak(
+        string fromBatchKey, object? fromSortKey, Type fromRenderableType,
+        string toBatchKey, object? toSortKey, Type toRenderableType, BreakReason reason)
+    {
+        BreakGroupKey groupKey = new(
+            fromBatchKey, fromSortKey, fromRenderableType, toBatchKey, toSortKey, toRenderableType, reason);
+        _breakGroupCounts[groupKey] = _breakGroupCounts.TryGetValue(groupKey, out int existing) ? existing + 1 : 1;
+
+        TypeGroupKey typeKey = new(fromRenderableType, toRenderableType);
+        _breakTypeGroupCounts[typeKey] = _breakTypeGroupCounts.TryGetValue(typeKey, out int existingTypeCount) ? existingTypeCount + 1 : 1;
+    }
 
     /// <summary>
     /// Every distinct break this build produced, most-frequent first - "what's alternating," not
@@ -207,7 +286,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 ToBatchKey = pair.Key.ToBatchKey,
                 ToSortKey = pair.Key.ToSortKey,
                 ToRenderableType = pair.Key.ToRenderableType,
-                BlockedByOverlap = pair.Key.BlockedByOverlap,
+                Reason = pair.Key.Reason,
                 Count = pair.Value,
             });
         }
@@ -243,10 +322,28 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     private bool[] _drawnBuffer = Array.Empty<bool>();
     private readonly List<int> _availableBuffer = new List<int>();
 
+    // The "running" batch key/sort key/type, and whether the next comparison against it must be
+    // treated as a forced break regardless of key equality. Unlike the per-window Entry/indegree
+    // scratch above, these must be INSTANCE state rather than FlushWindow locals: a clip boundary
+    // splits one BuildDrawList call into several independent FlushWindow calls (Renderer.cs and
+    // ProcessRenderable's clip branch each start a fresh window), and entering/exiting a clip is a
+    // real cost that must be attributed against whatever was running *before* that window split,
+    // not lost because each FlushWindow call used to start fresh with a local set to null. Reset
+    // once per BuildDrawList call (a fresh pass over the render list), not once per host frame -
+    // that's what MergeBlockedByOverlapCount/etc do, via ResetBreakTally.
+    private string? _runningBatchKey;
+    private object? _runningSortKey;
+    private Type? _runningRenderableType;
+    private bool _forceNextTransition;
+
     /// <inheritdoc/>
     public void BuildDrawList(Layer layer, List<DrawCommand> destination, Camera? camera = null)
     {
         destination.Clear();
+        _runningBatchKey = null;
+        _runningSortKey = null;
+        _runningRenderableType = null;
+        _forceNextTransition = false;
 
         ClipBoundsSource clipBounds = camera != null
             ? new ClipBoundsSource(camera, layer)
@@ -262,6 +359,10 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         ClipBoundsSource clipBounds = default)
     {
         destination.Clear();
+        _runningBatchKey = null;
+        _runningSortKey = null;
+        _runningRenderableType = null;
+        _forceNextTransition = false;
         ProcessWindow(roots, clipBounds, destination);
     }
 
@@ -301,6 +402,14 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 {
                     runEnd++;
                 }
+
+                // Each same-Y run must reorder independently of every other run (see the doc
+                // comment above) - reset the running key/forced-transition state so it doesn't
+                // leak across the row boundary the way it's meant to leak across a clip boundary.
+                _runningBatchKey = null;
+                _runningSortKey = null;
+                _runningRenderableType = null;
+                _forceNextTransition = false;
 
                 List<Entry> window = RentWindow();
                 for (int i = runStart; i < runEnd; i++)
@@ -372,6 +481,16 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             // (the clip-bearing node itself draws inside its own clip, matching the legacy
             // walk in HierarchicalOrderer).
             FlushWindow(currentWindow, destination);
+
+            // #4575 follow-up: entering a clip always forces a real flush
+            // (Renderer.AdjustRenderStates restarts SpriteBatch on any clip change) -
+            // unconditionally, regardless of whether this renderable's own BatchKey happens to
+            // match whatever was running. Consume any already-pending forced transition (e.g.
+            // from exiting a prior sibling clip) into this same recording instead of double-
+            // counting it separately.
+            _forceNextTransition = false;
+            RecordHardBoundaryTransition(renderable.BatchKey, renderable.BatchSortKey, renderable.GetType());
+
             destination.Add(new DrawCommand(DrawCommandKind.BeginClip, renderable));
 
             List<Entry> innerWindow = RentWindow();
@@ -401,6 +520,11 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             FlushWindow(innerWindow, destination);
             ReturnWindow(innerWindow);
             destination.Add(new DrawCommand(DrawCommandKind.EndClip, renderable));
+
+            // Exiting a clip ALSO forces a flush (Renderer.Draw's didClipChange exit branch) -
+            // whatever gets chosen next, in this window or a sibling one, must be treated as a
+            // forced break too, regardless of what its own key turns out to be.
+            _forceNextTransition = true;
         }
         else
         {
@@ -531,16 +655,13 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             }
         }
 
-        string? currentBatchKey = null;
-        object? currentSortKey = null;
-        Type? currentRenderableType = null;
         while (available.Count > 0)
         {
             int chosen = -1;
             for (int k = 0; k < available.Count; k++)
             {
                 int idx = available[k];
-                if (window[idx].BatchKey == currentBatchKey && Equals(window[idx].BatchSortKey, currentSortKey))
+                if (window[idx].BatchKey == _runningBatchKey && Equals(window[idx].BatchSortKey, _runningSortKey))
                 {
                     if (chosen == -1 || idx < chosen)
                     {
@@ -553,7 +674,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 for (int k = 0; k < available.Count; k++)
                 {
                     int idx = available[k];
-                    if (window[idx].BatchKey == currentBatchKey)
+                    if (window[idx].BatchKey == _runningBatchKey)
                     {
                         if (chosen == -1 || idx < chosen)
                         {
@@ -578,45 +699,97 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             // the last emitted item) as either overlap-blocked (a same-key item is still pending,
             // just not yet unblocked) or a genuine break (nothing pending shares the old key).
             // Skipped on the very first emission - there's no prior run to have broken yet.
-            if (currentBatchKey != null &&
-                !(window[chosen].BatchKey == currentBatchKey && Equals(window[chosen].BatchSortKey, currentSortKey)))
-            {
-                bool blockedCandidateExists = false;
-                for (int k = 0; k < n; k++)
-                {
-                    if (!drawn[k] && k != chosen &&
-                        window[k].BatchKey == currentBatchKey && Equals(window[k].BatchSortKey, currentSortKey))
-                    {
-                        blockedCandidateExists = true;
-                        break;
-                    }
-                }
+            //
+            // Also skipped for a transparent item: empty BatchKey AND not a render target AND not
+            // a clip. BatchOrchestrator.OnRenderable treats empty BatchKey as a complete no-op (no
+            // flush, no StartBatch/EndBatch, _currentBatchKey left unchanged) for a plain
+            // ContainerRuntime, and InvisibleRenderable.Render submits no vertices - free at the
+            // real GPU level, so counting it here would be a false positive.
+            //
+            // A render target or a pending forced transition (set when we just entered/exited a
+            // clip, or just drew a render target) is UNCONDITIONALLY a break, regardless of
+            // whether the key happens to match - HardBoundaryTransitionCount, never
+            // MergeBlockedByOverlapCount/NoCandidateInWindowBreakCount, since no reordering could
+            // ever have avoided it (issue #4575 follow-up).
+            bool chosenIsTransparentContainer = string.IsNullOrEmpty(window[chosen].BatchKey) &&
+                !window[chosen].Item.IsRenderTarget && !window[chosen].Item.ClipsChildren;
+            bool forced = _forceNextTransition || window[chosen].Item.IsRenderTarget;
+            _forceNextTransition = false;
 
-                if (blockedCandidateExists)
+            if (!chosenIsTransparentContainer)
+            {
+                Type toRenderableType = window[chosen].Item.GetType();
+
+                if (_runningBatchKey == null)
                 {
-                    MergeBlockedByOverlapCount++;
+                    // Nothing preceded this item in the window - no reordering choice was even
+                    // possible - but it is still a real draw call, so it gets its own break entry
+                    // rather than being silently exempted (see BreakReason.NoPredecessor).
+                    RecordBreak(
+                        NoPredecessorBatchKey, null, NoPredecessorType,
+                        window[chosen].BatchKey, window[chosen].BatchSortKey, toRenderableType,
+                        BreakReason.NoPredecessor);
                 }
                 else
                 {
-                    NoCandidateInWindowBreakCount++;
+                    bool exactMatch = window[chosen].BatchKey == _runningBatchKey &&
+                        Equals(window[chosen].BatchSortKey, _runningSortKey);
+
+                    if (forced)
+                    {
+                        HardBoundaryTransitionCount++;
+                        RecordBreak(
+                            _runningBatchKey, _runningSortKey, _runningRenderableType!,
+                            window[chosen].BatchKey, window[chosen].BatchSortKey, toRenderableType,
+                            BreakReason.HardBoundary);
+                    }
+                    else if (!exactMatch)
+                    {
+                        bool blockedCandidateExists = false;
+                        for (int k = 0; k < n; k++)
+                        {
+                            if (!drawn[k] && k != chosen &&
+                                window[k].BatchKey == _runningBatchKey && Equals(window[k].BatchSortKey, _runningSortKey))
+                            {
+                                blockedCandidateExists = true;
+                                break;
+                            }
+                        }
+
+                        BreakReason reason;
+                        if (blockedCandidateExists)
+                        {
+                            MergeBlockedByOverlapCount++;
+                            reason = BreakReason.BlockedByOverlap;
+                        }
+                        else
+                        {
+                            NoCandidateInWindowBreakCount++;
+                            reason = BreakReason.NoCandidateInWindow;
+                        }
+
+                        RecordBreak(
+                            _runningBatchKey, _runningSortKey, _runningRenderableType!,
+                            window[chosen].BatchKey, window[chosen].BatchSortKey, toRenderableType, reason);
+                    }
                 }
-
-                Type toRenderableType = window[chosen].Item.GetType();
-                BreakGroupKey groupKey = new(
-                    currentBatchKey, currentSortKey, currentRenderableType!,
-                    window[chosen].BatchKey, window[chosen].BatchSortKey, toRenderableType,
-                    blockedCandidateExists);
-                _breakGroupCounts[groupKey] = _breakGroupCounts.TryGetValue(groupKey, out int existing) ? existing + 1 : 1;
-
-                TypeGroupKey typeKey = new(currentRenderableType!, toRenderableType);
-                _breakTypeGroupCounts[typeKey] = _breakTypeGroupCounts.TryGetValue(typeKey, out int existingTypeCount) ? existingTypeCount + 1 : 1;
             }
 
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
             drawn[chosen] = true;
-            currentBatchKey = window[chosen].BatchKey;
-            currentSortKey = window[chosen].BatchSortKey;
-            currentRenderableType = window[chosen].Item.GetType();
+            if (!chosenIsTransparentContainer)
+            {
+                _runningBatchKey = window[chosen].BatchKey;
+                _runningSortKey = window[chosen].BatchSortKey;
+                _runningRenderableType = window[chosen].Item.GetType();
+            }
+            if (window[chosen].Item.IsRenderTarget)
+            {
+                // Drawing the target is only half the cost - DrawRenderTargetToScreen also
+                // restores the normal effect afterward (its own BeginSpriteBatch with no
+                // override), so whatever comes next is forced too, regardless of its own key.
+                _forceNextTransition = true;
+            }
             available.Remove(chosen);
 
             List<int> succ = successors[chosen];
@@ -631,5 +804,33 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         }
 
         window.Clear();
+    }
+
+    /// <summary>
+    /// Unconditionally records a <see cref="BreakReason.HardBoundary"/> transition from whatever
+    /// is currently running to <paramref name="toBatchKey"/>/<paramref name="toSortKey"/>/
+    /// <paramref name="toRenderableType"/>, then makes that the new running state - used when
+    /// entering a <see cref="IRenderableIpso.ClipsChildren"/> renderable, where the transition
+    /// happens outside <see cref="FlushWindow"/>'s own per-item loop (issue #4575 follow-up).
+    /// </summary>
+    private void RecordHardBoundaryTransition(string toBatchKey, object? toSortKey, Type toRenderableType)
+    {
+        if (_runningBatchKey != null)
+        {
+            HardBoundaryTransitionCount++;
+            RecordBreak(
+                _runningBatchKey, _runningSortKey, _runningRenderableType!,
+                toBatchKey, toSortKey, toRenderableType, BreakReason.HardBoundary);
+        }
+        else
+        {
+            // The clip is the very first thing in this window - nothing to force away from, but
+            // still a real draw call (see BreakReason.NoPredecessor).
+            RecordBreak(NoPredecessorBatchKey, null, NoPredecessorType, toBatchKey, toSortKey, toRenderableType, BreakReason.NoPredecessor);
+        }
+
+        _runningBatchKey = toBatchKey;
+        _runningSortKey = toSortKey;
+        _runningRenderableType = toRenderableType;
     }
 }

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -46,6 +46,88 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     /// </summary>
     public int NoCandidateInWindowBreakCount { get; private set; }
 
+    /// <summary>
+    /// One distinct kind of batch break and how many times it happened in the last build - e.g.
+    /// "46 times: SpriteRuntime (SpriteBatch/&lt;texture A&gt;) -&gt; RectangleRuntime
+    /// (Apos.Shapes), blocked by overlap". <see cref="FromSortKey"/>/<see cref="ToSortKey"/> are
+    /// raw <see cref="IRenderable.BatchSortKey"/> values (e.g. a <c>Texture2D</c> reference) -
+    /// Gum core doesn't know the backend type, so a caller that does (FRB2, a sample) formats them
+    /// (e.g. <c>((Texture2D)key)?.Name</c>) rather than Gum guessing a generic description.
+    /// </summary>
+    public readonly struct BatchBreakGroup
+    {
+        public string FromBatchKey { get; init; }
+        public object? FromSortKey { get; init; }
+        public Type FromRenderableType { get; init; }
+        public string ToBatchKey { get; init; }
+        public object? ToSortKey { get; init; }
+        public Type ToRenderableType { get; init; }
+        public bool BlockedByOverlap { get; init; }
+        public int Count { get; init; }
+    }
+
+    private readonly struct BreakGroupKey : IEquatable<BreakGroupKey>
+    {
+        public readonly string FromBatchKey;
+        public readonly object? FromSortKey;
+        public readonly Type FromRenderableType;
+        public readonly string ToBatchKey;
+        public readonly object? ToSortKey;
+        public readonly Type ToRenderableType;
+        public readonly bool BlockedByOverlap;
+
+        public BreakGroupKey(string fromBatchKey, object? fromSortKey, Type fromRenderableType,
+            string toBatchKey, object? toSortKey, Type toRenderableType, bool blockedByOverlap)
+        {
+            FromBatchKey = fromBatchKey;
+            FromSortKey = fromSortKey;
+            FromRenderableType = fromRenderableType;
+            ToBatchKey = toBatchKey;
+            ToSortKey = toSortKey;
+            ToRenderableType = toRenderableType;
+            BlockedByOverlap = blockedByOverlap;
+        }
+
+        public bool Equals(BreakGroupKey other) =>
+            FromBatchKey == other.FromBatchKey && Equals(FromSortKey, other.FromSortKey) &&
+            FromRenderableType == other.FromRenderableType && ToBatchKey == other.ToBatchKey &&
+            Equals(ToSortKey, other.ToSortKey) && ToRenderableType == other.ToRenderableType &&
+            BlockedByOverlap == other.BlockedByOverlap;
+
+        public override bool Equals(object? obj) => obj is BreakGroupKey other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(
+            FromBatchKey, FromSortKey, FromRenderableType, ToBatchKey, ToSortKey, ToRenderableType, BlockedByOverlap);
+    }
+
+    private readonly Dictionary<BreakGroupKey, int> _breakGroupCounts = new();
+
+    /// <summary>
+    /// Every distinct break this build produced, most-frequent first - "what's alternating," not
+    /// just a count of how often something did. Recomputed from this build's tallies each call;
+    /// cheap unless you're calling it every frame in a hot loop (issue #4575).
+    /// </summary>
+    public IReadOnlyList<BatchBreakGroup> GetBreakGroups()
+    {
+        List<BatchBreakGroup> result = new(_breakGroupCounts.Count);
+        foreach (KeyValuePair<BreakGroupKey, int> pair in _breakGroupCounts)
+        {
+            result.Add(new BatchBreakGroup
+            {
+                FromBatchKey = pair.Key.FromBatchKey,
+                FromSortKey = pair.Key.FromSortKey,
+                FromRenderableType = pair.Key.FromRenderableType,
+                ToBatchKey = pair.Key.ToBatchKey,
+                ToSortKey = pair.Key.ToSortKey,
+                ToRenderableType = pair.Key.ToRenderableType,
+                BlockedByOverlap = pair.Key.BlockedByOverlap,
+                Count = pair.Value,
+            });
+        }
+        result.Sort((a, b) => b.Count.CompareTo(a.Count));
+        return result;
+    }
+
     private struct Entry
     {
         public IRenderableIpso Item;
@@ -80,6 +162,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         destination.Clear();
         MergeBlockedByOverlapCount = 0;
         NoCandidateInWindowBreakCount = 0;
+        _breakGroupCounts.Clear();
 
         ClipBoundsSource clipBounds = camera != null
             ? new ClipBoundsSource(camera, layer)
@@ -97,6 +180,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         destination.Clear();
         MergeBlockedByOverlapCount = 0;
         NoCandidateInWindowBreakCount = 0;
+        _breakGroupCounts.Clear();
         ProcessWindow(roots, clipBounds, destination);
     }
 
@@ -368,6 +452,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
         string? currentBatchKey = null;
         object? currentSortKey = null;
+        Type? currentRenderableType = null;
         while (available.Count > 0)
         {
             int chosen = -1;
@@ -434,12 +519,19 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 {
                     NoCandidateInWindowBreakCount++;
                 }
+
+                BreakGroupKey groupKey = new(
+                    currentBatchKey, currentSortKey, currentRenderableType!,
+                    window[chosen].BatchKey, window[chosen].BatchSortKey, window[chosen].Item.GetType(),
+                    blockedCandidateExists);
+                _breakGroupCounts[groupKey] = _breakGroupCounts.TryGetValue(groupKey, out int existing) ? existing + 1 : 1;
             }
 
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
             drawn[chosen] = true;
             currentBatchKey = window[chosen].BatchKey;
             currentSortKey = window[chosen].BatchSortKey;
+            currentRenderableType = window[chosen].Item.GetType();
             available.Remove(chosen);
 
             List<int> succ = successors[chosen];

--- a/RenderingLibrary/Graphics/Layer.cs
+++ b/RenderingLibrary/Graphics/Layer.cs
@@ -92,54 +92,66 @@ namespace RenderingLibrary.Graphics
         public void Insert(int index, IRenderableIpso renderable) => mRenderables.Insert(index, renderable);
 
         /// <summary>
-        /// This is a stable sort on Z.  It's incredibly fast on already-sorted lists so we'll do this over something like the built-in 
+        /// This is a stable sort on Z.  It's incredibly fast on already-sorted lists so we'll do this over something like the built-in
         /// binary sorts that .NET offers.
         /// </summary>
         public void SortRenderables()
         {
+            SortByZ(mRenderables, SecondarySortOnY);
+        }
+
+        /// <summary>
+        /// Stable sort on <see cref="IRenderableIpso.Z"/> (then, when <paramref name="secondarySortOnY"/>
+        /// is true, on absolute Y for equal-Z entries), extracted out of <see cref="SortRenderables"/> so
+        /// a caller with a flat list of top-level renderables that isn't a <see cref="Layer"/> - the
+        /// deferred immediate-mode flush in <c>Renderer.End</c> - can sort the same way before handing
+        /// the list to <see cref="IRenderableOrderer.BuildDrawList(IList{IRenderableIpso}, List{DrawCommand}, ClipBoundsSource)"/>.
+        /// </summary>
+        internal static void SortByZ(List<IRenderableIpso> renderables, bool secondarySortOnY = false)
+        {
             /////////////Early Out//////////////
-            if (mRenderables.Count < 2)
+            if (renderables.Count < 2)
                 return;
             ///////////End Early Out////////////
 
             int whereObjectBelongs;
 
-            for (int i = 1; i < mRenderables.Count; i++)
+            for (int i = 1; i < renderables.Count; i++)
             {
-                var atI = mRenderables[i];
-                if ((atI).Z < (mRenderables[i - 1]).Z)
+                var atI = renderables[i];
+                if ((atI).Z < (renderables[i - 1]).Z)
                 {
                     if (i == 1)
                     {
-                        mRenderables.Insert(0, atI);
-                        mRenderables.RemoveAt(i + 1);
+                        renderables.Insert(0, atI);
+                        renderables.RemoveAt(i + 1);
                         continue;
                     }
 
                     for (whereObjectBelongs = i - 2; whereObjectBelongs > -1; whereObjectBelongs--)
                     {
-                        if (atI.Z >= (mRenderables[whereObjectBelongs]).Z)
+                        if (atI.Z >= (renderables[whereObjectBelongs]).Z)
                         {
-                            mRenderables.Insert(whereObjectBelongs + 1, atI);
-                            mRenderables.RemoveAt(i + 1);
+                            renderables.Insert(whereObjectBelongs + 1, atI);
+                            renderables.RemoveAt(i + 1);
                             break;
                         }
-                        else if (whereObjectBelongs == 0 && atI.Z < (mRenderables[0]).Z)
+                        else if (whereObjectBelongs == 0 && atI.Z < (renderables[0]).Z)
                         {
-                            mRenderables.Insert(0, atI);
-                            mRenderables.RemoveAt(i + 1);
+                            renderables.Insert(0, atI);
+                            renderables.RemoveAt(i + 1);
                             break;
                         }
                     }
                 }
             }
 
-            if (SecondarySortOnY)
+            if (secondarySortOnY)
             {
-                for (int i = 1; i < mRenderables.Count; i++)
+                for (int i = 1; i < renderables.Count; i++)
                 {
-                    var atI = mRenderables[i];
-                    var atIMinus1 = mRenderables[i - 1];
+                    var atI = renderables[i];
+                    var atIMinus1 = renderables[i - 1];
 
                     var atIAbsoluteY = atI.GetAbsoluteY();
 
@@ -147,26 +159,26 @@ namespace RenderingLibrary.Graphics
                     {
                         if (i == 1)
                         {
-                            mRenderables.Insert(0, atI);
-                            mRenderables.RemoveAt(i + 1);
+                            renderables.Insert(0, atI);
+                            renderables.RemoveAt(i + 1);
                             continue;
                         }
 
                         for (whereObjectBelongs = i - 2; whereObjectBelongs > -1; whereObjectBelongs--)
                         {
-                            if (atI.Z >= (mRenderables[whereObjectBelongs]).Z ||
-                                atIAbsoluteY >= (mRenderables[whereObjectBelongs]).GetAbsoluteY())
+                            if (atI.Z >= (renderables[whereObjectBelongs]).Z ||
+                                atIAbsoluteY >= (renderables[whereObjectBelongs]).GetAbsoluteY())
                             {
-                                mRenderables.Insert(whereObjectBelongs + 1, atI);
-                                mRenderables.RemoveAt(i + 1);
+                                renderables.Insert(whereObjectBelongs + 1, atI);
+                                renderables.RemoveAt(i + 1);
                                 break;
                             }
                             else if (whereObjectBelongs == 0 &&
-                                atI.Z < (mRenderables[0]).Z &&
-                                atIAbsoluteY < (mRenderables[0]).GetAbsoluteY())
+                                atI.Z < (renderables[0]).Z &&
+                                atIAbsoluteY < (renderables[0]).GetAbsoluteY())
                             {
-                                mRenderables.Insert(0, atI);
-                                mRenderables.RemoveAt(i + 1);
+                                renderables.Insert(0, atI);
+                                renderables.RemoveAt(i + 1);
                                 break;
                             }
                         }

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -822,8 +822,6 @@ public class Renderer : IRenderer
 
     public void End()
     {
-        spriteRenderer.ForcedMatrix = null;
-
         if (_deferredImmediateModeRoots.Count > 0)
         {
             Layer.SortByZ(_deferredImmediateModeRoots);
@@ -842,6 +840,14 @@ public class Renderer : IRenderer
         _batchOrchestrator.FlushAndReset(SystemManagers.Default);
 
         spriteRenderer.EndSpriteBatch();
+
+        // Cleared only once everything this cycle submits has gone through. Every
+        // re-BeginSpriteBatch (a clip enter/exit, an orchestrator flush) composes ForcedMatrix
+        // into the transform it hands the SpriteBatch, and in Deferred mode all of those happen
+        // inside the Submit above - so clearing any earlier drops the caller's matrix on exactly
+        // the draws that needed it. Begin always reassigns it (null included), so no cycle can
+        // inherit a stale matrix from this one.
+        spriteRenderer.ForcedMatrix = null;
 
 #if !FNA
         if (GraphicsDevice != null)

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -89,6 +89,14 @@ public class Renderer : IRenderer
     private bool _referencedRenderTargetsCollectedForHostFrame;
     private bool _perfStatsResetForHostFrame;
     private readonly HashSet<IRenderableIpso> _referencedRenderTargetOwners = new();
+
+    // GumBatchDrawMode.Deferred scratch state for the current Begin/End cycle (immediate-mode
+    // path only - RenderLayer has its own _scratchCommands). Separate buffers rather than reusing
+    // _scratchCommands/_bakeCommands so this can never stomp either of those in-flight lists,
+    // mirroring why the render-target bake owns _bakeCommands instead of sharing _scratchCommands.
+    private GumBatchDrawMode _immediateModeDrawMode = GumBatchDrawMode.Immediate;
+    private readonly List<IRenderableIpso> _deferredImmediateModeRoots = new();
+    private readonly List<DrawCommand> _deferredImmediateModeCommands = new();
 #if !FNA
     // Set at the start of each immediate-mode Begin/End cycle (Renderer.Begin/Draw/End, the path
     // GumBatch wraps) so End can take the same before/after GraphicsDevice.Metrics.DrawCount delta
@@ -719,8 +727,36 @@ public class Renderer : IRenderer
 
 
     // Immediate mode calls:
-    public void Begin(Microsoft.Xna.Framework.Matrix? spriteBatchMatrix = null)
+    /// <summary>
+    /// How <see cref="Draw(IRenderableIpso)"/> calls between a <see cref="Begin"/>/<see cref="End"/>
+    /// pair are submitted. Mirrors MonoGame's own <c>SpriteSortMode.Immediate</c>/<c>Deferred</c>
+    /// distinction for the same reason: batching needs more than one draw visible at once.
+    /// </summary>
+    public enum GumBatchDrawMode
     {
+        /// <summary>
+        /// Each <see cref="Draw(IRenderableIpso)"/> call submits immediately, in call order. The
+        /// default - existing behavior for every caller that doesn't opt into <see cref="Deferred"/>.
+        /// </summary>
+        Immediate,
+
+        /// <summary>
+        /// <see cref="Draw(IRenderableIpso)"/> calls accumulate instead of submitting immediately.
+        /// At <see cref="End"/> they are stable-sorted by <see cref="IRenderableIpso.Z"/> (same
+        /// algorithm as <see cref="Layer.SortRenderables"/>) and run through the active
+        /// <see cref="SiblingOrdering"/> as if they were siblings in one layer, so separate
+        /// <see cref="Draw(IRenderableIpso)"/> calls can batch together (e.g. with
+        /// <see cref="BatchKeyGroupedOrderer"/>). A raw draw issued directly on the wrapped
+        /// <c>SpriteBatch</c> between <see cref="Begin"/> and <see cref="End"/> no longer shares a
+        /// submission-order guarantee with Gum's own (now-deferred) draws - the same caveat
+        /// MonoGame gives for its own <c>SpriteSortMode.Deferred</c>.
+        /// </summary>
+        Deferred,
+    }
+
+    public void Begin(Microsoft.Xna.Framework.Matrix? spriteBatchMatrix = null, GumBatchDrawMode mode = GumBatchDrawMode.Immediate)
+    {
+        _immediateModeDrawMode = mode;
         TryResetPerformanceStatsForHostFrame();
 #if !FNA
         _immediateModeDrawCountBeforeCycle = GraphicsDevice?.Metrics.DrawCount ?? 0;
@@ -751,7 +787,17 @@ public class Renderer : IRenderer
         // are not supported on this path.
         InvokePreRenderRecursively(renderable);
 
-        Draw(SystemManagers.Default, _layers[0], renderable);
+        if (_immediateModeDrawMode == GumBatchDrawMode.Deferred)
+        {
+            // Accumulate instead of submitting now. Flushed at End() via the same
+            // SortByZ + SiblingOrdering.BuildDrawList + Submit pipeline RenderLayer uses, so
+            // draws from separate Draw() calls in this cycle can batch together.
+            _deferredImmediateModeRoots.Add(renderable);
+        }
+        else
+        {
+            Draw(SystemManagers.Default, _layers[0], renderable);
+        }
     }
 
     private void InvokePreRenderRecursively(IRenderableIpso renderable)
@@ -777,6 +823,15 @@ public class Renderer : IRenderer
     public void End()
     {
         spriteRenderer.ForcedMatrix = null;
+
+        if (_deferredImmediateModeRoots.Count > 0)
+        {
+            Layer.SortByZ(_deferredImmediateModeRoots);
+            SiblingOrdering.BuildDrawList(
+                _deferredImmediateModeRoots, _deferredImmediateModeCommands, new ClipBoundsSource(mCamera, _layers[0]));
+            Submit(_deferredImmediateModeCommands, SystemManagers.Default, _layers[0]);
+            _deferredImmediateModeRoots.Clear();
+        }
 
         // Mirror RenderLayer's end-of-walk: flush any pending custom batch and reset state
         // before ending SpriteBatch. Without this, the next Renderer.Begin cycle inherits
@@ -1617,7 +1672,7 @@ public class GumBatch
         internalTextForRendering = new Text(systemManagers);
     }
 
-    public void Begin(Matrix? spriteBatchMatrix = null)
+    public void Begin(Matrix? spriteBatchMatrix = null, Renderer.GumBatchDrawMode mode = Renderer.GumBatchDrawMode.Immediate)
     {
         if(State == GumBatchState.BeginCalled)
         {
@@ -1631,7 +1686,7 @@ public class GumBatch
         systemManagers.Renderer.Camera.ClientLeft = systemManagers.Renderer.GraphicsDevice.Viewport.X;
         systemManagers.Renderer.Camera.ClientTop = systemManagers.Renderer.GraphicsDevice.Viewport.Y;
 
-        systemManagers.Renderer.Begin(spriteBatchMatrix);
+        systemManagers.Renderer.Begin(spriteBatchMatrix, mode);
     }
 
     public void DrawString(BitmapFont font, string text, Microsoft.Xna.Framework.Vector2 position, Microsoft.Xna.Framework.Color color)

--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -1569,6 +1569,14 @@ public class Renderer : IRenderer
     {
         spriteRenderer.ClearPerformanceRecordingVariables();
         RenderStateChangeStatistics.Reset();
+
+        // Same reset cadence as the two statistics above (every Draw(SystemManagers) call on the
+        // layered path, once per host frame on the immediate-mode path via
+        // TryResetPerformanceStatsForHostFrame) - see BatchKeyGroupedOrderer.ResetBreakTally.
+        if (SiblingOrdering is BatchKeyGroupedOrderer orderer)
+        {
+            orderer.ResetBreakTally();
+        }
     }
 
     /// <summary>

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/DrawCallStressScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/DrawCallStressScreen.cs
@@ -19,6 +19,12 @@ namespace MonoGameGumInCode.Screens;
 // which reorders draws into contiguous same-texture runs using each renderable's BatchSortKey -
 // the fix. Toggle it to see the draw-call count collapse from ~80 to ~2 live.
 //
+// Each row is nested in its own transparent ContainerRuntime, matching what the Gum tool produces
+// for a reusable component, which also makes this cover #4579: a wrapper's bounds encompass its
+// children, so they stay blocked behind it in the reorderer's precedence graph until it is chosen.
+// Without the reorderer's free-container tier the wrapper is only reached by the last-resort tier,
+// and grouping collapses nothing (~80 either way) no matter how many identical rows exist.
+//
 // Tick(elapsedSeconds) is unused today (no animation) but present for symmetry with TextScreen and
 // in case a future variant wants to grow/shrink the row count live.
 internal class DrawCallStressScreen : FrameworkElement
@@ -56,6 +62,11 @@ internal class DrawCallStressScreen : FrameworkElement
         const int rowCount = 40;
         for (int i = 0; i < rowCount; i++)
         {
+            var rowContainer = new ContainerRuntime();
+            rowContainer.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+            rowContainer.Width = 0;
+            rowContainer.Height = 32;
+
             var row = new NineSliceRuntime();
             row.SourceFileName = "Frame.png";
             row.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
@@ -68,7 +79,8 @@ internal class DrawCallStressScreen : FrameworkElement
             label.Y = 6;
             row.Children.Add(label);
 
-            stack.Children.Add(row);
+            rowContainer.Children.Add(row);
+            stack.Children.Add(rowContainer);
         }
 
         UpdateOrderingButtonText();

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -126,6 +126,72 @@ public class GumBatchDeferredDrawModeTests : BaseTestClass
     }
 
     /// <summary>
+    /// Ground-truth check prompted by an FRB2 report of RenderStateChangeStatistics.DrawCallCount
+    /// (13) exceeding the real GraphicsDevice.Metrics.DrawCount total for the whole frame (8) - a
+    /// subset can never legitimately exceed the whole. This independently measures the true
+    /// Metrics delta across two Begin/End cycles in one host frame (mirroring FRB2's per-camera +
+    /// overlay shape) and asserts Gum's own tally matches it exactly, to prove or disprove that
+    /// Renderer's own delta-tracking is the source of the discrepancy.
+    /// </summary>
+    [Fact]
+    public void MultipleCyclesInOneHostFrame_DrawCallCountMatchesTrueGpuTotalForTheFrame()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Texture2D texture = new(game.GraphicsDevice, 1, 1);
+        texture.SetData(new[] { Color.Red });
+
+        RectangleRuntime cardA = new();
+        cardA.IsFilled = true;
+        cardA.Width = 10;
+        cardA.Height = 10;
+        RectangleRuntime cardB = new();
+        cardB.IsFilled = true;
+        cardB.Width = 10;
+        cardB.Height = 10;
+        cardB.X = 50;
+        SpriteRuntime overlayText = CreateSprite(texture, 0);
+
+        try
+        {
+            // Warm-up cycle: discard first-time costs (e.g. default texture load) before
+            // measuring, matching the pattern used elsewhere in this file.
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Begin();
+            renderer.End();
+
+            AdvanceHostFrame(managers, ref hostTime);
+            long trueDrawCountBefore = game.GraphicsDevice.Metrics.DrawCount;
+
+            // Cycle 1: "main camera" pass drawing two cards, Deferred (FRB2's actual mode).
+            renderer.Begin(mode: Renderer.GumBatchDrawMode.Deferred);
+            renderer.Draw(cardA);
+            renderer.Draw(cardB);
+            renderer.End();
+
+            // Cycle 2: "overlay" pass - a second Begin/End cycle in the SAME host frame, matching
+            // FRB2's per-camera-plus-overlay shape.
+            renderer.Begin();
+            renderer.Draw(overlayText);
+            renderer.End();
+
+            long trueDrawCountAfter = game.GraphicsDevice.Metrics.DrawCount;
+            int trueDrawCallCountThisFrame = (int)(trueDrawCountAfter - trueDrawCountBefore);
+
+            renderer.RenderStateChangeStatistics.DrawCallCount.ShouldBe(trueDrawCallCountThisFrame);
+        }
+        finally
+        {
+            texture.Dispose();
+        }
+    }
+
+    /// <summary>
     /// Pins the Renderer-side wiring for issue #4575's follow-up: Renderer resets
     /// BatchKeyGroupedOrderer's break tally at the same points it resets
     /// RenderStateChangeStatistics - once per host frame on this (Deferred) path - so it

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -125,6 +125,62 @@ public class GumBatchDeferredDrawModeTests : BaseTestClass
         }
     }
 
+    /// <summary>
+    /// Pins the Renderer-side wiring for issue #4575's follow-up: Renderer resets
+    /// BatchKeyGroupedOrderer's break tally at the same points it resets
+    /// RenderStateChangeStatistics - once per host frame on this (Deferred) path - so it
+    /// accumulates across multiple Begin/End cycles in one frame instead of the second cycle
+    /// wiping out the first's tally, and still resets cleanly on the next frame.
+    /// </summary>
+    [Fact]
+    public void Deferred_MultipleCyclesInOneHostFrame_AccumulateOrdererTally_ResetsNextFrame()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Texture2D textureA = new(game.GraphicsDevice, 1, 1);
+        textureA.SetData(new[] { Color.Red });
+        Texture2D textureB = new(game.GraphicsDevice, 1, 1);
+        textureB.SetData(new[] { Color.Blue });
+
+        IRenderableOrderer originalOrdering = Renderer.SiblingOrdering;
+        try
+        {
+            Renderer.SiblingOrdering = BatchKeyGroupedOrderer.Instance;
+
+            void RunOneCycleOfAlternatingSprites()
+            {
+                renderer.Begin(mode: Renderer.GumBatchDrawMode.Deferred);
+                for (int i = 0; i < 4; i++)
+                {
+                    renderer.Draw(CreateSprite(i % 2 == 0 ? textureA : textureB, i * 10));
+                }
+                renderer.End();
+            }
+
+            AdvanceHostFrame(managers, ref hostTime);
+            RunOneCycleOfAlternatingSprites();
+            ((BatchKeyGroupedOrderer)Renderer.SiblingOrdering).NoCandidateInWindowBreakCount.ShouldBe(1);
+
+            RunOneCycleOfAlternatingSprites(); // same host frame - no AdvanceHostFrame call
+            ((BatchKeyGroupedOrderer)Renderer.SiblingOrdering).NoCandidateInWindowBreakCount.ShouldBe(2);
+
+            AdvanceHostFrame(managers, ref hostTime);
+            RunOneCycleOfAlternatingSprites();
+            ((BatchKeyGroupedOrderer)Renderer.SiblingOrdering).NoCandidateInWindowBreakCount.ShouldBe(1);
+        }
+        finally
+        {
+            Renderer.SiblingOrdering = originalOrdering;
+            textureA.Dispose();
+            textureB.Dispose();
+        }
+    }
+
     private class MinimalGame : Game
     {
         private readonly GraphicsDeviceManager _graphics;

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -1,0 +1,157 @@
+using Gum.GueDeriving;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using RenderingLibrary;
+using RenderingLibrary.Content;
+using RenderingLibrary.Graphics;
+using Shouldly;
+using Xunit;
+
+namespace MonoGameGum.IntegrationTests.MonoGameGum.Rendering;
+
+/// <summary>
+/// Pins <see cref="Renderer.GumBatchDrawMode.Deferred"/> (issue #4573): multiple <see cref="Renderer.Draw(IRenderableIpso)"/>
+/// calls within one <see cref="Renderer.Begin"/>/<see cref="Renderer.End"/> cycle accumulate and run
+/// through the active <see cref="Renderer.SiblingOrdering"/> once at <c>End</c>, instead of each call
+/// submitting immediately and unbatched. <see cref="Renderer.GumBatchDrawMode.Immediate"/> (the
+/// default, no mode argument) is pinned unchanged here - this feature is purely additive.
+/// </summary>
+public class GumBatchDeferredDrawModeTests : BaseTestClass
+{
+    private static void AdvanceHostFrame(SystemManagers managers, ref double hostTime)
+    {
+        hostTime += 1.0 / 60.0;
+        managers.Activity(hostTime);
+    }
+
+    private static SpriteRuntime CreateSprite(Texture2D texture, float y)
+    {
+        SpriteRuntime sprite = new();
+        sprite.Texture = texture;
+        sprite.Y = y;
+        return sprite;
+    }
+
+    [Fact]
+    public void Immediate_AlternatingTextureSprites_StillAddsOneDrawCallPerSprite()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Texture2D textureA = new(game.GraphicsDevice, 1, 1);
+        textureA.SetData(new[] { Color.Red });
+        Texture2D textureB = new(game.GraphicsDevice, 1, 1);
+        textureB.SetData(new[] { Color.Blue });
+
+        IRenderableOrderer originalOrdering = Renderer.SiblingOrdering;
+        try
+        {
+            Renderer.SiblingOrdering = BatchKeyGroupedOrderer.Instance;
+
+            const int spriteCount = 10;
+            SpriteRuntime[] sprites = new SpriteRuntime[spriteCount];
+            for (int i = 0; i < spriteCount; i++)
+            {
+                sprites[i] = CreateSprite(i % 2 == 0 ? textureA : textureB, i * 10);
+            }
+
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Begin(); // Immediate is the default - no mode argument.
+            foreach (SpriteRuntime sprite in sprites)
+            {
+                renderer.Draw(sprite);
+            }
+            renderer.End();
+
+            renderer.RenderStateChangeStatistics.DrawCallCount.ShouldBe(spriteCount);
+        }
+        finally
+        {
+            Renderer.SiblingOrdering = originalOrdering;
+            textureA.Dispose();
+            textureB.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Deferred_AlternatingTextureSprites_CollapsesToOneDrawCallPerTexture()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Texture2D textureA = new(game.GraphicsDevice, 1, 1);
+        textureA.SetData(new[] { Color.Red });
+        Texture2D textureB = new(game.GraphicsDevice, 1, 1);
+        textureB.SetData(new[] { Color.Blue });
+
+        IRenderableOrderer originalOrdering = Renderer.SiblingOrdering;
+        try
+        {
+            Renderer.SiblingOrdering = BatchKeyGroupedOrderer.Instance;
+
+            const int spriteCount = 10;
+            SpriteRuntime[] sprites = new SpriteRuntime[spriteCount];
+            for (int i = 0; i < spriteCount; i++)
+            {
+                sprites[i] = CreateSprite(i % 2 == 0 ? textureA : textureB, i * 10);
+            }
+
+            AdvanceHostFrame(managers, ref hostTime);
+            renderer.Begin(mode: Renderer.GumBatchDrawMode.Deferred);
+            foreach (SpriteRuntime sprite in sprites)
+            {
+                renderer.Draw(sprite);
+            }
+            renderer.End();
+
+            // Same alternating-texture scene as the Immediate test above, but now batched across
+            // the separate Draw() calls since they share one End()-time BuildDrawList/Submit pass:
+            // one draw call per distinct texture instead of one per sprite.
+            renderer.RenderStateChangeStatistics.DrawCallCount.ShouldBe(2);
+        }
+        finally
+        {
+            Renderer.SiblingOrdering = originalOrdering;
+            textureA.Dispose();
+            textureB.Dispose();
+        }
+    }
+
+    private class MinimalGame : Game
+    {
+        private readonly GraphicsDeviceManager _graphics;
+
+        public MinimalGame()
+        {
+            LoaderManager.Self?.DisposeAndClear();
+            _graphics = new GraphicsDeviceManager(this);
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            global::Gum.GumService.Default.Initialize(this, global::Gum.Forms.DefaultVisualsVersion.V3);
+        }
+
+        protected override void Update(GameTime gameTime) { }
+        protected override void Draw(GameTime gameTime) => GraphicsDevice.Clear(Color.CornflowerBlue);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (global::Gum.GumService.Default.IsInitialized)
+            {
+                global::Gum.GumService.Default.Uninitialize();
+            }
+            LoaderManager.Self?.DisposeAndClear();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -247,6 +247,77 @@ public class GumBatchDeferredDrawModeTests : BaseTestClass
         }
     }
 
+    /// <summary>
+    /// Records <see cref="SpriteRenderer.ForcedMatrix"/> as it stands at the moment this renderable
+    /// is actually submitted. Every re-<c>BeginSpriteBatch</c> (a clip enter/exit, a batch flush)
+    /// composes ForcedMatrix into the transform it hands the SpriteBatch, so whatever this captures
+    /// is what the GPU would be drawing with.
+    /// </summary>
+    private class ForcedMatrixProbe : ContainerRuntime
+    {
+        public Matrix? ObservedForcedMatrix { get; private set; }
+        public bool WasRendered { get; private set; }
+
+        public override void Render(ISystemManagers managers)
+        {
+            ObservedForcedMatrix = ((SystemManagers)managers).Renderer.SpriteRenderer.ForcedMatrix;
+            WasRendered = true;
+            base.Render(managers);
+        }
+    }
+
+    [Fact]
+    public void Deferred_WithForcedMatrixAndAClip_StillHasForcedMatrixWhenTheClippedSubtreeSubmits()
+    {
+        // Renderer.End() clears spriteRenderer.ForcedMatrix, then runs the Deferred submit. In
+        // Immediate mode every Draw() had already submitted while the matrix was still set, so
+        // nothing noticed. In Deferred mode the whole submit - including the re-BeginSpriteBatch
+        // that entering a clip forces - happens after the clear, so the clipped subtree renders at
+        // the camera transform instead of the caller's.
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Matrix forced = Matrix.CreateScale(3f);
+
+        ContainerRuntime clip = new();
+        clip.ClipsChildren = true;
+        clip.Width = 100;
+        clip.Height = 100;
+
+        ForcedMatrixProbe probe = new();
+        probe.Width = 10;
+        probe.Height = 10;
+        clip.Children.Add(probe);
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(forced, Renderer.GumBatchDrawMode.Immediate);
+        renderer.Draw(clip);
+        renderer.End();
+
+        probe.WasRendered.ShouldBeTrue();
+        probe.ObservedForcedMatrix.ShouldBe(forced, "Immediate mode baseline");
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(forced, Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(clip);
+        renderer.End();
+
+        // The two modes must agree - Deferred is meant to change batching, not transforms.
+        probe.ObservedForcedMatrix.ShouldBe(forced);
+
+        // And the matrix must not leak into the next cycle, which passes none.
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(null, Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(clip);
+        renderer.End();
+
+        probe.ObservedForcedMatrix.ShouldBeNull();
+    }
+
     private class MinimalGame : Game
     {
         private readonly GraphicsDeviceManager _graphics;

--- a/docs/code/performance-and-optimization/batchkeygroupedorderer.md
+++ b/docs/code/performance-and-optimization/batchkeygroupedorderer.md
@@ -83,3 +83,19 @@ If both rows are low, your begins come from clipping instead, and the orderer wi
 {% hint style="info" %}
 `LastFrameDrawStates` only sees `SpriteBatch.Begin` calls. Apos.Shapes batch starts are not counted there, so the total batch count is higher than the reported number. `RenderStateChangeStatistics.DrawCallCount` is backend-neutral and counts every actual GPU draw call, including Apos.Shapes ones, so prefer it when you want a single before/after number.
 {% endhint %}
+
+### Diagnosing a Smaller-Than-Expected Win
+
+If the draw-call count drops less than you expected after enabling the orderer, two different things could be happening, and `BatchKeyGroupedOrderer.Instance` can tell you which without guessing:
+
+* **`MergeBlockedByOverlapCount`** - the orderer wanted to keep a run going, but a matching item was still pending behind something its bounds overlap. This is the orderer's own correctness rule (never reorder across overlapping bounds) doing its job; no amount of reordering fixes it. If this number is high, the real fix is removing the alternation itself, for example packing the alternating textures into one shared atlas, since same-texture consecutive draws merge for free regardless of overlap or Z order.
+* **`NoCandidateInWindowBreakCount`** - nothing pending shared the running key at all. That's genuine content alternation (or simply the end of a reorder window), and is exactly what the orderer is designed to collapse when it can.
+
+Both reset at the start of every `BuildDrawList` call, so read them right after the one draw pass you're measuring:
+
+```csharp
+// Draw
+var orderer = (BatchKeyGroupedOrderer)Renderer.SiblingOrdering;
+System.Diagnostics.Debug.WriteLine(
+    $"Overlap-blocked: {orderer.MergeBlockedByOverlapCount}, No candidate: {orderer.NoCandidateInWindowBreakCount}");
+```

--- a/docs/code/rendering/gumbatch.md
+++ b/docs/code/rendering/gumbatch.md
@@ -31,6 +31,24 @@ GumBatch draws through the same `Camera` as the rest of Gum, the one at `GumServ
 Because the matrix composes on top of the camera, setting `Camera.Zoom` to a non-default value **and** passing a scaling matrix to `Begin(Matrix)` applies the scale twice. Drive scaling from a single source: either leave the matrix off and use `Camera.Zoom`, or pass a matrix and keep `Camera.Zoom` at `1`.
 {% endhint %}
 
+### Batching Multiple Draw Calls: Deferred Mode
+
+`Begin` takes an optional `GumBatchDrawMode`, mirroring MonoGame's own `SpriteSortMode.Immediate`/`Deferred` distinction:
+
+```csharp
+// Draw
+Core.GumBatch.Begin(mode: RenderingLibrary.Graphics.Renderer.GumBatchDrawMode.Deferred);
+Core.GumBatch.Draw(cardOne);
+Core.GumBatch.Draw(cardTwo);
+Core.GumBatch.End();
+```
+
+`Immediate` is the default and matches every example on this page: each `Draw` call submits right away, in call order. `Deferred` instead collects every `Draw` call made before the matching `End` and, at `End`, sorts them by `Z` (same stable sort a `Layer` uses for its own top-level renderables) and runs them through the active `Renderer.SiblingOrdering`. This lets separate `Draw` calls batch together, for example under [BatchKeyGroupedOrderer](../performance-and-optimization/batchkeygroupedorderer.md), which they otherwise can't since each `Immediate` call is its own isolated submission. Reach for `Deferred` when you draw many small pieces of content through separate `Draw` calls (for example, one call per game entity) and want them to batch as if they were siblings under one parent.
+
+{% hint style="warning" %}
+`Deferred` only reorders Gum's own `Draw` calls relative to each other. It does not change when raw draws issued directly on `gumBatch.SpriteBatch` submit (see [Mixing with SpriteBatch](#mixing-with-spritebatch) below) - those still submit immediately, at their own call site. So a raw `SpriteBatch` draw interleaved with `Deferred` `Draw` calls no longer shares a predictable position with them in the final paint order, since Gum's own draws are pushed to the end of the cycle.
+{% endhint %}
+
 ### Rendering TextRuntimes
 
 The most flexible way to draw text with GumBatch is to create a `TextRuntime`. TextRuntimes support all of Gum's layout rules (wrapping, alignment, rotation, sizing) and integrate with Gum's font system so you can set `Font` and `FontSize` directly and let KernSmith create the atlas on demand.


### PR DESCRIPTION
## Summary

`Renderer.Begin`/`Draw`/`End` (what `GumBatch` wraps) submits each top-level `Draw()` call immediately and recursively, so nothing can batch across separate `Draw()` calls even when they share a texture/`BatchKey` - unlike the layered path, which sorts and builds one flat `DrawCommand` list per `Layer` before submitting. This matters for a host drawing many small entities through `GumBatch` (e.g. FRB2 drawing one playing-card entity per `Draw()` call): draws can't batch no matter what `SiblingOrdering` is set, since each call is its own isolated submission.

Adds an opt-in `Renderer.GumBatchDrawMode` (mirrors MonoGame's own `SpriteSortMode.Immediate`/`Deferred`), passed to `Begin(mode:)`, defaulting to `Immediate` (today's exact behavior, unchanged). In `Deferred` mode, `Draw()` accumulates renderables into a scratch list instead of submitting; `End` stable-sorts that list by `Z` (`Layer.SortByZ`, extracted out of `Layer.SortRenderables` so both share the algorithm) and runs it through the active `Renderer.SiblingOrdering` (e.g. `BatchKeyGroupedOrderer`) + `Submit` once, so separate `Draw()` calls can batch together.

Purely additive - no existing behavior changes for callers that don't pass `mode`.

Closes #4573

## Test plan

- [x] `LayerSortByZTests`: pins `Layer.SortByZ` correctness and stability (extraction didn't change behavior).
- [x] `GumBatchDeferredDrawModeTests`: `Immediate` (default) still one draw call per sprite across alternating textures; `Deferred` collapses to one draw call per distinct texture under `BatchKeyGroupedOrderer`.
- [x] Full `MonoGameGum.Tests` (2237) and `MonoGameGum.IntegrationTests` (110) suites green.
- [x] `KniGum`, `RaylibGum`, `SkiaGum` build clean (0 new warnings/errors).
- [x] FRB1 canary (`GumCore.DesktopGlNet6.csproj`, net6.0 + net8.0): pass, matches baseline.
- Manual test: needed - this changes real draw batching/order. Testing directly against a real FRB2 game (Solitaire) rather than a synthetic sample.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nmz8Kz9gJyiP64APB87czb
