### PR TITLE
Document packing .gumpkg from MSBuild, correct the bundle load contract

### DIFF
--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -74,16 +74,7 @@ That includes a `.ttf` the project references through `Font` or `CustomFontFile`
 **Shipping September 2026:** Reading a bundled `.ttf` at runtime ships in the September release, or now if building Gum from source. Before this, the font was packed into the `.gumpkg` but the runtime looked for it on disk and fell back to the default font.
 {% endhint %}
 
-Because the choice is just the string you pass, you can keep loose files while developing, where [hot reload](../code/debugging/hot-reload.md) works, and load the bundle in a published build:
-
-```csharp
-// Initialize
-#if DEBUG
-GumService.Default.Initialize(graphics, gumProjectFile: "MyProject/MyProject.gumx");
-#else
-GumService.Default.Initialize(graphics, gumProjectFile: "MyProject.gumpkg");
-#endif
-```
+Because the choice is just the string you pass, a game can keep loose files while developing, where [hot reload](../code/debugging/hot-reload.md) works, and load the bundle in a published build. How it decides between the two paths is up to you.
 
 {% hint style="warning" %}
 The bundle loader requires .NET 7 or greater (it uses `System.Formats.Tar`). On older targets, passing a `.gumpkg` path throws.
@@ -147,7 +138,7 @@ The loose `.gumx` and its element files are still copied to the output folder by
 </ItemGroup>
 ```
 
-Pair this with the `#if DEBUG` initialization shown above, and each configuration ships the files it actually loads.
+Each configuration then ships only the files it loads, so make sure the path your game passes to `Initialize` matches the configuration it was built in.
 
 ### Packing on publish instead
 

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -66,7 +66,7 @@ Pass the bundle to `Initialize` in place of the `.gumx`:
 GumService.Default.Initialize(graphics, gumProjectFile: "MyProject.gumpkg");
 ```
 
-The extension you pass decides how Gum loads the project. A path ending in `.gumx` (or `.gumj`) reads loose files, and a path ending in `.gumpkg` serves every element, texture, and font read from inside the bundle. Gum does not look for a sibling file of the other kind, so a `.gumpkg` sitting next to your loose project stays unused until you name it.
+The extension you pass decides how Gum loads the project. A path ending in `.gumx` (or `.gumj`) reads loose files, and a path ending in `.gumpkg` serves every element, texture, and font read from inside the bundle. Gum does not look for a sibling file of the other kind, so a `.gumpkg` sitting next to your loose project is ignored unless you pass its path to `Initialize`.
 
 That includes a `.ttf` the project references through `Font` or `CustomFontFile`. Runtime font generation (KernSmith on MonoGame, KNI, FNA, and raylib, or SkiaSharp's own rasterizer) reads the font out of the bundle, so a project that rasterizes its fonts at runtime runs from a `.gumpkg` alone with no loose files and no `FontCache/` folder.
 

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -76,10 +76,6 @@ That includes a `.ttf` the project references through `Font` or `CustomFontFile`
 
 Because the choice is just the string you pass, a game can keep loose files while developing, where [hot reload](../code/debugging/hot-reload.md) works, and load the bundle in a published build. How it decides between the two paths is up to you.
 
-{% hint style="warning" %}
-The bundle loader requires .NET 7 or greater (it uses `System.Formats.Tar`). On older targets, passing a `.gumpkg` path throws.
-{% endhint %}
-
 ## Packing From Your Build
 
 Running `gumcli pack` by hand before every release is easy to forget, and a stale `.gumpkg` looks exactly like a fresh one. An MSBuild target packs the project as part of the build instead, so the bundle is always as new as the files it came from.

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -59,13 +59,14 @@ Ratio:           27.0%
 
 ## Loading a `.gumpkg` at runtime
 
-In MonoGame, load the project the same way you would a loose project:
+Pass the bundle to `Initialize` in place of the `.gumx`:
 
 ```csharp
