### PR TITLE
Keep non-mirrored raw renderables when clearing a GraphicalUiElementCollection

### DIFF
--- a/GumCommon/Collections/GraphicalUiElementCollection.cs
+++ b/GumCommon/Collections/GraphicalUiElementCollection.cs
@@ -324,13 +324,39 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
-            if (_innerNoReset != null)
+            // Equal counts means every inner item is mirrored here, so a wholesale clear is
+            // both correct and cheaper. Otherwise the inner collection also holds raw
+            // non-GraphicalUiElement renderables this wrapper never mirrored - a shape runtime's
+            // auto-wired stroke (see ToInnerIndex) - and clearing wholesale would destroy the
+            // shape's stroke along with the user's children, with nothing to re-create it.
+            if (_innerCollection.Count == base.Items.Count)
             {
-                _innerNoReset.ClearWithoutNotification();
+                if (_innerNoReset != null)
+                {
+                    _innerNoReset.ClearWithoutNotification();
+                }
+                else
+                {
+                    _innerCollection.Clear();
+                }
             }
             else
             {
-                _innerCollection.Clear();
+                for (int i = base.Items.Count - 1; i > -1; i--)
+                {
+                    int innerIndex = _innerCollection.IndexOf(base.Items[i]);
+                    if (innerIndex > -1)
+                    {
+                        if (_innerNoReset != null)
+                        {
+                            _innerNoReset.RemoveAtWithoutNotification(innerIndex);
+                        }
+                        else
+                        {
+                            _innerCollection.RemoveAt(innerIndex);
+                        }
+                    }
+                }
             }
             base.ClearItems();
         }

--- a/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
+++ b/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
@@ -79,6 +79,39 @@ public class GraphicalUiElementCollectionTests : BaseTestClass
     }
 
     [Fact]
+    public void Clear_OnAShapeRuntime_RemovesTheChildrenButKeepsTheAutoWiredStroke()
+    {
+        // A RectangleRuntime's Children wrap its fill renderable's raw child list, which already
+        // holds the auto-wired stroke - so a wholesale inner Clear() destroyed the stroke along
+        // with the user's children and nothing re-created it, leaving the rectangle unstroked.
+        RectangleRuntime rectangle = new();
+        IRenderableIpso fill = (IRenderableIpso)rectangle.RenderableComponent;
+        IRenderableIpso stroke = fill.Children.ShouldHaveSingleItem();
+
+        ContainerRuntime child = new();
+        rectangle.Children.Add(child);
+        rectangle.Children.Clear();
+
+        rectangle.Children.ShouldBeEmpty();
+        fill.Children.ShouldBe(new[] { stroke });
+    }
+
+    [Fact]
+    public void Clear_WithOnlyMirroredItems_EmptiesBothCollections()
+    {
+        ObservableCollection<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        wrapper.Add(new ContainerRuntime());
+        wrapper.Add(new ContainerRuntime());
+
+        wrapper.Clear();
+
+        wrapper.ShouldBeEmpty();
+        innerCollection.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Remove_WithARawNonGraphicalUiElementItemBeforeIt_RemovesTheCorrectItem()
     {
         // Same root cause as the Add test, for RemoveItem: the wrapper's logical index doesn't


### PR DESCRIPTION
Confirmed real, not theoretical. `GraphicalUiElementCollection.ClearItems` cleared the whole inner collection, but that collection can also hold raw non-`GraphicalUiElement` renderables the wrapper never mirrored — a shape runtime's auto-wired stroke, attached to the fill renderable's `Children` before any user child exists. So `someShape.Children.Clear()` destroyed the stroke too, and nothing re-created it.

`ClearItems` now removes only the mirrored entries when unmirrored raw items are present, mirroring how `RemoveItem` targets a specific inner index. Equal counts mean everything inner is mirrored, so the cheap wholesale clear is kept for that case.

**Proof:** a red test on a real `RectangleRuntime` (no mocks) — `Children.Add(child); Children.Clear()` left the fill with 0 children instead of the stroke. Also reproduced visually in `MonoGameGumInCode`: a rectangle that had `Children.Clear()` called rendered with no outline, and regained it after the fix.

FRB canary (`GumCore.DesktopGlNet6`): pass. `MonoGameGum.Tests`: 2256 green.

Closes #4582
