### PR TITLE
Fix null GumUI.LocalizationService on raylib

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -1,4 +1,5 @@
 ﻿using Gum.GueDeriving;
+using Gum.Localization;
 using Gum.Managers;
 using Gum.Wireframe;
 using GumRuntime;
@@ -18,7 +19,7 @@ using RenderingLibrary.Content;
 
 
 namespace RenderingLibrary;
-public class SystemManagers : ISystemManagers
+public partial class SystemManagers : ISystemManagers
 {
     int mPrimaryThreadId;
 
@@ -108,33 +109,45 @@ public class SystemManagers : ISystemManagers
 
     public void Initialize()
     {
-
-        Renderer.Camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
-
         bool fullInstantiation = true;
 
+        // Order below mirrors RenderingLibrary/SystemManagers.cs's fullInstantiation block
+        // (MonoGame/KNI/FNA) line-for-line wherever raylib has an equivalent, so the two files
+        // stay easy to diff against each other as they converge (#4576: raylib's copy had
+        // silently dropped the LocalizationService/ThrowExceptionsForMissingFiles wiring below
+        // because nothing kept the two in sync). Steps XNA has that raylib genuinely cannot
+        // (embedded font preloading, Renderer.ApplyCameraZoomOnWorldTranslation,
+        // Text.RenderBoundaryDefault, GraphicalUiElement.MissingFileBehavior - none of those
+        // members exist on raylib's own Renderer/Text) are intentionally omitted rather than
+        // stubbed out; tracked as remaining convergence gaps in #4577.
         if(fullInstantiation)
         {
             LoaderManager.Self.ContentLoader = new ContentLoader();
 
             GraphicalUiElement.SetPropertyOnRenderable = CustomSetPropertyOnRenderable.SetPropertyOnRenderable;
-            GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
-            GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
+            GraphicalUiElement.ApplyCachedTextureFromPixelData = PixelDataTextureApplier.ApplyCached;
+            GraphicalUiElement.ApplyPooledTextureFromPixelData = PixelDataTextureApplier.ApplyPooled;
+            CustomSetPropertyOnRenderable.LocalizationService ??= new LocalizationService();
             // Wire the font loader here (not in a renderable's static ctor) so it is re-established on
             // every Initialize, matching the other delegates and MonoGame's SystemManagers. GumService
             // teardown nulls UpdateFontFromProperties; without re-wiring here, the direct font-property
             // setters silently stop loading fonts after a teardown/reinitialize cycle.
             GraphicalUiElement.UpdateFontFromProperties = CustomSetPropertyOnRenderable.UpdateToFontValues;
-            GraphicalUiElement.ApplyCachedTextureFromPixelData = PixelDataTextureApplier.ApplyCached;
-            GraphicalUiElement.ApplyPooledTextureFromPixelData = PixelDataTextureApplier.ApplyPooled;
+            GraphicalUiElement.ThrowExceptionsForMissingFiles = CustomSetPropertyOnRenderable.ThrowExceptionsForMissingFiles;
 
-            // raylib seems to use a resources folder, but I don't think we should make any
-            // assumptions
-            //ToolsUtilities.FileManager.RelativeDirectory = "Content/";
+            GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
+            GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
+
+            Renderer.Camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
 
             ElementSaveExtensions.CustomCreateGraphicalComponentFunc = RenderableCreator.HandleCreateGraphicalComponent;
 
             StandardElementsManager.Self.Initialize();
+
+            // raylib seems to use a resources folder, but I don't think we should make any
+            // assumptions (unlike MonoGame/KNI/FNA, which default ToolsUtilities.FileManager.RelativeDirectory
+            // to "Content/" here - see #4577).
+            //ToolsUtilities.FileManager.RelativeDirectory = "Content/";
 
             RegisterComponentRuntimeInstantiations();
         }

--- a/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
+++ b/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
@@ -1,7 +1,9 @@
 using Gum.Forms;
 using Gum.Forms.Controls;
+using Gum.Localization;
 using Gum.Wireframe;
 using RaylibGum;
+using RaylibGum.Renderables;
 using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
@@ -34,6 +36,56 @@ public class GumServiceInitializeTests
         finally
         {
             GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldAssignDefaultLocalizationService()
+    {
+        // Tear down the assembly-wide state so we can observe a cold init, and clear the
+        // static LocalizationService so a leftover instance from another test can't mask
+        // Initialize() failing to assign one (#4576 - GumUI.LocalizationService returned
+        // null on raylib because SystemManagers.Initialize() never wired it up).
+        // Qualified as Gum.GumService (the modern, non-obsolete class) to stay warning-free -
+        // same reasoning as TestAssemblyInitialize.ApplyDefaultTestState.
+        Gum.GumService.Default.Uninitialize();
+        CustomSetPropertyOnRenderable.LocalizationService = null;
+
+        try
+        {
+            Gum.GumService.Default.Initialize(DefaultVisualsVersion.V3);
+
+            CustomSetPropertyOnRenderable.LocalizationService.ShouldNotBeNull();
+        }
+        finally
+        {
+            CustomSetPropertyOnRenderable.LocalizationService = null;
+            Gum.GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldAssignThrowExceptionsForMissingFilesDelegate()
+    {
+        // Same shape as Initialize_ShouldAssignDefaultLocalizationService above: the docs
+        // (files-and-fonts/font-strategies.md) tell users to call
+        // GraphicalUiElement.ThrowExceptionsForMissingFiles(textRuntime) directly, but on raylib
+        // SystemManagers.Initialize() never assigned the delegate, so calling it NREs.
+        Gum.GumService.Default.Uninitialize();
+        GraphicalUiElement.ThrowExceptionsForMissingFiles = null;
+
+        try
+        {
+            Gum.GumService.Default.Initialize(DefaultVisualsVersion.V3);
+
+            GraphicalUiElement.ThrowExceptionsForMissingFiles.ShouldNotBeNull();
+        }
+        finally
+        {
+            GraphicalUiElement.ThrowExceptionsForMissingFiles = null;
+            Gum.GumService.Default.Uninitialize();
             TestAssemblyInitialize.ApplyDefaultTestState();
         }
     }


### PR DESCRIPTION
## Summary
- `SystemManagers.Initialize()` on raylib never wired `CustomSetPropertyOnRenderable.LocalizationService` or `GraphicalUiElement.ThrowExceptionsForMissingFiles`, unlike the MonoGame/KNI/FNA copy of `SystemManagers.cs` - both docs-promised APIs NRE'd on raylib (#4576 reported the localization one, following the docs example exactly).
- Reordered/renamed/commented raylib's `fullInstantiation` block to mirror the XNA-family one line-for-line wherever raylib has an equivalent, so the two per-platform files stay easy to diff against each other going forward instead of drifting silently again.
- Remaining gaps that need their own behavior decision (not safe same-behavior ports) are filed as #4577.

## Test plan
- [x] `dotnet test Tests/RaylibGum.Tests/RaylibGum.Tests.csproj` - full suite green (634/634)
- [x] New tests `Initialize_ShouldAssignDefaultLocalizationService` / `Initialize_ShouldAssignThrowExceptionsForMissingFilesDelegate` fail on `main`, pass after the fix
- [x] `dotnet build MonoGameGum/MonoGameGum.csproj` - unaffected, 0 errors, no new warnings

Manual test: not needed - covered by unit tests + compilation; no rendering/visual surface changed.
FRB canary: not needed - raylib's `SystemManagers.cs` is not part of `GumCoreShared.projitems`/FRB's shared build.

Closes #4576