-GumService.Default.Initialize(graphics, gumProjectFile: "MyProject/MyProject.gumx");
+// Initialize
+GumService.Default.Initialize(graphics, gumProjectFile: "MyProject.gumpkg");
 ```
 
-If a sibling `.gumpkg` is found and the loose `.gumx` is **not** present, the loader transparently switches to bundle mode and serves all element, texture, and font reads from the bundle.
+The extension you pass decides how Gum loads the project. A path ending in `.gumx` (or `.gumj`) reads loose files, and a path ending in `.gumpkg` serves every element, texture, and font read from inside the bundle. Gum does not look for a sibling file of the other kind, so a `.gumpkg` sitting next to your loose project stays unused until you name it.
 
 That includes a `.ttf` the project references through `Font` or `CustomFontFile`. Runtime font generation (KernSmith on MonoGame, KNI, FNA, and raylib, or SkiaSharp's own rasterizer) reads the font out of the bundle, so a project that rasterizes its fonts at runtime runs from a `.gumpkg` alone with no loose files and no `FontCache/` folder.
 
@@ -73,10 +74,103 @@ That includes a `.ttf` the project references through `Font` or `CustomFontFile`
 **Shipping September 2026:** Reading a bundled `.ttf` at runtime ships in the September release, or now if building Gum from source. Before this, the font was packed into the `.gumpkg` but the runtime looked for it on disk and fell back to the default font.
 {% endhint %}
 
-**Loose wins when both exist.** This is intentional — during development you keep the loose files (and hot reload) working, and in a published build you ship only the `.gumpkg`.
+Because the choice is just the string you pass, you can keep loose files while developing, where [hot reload](../code/debugging/hot-reload.md) works, and load the bundle in a published build:
+
+```csharp
+// Initialize
+#if DEBUG
+GumService.Default.Initialize(graphics, gumProjectFile: "MyProject/MyProject.gumx");
+#else
+GumService.Default.Initialize(graphics, gumProjectFile: "MyProject.gumpkg");
+#endif
+```
 
 {% hint style="warning" %}
-The bundle loader requires .NET 7 or greater (it uses `System.Formats.Tar`). On older targets the `.gumpkg` is ignored and the loader falls back to loose-file resolution.
+The bundle loader requires .NET 7 or greater (it uses `System.Formats.Tar`). On older targets, passing a `.gumpkg` path throws.
+{% endhint %}
+
+## Packing From Your Build
+
+Running `gumcli pack` by hand before every release is easy to forget, and a stale `.gumpkg` looks exactly like a fresh one. An MSBuild target packs the project as part of the build instead, so the bundle is always as new as the files it came from.
+
+### Make GumCli available to the build
+
+Install **GumCli** as a *local* tool so the version is recorded in source control and build machines do not need a global install. Run this once in your repository root:
+
+```
+dotnet new tool-manifest
+dotnet tool install GumCli
+```
+
+This creates `.config/dotnet-tools.json`, which you check in. On a fresh clone or a build server, `dotnet tool restore` installs the recorded version, and you invoke the tool as `dotnet gumcli`.
+
+If you would rather install **GumCli** globally (`dotnet tool install -g GumCli`), invoke it as plain `gumcli` in the examples below, and make sure every build machine has it installed.
+
+### Add the target
+
+Add the following to your game's `.csproj`, adjusting the paths to match your project:
+
+```xml
+<ItemGroup>
+    <GumSourceFile Include="GumProject\**\*.*" />
+</ItemGroup>
+
+<Target Name="PackGumProject"
+        AfterTargets="Build"
+        Condition="'$(Configuration)' == 'Release'"
+        Inputs="@(GumSourceFile)"
+        Outputs="$(OutDir)MyProject.gumpkg">
+    <Exec Command="dotnet tool restore" />
+    <Exec Command="dotnet gumcli pack &quot;GumProject\MyProject.gumx&quot; -o &quot;$(OutDir)MyProject.gumpkg&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+</Target>
+```
+
+What each piece does:
+
+* `AfterTargets="Build"` runs the pack once the normal build finishes, so the bundle lands in the same output folder as your game.
+* `Condition` limits packing to `Release` builds. Debug builds keep loading loose files, which is what hot reload needs.
+* `Inputs` and `Outputs` make the target incremental. MSBuild skips it when the bundle is newer than every file in the Gum project, so an unchanged project does not pay for a repack on every build.
+* `WorkingDirectory` lets you write the project path relative to the `.csproj` instead of spelling out an absolute path.
+
+`gumcli pack` returns a non-zero exit code when a referenced file is missing or the project fails to load, and `Exec` turns that into a build failure. A project with a broken reference fails the build instead of shipping a bundle with holes in it.
+
+### Keep loose files out of a release build
+
+The loose `.gumx` and its element files are still copied to the output folder by the `CopyToOutputDirectory` entry you added when [setting up the project](../code/getting-started/setup/loading-a-gum-project-.gumx.md). Add a condition so a `Release` build ships only the bundle:
+
+```xml
+<ItemGroup Condition="'$(Configuration)' != 'Release'">
+    <None Update="GumProject\**\*.*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+</ItemGroup>
+```
+
+Pair this with the `#if DEBUG` initialization shown above, and each configuration ships the files it actually loads.
+
+### Packing on publish instead
+
+If you only want a bundle in published output, target `Publish` and write into the publish folder:
+
+```xml
+<Target Name="PackGumProject" AfterTargets="Publish">
+    <Exec Command="dotnet gumcli pack &quot;GumProject\MyProject.gumx&quot; -o &quot;$(PublishDir)MyProject.gumpkg&quot;"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+</Target>
+```
+
+### Regenerating fonts first
+
+If your build also generates bitmap fonts, run [`gumcli fonts`](fonts.md) before packing so the `FontCache` files exist when `pack` looks for them:
+
+```xml
+<Exec Command="dotnet gumcli fonts &quot;GumProject\MyProject.gumx&quot;"
+      WorkingDirectory="$(MSBuildProjectDirectory)" />
+```
+
+{% hint style="info" %}
+`gumcli fonts` is Windows only, since it drives `bmfont.exe`. On a Linux or macOS build agent, either commit the generated `FontCache` files to source control, or pack with `--include core,external` and let the runtime rasterize fonts from a `.ttf`.
 {% endhint %}
 
 ## Exit Codes

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -28,19 +28,19 @@ The Gum WYSIWYG editor still saves loose files. `.gumpkg` is purely a packaging 
 Pack with default categories (everything):
 
 ```
-gumcli pack MyProject/MyProject.gumx
+gumcli pack GumProject/GumProject.gumx
 ```
 
