### PR TITLE
Translate raw inner indices in GraphicalUiElementCollection's Replace and Move paths (#4585)

### DIFF
--- a/GumCommon/Collections/GraphicalUiElementCollection.cs
+++ b/GumCommon/Collections/GraphicalUiElementCollection.cs
@@ -117,28 +117,53 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
                     }
                     break;
 
-                // Replace/Move below still assume a raw index equals this wrapper's logical
-                // index, so they share Add/Remove's latent bug when a non-GraphicalUiElement item
-                // is interleaved - untested and unproven in practice; fix alongside a pinning test
-                // if that changes (see the outer MoveItem's remarks).
                 case NotifyCollectionChangedAction.Replace:
-                    if (e.NewItems != null && e.NewItems.Count > 0)
                     {
-                        int index = e.NewStartingIndex;
-                        foreach (var item in e.NewItems)
+                        // A replacement that is NOT a GraphicalUiElement still has to unmirror
+                        // whatever it replaced - otherwise this wrapper keeps holding an item the
+                        // inner collection no longer contains, and every later index lookup
+                        // against it returns -1 (issue #4585).
+                        int oldCount = e.OldItems?.Count ?? 0;
+                        int newCount = e.NewItems?.Count ?? 0;
+                        for (int i = 0; i < Math.Max(oldCount, newCount); i++)
                         {
-                            if (item is GraphicalUiElement gue)
+                            int replacedIndex = i < oldCount && e.OldItems![i] is GraphicalUiElement replaced
+                                ? base.Items.IndexOf(replaced)
+                                : -1;
+
+                            if (i < newCount && e.NewItems![i] is GraphicalUiElement replacement)
                             {
-                                base.SetItem(index++, gue);
+                                if (replacedIndex >= 0)
+                                {
+                                    base.SetItem(replacedIndex, replacement);
+                                }
+                                else
+                                {
+                                    // Replacing a raw item with a mirrored one is a logical insert,
+                                    // positioned the same way the Add branch positions one.
+                                    base.InsertItem(LogicalIndexOf(e.NewStartingIndex + i), replacement);
+                                }
+                            }
+                            else if (replacedIndex >= 0)
+                            {
+                                base.RemoveAt(replacedIndex);
                             }
                         }
                     }
                     break;
 
                 case NotifyCollectionChangedAction.Move:
-                    var movedItem = base.Items[e.OldStartingIndex];
-                    base.RemoveAt(e.OldStartingIndex);
-                    base.InsertItem(e.NewStartingIndex, movedItem);
+                    // Only a moved GraphicalUiElement changes this wrapper's order - moving a raw
+                    // item leaves the mirrored sequence intact. e.NewStartingIndex is a RAW index,
+                    // so translate it rather than assuming it equals the logical one.
+                    if (e.NewItems?.Count > 0 && e.NewItems[0] is GraphicalUiElement movedItem)
+                    {
+                        int oldLogicalIndex = base.Items.IndexOf(movedItem);
+                        if (oldLogicalIndex >= 0)
+                        {
+                            base.MoveItem(oldLogicalIndex, LogicalIndexOf(e.NewStartingIndex));
+                        }
+                    }
                     break;
 
                 case NotifyCollectionChangedAction.Reset:
@@ -186,6 +211,32 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     /// </summary>
     private int ToInnerIndex(int logicalIndex) =>
         logicalIndex >= base.Items.Count ? _innerCollection.Count : _innerCollection.IndexOf(base.Items[logicalIndex]);
