### PR TITLE
Correct BatchKeyGroupedOrderer counter reset cadence in docs and document HardBoundaryTransitionCount

### DIFF
--- a/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BatchKeyGroupedOrdererTests.cs
@@ -467,6 +467,50 @@ public class BatchKeyGroupedOrdererTests : BaseTestClass
     }
 
     [Fact]
+    public void MultipleBuildsWithoutReset_AccumulateAllThreeCounters_AndResetBreakTallyClearsThemAll()
+    {
+        // Pins what the published guide (docs/code/performance-and-optimization/batchkeygroupedorderer.md)
+        // tells readers: all three counters, HardBoundaryTransitionCount included, keep counting
+        // across BuildDrawList calls and only ResetBreakTally clears them.
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        // Overlap chain: a(sb) overlaps b(apos) overlaps c(sb), so c can't rejoin a's run.
+        FakeRenderable a = new FakeRenderable("a", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable b = new FakeRenderable("b", "Apos.Shapes") { X = 5, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable c = new FakeRenderable("c", "SpriteBatch") { X = 12, Y = 0, Width = 10, Height = 10 };
+        List<DrawCommand> commands = new List<DrawCommand>();
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(BuildLayer(a, b, c), commands);
+
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(0);
+
+        // A second, unrelated build in the same tally window: entering the clip is a hard boundary
+        // even though its key matches, and the apos child inside it is a no-candidate break.
+        FakeRenderable sb = new FakeRenderable("sb", "SpriteBatch") { X = 0, Y = 0, Width = 10, Height = 10 };
+        FakeRenderable clip = new FakeRenderable("clip", "SpriteBatch")
+        {
+            X = 50, Y = 0, Width = 10, Height = 10, ClipsChildren = true,
+        };
+        AddChild(clip, "child", "Apos.Shapes");
+
+        BatchKeyGroupedOrderer.Instance.BuildDrawList(BuildLayer(sb, clip), commands);
+
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(1);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(2);
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(1);
+
+        BatchKeyGroupedOrderer.Instance.ResetBreakTally();
+
+        BatchKeyGroupedOrderer.Instance.MergeBlockedByOverlapCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.NoCandidateInWindowBreakCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.HardBoundaryTransitionCount.ShouldBe(0);
+        BatchKeyGroupedOrderer.Instance.GetBreakGroups().ShouldBeEmpty();
+        BatchKeyGroupedOrderer.Instance.GetBreakGroupsByType().ShouldBeEmpty();
+    }
+
+    [Fact]
     public void GetBreakGroupsByType_FormatsAsShortTypeArrowWithCount()
     {
         BatchKeyGroupedOrderer.Instance.ResetBreakTally();

--- a/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
+++ b/RenderingLibrary/Graphics/BatchKeyGroupedOrderer.cs
@@ -194,7 +194,8 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
 
     /// <summary>
     /// Clears <see cref="MergeBlockedByOverlapCount"/>, <see cref="NoCandidateInWindowBreakCount"/>,
-    /// and every tally behind <see cref="GetBreakGroups"/>/<see cref="GetBreakGroupsByType"/>.
+    /// <see cref="HardBoundaryTransitionCount"/>, and every tally behind
+    /// <see cref="GetBreakGroups"/>/<see cref="GetBreakGroupsByType"/>.
     /// <see cref="Renderer"/> calls this at the same points it resets
     /// <see cref="RenderStateChangeStatistics"/>; call it yourself if you drive this orderer
     /// directly (issue #4575).
@@ -269,9 +270,10 @@ public sealed class BatchKeyGroupedOrderer : IRenderableOrderer
     }
 
     /// <summary>
-    /// Every distinct break this build produced, most-frequent first - "what's alternating," not
-    /// just a count of how often something did. Recomputed from this build's tallies each call;
-    /// cheap unless you're calling it every frame in a hot loop (issue #4575).
+    /// Every distinct break since the last <see cref="ResetBreakTally"/>, most-frequent first -
+    /// "what's alternating," not just a count of how often something did. Recomputed from the
+    /// current tallies each call; cheap unless you're calling it every frame in a hot loop
+    /// (issue #4575).
     /// </summary>
     public IReadOnlyList<BatchBreakGroup> GetBreakGroups()
     {

--- a/docs/code/performance-and-optimization/batchkeygroupedorderer.md
+++ b/docs/code/performance-and-optimization/batchkeygroupedorderer.md
@@ -86,16 +86,19 @@ If both rows are low, your begins come from clipping instead, and the orderer wi
 
 ### Diagnosing a Smaller-Than-Expected Win
 
-If the draw-call count drops less than you expected after enabling the orderer, two different things could be happening, and `BatchKeyGroupedOrderer.Instance` can tell you which without guessing:
+If the draw-call count drops less than you expected after enabling the orderer, three counters on `BatchKeyGroupedOrderer.Instance` tell you where the remaining draw calls come from, without guessing:
 
 * **`MergeBlockedByOverlapCount`** - the orderer wanted to keep a run going, but a matching item was still pending behind something its bounds overlap. This is the orderer's own correctness rule (never reorder across overlapping bounds) doing its job; no amount of reordering fixes it. If this number is high, the real fix is removing the alternation itself, for example packing the alternating textures into one shared atlas, since same-texture consecutive draws merge for free regardless of overlap or Z order.
 * **`NoCandidateInWindowBreakCount`** - nothing pending shared the running key at all. That's genuine content alternation (or simply the end of a reorder window), and is exactly what the orderer is designed to collapse when it can.
+* **`HardBoundaryTransitionCount`** - entering or leaving a renderable that clips its children, or one that draws to a render target, forced the break on its own. Gum restarts the batch on every clip change, and a render target gets its own flush plus bind and restore cycle, so no reordering can avoid either. If this number dominates, your draw calls come from clipping and render targets rather than from alternation, and the fix is to use fewer of them.
 
-Both reset at the start of every `BuildDrawList` call, so read them right after the one draw pass you're measuring:
+All three keep counting until `ResetBreakTally` runs, which happens on the same cadence as `RenderStateChangeStatistics`: once per `Renderer.Draw(SystemManagers)` pass, which is what `GumUI.Draw()` runs, and once per host frame when you draw through [GumBatch](lastframedrawstates.md#immediate-mode-gumbatch-callers)'s `Begin`/`Draw`/`End`. On the GumBatch path that means the values cover every `Begin`/`End` cycle in the frame, not only the cycle you just ran. If you drive the orderer yourself, for example from a unit test, call `ResetBreakTally` between the builds you want measured separately.
 
 ```csharp
 // Draw
 var orderer = (BatchKeyGroupedOrderer)Renderer.SiblingOrdering;
 System.Diagnostics.Debug.WriteLine(
-    $"Overlap-blocked: {orderer.MergeBlockedByOverlapCount}, No candidate: {orderer.NoCandidateInWindowBreakCount}");
+    $"Overlap-blocked: {orderer.MergeBlockedByOverlapCount}, No candidate: {orderer.NoCandidateInWindowBreakCount}, Hard boundary: {orderer.HardBoundaryTransitionCount}");
 ```
+
+The counters are totals. For the detail behind them, `GetBreakGroups()` returns every distinct break since the last reset, most frequent first: the renderable types on each side, their `BatchKey` and `BatchSortKey` values, and a `BreakReason` naming which of the cases above caused it. `GetBreakGroupsByType()` rolls the same data up to just the two renderable types, and its `ToString()` prints text you can log as-is, such as `Sprite->RoundedRectangle (14)`.


### PR DESCRIPTION
The BatchKeyGroupedOrderer guide said the break counters "reset at the start of every `BuildDrawList` call." They don't. `ResetBreakTally` clears them, and `Renderer` calls that once per `Renderer.Draw(SystemManagers)` pass or once per host frame on the `GumBatch` immediate-mode path. Anyone following the old snippet on that path was reading a whole frame's accumulated total while believing it covered the single `Begin`/`End` cycle they were measuring.

Changes:

- Corrected the cadence sentence, including the note that a caller driving the orderer directly (a unit test) must call `ResetBreakTally` itself.
- Documented the third counter, `HardBoundaryTransitionCount` (clip and render-target boundaries no reordering can avoid), which the section predated.
- Pointed at `GetBreakGroups()` / `GetBreakGroupsByType()` / `BreakReason` for the per-break detail the counters summarize.
- Added a test pinning that all three counters accumulate across `BuildDrawList` calls and that `ResetBreakTally` clears them all.
- Fixed two XML docs with the same drift: `ResetBreakTally`'s summary omitted `HardBoundaryTransitionCount`, and `GetBreakGroups` claimed per-build rather than per-tally scope.

Manual test: not needed, docs/comments/test only. FRB canary: not needed, the FRB1-shared edit is comment text only.

Closes #4586
