### PR TITLE
Keep ForcedMatrix set until the Deferred submit finishes

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -822,8 +822,6 @@ public class Renderer : IRenderer
 
     public void End()
     {
-        spriteRenderer.ForcedMatrix = null;
-
         if (_deferredImmediateModeRoots.Count > 0)
         {
             Layer.SortByZ(_deferredImmediateModeRoots);
@@ -842,6 +840,14 @@ public class Renderer : IRenderer
         _batchOrchestrator.FlushAndReset(SystemManagers.Default);
 
         spriteRenderer.EndSpriteBatch();
+
+        // Cleared only once everything this cycle submits has gone through. Every
+        // re-BeginSpriteBatch (a clip enter/exit, an orchestrator flush) composes ForcedMatrix
+        // into the transform it hands the SpriteBatch, and in Deferred mode all of those happen
+        // inside the Submit above - so clearing any earlier drops the caller's matrix on exactly
+        // the draws that needed it. Begin always reassigns it (null included), so no cycle can
+        // inherit a stale matrix from this one.
+        spriteRenderer.ForcedMatrix = null;
 
 #if !FNA
         if (GraphicsDevice != null)

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -247,6 +247,77 @@ public class GumBatchDeferredDrawModeTests : BaseTestClass
         }
     }
 
+    /// <summary>
+    /// Records <see cref="SpriteRenderer.ForcedMatrix"/> as it stands at the moment this renderable
+    /// is actually submitted. Every re-<c>BeginSpriteBatch</c> (a clip enter/exit, a batch flush)
+    /// composes ForcedMatrix into the transform it hands the SpriteBatch, so whatever this captures
+    /// is what the GPU would be drawing with.
+    /// </summary>
+    private class ForcedMatrixProbe : ContainerRuntime
+    {
+        public Matrix? ObservedForcedMatrix { get; private set; }
+        public bool WasRendered { get; private set; }
+
+        public override void Render(ISystemManagers managers)
+        {
+            ObservedForcedMatrix = ((SystemManagers)managers).Renderer.SpriteRenderer.ForcedMatrix;
+            WasRendered = true;
+            base.Render(managers);
+        }
+    }
+
+    [Fact]
+    public void Deferred_WithForcedMatrixAndAClip_StillHasForcedMatrixWhenTheClippedSubtreeSubmits()
+    {
+        // Renderer.End() clears spriteRenderer.ForcedMatrix, then runs the Deferred submit. In
+        // Immediate mode every Draw() had already submitted while the matrix was still set, so
+        // nothing noticed. In Deferred mode the whole submit - including the re-BeginSpriteBatch
+        // that entering a clip forces - happens after the clear, so the clipped subtree renders at
+        // the camera transform instead of the caller's.
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        Matrix forced = Matrix.CreateScale(3f);
+
+        ContainerRuntime clip = new();
+        clip.ClipsChildren = true;
+        clip.Width = 100;
+        clip.Height = 100;
+
+        ForcedMatrixProbe probe = new();
+        probe.Width = 10;
+        probe.Height = 10;
+        clip.Children.Add(probe);
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(forced, Renderer.GumBatchDrawMode.Immediate);
+        renderer.Draw(clip);
+        renderer.End();
+
+        probe.WasRendered.ShouldBeTrue();
+        probe.ObservedForcedMatrix.ShouldBe(forced, "Immediate mode baseline");
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(forced, Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(clip);
+        renderer.End();
+
+        // The two modes must agree - Deferred is meant to change batching, not transforms.
+        probe.ObservedForcedMatrix.ShouldBe(forced);
+
+        // And the matrix must not leak into the next cycle, which passes none.
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(null, Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(clip);
+        renderer.End();
+
+        probe.ObservedForcedMatrix.ShouldBeNull();
+    }
+
     private class MinimalGame : Game
     {
         private readonly GraphicsDeviceManager _graphics;


### PR DESCRIPTION
## Summary

`Renderer.End()` cleared `spriteRenderer.ForcedMatrix` as its **first** statement, then ran the `Deferred` submit below it.

In `Immediate` mode every `Draw()` had already submitted while the matrix was still set, so nothing noticed. In `Deferred` mode the entire submit happens inside `End()` — including the re-`BeginSpriteBatch` that entering or exiting a clip forces (`Submit` → `BeginClipScope` → `BeginSpriteBatch`) — and every `BeginSpriteBatch` composes `ForcedMatrix` into the transform it hands the `SpriteBatch`. So `GumBatch.Begin(matrix, mode: Deferred)` over a tree containing a `ClipsChildren` container rendered the clipped subtree at the camera transform instead of the caller's.

Moves the clear to after `EndSpriteBatch()`, once everything the cycle submits has gone through. `Begin` always reassigns `ForcedMatrix` (null included), so no cycle can inherit a stale matrix from a previous one.

Found while building #4580 on top of #4574; not caught by CI because no existing test combined `Deferred` + a forced matrix + a clip.

## Test plan

- [x] `Deferred_WithForcedMatrixAndAClip_StillHasForcedMatrixWhenTheClippedSubtreeSubmits` — a probe renderable inside a clip records `SpriteRenderer.ForcedMatrix` at the moment it is actually submitted, which is exactly what every re-`BeginSpriteBatch` composes into the GPU transform. Verified red first: `ObservedForcedMatrix` came back `null` against the expected scale-3 matrix. Green after the move.
- [x] The same test pins **mode parity** (`Immediate` sees the matrix too — `Deferred` is meant to change batching, not transforms) and that the matrix does not leak into a following cycle that passes none.
- [x] `MonoGameGum.IntegrationTests` 113, `MonoGameGum.Tests` 2254 — green.
- [x] `KniGum`, `RaylibGum` build clean; zero new warnings in the touched files.
- [x] FRB1 canary (`GumCore.DesktopGlNet6`): pass — `RenderingLibrary\Graphics\Renderer.cs` is in `GumCoreShared.projitems`, so this is FRB1-shared source.
- Manual test: not needed — the assertion captures the exact transform value a visual check could only approximate by eye, and the failing-then-passing probe is the proof.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FvPbnUZnPGym55tMi4VsEA