+
+    /// <summary>
+    /// Maps a logical move to the index the moved item must land on in <see cref="_innerCollection"/>
+    /// once it has been lifted out of <paramref name="innerOldIndex"/> - both the inner collection's
+    /// Move and <c>MoveWithoutNotification</c> insert into the post-removal list. The item lands
+    /// directly before whichever mirrored item follows it in the new logical order, or directly
+    /// after the last mirrored one when it is moving to the logical end. Unlike
+    /// <see cref="ToInnerIndex"/>'s append, a move must NOT land after trailing raw
+    /// non-GraphicalUiElement items - reordering mirrored children can't relocate items this
+    /// wrapper doesn't own.
+    /// </summary>
+    private int ToInnerMoveTarget(int oldIndex, int newIndex, int innerOldIndex)
+    {
+        // Only a forward move reaches the logical end, so the neighbour to anchor on is the current
+        // last mirrored item - never the moved one, since MoveItem short-circuits an unchanged index.
+        bool isMovingToEnd = newIndex >= oldIndex && newIndex + 1 >= base.Items.Count;
+        int neighbourIndex = isMovingToEnd
+            ? base.Items.Count - 1
+            : (newIndex < oldIndex ? newIndex : newIndex + 1);
+
+        int innerNeighbourIndex = _innerCollection.IndexOf(base.Items[neighbourIndex]);
+        int postRemovalIndex = innerNeighbourIndex > innerOldIndex
+            ? innerNeighbourIndex - 1
+            : innerNeighbourIndex;
+        return isMovingToEnd ? postRemovalIndex + 1 : postRemovalIndex;
+    }
 
     /// <summary>
     /// The inverse of <see cref="ToInnerIndex"/>: how many of the first <paramref name="innerIndex"/>
@@ -369,18 +420,11 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
     /// <summary>
     /// Moves an item from one index to another.
     /// </summary>
