### PR TITLE
Clear the Deferred flush's scratch lists in a finally (#4584)

### DIFF
--- a/RenderingLibrary/Graphics/Renderer.cs
+++ b/RenderingLibrary/Graphics/Renderer.cs
@@ -824,11 +824,23 @@ public class Renderer : IRenderer
     {
         if (_deferredImmediateModeRoots.Count > 0)
         {
-            Layer.SortByZ(_deferredImmediateModeRoots);
-            SiblingOrdering.BuildDrawList(
-                _deferredImmediateModeRoots, _deferredImmediateModeCommands, new ClipBoundsSource(mCamera, _layers[0]));
-            Submit(_deferredImmediateModeCommands, SystemManagers.Default, _layers[0]);
-            _deferredImmediateModeRoots.Clear();
+            try
+            {
+                Layer.SortByZ(_deferredImmediateModeRoots);
+                SiblingOrdering.BuildDrawList(
+                    _deferredImmediateModeRoots, _deferredImmediateModeCommands, new ClipBoundsSource(mCamera, _layers[0]));
+                Submit(_deferredImmediateModeCommands, SystemManagers.Default, _layers[0]);
+            }
+            finally
+            {
+                // Both lists must be dropped even when a renderable's Render throws out of Submit.
+                // Otherwise the next End() re-submits this cycle's roots on top of its own - a
+                // stale draw in whatever frame follows an exception the game catches and continues
+                // from (#4584). Clearing the commands here also releases this cycle's renderable
+                // references instead of holding them until the next BuildDrawList overwrites them.
+                _deferredImmediateModeRoots.Clear();
+                _deferredImmediateModeCommands.Clear();
+            }
         }
 
         // Mirror RenderLayer's end-of-walk: flush any pending custom batch and reset state

--- a/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
+++ b/Tests/MonoGameGum.IntegrationTests/MonoGameGum/Rendering/GumBatchDeferredDrawModeTests.cs
@@ -397,6 +397,73 @@ public class GumBatchDeferredDrawModeTests : BaseTestClass
         }
     }
 
+    /// <summary>
+    /// Renders normally but records how many times it was submitted.
+    /// </summary>
+    private class RenderCountProbe : ContainerRuntime
+    {
+        public int RenderCount { get; private set; }
+
+        public RenderCountProbe()
+        {
+            Width = 10;
+            Height = 10;
+        }
+
+        public override void Render(ISystemManagers managers)
+        {
+            RenderCount++;
+            base.Render(managers);
+        }
+    }
+
+    /// <summary>
+    /// Throws out of <c>Render</c>, so the deferred flush's Submit throws mid-cycle.
+    /// </summary>
+    private class ThrowingRenderProbe : RenderCountProbe
+    {
+        public override void Render(ISystemManagers managers)
+        {
+            base.Render(managers);
+            throw new InvalidOperationException("Simulated renderable failure.");
+        }
+    }
+
+    /// <summary>
+    /// Issue #4584: the deferred flush cleared its accumulated roots only after Submit returned, so
+    /// a renderable that threw left the whole failed cycle queued. The next Begin/End then drew the
+    /// previous cycle's roots on top of its own - a stale-draw corruption in whatever frame follows
+    /// an exception a game catches and continues from.
+    /// </summary>
+    [Fact]
+    public void Deferred_WhenSubmitThrows_DoesNotResubmitTheFailedCycleOnTheNextCycle()
+    {
+        using MinimalGame game = new();
+        game.RunOneFrame();
+
+        SystemManagers managers = SystemManagers.Default;
+        Renderer renderer = managers.Renderer;
+        double hostTime = 0;
+
+        ThrowingRenderProbe thrower = new();
+        RenderCountProbe nextCycleProbe = new();
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(mode: Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(thrower);
+        Should.Throw<InvalidOperationException>(() => renderer.End());
+
+        thrower.RenderCount.ShouldBe(1);
+
+        AdvanceHostFrame(managers, ref hostTime);
+        renderer.Begin(mode: Renderer.GumBatchDrawMode.Deferred);
+        renderer.Draw(nextCycleProbe);
+        Should.NotThrow(() => renderer.End());
+
+        thrower.RenderCount.ShouldBe(1, "the failed cycle's roots must not survive into the next cycle");
+        nextCycleProbe.RenderCount.ShouldBe(1);
+    }
+
     private class MinimalGame : Game
     {
         private readonly GraphicsDeviceManager _graphics;


### PR DESCRIPTION
`Renderer.End`'s Deferred block cleared `_deferredImmediateModeRoots` only *after* `Submit` returned, so a renderable that threw out of `Render` left the whole failed cycle queued — the next `Begin`/`End` then re-submitted it on top of its own roots. Wrapped the sort/build/submit in `try`/`finally` and clear both scratch lists there; clearing `_deferredImmediateModeCommands` alongside also drops the cycle's renderable references instead of holding them until the next `BuildDrawList` overwrites them.

The issue was filed UNVERIFIED. Confirmed red first: the new integration test failed because the second `End()` re-ran the previous cycle's throwing renderable.

Manual test: not needed — the integration test runs against a real `GraphicsDevice` and asserts the exact observable symptom.
FRB canary: pass.

Closes #4584