-Pack to a specific output path:
+Pack to a specific output folder:
 
 ```
-gumcli pack MyProject/MyProject.gumx -o build/MyProject.gumpkg
+gumcli pack GumProject/GumProject.gumx -o build/GumProject.gumpkg
 ```
 
 Omit the font cache (e.g. when your build pipeline regenerates bitmap fonts via `gumcli fonts`):
 
 ```
-gumcli pack MyProject/MyProject.gumx --include core,external
+gumcli pack GumProject/GumProject.gumx --include core,external
 ```
 
 ## Output
@@ -48,7 +48,7 @@ gumcli pack MyProject/MyProject.gumx --include core,external
 The command prints per-category file counts together with uncompressed and compressed byte sizes plus the overall compression ratio, for example:
 
 ```
-Packed 83 files into C:\Games\MyProject\MyProject.gumpkg
+Packed 83 files into C:\Games\MyGame\GumProject.gumpkg
   Core:          42
   FontCache:     18
   External:      23
@@ -63,10 +63,16 @@ Pass the bundle to `Initialize` in place of the `.gumx`:
 
 ```csharp
 // Initialize
-GumService.Default.Initialize(graphics, gumProjectFile: "MyProject.gumpkg");
+GumService.Default.Initialize(graphics, gumProjectFile: "GumProject.gumpkg");
 ```
 
 The extension you pass decides how Gum loads the project. A path ending in `.gumx` (or `.gumj`) reads loose files, and a path ending in `.gumpkg` serves every element, texture, and font read from inside the bundle. Gum does not look for a sibling file of the other kind, so a `.gumpkg` sitting next to your loose project is ignored unless you pass its path to `Initialize`.
+
+A bundle path resolves from the same starting folder as a loose project path, so the two differ only by the part that used to name the project folder. On MonoGame, KNI, and FNA that starting folder is your game's `Content` folder: `"GumProject/GumProject.gumx"` loads `Content/GumProject/GumProject.gumx`, and the sample above loads `Content/GumProject.gumpkg`. On raylib and Silk.NET the path starts at the folder holding the executable, so a project loaded as `"resources/GumProject/GumProject.gumx"` becomes `"resources/GumProject.gumpkg"`.
+
+{% hint style="warning" %}
+A bundle keeps the file name of the project it holds. Gum reads a `.gumpkg` by looking inside it for a project file of the same name, so `GumProject.gumpkg` must hold `GumProject.gumx`, and loading a renamed bundle throws. Use `-o` to choose the folder, not the file name.
+{% endhint %}
 
 That includes a `.ttf` the project references through `Font` or `CustomFontFile`. Runtime font generation (KernSmith on MonoGame, KNI, FNA, and raylib, or SkiaSharp's own rasterizer) reads the font out of the bundle, so a project that rasterizes its fonts at runtime runs from a `.gumpkg` alone with no loose files and no `FontCache/` folder.
 
@@ -99,23 +105,25 @@ Add the following to your game's `.csproj`, adjusting the paths to match your pr
 
 ```xml
 <ItemGroup>