-    /// <remarks>
-    /// Unlike <see cref="InsertItem"/>/<see cref="RemoveItem"/>/<see cref="SetItem"/> above, this
-    /// still assumes logical index == inner index and has the same latent bug when a raw
-    /// non-GraphicalUiElement item is interleaved (untested and unproven in practice - nothing
-    /// observed so far calls Move on a collection with such an item present; fix alongside a
-    /// pinning test if that changes).
-    /// </remarks>
     protected override void MoveItem(int oldIndex, int newIndex)
     {
         ThrowIfReadOnly();
 
-        if (_isUpdatingFromInner)
+        if (_isUpdatingFromInner || oldIndex == newIndex)
         {
             base.MoveItem(oldIndex, newIndex);
             return;
@@ -389,13 +433,15 @@ public class GraphicalUiElementCollection : ObservableCollectionNoReset<Graphica
         _isUpdatingFromOuter = true;
         try
         {
+            int innerOldIndex = _innerCollection.IndexOf(base.Items[oldIndex]);
+            int innerNewIndex = ToInnerMoveTarget(oldIndex, newIndex, innerOldIndex);
             if (_innerNoReset != null)
             {
-                _innerNoReset.MoveWithoutNotification(oldIndex, newIndex);
+                _innerNoReset.MoveWithoutNotification(innerOldIndex, innerNewIndex);
             }
             else
             {
-                _innerCollection.Move(oldIndex, newIndex);
+                _innerCollection.Move(innerOldIndex, innerNewIndex);
             }
             base.MoveItem(oldIndex, newIndex);
         }

--- a/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
+++ b/MonoGameGum.Tests/Collections/GraphicalUiElementCollectionTests.cs
@@ -112,6 +112,185 @@ public class GraphicalUiElementCollectionTests : BaseTestClass
     }
 
     [Fact]
+    public void InnerMove_OfARawNonGraphicalUiElementItem_LeavesTheMirroredOrderUnchanged()
+    {
+        // Reordering an unmirrored item can't change the order of the mirrored ones.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        innerCollection.Add(new RawRenderable("stroke"));
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        innerCollection.Add(first);
+        innerCollection.Add(second);
+
+        innerCollection.Move(0, 2);
+
+        wrapper.ShouldBe(new Gum.Wireframe.GraphicalUiElement[] { first, second });
+    }
+
+    [Fact]
+    public void InnerMove_WithARawNonGraphicalUiElementItemBeforeIt_MirrorsTheNewOrder()
+    {
+        // The inner handler's Move branch treats e.OldStartingIndex/e.NewStartingIndex (RAW inner
+        // indices) as this wrapper's logical indices. With a raw item interleaved the two differ,
+        // so it reorders the wrong entries - or, as here, indexes straight past the wrapper's end.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        innerCollection.Add(new RawRenderable("stroke")); // raw index 0, not mirrored
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        innerCollection.Add(first);
+        innerCollection.Add(second);
+
+        innerCollection.Move(1, 2);
+
+        wrapper.ShouldBe(new Gum.Wireframe.GraphicalUiElement[] { second, first });
+    }
+
+    [Fact]
+    public void InnerReplace_OfAMirroredItemWithARawNonGraphicalUiElement_UnmirrorsTheReplacedItem()
+    {
+        // The inner handler's Replace branch only mirrors a new item that IS a GraphicalUiElement;
+        // when the replacement is a raw renderable it does nothing at all, leaving the wrapper
+        // holding an item the inner collection no longer contains. That is the only route found
+        // that desyncs the two collections, and it is what makes RemoveItem/SetItem's unguarded
+        // `_innerCollection.IndexOf(base.Items[index])` able to return -1 (issue #4585).
+        ObservableCollection<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        ContainerRuntime text = new() { Name = "text" };
+        innerCollection.Add(text); // mirrored into the wrapper at logical index 0
+
+        innerCollection[0] = new RawRenderable("stroke");
+
+        wrapper.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void InnerReplace_OfARawNonGraphicalUiElementWithAMirroredItem_InsertsItAtTheCorrectLogicalIndex()
+    {
+        // The mirror image of the test above: nothing leaves the wrapper, and the replacement is a
+        // logical insert positioned the way the Add branch positions one.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        innerCollection.Add(new RawRenderable("stroke")); // raw index 0, not mirrored
+        ContainerRuntime text = new() { Name = "text" };
+        innerCollection.Add(text);
+
+        ContainerRuntime replacement = new() { Name = "replacement" };
+        innerCollection[0] = replacement;
+
+        wrapper.ShouldBe(new Gum.Wireframe.GraphicalUiElement[] { replacement, text });
+    }
+
+    [Fact]
+    public void InnerReplace_WithARawNonGraphicalUiElementItemBeforeIt_MirrorsToTheCorrectLogicalIndex()
+    {
+        // Same branch, second failure mode: it treats e.NewStartingIndex (a RAW inner index) as
+        // this wrapper's logical index. With a raw item interleaved the two differ, so the
+        // replacement lands in the wrong wrapper slot - the wrapper keeps the replaced item and
+        // drops a still-present one. See the Add branch's LogicalIndexOf for the correct mapping.
+        ObservableCollection<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        innerCollection.Add(new RawRenderable("stroke")); // raw index 0, not mirrored
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        innerCollection.Add(first);
+        innerCollection.Add(second);
+
+        ContainerRuntime replacement = new() { Name = "replacement" };
+        innerCollection[1] = replacement;
+
+        wrapper.ShouldBe(new Gum.Wireframe.GraphicalUiElement[] { replacement, second });
+    }
+
+    [Fact]
+    public void Move_ToTheEndWithATrailingRawNonGraphicalUiElementItem_LeavesTheRawItemLast()
+    {
+        // Reordering mirrored children must not relocate items this wrapper doesn't own. Landing
+        // after ALL inner items is the Add convention (see ToInnerIndex) and is wrong here - a
+        // move to the logical end belongs directly after the last mirrored item.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        wrapper.Add(first);
+        wrapper.Add(second);
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // trailing raw item, not mirrored
+
+        wrapper.Move(0, 1);
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { second, first, stroke });
+    }
+
+    [Fact]
+    public void Move_ToTheSameIndex_LeavesTheInnerCollectionUntouched()
+    {
+        // A logical no-op must stay a no-op in the raw draw list too - "move to the logical end"
+        // otherwise relocates the item past trailing raw renderables nobody asked to reorder.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        ContainerRuntime text = new() { Name = "text" };
+        wrapper.Add(text);
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // trailing raw item, not mirrored
+
+        wrapper.Move(0, 0);
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { text, stroke });
+    }
+
+    [Fact]
+    public void Move_TowardTheFrontWithARawNonGraphicalUiElementItemBeforeIt_LandsBeforeItsNewSuccessor()
+    {
+        // Moving backwards resolves the target off the mirrored item the moved one must precede,
+        // rather than off the logical index - the two differ once a raw item is interleaved.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // raw index 0, not mirrored
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        ContainerRuntime third = new() { Name = "third" };
+        innerCollection.Add(first);
+        innerCollection.Add(second);
+        innerCollection.Add(third);
+
+        wrapper.Move(2, 0);
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { stroke, third, first, second });
+    }
+
+    [Fact]
+    public void Move_WithARawNonGraphicalUiElementItemBeforeIt_MovesTheCorrectInnerItem()
+    {
+        // ItemsControl/ListBox reorder their items through this path. It passed the logical
+        // indices straight to the inner collection, so with a raw item interleaved - a shape
+        // runtime's auto-wired stroke (see ToInnerIndex) - it shuffled the wrong raw entries.
+        ObservableCollectionNoReset<IRenderableIpso> innerCollection = new();
+        GraphicalUiElementCollection wrapper = new(innerCollection);
+
+        RawRenderable stroke = new("stroke");
+        innerCollection.Add(stroke); // raw index 0, not mirrored
+        ContainerRuntime first = new() { Name = "first" };
+        ContainerRuntime second = new() { Name = "second" };
+        innerCollection.Add(first);
+        innerCollection.Add(second);
+
+        wrapper.Move(0, 1);
+
+        innerCollection.ShouldBe(new IRenderableIpso[] { stroke, second, first });
+    }
+
+    [Fact]
     public void Remove_WithARawNonGraphicalUiElementItemBeforeIt_RemovesTheCorrectItem()
     {
         // Same root cause as the Add test, for RemoveItem: the wrapper's logical index doesn't


### PR DESCRIPTION
Closes #4585.

#4585 asked whether `RemoveItem`/`SetItem`'s unguarded `IndexOf` can return -1, and to prove it before adding a guard. It can, but the guard would have treated the symptom.

**Cause.** `InnerCollection_CollectionChanged`'s `Replace` branch did nothing when the replacement wasn't a `GraphicalUiElement`, so the wrapper kept holding an item the inner collection no longer contained. Every later `IndexOf` against it returned -1, and `RemoveAt(-1)` threw from inside the collection. It also used `e.NewStartingIndex`, a raw inner index, as a logical one, which the `Add` branch already knows to translate via `LogicalIndexOf`.

The `Move` branch and the outer `MoveItem` had the same raw-vs-logical confusion. That one is reachable from shipped code: `ItemsControl` and `ListBox` reorder through `MoveItem`, so a shape runtime's auto-wired stroke in the inner list made them shuffle the wrong entries.

**Change.** Translate raw indices in both branches, unmirror a replaced item whose replacement isn't mirrored, and map a logical `Move` onto the inner list off the neighbour it must land next to (new `ToInnerMoveTarget`). A reorder of mirrored children never relocates unmirrored raw renderables, at either end; a same-index `Move` short-circuits entirely. No -1 guard was added: with these fixed, no route to desync was found.

Strict no-op when every inner item is mirrored, which is all normal usage.

**Tests.** Nine new tests in `GraphicalUiElementCollectionTests`, all red before the fix except the no-op `Move` guard, which was verified by inverting the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKato4xvgQ1qQ7PmMryXz2
