### PR TITLE
Merge same-key draw runs across sibling component instances (#4579)

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -626,6 +626,50 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void BuildDrawList_FreeContainerChosenAfterAClipExit_DoesNotSwallowTheForcedTransition()
+    {
+        // A free container is exempt from break accounting because it submits nothing - but it
+        // must not CONSUME the pending forced transition a clip exit left behind either. The real
+        // renderable that follows is the one the GPU actually flushes for, so the hard boundary
+        // belongs to it. Without this, HardBoundaryTransitionCount undercounts and the break
+        // groups stop reconciling against the frame's true draw-call count.
+        //
+        // The free-container tier (#4579) is what makes this the likely path rather than a corner
+        // case: after a clip exits, an available wrapper now outranks the smallest-DFS fallback.
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch")
+        {
+            X = 0, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+
+        FakeRenderable container = new FakeRenderable("container", "") { X = 50, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable containerChild = AddChild(container, "containerChild");
+        containerChild.X = 50; containerChild.Y = 0; containerChild.Width = 10; containerChild.Height = 10;
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+        Layer layer = BuildLayer(clip, container);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "BeginClip:clip",
+            "DrawRenderable:clip",
+            "EndClip:clip",
+            "DrawRenderable:container",
+            "DrawRenderable:containerChild",
+        });
+
+        // The clip entry has nothing running to force away from (NoPredecessor, not a hard
+        // boundary). The clip EXIT is the one that counts, and it must land on containerChild -
+        // note its key matches what the clip left running, so without the forced flag it would be
+        // recorded as no break at all.
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(0);
+    }
+
+    [Fact]
     public void BuildDrawList_RenderUsingHierarchyFalse_DoesNotRecurse()
     {
         bool originalValue = Renderer.RenderUsingHierarchy;
@@ -879,22 +923,18 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
-    public void BuildDrawList_TwoNestedNonOverlappingCardGroups_DoesNotMergeAcrossContainers()
+    public void BuildDrawList_TwoNestedNonOverlappingCardGroups_MergesSameKeyRunsAcrossContainers()
     {
-        // Known limitation - see issue #4579. Two card-shaped groups (2x same-key "rectangle", 2x
-        // same-key "text", 1x "icon" each), each wrapped in its own container (mirroring a real
-        // Gum component instance), placed with zero bounding-box overlap between containers.
-        // Coordinates are the ACTUAL bounds measured from a live 2-card TestScreenFrb run
-        // (Solitaire sample, FlatRedBall2 repo) - not assumed ones.
+        // Issue #4579. Two card-shaped groups (2x same-key "rectangle", 2x same-key "text", 1x
+        // "icon" each), each wrapped in its own container (mirroring a real Gum component
+        // instance), placed with zero bounding-box overlap between containers. Coordinates are the
+        // ACTUAL bounds measured from a live 2-card TestScreenFrb run (Solitaire sample,
+        // FlatRedBall2 repo) - not assumed ones.
         //
-        // A flat (non-nested) version of this same scene merges perfectly (0 extra breaks per
-        // additional group) - the orderer CAN merge same-key items across non-overlapping groups.
-        // But once each group is wrapped in its own container, nothing merges across containers at
-        // all: the container itself never matches the running batch key (it's a transparent
-        // wrapper), so it's only reached via the "smallest DFS index" fallback tier - by which
-        // point the algorithm has already drained the first card's non-matching items instead of
-        // reaching into the second card's container while a same-key run was still active. This
-        // pins the CURRENT (suboptimal) behavior so a future fix has a red-then-green target.
+        // A transparent container is a free choice: it submits no vertices and leaves the running
+        // key alone, so the free-container tier picks both containers up front, which unblocks
+        // both cards' children while each same-key run is still active. The result is one run per
+        // distinct key regardless of how many card instances exist.
         BatchKeyGroupedOrderer.Instance.ResetBreakTally();
         object fontTex = new object();
         object iconTex = new object();
@@ -905,9 +945,7 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
             float dx = card * 100; // card0 Entity.X=0, card1 Entity.X=100 (measured)
             // Real cards are NESTED: each CardGum.Visual is its own container (empty BatchKey,
             // full card bounds), and Background/Border/RankText1/RankText2/SuitIcon are its
-            // CHILDREN - not flat top-level siblings like the previous version of this test
-            // assumed. Testing whether that nesting (not bounds/keys, both already proven fine)
-            // is what defeats cross-card merging.
+            // CHILDREN - not flat top-level siblings.
             FakeRenderable cardContainer = new FakeRenderable($"card{card}", "") { X = 360 + dx, Y = 264, Width = 80, Height = 112 };
             layer.Add(cardContainer);
 
@@ -930,22 +968,61 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
         List<DrawCommand> commands = new List<DrawCommand>();
         BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
 
-        // Fully sequential per container - bg1/border1 never get pulled forward to merge with
-        // bg0/border0, even though nothing overlaps and their keys match exactly.
+        // Three runs, not six: both cards' Apos.Shapes rectangles merge, then both cards' font-
+        // texture texts, then both icons. Within a card, DFS order is still preserved wherever
+        // bounds overlap (bg before border, rank1 before rank2, texts before the icon they sit on).
         Describe(commands).ShouldBe(new[]
         {
             "DrawRenderable:card0",
+            "DrawRenderable:card1",
             "DrawRenderable:bg0",
             "DrawRenderable:border0",
-            "DrawRenderable:rank1_0",
-            "DrawRenderable:rank2_0",
-            "DrawRenderable:icon0",
-            "DrawRenderable:card1",
             "DrawRenderable:bg1",
             "DrawRenderable:border1",
+            "DrawRenderable:rank1_0",
+            "DrawRenderable:rank2_0",
             "DrawRenderable:rank1_1",
             "DrawRenderable:rank2_1",
+            "DrawRenderable:icon0",
             "DrawRenderable:icon1",
+        });
+
+        // The only remaining breaks are genuine content alternation (rect -> text -> icon), not
+        // per-instance repetition: adding more cards adds no further breaks.
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildDrawList_FreeContainerOverlappingAnEarlierDraw_StaysBehindItAndBehindAnActiveRun()
+    {
+        // Guards the two ways the free-container tier could break the class's core promise
+        // (#4579). The container is transparent and so a "free" pick, but it must still be the
+        // LOWEST-priority tier above the smallest-DFS fallback:
+        //
+        //  1. It must not jump an overlap edge. The container's bounds cover apos0, so apos0 must
+        //     draw first - if the tier ignored indegree the container (and its child) would be
+        //     hoisted to the front and the child sprite would paint under apos0 instead of over.
+        //  2. It must not preempt a real same-key match. Once apos0 has started an Apos.Shapes
+        //     run, apos1 continues that run; the container waits even though picking it is free.
+        FakeRenderable apos0 = new FakeRenderable("apos0", "Apos.Shapes") { X = 0, Y = 0, Width = 100, Height = 100 };
+
+        FakeRenderable container = new FakeRenderable("container", "") { X = 0, Y = 0, Width = 100, Height = 100 };
+        FakeRenderable containerChild = AddChild(container, "containerChild");
+        containerChild.X = 0; containerChild.Y = 0; containerChild.Width = 100; containerChild.Height = 100;
+
+        FakeRenderable apos1 = new FakeRenderable("apos1", "Apos.Shapes") { X = 200, Y = 0, Width = 10, Height = 10 };
+
+        Layer layer = BuildLayer(apos0, container, apos1);
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(layer, commands);
+
+        Describe(commands).ShouldBe(new[]
+        {
+            "DrawRenderable:apos0",
+            "DrawRenderable:apos1",
+            "DrawRenderable:container",
+            "DrawRenderable:containerChild",
         });
     }
 

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -300,6 +300,19 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         public System.Drawing.Rectangle Bounds;
         public string BatchKey;
         public object? BatchSortKey;
+
+        /// <summary>
+        /// True for a plain wrapper (empty <see cref="IRenderable.BatchKey"/>, not a render target,
+        /// not a clip) — the shape a Gum component instance's root takes.
+        /// <see cref="BatchOrchestrator.OnRenderable"/> treats an empty BatchKey as a complete
+        /// no-op (no flush, no StartBatch/EndBatch, running key left alone) and
+        /// <c>InvisibleRenderable.Render</c> submits no vertices, so emitting one costs nothing at
+        /// the GPU level. That makes it both exempt from break accounting and a free choice for
+        /// the topological sort — see the free-container tier in <see cref="FlushWindow"/>.
+        /// Computed once per entry rather than per selection: <see cref="FlushWindow"/>'s tiebreak
+        /// scans it on every pick.
+        /// </summary>
+        public bool IsFreeContainer;
     }
 
     // Scratch state pooled on the instance (#4200) so a build does not allocate after warm-up,
@@ -547,12 +560,14 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
     private static void AddEntry(IRenderableIpso renderable, List<Entry> window)
     {
+        string batchKey = renderable.BatchKey ?? string.Empty;
         window.Add(new Entry
         {
             Item = renderable,
             Bounds = GetEffectiveBounds(renderable),
-            BatchKey = renderable.BatchKey ?? string.Empty,
+            BatchKey = batchKey,
             BatchSortKey = renderable.BatchSortKey,
+            IsFreeContainer = batchKey.Length == 0 && !renderable.IsRenderTarget && !renderable.ClipsChildren,
         });
     }
 
@@ -642,9 +657,20 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
         // Among items with indegree 0, prefer one whose (BatchKey, BatchSortKey) matches the
         // last emitted exactly (keeps same-texture runs contiguous); failing that, one whose
         // BatchKey alone matches (keeps the coarser SpriteBatch/Apos.Shapes grouping
-        // BatchOrchestrator relies on, even when BatchSortKey differs or is unset). Ties within
-        // a tier break by smallest DFS index for determinism. No match at all → smallest DFS
-        // overall.
+        // BatchOrchestrator relies on, even when BatchSortKey differs or is unset); failing that,
+        // a free container (Entry.IsFreeContainer) — emitting one submits nothing and leaves the
+        // running key alone, so it is strictly better than committing to a real key change, and
+        // it unblocks the container's children while the running key may still be worth
+        // continuing. Ties within a tier break by smallest DFS index for determinism. No match at
+        // all → smallest DFS overall.
+        //
+        // The free-container tier is what makes same-key runs merge across sibling instances of
+        // the same Gum component (#4579): each instance's root is a transparent wrapper whose
+        // bounds encompass its children, so those children have a precedence edge from it and stay
+        // unavailable until it is chosen. Without this tier a wrapper is only ever reached via the
+        // last-resort smallest-DFS tier — by which point the first instance's non-matching items
+        // have already been drained and the running key has moved on, so nothing merges across
+        // instances no matter how many identical, non-overlapping ones exist.
         List<int> available = _availableBuffer;
         available.Clear();
         for (int i = 0; i < n; i++)
@@ -688,6 +714,20 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
                 for (int k = 0; k < available.Count; k++)
                 {
                     int idx = available[k];
+                    if (window[idx].IsFreeContainer)
+                    {
+                        if (chosen == -1 || idx < chosen)
+                        {
+                            chosen = idx;
+                        }
+                    }
+                }
+            }
+            if (chosen == -1)
+            {
+                for (int k = 0; k < available.Count; k++)
+                {
+                    int idx = available[k];
                     if (chosen == -1 || idx < chosen)
                     {
                         chosen = idx;
@@ -700,23 +740,27 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
             // just not yet unblocked) or a genuine break (nothing pending shares the old key).
             // Skipped on the very first emission - there's no prior run to have broken yet.
             //
-            // Also skipped for a transparent item: empty BatchKey AND not a render target AND not
-            // a clip. BatchOrchestrator.OnRenderable treats empty BatchKey as a complete no-op (no
-            // flush, no StartBatch/EndBatch, _currentBatchKey left unchanged) for a plain
-            // ContainerRuntime, and InvisibleRenderable.Render submits no vertices - free at the
-            // real GPU level, so counting it here would be a false positive.
+            // Also skipped for a free container (Entry.IsFreeContainer) - it is free at the real
+            // GPU level, so counting it here would be a false positive.
             //
             // A render target or a pending forced transition (set when we just entered/exited a
             // clip, or just drew a render target) is UNCONDITIONALLY a break, regardless of
             // whether the key happens to match - HardBoundaryTransitionCount, never
             // MergeBlockedByOverlapCount/NoCandidateInWindowBreakCount, since no reordering could
             // ever have avoided it (issue #4575 follow-up).
-            bool chosenIsTransparentContainer = string.IsNullOrEmpty(window[chosen].BatchKey) &&
-                !window[chosen].Item.IsRenderTarget && !window[chosen].Item.ClipsChildren;
+            bool chosenIsFreeContainer = window[chosen].IsFreeContainer;
             bool forced = _forceNextTransition || window[chosen].Item.IsRenderTarget;
-            _forceNextTransition = false;
 
-            if (!chosenIsTransparentContainer)
+            // A free container is exempt from break accounting, so it must not CONSUME a pending
+            // forced transition either - the real renderable after it is the one the GPU actually
+            // flushes for, and the hard boundary belongs to it. Leaving the flag set keeps the
+            // break groups reconciling against the frame's true draw-call count.
+            if (!chosenIsFreeContainer)
+            {
+                _forceNextTransition = false;
+            }
+
+            if (!chosenIsFreeContainer)
             {
                 Type toRenderableType = window[chosen].Item.GetType();
 
@@ -777,7 +821,7 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
             destination.Add(new DrawCommand(DrawCommandKind.DrawRenderable, window[chosen].Item));
             drawn[chosen] = true;
-            if (!chosenIsTransparentContainer)
+            if (!chosenIsFreeContainer)
             {
                 _runningBatchKey = window[chosen].BatchKey;
                 _runningSortKey = window[chosen].BatchSortKey;

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/DrawCallStressScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/DrawCallStressScreen.cs
@@ -19,6 +19,12 @@ namespace MonoGameGumInCode.Screens;
 // which reorders draws into contiguous same-texture runs using each renderable's BatchSortKey -
 // the fix. Toggle it to see the draw-call count collapse from ~80 to ~2 live.
 //
+// Each row is nested in its own transparent ContainerRuntime, matching what the Gum tool produces
+// for a reusable component, which also makes this cover #4579: a wrapper's bounds encompass its
+// children, so they stay blocked behind it in the reorderer's precedence graph until it is chosen.
+// Without the reorderer's free-container tier the wrapper is only reached by the last-resort tier,
+// and grouping collapses nothing (~80 either way) no matter how many identical rows exist.
+//
 // Tick(elapsedSeconds) is unused today (no animation) but present for symmetry with TextScreen and
 // in case a future variant wants to grow/shrink the row count live.
 internal class DrawCallStressScreen : FrameworkElement
@@ -56,6 +62,11 @@ internal class DrawCallStressScreen : FrameworkElement
         const int rowCount = 40;
         for (int i = 0; i < rowCount; i++)
         {
+            var rowContainer = new ContainerRuntime();
+            rowContainer.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
+            rowContainer.Width = 0;
+            rowContainer.Height = 32;
+
             var row = new NineSliceRuntime();
             row.SourceFileName = "Frame.png";
             row.WidthUnits = Gum.DataTypes.DimensionUnitType.RelativeToParent;
@@ -68,7 +79,8 @@ internal class DrawCallStressScreen : FrameworkElement
             label.Y = 6;
             row.Children.Add(label);
 
-            stack.Children.Add(row);
+            rowContainer.Children.Add(row);
+            stack.Children.Add(rowContainer);
         }
 
         UpdateOrderingButtonText();


### PR DESCRIPTION
## Summary

`BatchKeyGroupedOrderer`'s Kahn tiebreak could only reach a transparent container — a Gum component instance's root — via its last-resort smallest-DFS tier. Since such a container's bounds encompass its children, those children stay blocked behind it in the precedence graph until it is chosen; by then the previous instance's non-matching items have been drained and the running batch key has moved on. Net effect: no cross-instance merging at all, no matter how many identical, non-overlapping instances exist. That's the normal path — any screen with 2+ instances of the same component hits it.

Adds a **free-container tier** between the coarse-`BatchKey` match and the smallest-DFS fallback: prefer an available free container (empty `BatchKey`, not a render target, not a clip). Emitting one submits no vertices and leaves the running key alone, so it beats committing to a real key change, and it unblocks the container's children while the run is still hot.

The overlap-preservation guarantee is untouched — the tier still only picks among indegree-0 entries, so anything overlapping an earlier undrawn item stays blocked. Cost is an `O(available)` scan over a `bool` cached on `Entry`, run only when the two key-matching tiers already missed; no allocations and no change to the existing `O(n^2)` edge build. (The issue suggested a lookahead into blocked subtrees — not needed, since this branch already carries the running key *through* a transparent container.)

The issue's repro scene goes from 6 runs to 3, flat regardless of card count:

```
card0, card1, bg0, border0, bg1, border1, rank1_0, rank2_0, rank1_1, rank2_1, icon0, icon1
```

Also fixes an accounting hole the new tier makes live: a free container consumed the pending forced transition left by a clip exit, so `HardBoundaryTransitionCount` undercounted and the break groups stopped reconciling against the frame's true draw-call count. The free container is exempt from break accounting, so the hard boundary belongs to the real renderable that follows.

Based on #4574 — the gap only exists on that branch, which is where the transparent-container running-key carry-through lives.

Closes #4579

## Test plan

- [x] `..._TwoNestedNonOverlappingCardGroups_...`: #4574 pinned this as a "known limitation"; flipped to assert the merged order. Red before the tier, green after.
- [x] `..._FreeContainerOverlappingAnEarlierDraw_StaysBehindItAndBehindAnActiveRun`: pins that the tier can't jump an overlap edge or preempt a real key match. Verified it discriminates — promoting the tier above the key-match tiers turns it red.
- [x] `..._FreeContainerChosenAfterAClipExit_DoesNotSwallowTheForcedTransition`: red-then-green on the accounting fix.
- [x] `MonoGameGum.Tests` 2254, `MonoGameGum.IntegrationTests` 112, `MonoGameGum.Tests.V3` 154 — all green.
- [x] `KniGum`, `RaylibGum`, `SkiaGum`, `MonoGameGumInCode` build clean; zero new warnings.
- [x] FRB1 canary (`GumCore.DesktopGlNet6`): pass, zero errors.
- Manual test: needed — `DrawCallStressScreen` now nests each row in its own `ContainerRuntime`, so the existing "Group by texture" toggle exercises this path (without the fix, nesting makes grouping collapse nothing).

## Review notes

A `/code-review` pass over this stack surfaced several findings in #4574's own code that are **not** addressed here — posting them on #4574 separately. The notable one: `Renderer.End()` clears `spriteRenderer.ForcedMatrix` *before* the new `Deferred` block submits, so `GumBatch.Begin(matrix, mode: Deferred)` renders clipped subtrees at the wrong transform.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FvPbnUZnPGym55tMi4VsEA