-    <GumSourceFile Include="GumProject\**\*.*" />
+    <GumSourceFile Include="Content\GumProject\**\*.*" />
 </ItemGroup>
 
 <Target Name="PackGumProject"
         AfterTargets="Build"
         Condition="'$(Configuration)' == 'Release'"
         Inputs="@(GumSourceFile)"
-        Outputs="$(OutDir)MyProject.gumpkg">
+        Outputs="$(OutDir)Content\GumProject.gumpkg">
     <Exec Command="dotnet tool restore" />
-    <Exec Command="dotnet gumcli pack &quot;GumProject\MyProject.gumx&quot; -o &quot;$(OutDir)MyProject.gumpkg&quot;"
+    <Exec Command="dotnet gumcli pack &quot;Content\GumProject\GumProject.gumx&quot; -o &quot;$(OutDir)Content\GumProject.gumpkg&quot;"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 </Target>
 ```
 
+The paths above follow the MonoGame, KNI, and FNA layout, where the Gum project lives in `Content\GumProject` and the game loads it as `"GumProject.gumpkg"`. On raylib, swap `Content` for `resources` in both the item and the output path, and load the bundle as `"resources/GumProject.gumpkg"`.
+
 What each piece does:
 
-* `AfterTargets="Build"` runs the pack once the normal build finishes, so the bundle lands in the same output folder as your game.
+* `AfterTargets="Build"` runs the pack once the normal build finishes, so the bundle lands in the output folder alongside the rest of your content.
 * `Condition` limits packing to `Release` builds. Debug builds keep loading loose files, which is what hot reload needs.
 * `Inputs` and `Outputs` make the target incremental. MSBuild skips it when the bundle is newer than every file in the Gum project, so an unchanged project does not pay for a repack on every build.
 * `WorkingDirectory` lets you write the project path relative to the `.csproj` instead of spelling out an absolute path.
@@ -124,11 +132,11 @@ What each piece does:
 
 ### Keep loose files out of a release build
 
-The loose `.gumx` and its element files are still copied to the output folder by the `CopyToOutputDirectory` entry you added when [setting up the project](../code/getting-started/setup/loading-a-gum-project-.gumx.md). Add a condition so a `Release` build ships only the bundle:
+Every configuration copies the loose `.gumx` and its element files to the output folder, through the `CopyToOutputDirectory` entry you added when [setting up the project](../code/getting-started/setup/loading-a-gum-project-.gumx.md). Add a condition to that entry so a `Release` build ships only the bundle:
 
 ```xml
 <ItemGroup Condition="'$(Configuration)' != 'Release'">
-    <None Update="GumProject\**\*.*">
+    <None Update="Content\GumProject\**\*.*">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 </ItemGroup>
@@ -142,7 +150,7 @@ If you only want a bundle in published output, target `Publish` and write into t
 
 ```xml
 <Target Name="PackGumProject" AfterTargets="Publish">
-    <Exec Command="dotnet gumcli pack &quot;GumProject\MyProject.gumx&quot; -o &quot;$(PublishDir)MyProject.gumpkg&quot;"
+    <Exec Command="dotnet gumcli pack &quot;Content\GumProject\GumProject.gumx&quot; -o &quot;$(PublishDir)Content\GumProject.gumpkg&quot;"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 </Target>
 ```
@@ -152,7 +160,7 @@ If you only want a bundle in published output, target `Publish` and write into t
 If your build also generates bitmap fonts, run [`gumcli fonts`](fonts.md) before packing so the `FontCache` files exist when `pack` looks for them:
 
 ```xml
-<Exec Command="dotnet gumcli fonts &quot;GumProject\MyProject.gumx&quot;"
+<Exec Command="dotnet gumcli fonts &quot;Content\GumProject\GumProject.gumx&quot;"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
 ```
 

--- a/docs/cli/pack.md
+++ b/docs/cli/pack.md
@@ -31,7 +31,7 @@ Pack with default categories (everything):
 gumcli pack GumProject/GumProject.gumx
 ```
 
-Pack to a specific output folder:
+Pack to a specific output path:
 
 ```
 gumcli pack GumProject/GumProject.gumx -o build/GumProject.gumpkg
@@ -68,13 +68,17 @@ GumService.Default.Initialize(graphics, gumProjectFile: "GumProject.gumpkg");
 
 The extension you pass decides how Gum loads the project. A path ending in `.gumx` (or `.gumj`) reads loose files, and a path ending in `.gumpkg` serves every element, texture, and font read from inside the bundle. Gum does not look for a sibling file of the other kind, so a `.gumpkg` sitting next to your loose project is ignored unless you pass its path to `Initialize`.
 
-A bundle path resolves from the same starting folder as a loose project path, so the two differ only by the part that used to name the project folder. On MonoGame, KNI, and FNA that starting folder is your game's `Content` folder: `"GumProject/GumProject.gumx"` loads `Content/GumProject/GumProject.gumx`, and the sample above loads `Content/GumProject.gumpkg`. On raylib and Silk.NET the path starts at the folder holding the executable, so a project loaded as `"resources/GumProject/GumProject.gumx"` becomes `"resources/GumProject.gumpkg"`.
+A bundle path resolves from the same starting folder as a loose project path. On MonoGame, KNI, and FNA that folder is your game's `Content` folder, so `"GumProject/GumProject.gumx"` loads `Content/GumProject/GumProject.gumx` and the sample above loads `Content/GumProject.gumpkg`. On raylib the path starts at the folder holding the executable, so a project loaded as `"resources/GumProject/GumProject.gumx"` becomes `"resources/GumProject.gumpkg"`.
 
 {% hint style="warning" %}
-A bundle keeps the file name of the project it holds. Gum reads a `.gumpkg` by looking inside it for a project file of the same name, so `GumProject.gumpkg` must hold `GumProject.gumx`, and loading a renamed bundle throws. Use `-o` to choose the folder, not the file name.
+A bundle keeps the file name of the project it holds. Gum reads a `.gumpkg` by looking inside it for a project file of the same name, so `GumProject.gumpkg` must hold `GumProject.gumx`, and loading a renamed bundle throws. The comparison is exact, including capitalization, on every platform. `-o` names the file to write, so point it at a different folder rather than a different name.
 {% endhint %}
 
-That includes a `.ttf` the project references through `Font` or `CustomFontFile`. Runtime font generation (KernSmith on MonoGame, KNI, FNA, and raylib, or SkiaSharp's own rasterizer) reads the font out of the bundle, so a project that rasterizes its fonts at runtime runs from a `.gumpkg` alone with no loose files and no `FontCache/` folder.
+{% hint style="info" %}
+Bundle loading is available on MonoGame, KNI, FNA, and raylib. SkiaGum and Silk.NET load loose project files only, so pass them a `.gumx` path.
+{% endhint %}
+
+That includes a `.ttf` the project references through `Font` or `CustomFontFile`. Runtime font generation (KernSmith on MonoGame, KNI, FNA, and raylib) reads the font out of the bundle, so a project that rasterizes its fonts at runtime runs from a `.gumpkg` alone with no loose files and no `FontCache/` folder.
 
 {% hint style="info" %}
 **Shipping September 2026:** Reading a bundled `.ttf` at runtime ships in the September release, or now if building Gum from source. Before this, the font was packed into the `.gumpkg` but the runtime looked for it on disk and fell back to the default font.
@@ -114,6 +118,7 @@ Add the following to your game's `.csproj`, adjusting the paths to match your pr
         Inputs="@(GumSourceFile)"
         Outputs="$(OutDir)Content\GumProject.gumpkg">
     <Exec Command="dotnet tool restore" />
+    <MakeDir Directories="$(OutDir)Content" />
     <Exec Command="dotnet gumcli pack &quot;Content\GumProject\GumProject.gumx&quot; -o &quot;$(OutDir)Content\GumProject.gumpkg&quot;"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 </Target>
@@ -123,9 +128,10 @@ The paths above follow the MonoGame, KNI, and FNA layout, where the Gum project 
 
 What each piece does:
 
-* `AfterTargets="Build"` runs the pack once the normal build finishes, so the bundle lands in the output folder alongside the rest of your content.
-* `Condition` limits packing to `Release` builds. Debug builds keep loading loose files, which is what hot reload needs.
+* `AfterTargets="Build"` runs the pack once the normal build finishes, so the bundle lands in the build output alongside the rest of your content. `dotnet publish` does not carry it any further, so see [Packing for publish](pack.md#packing-for-publish) if you publish.
+* `Condition` limits packing to `Release` builds, since Debug builds keep loading loose files, which is what hot reload needs. Your game has to ask for the bundle only in the configuration that produces one, or it looks for a `.gumpkg` that was never written.
 * `Inputs` and `Outputs` make the target incremental. MSBuild skips it when the bundle is newer than every file in the Gum project, so an unchanged project does not pay for a repack on every build.
+* `MakeDir` creates the content folder, because `pack` writes the bundle but does not create the folder holding it.
 * `WorkingDirectory` lets you write the project path relative to the `.csproj` instead of spelling out an absolute path.
 
 `gumcli pack` returns a non-zero exit code when a referenced file is missing or the project fails to load, and `Exec` turns that into a build failure. A project with a broken reference fails the build instead of shipping a bundle with holes in it.
@@ -142,14 +148,16 @@ Every configuration copies the loose `.gumx` and its element files to the output
 </ItemGroup>
 ```
 
-Each configuration then ships only the files it loads, so make sure the path your game passes to `Initialize` matches the configuration it was built in.
+Each configuration then ships only the files it loads.
 
-### Packing on publish instead
+### Packing for publish
 
-If you only want a bundle in published output, target `Publish` and write into the publish folder:
+A bundle written into the build output is not copied to the publish folder, so a game you ship with `dotnet publish` wants its own target:
 
 ```xml
-<Target Name="PackGumProject" AfterTargets="Publish">
+<Target Name="PackGumProjectForPublish" AfterTargets="Publish">
+    <Exec Command="dotnet tool restore" />
+    <MakeDir Directories="$(PublishDir)Content" />
     <Exec Command="dotnet gumcli pack &quot;Content\GumProject\GumProject.gumx&quot; -o &quot;$(PublishDir)Content\GumProject.gumpkg&quot;"
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 </Target>

--- a/docs/code/debugging/hot-reload.md
+++ b/docs/code/debugging/hot-reload.md
@@ -59,7 +59,7 @@ If your code clears (`= null`) or replaces the `Tag` on a visual that was create
 ## Platform Support
 
 {% hint style="info" %}
-Hot reload requires loose project files on disk; it does not watch inside `.gumpkg` bundles. If a sibling `.gumpkg` exists alongside the loose `.gumx`, the loose path wins (see [pack](../../cli/pack.md)) and watchers fire normally. A bundle-only deployment (no loose `.gumx`) loads at startup but cannot hot-reload.
+Hot reload requires loose project files on disk; it does not watch inside `.gumpkg` bundles. Initializing with a `.gumx` path loads loose files and watchers fire normally, even when a `.gumpkg` sits next to them (see [pack](../../cli/pack.md)). Initializing with a `.gumpkg` path loads at startup but cannot hot-reload.
 
 If hot reload from a `.gumpkg` (e.g. for a hot-swap-on-deploy workflow) would be useful to you, let us know on [Discord](https://discord.gg/EvqwmSQuBz) or file an issue on [GitHub](https://github.com/vchelaru/Gum/issues) — real usage reports help us prioritize.
 {% endhint %}

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -58,10 +58,10 @@ It's recommended practice to set the RelativeDirectory to your Gum project's loc
 
 ### Loading from a `.gumpkg` Bundle
 
-In addition to loose files, Gum can load a project from a single-file `.gumpkg` bundle produced by [`gumcli pack`](../../cli/pack.md). When `GumService.Initialize` is called with a `.gumx` path:
+In addition to loose files, Gum can load a project from a single-file `.gumpkg` bundle produced by [`gumcli pack`](../../cli/pack.md). The path you hand to `GumService.Initialize` decides which one you get:
 
-* If the loose `.gumx` exists, Gum loads from loose files (the dev-time path; hot reload also works in this mode).
-* If only a sibling `.gumpkg` exists, Gum reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory.
+* A path ending in `.gumx` (or `.gumj`) loads loose files. This is the dev-time path, and hot reload works in this mode.
+* A path ending in `.gumpkg` reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory.
 
 "Fonts" here covers both kinds: the baked `FontCache` `.fnt` and `.png` pages, and a `.ttf` the project rasterizes at runtime.
 

--- a/docs/code/files-and-fonts/file-loading.md
+++ b/docs/code/files-and-fonts/file-loading.md
@@ -61,7 +61,7 @@ It's recommended practice to set the RelativeDirectory to your Gum project's loc
 In addition to loose files, Gum can load a project from a single-file `.gumpkg` bundle produced by [`gumcli pack`](../../cli/pack.md). The path you hand to `GumService.Initialize` decides which one you get:
 
 * A path ending in `.gumx` (or `.gumj`) loads loose files. This is the dev-time path, and hot reload works in this mode.
-* A path ending in `.gumpkg` reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory.
+* A path ending in `.gumpkg` reads element XML, textures, and fonts from inside the bundle via `FileManager.CustomGetStreamFromFile`. No loose copy is needed in the output directory. MonoGame, KNI, FNA, and raylib load bundles; SkiaGum and Silk.NET read loose files only.
 
 "Fonts" here covers both kinds: the baked `FontCache` `.fnt` and `.png` pages, and a `.ttf` the project rasterizes at runtime.
 

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -313,7 +313,7 @@ text.Font = "Content/Fonts/Bungee-Regular.ttf";
 text.FontSize = 24;
 ```
 
-SkiaGum reads the file the same way it reads any other asset, so a `.ttf` inside a [`.gumpkg` bundle](../../cli/pack.md), or one served by your own `FileManager.CustomGetStreamFromFile` function, loads exactly like a file on disk. See [Where a .ttf Can Live](font-strategies.md#where-a-ttf-can-live).
+SkiaGum reads the file the same way it reads any other asset, so a `.ttf` served by your own `FileManager.CustomGetStreamFromFile` function loads exactly like a file on disk. SkiaGum and Silk.NET load loose project files only, so a [`.gumpkg` bundle](../../cli/pack.md) is not an option there. See [Where a .ttf Can Live](font-strategies.md#where-a-ttf-can-live).
 
 For a font you already hold as bytes, an embedded resource for example, call `SkiaGum.Content.Fonts.GumFontMapper.RegisterFont(familyName, fontBytes)` and then assign `Font = familyName`. That method also takes an optional style name, so you can register a bold or italic version alongside the regular one.
 


### PR DESCRIPTION
Adds a "Packing From Your Build" section to `docs/cli/pack.md`: GumCli as a local tool, an incremental `AfterTargets="Build"` target, keeping loose files out of `Release` output, publish-time packing, and running `gumcli fonts` first.

While writing it, found the runtime contract documented on three pages was stale. `GumBundleLoader.Resolve` picks loose vs bundle from the extension of the path passed to `Initialize` and does no sibling probing (that went away in #2941), so "pass the `.gumx` and Gum falls back to a sibling `.gumpkg`" / "loose wins when both exist" was wrong, as was the pre-net7 note claiming a fallback instead of a throw. Corrected in `pack.md`, `file-loading.md`, and `hot-reload.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeQr1jNrXyZjHeDSvpMwLP
