### PR TITLE
Route every project-file path through the project's own format

### DIFF
--- a/.claude/skills/gum-tool-save-classes/SKILL.md
+++ b/.claude/skills/gum-tool-save-classes/SKILL.md
@@ -7,7 +7,17 @@ description: Gum save/load data model. Triggers: GumProjectSave, ScreenSave, Com
 
 ## Overview
 
-Gum projects are serialized as XML files using .NET's `XmlSerializer`. Each logical type has its own file extension: `.gumx` (project), `.gusx` (screen), `.gucx` (component), `.gutx` (standard element), `.behx` (behavior).
+Gum projects are serialized as XML files using .NET's `XmlSerializer`. Each logical type has its own file extension: `.gumx` (project), `.gusx` (screen), `.gucx` (component), `.gutx` (standard element), `.behx` (behavior), `.ganx` (element animations).
+
+A project can instead be JSON, which is the AOT-safe format. Every extension is its XML counterpart with the trailing `x` swapped for `j` (`.gumj`/`.gusj`/`.gucj`/`.gutj`/`.behj`/`.ganj`); serializers live in `GumDataTypes/Serialization/Json/`. The project file's own extension is the single source of truth — `GumProjectSave.IsJsonFormat(fileName)` — and there is no content-sniffing anywhere in load or save.
+
+**Landmine:** any code composing an element's or behavior's on-disk path must route the extension through the project's format — `ElementSave.GetFileExtension(bool)`, `ElementReference.GetExtension(bool)`, `BehaviorReference.GetRelativeFilePath(bool)`, or the `IFileCommands.GetFullPathXmlFile` overloads, which already do. Using the bare `ElementSave.FileExtension` / `BehaviorReference.Extension` inside a JSON project writes a file the project never loads back, so the edit looks saved and is silently lost.
+
+**Landmine:** the animation sidecar carries two decisions — the file's extension and the serializer — and they must not be made separately. Read and write it through `ElementAnimationsSave.Load` / `.Save`, which dispatch on the file's own extension, and build the file name with `ElementAnimationsSave.GetFileNameSuffix(bool)`. The tool resolves the sidecar by the project's format while the runtime's `GumAnimationLoader` JSON-parses every `*Animations.ganj` it finds, so XML written to a `.ganj` reads fine in the tool and fails in the game.
+
+`ProjectFormatExtensionGuardTests` (in `GumToolUnitTests/Architecture/`) is a source scan that fails when a new bare-extension or raw-serializer site appears; its baselines list every sanctioned exception.
+
+Import and copy paths need more than a path fix: the source project's format is independent of the destination's, so a file moving between projects has to be deserialized and re-saved rather than byte-copied.
 
 All save classes live in `GumDataTypes/`.
 

--- a/Gum/DataTypes/ElementSaveExtensionMethods.GumTool.cs
+++ b/Gum/DataTypes/ElementSaveExtensionMethods.GumTool.cs
@@ -29,7 +29,9 @@ public static class ElementSaveExtensionMethodsGumTool
             return null;
         }
 
-        var extension = elementSave.FileExtension;
+        // Extension follows the open project's own format so a .gumj project resolves
+        // .gusj/.gucj/.gutj (issue #4595).
+        var extension = elementSave.GetFileExtension(GumProjectSave.IsJsonFormat(gumProject.FullFileName));
 
         var reference =
             gumProject.ScreenReferences.FirstOrDefault(item => item.Name == elementSave.Name) ??

--- a/Gum/Plugins/InternalPlugins/TreeView/TreeNodeFilePathExtensions.cs
+++ b/Gum/Plugins/InternalPlugins/TreeView/TreeNodeFilePathExtensions.cs
@@ -61,17 +61,23 @@ public static class TreeNodeFilePathExtensions
             throw new InvalidOperationException();
         }
 
+        // Extensions follow the open project's own format so a .gumj project resolves
+        // .gusj/.gucj/.gutj/.behj (issue #4595).
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(
+            Locator.GetRequiredService<IProjectManager>().GumProjectSave?.FullFileName ?? "");
+
         if (treeNode.IsStandardElementTreeNode() ||
             treeNode.IsComponentTreeNode() ||
             treeNode.IsScreenTreeNode())
         {
             ElementSave element = (ElementSave)treeNode.Tag!;
-            return treeNode.Parent!.GetTreeNodeFullFilePath() + treeNode.Text + "." + element.FileExtension;
+            return treeNode.Parent!.GetTreeNodeFullFilePath() + treeNode.Text + "." + element.GetFileExtension(isJsonFormat);
         }
 
         if (treeNode.IsBehaviorTreeNode())
         {
-            return treeNode.Parent!.GetTreeNodeFullFilePath() + treeNode.Text + "." + BehaviorReference.Extension;
+            return treeNode.Parent!.GetTreeNodeFullFilePath() + treeNode.Text + "." +
+                (isJsonFormat ? BehaviorReference.JsonExtension : BehaviorReference.Extension);
         }
 
         return treeNode.Parent!.GetTreeNodeFullFilePath() + treeNode.Text + "\\";

--- a/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
+++ b/Gum/StateAnimationPlugin/Managers/AnimationCollectionViewModelManager.cs
@@ -66,7 +66,7 @@ public class AnimationCollectionViewModelManager : IAnimationCollectionViewModel
         {
             try
             {
-                model = FileManager.XmlDeserialize<ElementAnimationsSave>(fileName.FullPath);
+                model = ElementAnimationsSave.Load(fileName.FullPath);
             }
             catch (Exception exception)
             {
@@ -94,7 +94,7 @@ public class AnimationCollectionViewModelManager : IAnimationCollectionViewModel
             var save = viewModel.ToSave();
 
             _fileWatchManager.IgnoreNextChangeUntil(fileName.FullPath);
-            FileManager.XmlSerialize(save, fileName.FullPath);
+            save.Save(fileName.FullPath);
         }
     }
 
@@ -106,7 +106,7 @@ public class AnimationCollectionViewModelManager : IAnimationCollectionViewModel
         if (fileName != null)
         {
             _fileWatchManager.IgnoreNextChangeUntil(fileName.FullPath);
-            FileManager.XmlSerialize(save, fileName.FullPath);
+            save.Save(fileName.FullPath);
         }
     }
 }

--- a/Gum/StateAnimationPlugin/Managers/DuplicateService.cs
+++ b/Gum/StateAnimationPlugin/Managers/DuplicateService.cs
@@ -1,3 +1,4 @@
+using Gum.StateAnimation.SaveClasses;
 ﻿using Gum;
 using Gum.DataTypes;
 using Gum.Managers;
@@ -34,8 +35,12 @@ namespace StateAnimationPlugin.Managers
             ///
             var projectDirectory = FileManager.GetDirectory(project.FullFileName);
 
-            var oldFile = new FilePath(projectDirectory + oldElement.Subfolder + "/" + oldElement.Name + "Animations.ganx");
-            var newFile = new FilePath(projectDirectory + newElement.Subfolder + "/" + newElement.Name + "Animations.ganx");
+            // Suffix follows the open project's own format so a .gumj project duplicates .ganj
+            // rather than looking for a .ganx that doesn't exist (issue #4595).
+            var suffix = ElementAnimationsSave.GetFileNameSuffix(GumProjectSave.IsJsonFormat(project.FullFileName));
+
+            var oldFile = new FilePath(projectDirectory + oldElement.Subfolder + "/" + oldElement.Name + suffix);
+            var newFile = new FilePath(projectDirectory + newElement.Subfolder + "/" + newElement.Name + suffix);
 
             if (oldFile.Exists())
             {

--- a/GumCommon/Bundle/GumProjectDependencyWalker.cs
+++ b/GumCommon/Bundle/GumProjectDependencyWalker.cs
@@ -193,10 +193,15 @@ public class GumProjectDependencyWalker
         }
         if (Directory.Exists(projectRootDirectory))
         {
-            string[] gumxFiles = Directory.GetFiles(projectRootDirectory, "*." + GumProjectSave.ProjectExtension, SearchOption.TopDirectoryOnly);
-            if (gumxFiles.Length == 1)
+            // Both formats are candidates - a bundled project can be .gumx or .gumj, and globbing
+            // only for .gumx made a JSON project unresolvable here (issue #4595).
+            string[] projectFiles = Directory
+                .GetFiles(projectRootDirectory, "*." + GumProjectSave.ProjectExtension, SearchOption.TopDirectoryOnly)
+                .Concat(Directory.GetFiles(projectRootDirectory, "*." + GumProjectSave.ProjectJsonExtension, SearchOption.TopDirectoryOnly))
+                .ToArray();
+            if (projectFiles.Length == 1)
             {
-                return NormalizeRelative(Path.GetFileName(gumxFiles[0]));
+                return NormalizeRelative(Path.GetFileName(projectFiles[0]));
             }
         }
         return null;

--- a/GumCommon/HostServices/GumAnimationLoader.cs
+++ b/GumCommon/HostServices/GumAnimationLoader.cs
@@ -146,7 +146,7 @@ public static class GumAnimationLoader
     }
 
     private static readonly string[] AnimationFileSuffixes =
-        { "Animations.ganx", "Animations.ganj" };
+        { ElementAnimationsSave.GetFileNameSuffix(isJsonFormat: false), ElementAnimationsSave.GetFileNameSuffix(isJsonFormat: true) };
 
     private static readonly string[] AnimationCategoryFolders =
         { "Screens/", "Components/", "StandardElements/" };

--- a/GumDataTypes/ElementSave.cs
+++ b/GumDataTypes/ElementSave.cs
@@ -91,6 +91,23 @@ namespace Gum.DataTypes
             get;
         }
 
+        /// <summary>
+        /// <see cref="FileExtension"/> (XML) or its JSON counterpart, matching the project's actual
+        /// format. Every JSON element extension is its XML counterpart with the trailing "x" swapped
+        /// for "j" (gusx-&gt;gusj, gucx-&gt;gucj, gutx-&gt;gutj), the same convention used by
+        /// <see cref="ElementReference.GetExtension(bool)"/>.
+        /// <para>
+        /// Any code composing an element's on-disk path must use this rather than
+        /// <see cref="FileExtension"/> directly - writing to the XML path inside a .gumj project
+        /// saves content the project never loads back (issue #4595).
+        /// </para>
+        /// </summary>
+        public string GetFileExtension(bool isJsonFormat)
+        {
+            string extension = FileExtension;
+            return isJsonFormat ? extension.Substring(0, extension.Length - 1) + "j" : extension;
+        }
+
         [XmlIgnore]
         public StateSave DefaultState
         {
@@ -205,10 +222,8 @@ namespace Gum.DataTypes
         public void Save(string fileName, bool useCompactFormat = false)
         {
             // No content-sniffing between XML and JSON - the target file's own extension decides
-            // the format, symmetric with ElementReference.DeserializeElement. Every JSON element
-            // extension is its XML counterpart with the trailing "x" swapped for "j"
-            // (gusx->gusj, gucx->gucj, gutx->gutj).
-            string jsonExtension = FileExtension.Substring(0, FileExtension.Length - 1) + "j";
+            // the format, symmetric with ElementReference.DeserializeElement.
+            string jsonExtension = GetFileExtension(isJsonFormat: true);
             bool isJsonFormat = string.Equals(FileManager.GetExtension(fileName), jsonExtension, StringComparison.OrdinalIgnoreCase);
             if (isJsonFormat)
             {

--- a/GumDataTypes/SaveClasses/ElementAnimationsSave.cs
+++ b/GumDataTypes/SaveClasses/ElementAnimationsSave.cs
@@ -1,13 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Gum.DataTypes;
+using Gum.DataTypes.Serialization.Json;
+using ToolsUtilities;
 
 namespace Gum.StateAnimation.SaveClasses;
 
 public class ElementAnimationsSave
 {
+    /// <summary>XML animation sidecar extension, as in <c>MyComponentAnimations.ganx</c>.</summary>
+    public const string FileExtension = "ganx";
+
+    /// <summary>JSON counterpart of <see cref="FileExtension"/>.</summary>
+    public const string JsonFileExtension = "ganj";
+
+    /// <summary>
+    /// The <c>Animations.ganx</c> / <c>Animations.ganj</c> suffix appended to an element's file name
+    /// (minus its own extension) to reach that element's animation sidecar.
+    /// </summary>
+    public static string GetFileNameSuffix(bool isJsonFormat) =>
+        "Animations." + (isJsonFormat ? JsonFileExtension : FileExtension);
+
     public List<AnimationSave> Animations
     {
         get;
@@ -23,6 +43,52 @@ public class ElementAnimationsSave
     {
         Animations = new List<AnimationSave>();
     }
+
+    /// <summary>
+    /// Writes this to <paramref name="fileName"/> as XML or JSON. As with
+    /// <see cref="ElementSave.Save"/> there is no content-sniffing: the target file's own extension
+    /// picks the serializer, so a <c>.ganj</c> path can never receive XML.
+    /// </summary>
+    // Gated because this file also compiles into GumDataTypesNet6.csproj (netstandard2.0),
+    // which has no trim attributes.
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Serializes ElementAnimationsSave, which GumCommon's ILLink.Descriptors.xml preserves in full (Gum.StateAnimation.SaveClasses.*, preserve=\"all\").")]
+#endif
+    public void Save(string fileName)
+    {
+        if (IsJsonFormat(fileName))
+        {
+            GumJsonFileSerializer.WriteToFile(fileName,
+                GumAnimationJsonFileSerializer.SerializeElementAnimations(this));
+        }
+        else
+        {
+            FileManager.XmlSerialize(this, fileName);
+        }
+    }
+
+    /// <summary>
+    /// Reads an <see cref="ElementAnimationsSave"/> from <paramref name="fileName"/>, picking the
+    /// deserializer off the file's own extension. Symmetric with <see cref="Save"/>.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Deserializes ElementAnimationsSave, which GumCommon's ILLink.Descriptors.xml preserves in full (Gum.StateAnimation.SaveClasses.*, preserve=\"all\").")]
+#endif
+    public static ElementAnimationsSave Load(string fileName)
+    {
+        return IsJsonFormat(fileName)
+            ? GumAnimationJsonFileSerializer.DeserializeElementAnimations(File.ReadAllText(fileName))
+            : FileManager.XmlDeserialize<ElementAnimationsSave>(fileName);
+    }
+
+    /// <summary>
+    /// True when <paramref name="fileName"/> is a <c>.ganj</c>. The single source of truth for
+    /// which serializer an animation file uses.
+    /// </summary>
+    public static bool IsJsonFormat(string fileName) =>
+        string.Equals(FileManager.GetExtension(fileName), JsonFileExtension, StringComparison.OrdinalIgnoreCase);
 
     public override string ToString()
     {

--- a/Tests/Gum.Cli.Tests/CheckReferencesCommandTests.cs
+++ b/Tests/Gum.Cli.Tests/CheckReferencesCommandTests.cs
@@ -70,6 +70,31 @@ public class CheckReferencesCommandTests : IDisposable
         result.ExitCode.ShouldBe(2);
     }
 
+    [Fact]
+    public void CheckReferences_WithFix_OnJsonProject_RewritesTheJsonElement()
+    {
+        // Issue #4595: --fix reconstructed the element's save path from the XML extension, so on a
+        // .gumj project it wrote a .gucx the project never loads - reporting "fixed" while the
+        // real .gucj kept the broken reference.
+        string xmlPath = CreateProjectWithUnpropagatedComponent("FixJson");
+        CliTestHelper.Run("convert-to-json", xmlPath).ExitCode.ShouldBe(0);
+
+        string jsonProjectPath = Path.ChangeExtension(xmlPath, ".gumj");
+        string componentDir = Path.Combine(Path.GetDirectoryName(xmlPath)!, "Components");
+
+        // Delete the XML siblings so a stale-file read cannot mask the bug.
+        File.Delete(xmlPath);
+        File.Delete(Path.Combine(componentDir, "BadComponent.gucx"));
+
+        CliTestHelper result = CliTestHelper.Run("check-references", jsonProjectPath, "--fix");
+
+        result.ExitCode.ShouldBe(0);
+        File.Exists(Path.Combine(componentDir, "BadComponent.gucx"))
+            .ShouldBeFalse("--fix must not resurrect an XML file inside a JSON project");
+        File.ReadAllText(Path.Combine(componentDir, "BadComponent.gucj"))
+            .ShouldContain("\"X\"", customMessage: "the propagated scalar should be persisted in the .gucj");
+    }
+
     private string CreateTestProject(string name)
     {
         string filePath = Path.Combine(_tempDirectory, name, name + ".gumx");

--- a/Tests/Gum.Presentation.Tests/AnimationTabRefreshLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/AnimationTabRefreshLogicTests.cs
@@ -1,0 +1,44 @@
+using Shouldly;
+using StateAnimationPlugin;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.Presentation.Tests;
+
+/// <summary>
+/// Pins which on-disk file changes live-reload the Animations tab. Both sidecar extensions must
+/// qualify: a JSON project's sidecar is .ganj, and recognizing only .ganx left the tab showing
+/// stale animations after an external edit in every converted project.
+/// </summary>
+public class AnimationTabRefreshLogicTests
+{
+    [Theory]
+    [InlineData("ganx")]
+    [InlineData("ganj")]
+    public void ShouldReloadAnimationsForChangedFile_IsTrue_ForTheSelectedElementsSidecar(string extension)
+    {
+        FilePath sidecar = new FilePath($@"C:\Project\Components\MyComponentAnimations.{extension}");
+
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(sidecar, sidecar).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("ganx")]
+    [InlineData("ganj")]
+    public void ShouldReloadAnimationsForChangedFile_IsFalse_ForAnotherElementsSidecar(string extension)
+    {
+        FilePath changed = new FilePath($@"C:\Project\Components\OtherAnimations.{extension}");
+        FilePath selected = new FilePath($@"C:\Project\Components\MyComponentAnimations.{extension}");
+
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, selected).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShouldReloadAnimationsForChangedFile_IsFalse_ForANonAnimationFile()
+    {
+        FilePath changed = new FilePath(@"C:\Project\Components\MyComponent.gucj");
+        FilePath selected = new FilePath(@"C:\Project\Components\MyComponentAnimations.ganj");
+
+        AnimationTabRefreshLogic.ShouldReloadAnimationsForChangedFile(changed, selected).ShouldBeFalse();
+    }
+}

--- a/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
+++ b/Tests/Gum.Presentation.Tests/FileCommandsTests.cs
@@ -384,6 +384,63 @@ public class FileCommandsTests : BaseTestClass
         File.Exists(Path.Combine(newDir, "DialogueScreen.gusx")).ShouldBeTrue();
     }
 
+    [Fact]
+    public void GetFullFileName_ShouldReturnJsonExtension_WhenProjectIsJsonFormat()
+    {
+        _tempDirectory = CreateTempDirectory();
+        _gumProject.FullFileName = Path.Combine(_tempDirectory, "MyProject.gumj");
+        ComponentSave component = new() { Name = "MyComponent" };
+
+        FilePath result = _fileCommands.GetFullFileName(component);
+
+        FilePath expectedDirectory = FileManager.GetDirectory(_gumProject.FullFileName);
+        FilePath expected = expectedDirectory.Original + "Components\\MyComponent.gucj";
+        result.FullPath.ShouldBe(expected.FullPath);
+    }
+
+    [Fact]
+    public void GetFullPathXmlFile_ForBehavior_ShouldReturnJsonExtension_WhenProjectIsJsonFormat()
+    {
+        _tempDirectory = CreateTempDirectory();
+        _gumProject.FullFileName = Path.Combine(_tempDirectory, "MyProject.gumj");
+        _gumProject.BehaviorReferences.Add(new BehaviorReference { Name = "ButtonBehavior" });
+        BehaviorSave behavior = new() { Name = "ButtonBehavior" };
+
+        FilePath result = _fileCommands.GetFullPathXmlFile(behavior);
+
+        FilePath expectedDirectory = FileManager.GetDirectory(_gumProject.FullFileName);
+        FilePath expected = expectedDirectory.Original + "Behaviors\\ButtonBehavior.behj";
+        result.FullPath.ShouldBe(expected.FullPath);
+    }
+
+    [Fact]
+    public void ForceSaveElement_ShouldWriteJsonFile_WhenProjectIsJsonFormat()
+    {
+        _tempDirectory = CreateTempDirectory();
+        Directory.CreateDirectory(Path.Combine(_tempDirectory, "Components"));
+        _gumProject.FullFileName = Path.Combine(_tempDirectory, "MyProject.gumj");
+
+        ComponentSave component = new() { Name = "MyComponent" };
+        component.States.Add(new Gum.DataTypes.Variables.StateSave { Name = "Default" });
+        _gumProject.Components.Add(component);
+        _gumProject.ComponentReferences.Add(new ElementReference
+        {
+            Name = "MyComponent",
+            ElementType = ElementType.Component
+        });
+
+        bool isNew;
+        _projectManager.Setup(p => p.AskUserForProjectNameIfNecessary(out isNew)).Returns(true);
+
+        _fileCommands.ForceSaveElement(component);
+
+        string jsonPath = Path.Combine(_tempDirectory, "Components", "MyComponent.gucj");
+        string xmlPath = Path.Combine(_tempDirectory, "Components", "MyComponent.gucx");
+
+        File.Exists(xmlPath).ShouldBeFalse("An XML .gucx file must NOT be written for a .gumj project");
+        File.Exists(jsonPath).ShouldBeTrue("The component must be saved as .gucj");
+    }
+
     #region Helpers
 
     private static string CreateResxContent(Dictionary<string, string> entries)

--- a/Tests/Gum.ProjectServices.Tests/FileElementAnimationsProviderTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/FileElementAnimationsProviderTests.cs
@@ -64,6 +64,35 @@ public class FileElementAnimationsProviderTests : IDisposable
         second.ShouldBeSameAs(first);
     }
 
+    [Fact]
+    public void GetAnimationsFor_ReturnsDeserializedAnimations_FromTheComponentsGanj_WhenProjectIsJsonFormat()
+    {
+        // Issue #4595: a .gumj project stores animations as .ganj. Looking only for .ganx made
+        // codegen and the error checker silently see zero animations.
+        _project.FullFileName = Path.Combine(_tempDirectory, "Project.gumj");
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        WriteGanj("Components", "FooAnimations.ganj", animationName: "Anim", keyframeStateName: "Cat/Idle");
+
+        ElementAnimationsSave? result = new FileElementAnimationsProvider().GetAnimationsFor(element, _project);
+
+        result.ShouldNotBeNull();
+        result!.Animations.Single().States.Single().StateName.ShouldBe("Cat/Idle");
+    }
+
+    private void WriteGanj(string relativeDirectory, string fileName, string animationName, string keyframeStateName)
+    {
+        string directory = Path.Combine(_tempDirectory, relativeDirectory);
+        Directory.CreateDirectory(directory);
+
+        AnimationSave animation = new AnimationSave { Name = animationName };
+        animation.States.Add(new AnimatedStateSave { StateName = keyframeStateName });
+        ElementAnimationsSave animations = new ElementAnimationsSave();
+        animations.Animations.Add(animation);
+
+        File.WriteAllText(Path.Combine(directory, fileName),
+            Gum.DataTypes.Serialization.Json.GumAnimationJsonFileSerializer.SerializeElementAnimations(animations));
+    }
+
     private void WriteGanx(string relativeDirectory, string fileName, string animationName, string keyframeStateName)
     {
         string directory = Path.Combine(_tempDirectory, relativeDirectory);

--- a/Tests/Gum.ProjectServices.Tests/JsonProjectFormatRoundTripTests.cs
+++ b/Tests/Gum.ProjectServices.Tests/JsonProjectFormatRoundTripTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.IO;
+using System.Linq;
+using Gum.DataTypes;
+using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Variables;
+using Gum.Logic.FileWatch;
+using Gum.StateAnimation.SaveClasses;
+using Moq;
+using Shouldly;
+using ToolsUtilities;
+using Xunit;
+
+namespace Gum.ProjectServices.Tests;
+
+/// <summary>
+/// End-to-end pins for the JSON project format: a .gumj project's element, behavior, and animation
+/// files must round-trip through the same on-disk paths the tool writes to and the loader reads
+/// from. The bug these guard against is silent — a write lands on a path the project never reads,
+/// so the tool reports success and the edit is gone at the next load.
+///
+/// Path resolution for the individual tool services is pinned in Gum.Presentation.Tests
+/// (FileCommandsTests, AnimationFilePathServiceTests); this file pins the data-model layer those
+/// services write through, so a serializer/extension disagreement fails here regardless of which
+/// caller introduced it.
+/// </summary>
+public class JsonProjectFormatRoundTripTests : IDisposable
+{
+    private readonly string _tempDirectory;
+
+    public JsonProjectFormatRoundTripTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), "GumJsonRoundTrip_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDirectory, recursive: true); } catch { }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ProjectSave_ThenLoad_RoundTripsEveryElement(bool isJsonFormat)
+    {
+        GumProjectSave project = BuildProject(isJsonFormat);
+
+        project.Save(project.FullFileName, saveElements: true);
+
+        GumProjectSave? reloaded = GumProjectSave.Load(project.FullFileName, out GumLoadResult result);
+
+        reloaded.ShouldNotBeNull();
+        result.MissingFiles.ShouldBeEmpty();
+        reloaded!.Components.Single(c => c.Name == "MyComponent").IsSourceFileMissing.ShouldBeFalse();
+        reloaded.Screens.Single(s => s.Name == "MyScreen").IsSourceFileMissing.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ElementSavedIndividually_IsSeenByASubsequentProjectLoad(bool isJsonFormat)
+    {
+        // The per-element save path (Ctrl+S on a component) is the one that lost data: it wrote the
+        // XML extension regardless of the project's format, so the JSON project reloaded the stale
+        // file and the edit vanished. Saving an element and reloading the project must surface it.
+        GumProjectSave project = BuildProject(isJsonFormat);
+        project.Save(project.FullFileName, saveElements: true);
+
+        ComponentSave component = project.Components.Single(c => c.Name == "MyComponent");
+        component.DefaultState.Variables.Add(new VariableSave
+        {
+            Name = "Width",
+            Value = 123.0f,
+            SetsValue = true,
+            Type = "float"
+        });
+
+        string elementPath = Path.Combine(_tempDirectory, component.Subfolder,
+            component.Name + "." + component.GetFileExtension(isJsonFormat));
+        component.Save(elementPath);
+
+        GumProjectSave reloaded = GumProjectSave.Load(project.FullFileName, out _)!;
+
+        reloaded.Components.Single(c => c.Name == "MyComponent")
+            .DefaultState.Variables.Single(v => v.Name == "Width")
+            .Value.ShouldBe(123.0f);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BehaviorSavedIndividually_IsSeenByASubsequentProjectLoad(bool isJsonFormat)
+    {
+        GumProjectSave project = BuildProject(isJsonFormat);
+        project.Save(project.FullFileName, saveElements: true);
+
+        BehaviorSave behavior = new() { Name = "MyBehavior", DefaultImplementation = "Controls/Button" };
+        BehaviorReference reference = project.BehaviorReferences.Single(b => b.Name == "MyBehavior");
+        string behaviorPath = Path.Combine(_tempDirectory, reference.GetRelativeFilePath(isJsonFormat));
+        Directory.CreateDirectory(Path.GetDirectoryName(behaviorPath)!);
+        behavior.Save(behaviorPath);
+
+        GumProjectSave reloaded = GumProjectSave.Load(project.FullFileName, out _)!;
+
+        reloaded.Behaviors.Single(b => b.Name == "MyBehavior")
+            .DefaultImplementation.ShouldBe("Controls/Button");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnimationSidecar_RoundTripsThroughTheProvider(bool isJsonFormat)
+    {
+        // The animation sidecar has two independent decisions - the file's extension and the
+        // serializer used to write it - and they were made in different places. Writing through
+        // ElementAnimationsSave.Save and reading through the provider crosses both.
+        GumProjectSave project = BuildProject(isJsonFormat);
+        project.Save(project.FullFileName, saveElements: true);
+
+        ComponentSave component = project.Components.Single(c => c.Name == "MyComponent");
+        string elementPath = Path.Combine(_tempDirectory, component.Subfolder,
+            component.Name + "." + component.GetFileExtension(isJsonFormat));
+
+        ElementAnimationsSave animations = new();
+        animations.Animations.Add(new AnimationSave { Name = "Blink" });
+        string sidecarPath = FileManager.RemoveExtension(elementPath)
+            + ElementAnimationsSave.GetFileNameSuffix(isJsonFormat);
+        animations.Save(sidecarPath);
+
+        ElementAnimationsSave? loaded = new FileElementAnimationsProvider()
+            .GetAnimationsFor(component, project);
+
+        loaded.ShouldNotBeNull();
+        loaded!.Animations.Single().Name.ShouldBe("Blink");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnimationSidecar_SerializerAndExtensionAgree(bool isJsonFormat)
+    {
+        // Directly pins the corruption case: a .ganj holding XML (or a .ganx holding JSON) reads
+        // back in the tool but fails in the runtime's animation loader, and vice versa.
+        ElementAnimationsSave animations = new();
+        animations.Animations.Add(new AnimationSave { Name = "Blink" });
+
+        string path = Path.Combine(_tempDirectory,
+            "FooAnimations." + (isJsonFormat ? "ganj" : "ganx"));
+        animations.Save(path);
+
+        string content = File.ReadAllText(path).TrimStart('﻿', ' ', '\r', '\n');
+        if (isJsonFormat)
+        {
+            content.ShouldStartWith("{");
+        }
+        else
+        {
+            content.ShouldStartWith("<");
+        }
+
+        ElementAnimationsSave.Load(path).Animations.Single().Name.ShouldBe("Blink");
+    }
+
+    [Fact]
+    public void ConvertedProject_LoadsEveryConvertedFile()
+    {
+        // The conversion is the moment both formats exist side by side. After it, loading the .gumj
+        // must resolve every element from its JSON file rather than falling back to a stale .gumx
+        // sibling or reporting it missing.
+        GumProjectSave project = BuildProject(isJsonFormat: false);
+        project.Save(project.FullFileName, saveElements: true);
+
+        BehaviorReference behaviorReference = project.BehaviorReferences.Single();
+        string xmlBehaviorPath = Path.Combine(_tempDirectory, behaviorReference.GetRelativeFilePath(false));
+        Directory.CreateDirectory(Path.GetDirectoryName(xmlBehaviorPath)!);
+        new BehaviorSave { Name = "MyBehavior", DefaultImplementation = "Controls/Button" }.Save(xmlBehaviorPath);
+
+        ComponentSave component = project.Components.Single();
+        string xmlElementPath = Path.Combine(_tempDirectory, component.Subfolder,
+            component.Name + "." + component.GetFileExtension(isJsonFormat: false));
+        ElementAnimationsSave animations = new();
+        animations.Animations.Add(new AnimationSave { Name = "Blink" });
+        animations.Save(FileManager.RemoveExtension(xmlElementPath)
+            + ElementAnimationsSave.GetFileNameSuffix(isJsonFormat: false));
+
+        project = GumProjectSave.Load(project.FullFileName, out _)!;
+
+        ConvertProjectToJsonResult conversion =
+            new ConvertProjectToJsonService(Mock.Of<IFileWatchIgnoreList>()).ConvertToJson(project);
+
+        GumProjectSave? converted = GumProjectSave.Load(conversion.ProjectFilePath, out GumLoadResult result);
+
+        converted.ShouldNotBeNull();
+        result.MissingFiles.ShouldBeEmpty();
+        converted!.Components.Single().IsSourceFileMissing.ShouldBeFalse();
+        converted.Behaviors.Single().DefaultImplementation.ShouldBe("Controls/Button");
+        conversion.AnimationCount.ShouldBe(1);
+
+        ElementAnimationsSave? convertedAnimations = new FileElementAnimationsProvider()
+            .GetAnimationsFor(converted.Components.Single(), converted);
+        convertedAnimations.ShouldNotBeNull();
+        convertedAnimations!.Animations.Single().Name.ShouldBe("Blink");
+    }
+
+    private GumProjectSave BuildProject(bool isJsonFormat)
+    {
+        string extension = isJsonFormat
+            ? GumProjectSave.ProjectJsonExtension
+            : GumProjectSave.ProjectExtension;
+
+        GumProjectSave project = new()
+        {
+            FullFileName = Path.Combine(_tempDirectory, "MyProject." + extension)
+        };
+
+        ComponentSave component = new() { Name = "MyComponent" };
+        component.States.Add(new StateSave { Name = "Default" });
+        project.Components.Add(component);
+        project.ComponentReferences.Add(new ElementReference
+        {
+            Name = component.Name,
+            ElementType = ElementType.Component
+        });
+
+        ScreenSave screen = new() { Name = "MyScreen" };
+        screen.States.Add(new StateSave { Name = "Default" });
+        project.Screens.Add(screen);
+        project.ScreenReferences.Add(new ElementReference
+        {
+            Name = screen.Name,
+            ElementType = ElementType.Screen
+        });
+
+        project.BehaviorReferences.Add(new BehaviorReference { Name = "MyBehavior" });
+
+        return project;
+    }
+
+}

--- a/Tool/Tests/GumToolUnitTests/Architecture/ProjectFormatExtensionGuardTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Architecture/ProjectFormatExtensionGuardTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace GumToolUnitTests.Architecture;
+
+/// <summary>
+/// A Gum project is either XML (.gumx) or JSON (.gumj), and every element, behavior, and animation
+/// file in it follows the project's format. Code that composes an on-disk path from the bare XML
+/// extension writes a file the project never loads back, so the edit looks saved and is lost.
+///
+/// That defect has appeared independently in the element save path, the behavior save path, the CLI
+/// fixer, standard-element recreation, the tree view, drag/drop, gumx import, and the animation
+/// sidecar. These are source-text scans that fail when a new site appears, because the compiler
+/// cannot tell a correct extension from an incorrect one — both are strings.
+///
+/// Use the format-aware accessors instead: <c>ElementSave.GetFileExtension(bool)</c>,
+/// <c>ElementReference.GetExtension(bool)</c>, <c>BehaviorReference.GetRelativeFilePath(bool)</c>,
+/// <c>ElementAnimationsSave.GetFileNameSuffix(bool)</c>, or <c>IFileCommands.GetFullPathXmlFile</c>,
+/// each driven by <c>GumProjectSave.IsJsonFormat(projectFileName)</c>.
+///
+/// Lower a baseline as sites are fixed; never raise one to make a new violation pass. Each remaining
+/// site is enumerated below with why it is legitimate.
+/// </summary>
+public class ProjectFormatExtensionGuardTests
+{
+    [Fact]
+    public void BareElementFileExtensionUses_DoesNotExceedBaseline()
+    {
+        // `element.FileExtension` is unconditionally the XML extension. The three remaining uses
+        // are all deliberate:
+        //   * GumProjectDependencyWalker — inside its own GetElementExtension(element, isJsonFormat)
+        //     helper, which applies the x->j swap.
+        //   * ConvertProjectToJsonService — reads the XML source it is converting FROM, by design.
+        //   * ElementFilePathHelper — has no access to the project file name, so it cannot know the
+        //     format; its callers only use the result via RemoveExtension() to reach a sibling file.
+        //     Its doc comment carries the do-not-use-for-the-element-file warning.
+        const int Baseline = 3;
+
+        // ElementAnimationsSave.FileExtension is a different constant (the .ganx sidecar), guarded
+        // by HardcodedAnimationSidecarSuffixes instead.
+        var pattern = new Regex(@"(?<!ElementAnimationsSave)\.FileExtension\b");
+
+        var violations = ProductionSourceFiles()
+            .SelectMany(MatchingLines(pattern))
+            .ToList();
+
+        violations.Count.ShouldBeLessThanOrEqualTo(Baseline, Describe(violations));
+    }
+
+    [Fact]
+    public void BareXmlExtensionConstantsInPathComposition_DoesNotExceedBaseline()
+    {
+        // Lines that name one of the XML extension constants. A match is excluded when the JSON
+        // counterpart appears within two lines — that is already both-format handling (a file-dialog
+        // filter, a recognized-extension set, a multi-line || chain). The files that *define* these
+        // accessors are excluded too; they are the seam everything else should route through.
+        //
+        // The remaining sites read from a known-XML source or create a brand-new project, which is
+        // always .gumx:
+        //   * GumxSourceService — the import-from-gumx source is fetched over HTTP and is XML-only
+        //     by design today; a .gumj source URL is an unimplemented feature, not a data-loss path.
+        //   * ProjectLoader — its silent-drop scan looks for XML element names that XmlSerializer
+        //     drops without error. JSON has no such failure mode, so the scan is XML-only.
+        //   * FormsThemeBehaviorStagingService — writes into a flat postbuild staging directory,
+        //     not into a Gum project.
+        const int Baseline = 8;
+
+        var pattern = new Regex(
+            @"(GumProjectSave\.(Screen|Component|Standard|Project)Extension|BehaviorReference\.Extension)\b");
+        var jsonAware = new Regex(@"JsonExtension|IsJsonFormat|GetFileExtension|GetExtension\(");
+
+        // These files declare the extension accessors themselves.
+        string[] accessorDefinitions =
+        {
+            "/GumDataTypes/ComponentSave.cs",
+            "/GumDataTypes/ScreenSave.cs",
+            "/GumDataTypes/StandardElementSave.cs",
+            "/GumDataTypes/ElementReference.cs",
+        };
+
+        var violations = ProductionSourceFiles()
+            .Where(f => !accessorDefinitions.Any(d => f.Replace('\\', '/').EndsWith(d, StringComparison.OrdinalIgnoreCase)))
+            .SelectMany(MatchingLinesWithContext(pattern, jsonAware, contextLines: 2))
+            .ToList();
+
+        violations.Count.ShouldBeLessThanOrEqualTo(Baseline, Describe(violations));
+    }
+
+    [Fact]
+    public void HardcodedAnimationSidecarSuffixes_DoesNotExceedBaseline()
+    {
+        // The "Animations.ganx"/"Animations.ganj" suffix must come from
+        // ElementAnimationsSave.GetFileNameSuffix(bool) so the suffix and the serializer can never
+        // disagree — an XML payload inside a .ganj breaks the runtime's animation loader, and the
+        // reverse leaves the Animations tab showing nothing.
+        const int Baseline = 0;
+
+        var pattern = new Regex(@"""Animations\.gan[xj]""");
+
+        var violations = ProductionSourceFiles()
+            .SelectMany(MatchingLines(pattern))
+            .ToList();
+
+        violations.Count.ShouldBeLessThanOrEqualTo(Baseline, Describe(violations));
+    }
+
+    [Fact]
+    public void XmlSerializerUsesOnAnimationFiles_DoesNotExceedBaseline()
+    {
+        // Reading or writing an ElementAnimationsSave must go through ElementAnimationsSave
+        // .Load/.Save, which pick the serializer off the file's own extension. A direct
+        // FileManager.XmlSerialize/XmlDeserialize call reintroduces the bug where the path says
+        // .ganj and the bytes say XML.
+        //
+        // Two remaining uses, both already holding a known-format payload rather than a path:
+        //   * GumAnimationLoader's .ganx branch — the file was selected by glob and is read from a
+        //     stream, so the runtime has no FilePath to dispatch on.
+        //   * GumxImportService — deserializes a known-XML source sidecar out of fetched bytes,
+        //     then re-saves it through ElementAnimationsSave.Save into the destination's format.
+        // ElementAnimationsSave itself is excluded: it is the dispatching implementation.
+        const int Baseline = 2;
+
+        var pattern = new Regex(@"Xml(Serialize|Deserialize)\w*<?\s*\(?\s*[^)]*ElementAnimationsSave");
+
+        var violations = ProductionSourceFiles()
+            .Where(f => !f.Replace('\\', '/').EndsWith("/GumDataTypes/SaveClasses/ElementAnimationsSave.cs",
+                StringComparison.OrdinalIgnoreCase))
+            .SelectMany(MatchingLines(pattern))
+            .ToList();
+
+        violations.Count.ShouldBeLessThanOrEqualTo(Baseline, Describe(violations));
+    }
+
+    /// <summary>
+    /// Like <see cref="MatchingLines"/>, but drops a match when <paramref name="exempt"/> matches
+    /// any line within <paramref name="contextLines"/> of it. Format handling is often spread over a
+    /// multi-line <c>||</c> chain or an adjacent <c>.Concat(...)</c>, where the XML and JSON halves
+    /// sit on different lines and a per-line check would flag correct code.
+    /// </summary>
+    private static Func<string, IEnumerable<(string File, int LineNumber, string Line)>> MatchingLinesWithContext(
+        Regex pattern, Regex exempt, int contextLines) =>
+        file =>
+        {
+            string[] lines = File.ReadAllLines(file);
+            return MatchingLines(pattern)(file).Where(item =>
+            {
+                int index = item.LineNumber - 1;
+                int start = System.Math.Max(0, index - contextLines);
+                int end = System.Math.Min(lines.Length - 1, index + contextLines);
+                for (int i = start; i <= end; i++)
+                {
+                    if (exempt.IsMatch(lines[i]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        };
+
+    private static Func<string, IEnumerable<(string File, int LineNumber, string Line)>> MatchingLines(Regex pattern) =>
+        file => File.ReadAllLines(file)
+            .Select((line, index) => (File: file, LineNumber: index + 1, Line: line))
+            .Where(item =>
+            {
+                string trimmed = item.Line.TrimStart();
+                bool isComment = trimmed.StartsWith("//") || trimmed.StartsWith("*") || trimmed.StartsWith("/*");
+                return !isComment && pattern.IsMatch(item.Line);
+            });
+
+    private static string Describe(IReadOnlyCollection<(string File, int LineNumber, string Line)> violations)
+    {
+        string repoRoot = FindRepoRoot();
+        var rendered = violations
+            .Select(v => $"  {Path.GetRelativePath(repoRoot, v.File)}:{v.LineNumber}  {v.Line.Trim()}");
+        return $"{violations.Count} site(s) found:{Environment.NewLine}{string.Join(Environment.NewLine, rendered)}";
+    }
+
+    /// <summary>
+    /// Every production .cs file in the projects that compose or serialize Gum project files. Test
+    /// projects, obj/bin output, and generated files are excluded — a test may legitimately assert
+    /// against a literal .gucx path.
+    /// </summary>
+    private static IEnumerable<string> ProductionSourceFiles()
+    {
+        string repoRoot = FindRepoRoot();
+        string[] roots =
+        {
+            Path.Combine(repoRoot, "Gum"),
+            Path.Combine(repoRoot, "GumDataTypes"),
+            Path.Combine(repoRoot, "GumCommon"),
+            Path.Combine(repoRoot, "Tools"),
+            Path.Combine(repoRoot, "Tool"),
+        };
+
+        return roots
+            .Where(Directory.Exists)
+            .SelectMany(root => Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            .Where(file =>
+            {
+                string normalized = file.Replace('\\', '/');
+                return !normalized.Contains("/obj/")
+                    && !normalized.Contains("/bin/")
+                    && !normalized.Contains("/Tests/")
+                    && !normalized.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)
+                    && !normalized.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase);
+            });
+    }
+
+    private static string FindRepoRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        for (int i = 0; i < 10; i++)
+        {
+            if (Directory.Exists(Path.Combine(current, "Gum")) && File.Exists(Path.Combine(current, "GumFull.sln")))
+            {
+                return current;
+            }
+            current = Path.GetFullPath(Path.Combine(current, ".."));
+        }
+        throw new DirectoryNotFoundException("Could not locate the repo root from " + AppContext.BaseDirectory);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/ImportFromGumxPlugin/GumxImportServiceTests.cs
@@ -12,6 +12,8 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using ToolsUtilities;
+using Gum.StateAnimation.SaveClasses;
+using System.Linq;
 
 namespace GumToolUnitTests.Plugins.ImportFromGumxPlugin;
 
@@ -30,6 +32,7 @@ public class GumxImportServiceTests : IDisposable
     private readonly FakeImportLogic _importLogic;
     private readonly FakeFileCommands _fileCommands = new();
     private readonly FakeProjectState _projectState;
+    private readonly GumProjectSave _gumProject;
 
     // ── system under test ─────────────────────────────────────────────────
     private readonly GumxSourceService _sourceService = new();
@@ -43,8 +46,8 @@ public class GumxImportServiceTests : IDisposable
         Directory.CreateDirectory(_projectDir);
         Directory.CreateDirectory(_sourceDir);
 
-        var gumProject = new GumProjectSave { FullFileName = Path.Combine(_projectDir, "Test.gumx") };
-        _projectState  = new FakeProjectState(_projectDir, gumProject);
+        _gumProject = new GumProjectSave { FullFileName = Path.Combine(_projectDir, "Test.gumx") };
+        _projectState  = new FakeProjectState(_projectDir, _gumProject);
         _importLogic   = new FakeImportLogic(_projectDir);
 
         _sut = new GumxImportService(_importLogic, _projectState, _fileCommands, _sourceService);
@@ -186,33 +189,100 @@ public class GumxImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ImportAsync_CopiesJsonAnimationSidecar_WhenSourceHasGanjFile()
+    public async Task ImportAsync_ConvertsJsonAnimationSidecarToXml_WhenDestinationProjectIsXmlFormat()
     {
-        // Issue #4182: importing from a source project whose animations were converted to JSON
-        // must copy the .ganj sidecar the same way .ganx already is - both are a plain byte copy,
-        // no format-specific parsing involved.
+        // Issue #4182 made the .ganj sidecar importable at all; issue #4595 made it land in the
+        // DESTINATION project's format. A .ganj byte-copied into a .gumx project is invisible to
+        // the Animations tab, which resolves the sidecar off the open project's format - so the
+        // source's JSON is re-serialized as XML here, animations intact.
         string componentName = "AnimatedButton";
         WriteSourceComponent(componentName);
-        string sourceGanjPath = Path.Combine(_sourceDir, "Components", $"{componentName}Animations.ganj");
-        File.WriteAllText(sourceGanjPath, "{}");
+        WriteSourceAnimationSidecar(componentName, isJsonFormat: true, animationName: "Blink");
 
         ComponentSave component = ComponentNoAssets(componentName);
         GumProjectSave source = SourceProject();
         source.Components.Add(component);
 
-        ImportSelections selections = new ImportSelections
-        {
-            DirectComponents = new() { component },
-            TransitiveComponents = new(),
-            DirectScreens = new(),
-            Behaviors = new(),
-            Standards = new(),
-        };
-
-        await _sut.ImportAsync(selections, source, _sourceDir, destinationSubfolder: "");
+        await _sut.ImportAsync(SelectionsForComponent(component), source, _sourceDir, destinationSubfolder: "");
 
         string destGanjPath = Path.Combine(_projectDir, "Components", $"{componentName}Animations.ganj");
+        string destGanxPath = Path.Combine(_projectDir, "Components", $"{componentName}Animations.ganx");
+        File.Exists(destGanjPath).ShouldBeFalse();
+        File.Exists(destGanxPath).ShouldBeTrue();
+        ElementAnimationsSave.Load(destGanxPath).Animations.Single().Name.ShouldBe("Blink");
+    }
+
+    [Fact]
+    public async Task ImportAsync_ConvertsXmlAnimationSidecarToJson_WhenDestinationProjectIsJsonFormat()
+    {
+        // The mirror of the test above: a .gumj destination receives .ganj, whatever the source was.
+        // A byte-copied .ganx here would be silently ignored by the tool, and a byte-copied XML
+        // payload written to a .ganj path would break the runtime's JSON animation loader.
+        _gumProject.FullFileName = Path.Combine(_projectDir, "Test.gumj");
+
+        string componentName = "AnimatedButton";
+        WriteSourceComponent(componentName);
+        WriteSourceAnimationSidecar(componentName, isJsonFormat: false, animationName: "Blink");
+
+        ComponentSave component = ComponentNoAssets(componentName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(component);
+
+        await _sut.ImportAsync(SelectionsForComponent(component), source, _sourceDir, destinationSubfolder: "");
+
+        string destGanjPath = Path.Combine(_projectDir, "Components", $"{componentName}Animations.ganj");
+        string destGanxPath = Path.Combine(_projectDir, "Components", $"{componentName}Animations.ganx");
+        File.Exists(destGanxPath).ShouldBeFalse();
         File.Exists(destGanjPath).ShouldBeTrue();
+        ElementAnimationsSave.Load(destGanjPath).Animations.Single().Name.ShouldBe("Blink");
+    }
+
+    [Fact]
+    public async Task ImportAsync_OverwriteResolution_WritesConflictingComponentInDestinationFormat_WhenProjectIsJsonFormat()
+    {
+        // The Overwrite path is the one GumxImportService writes itself (it bypasses IImportLogic),
+        // so the destination extension is its own decision. A .gumj project only ever loads .gucj,
+        // so writing .gucx here would silently discard the import (issue #4595).
+        _gumProject.FullFileName = Path.Combine(_projectDir, "Test.gumj");
+        _importLogic.IsJsonFormat = true;
+
+        string componentName = "JsonDestButton";
+        WriteSourceComponent(componentName);
+
+        Directory.CreateDirectory(Path.Combine(_projectDir, "Components"));
+        string destJsonPath = Path.Combine(_projectDir, "Components", $"{componentName}.gucj");
+        new ComponentSave { Name = componentName }.Save(destJsonPath);
+
+        ComponentSave component = ComponentNoAssets(componentName);
+        GumProjectSave source = SourceProject();
+        source.Components.Add(component);
+
+        ImportResult result = await _sut.ImportAsync(
+            SelectionsForComponent(component), source, _sourceDir, destinationSubfolder: "",
+            conflictResolution: ConflictResolution.Overwrite);
+
+        // The pre-existing .gucj must have been seen as the conflict, and the overwrite must have
+        // landed on it rather than creating a stray .gucx alongside.
+        result.ConflictingElements.ShouldBeEmpty();
+        File.Exists(Path.Combine(_projectDir, "Components", $"{componentName}.gucx")).ShouldBeFalse();
+        File.Exists(destJsonPath).ShouldBeTrue();
+    }
+
+    private static ImportSelections SelectionsForComponent(ComponentSave component) => new()
+    {
+        DirectComponents = new() { component },
+        TransitiveComponents = new(),
+        DirectScreens = new(),
+        Behaviors = new(),
+        Standards = new(),
+    };
+
+    private void WriteSourceAnimationSidecar(string componentName, bool isJsonFormat, string animationName)
+    {
+        ElementAnimationsSave animations = new();
+        animations.Animations.Add(new AnimationSave { Name = animationName });
+        animations.Save(Path.Combine(_sourceDir, "Components",
+            componentName + ElementAnimationsSave.GetFileNameSuffix(isJsonFormat)));
     }
 
     [Fact]
@@ -487,8 +557,11 @@ public class GumxImportServiceTests : IDisposable
         // (mirrors how FormsTemplate/Bubblegum link out to a shared Behaviors location).
         string sharedDir = Path.Combine(Path.GetDirectoryName(_sourceDir)!, "GumSharedBehaviors_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(sharedDir);
-        const string sharedContent = "<BehaviorSave><Name>LinkedBehavior</Name><Marker>shared</Marker></BehaviorSave>";
-        File.WriteAllText(Path.Combine(sharedDir, "LinkedBehavior.behx"), sharedContent);
+        // A real BehaviorSave field carries the marker: the import re-serializes into the
+        // destination project's own format rather than byte-copying (issue #4595), so only
+        // round-trippable content survives.
+        new BehaviorSave { Name = "LinkedBehavior", DefaultImplementation = "Shared/Linked" }
+            .Save(Path.Combine(sharedDir, "LinkedBehavior.behx"));
 
         try
         {
@@ -516,7 +589,9 @@ public class GumxImportServiceTests : IDisposable
             // Assert
             string destPath = Path.Combine(_projectDir, "Behaviors", "LinkedBehavior.behx");
             File.Exists(destPath).ShouldBeTrue();
-            File.ReadAllText(destPath).ShouldBe(sharedContent);
+            BehaviorSave imported = BehaviorReference.DeserializeBehavior(destPath, GumProjectSave.NativeVersion);
+            imported.Name.ShouldBe("LinkedBehavior");
+            imported.DefaultImplementation.ShouldBe("Shared/Linked");
             _importLogic.ImportedBehaviorPaths.ShouldContain(destPath);
         }
         finally
@@ -575,12 +650,12 @@ public class GumxImportServiceTests : IDisposable
         string destBehaviorDir = Path.Combine(_projectDir, "Behaviors");
         Directory.CreateDirectory(destBehaviorDir);
         string destPath = Path.Combine(destBehaviorDir, $"{behaviorName}.{BehaviorReference.Extension}");
-        File.WriteAllText(destPath, "<BehaviorSave><Name>Clickable</Name><Marker>original</Marker></BehaviorSave>");
+        new BehaviorSave { Name = behaviorName, DefaultImplementation = "Original" }.Save(destPath);
 
         string srcDir = Path.Combine(_sourceDir, "Behaviors");
         Directory.CreateDirectory(srcDir);
-        const string newContent = "<BehaviorSave><Name>Clickable</Name><Marker>updated</Marker></BehaviorSave>";
-        File.WriteAllText(Path.Combine(srcDir, $"{behaviorName}.{BehaviorReference.Extension}"), newContent);
+        new BehaviorSave { Name = behaviorName, DefaultImplementation = "Updated" }
+            .Save(Path.Combine(srcDir, $"{behaviorName}.{BehaviorReference.Extension}"));
 
         BehaviorSave behavior = new BehaviorSave { Name = behaviorName };
         GumProjectSave source = SourceProject();
@@ -602,7 +677,8 @@ public class GumxImportServiceTests : IDisposable
 
         // Assert
         result.ConflictingElements.ShouldBeEmpty();
-        File.ReadAllText(destPath).ShouldBe(newContent);
+        BehaviorReference.DeserializeBehavior(destPath, GumProjectSave.NativeVersion)
+            .DefaultImplementation.ShouldBe("Updated");
         _importLogic.ImportedBehaviorPaths.ShouldBeEmpty();
     }
 
@@ -929,6 +1005,16 @@ public class GumxImportServiceTests : IDisposable
 
         public FakeImportLogic(string projectDir) { _projectDir = projectDir; }
 
+        /// <summary>
+        /// The real ImportLogic saves through IFileCommands, which resolves the extension off the
+        /// open project's format. Mirror that here so a .gumj-destination test sees .gucj/.gusj,
+        /// as it would in the tool (issue #4595).
+        /// </summary>
+        public bool IsJsonFormat { get; set; }
+
+        private string ExtensionFor(string xmlExtension) =>
+            IsJsonFormat ? xmlExtension.Substring(0, xmlExtension.Length - 1) + "j" : xmlExtension;
+
         public List<string> ImportedComponentPaths { get; } = new();
         public List<string> ImportedScreenPaths    { get; } = new();
         public List<string> ImportedBehaviorPaths  { get; } = new();
@@ -947,7 +1033,7 @@ public class GumxImportServiceTests : IDisposable
         {
             _registeredComponents.Add(component);
             string destPath = Path.Combine(
-                _projectDir, "Components", $"{component.Name}.{GumProjectSave.ComponentExtension}");
+                _projectDir, "Components", $"{component.Name}.{ExtensionFor(GumProjectSave.ComponentExtension)}");
             Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
             component.Save(destPath, useCompactFormat: true);
             ImportedComponentPaths.Add(destPath);
@@ -964,7 +1050,7 @@ public class GumxImportServiceTests : IDisposable
         {
             _registeredScreens.Add(screen);
             string destPath = Path.Combine(
-                _projectDir, "Screens", $"{screen.Name}.{GumProjectSave.ScreenExtension}");
+                _projectDir, "Screens", $"{screen.Name}.{ExtensionFor(GumProjectSave.ScreenExtension)}");
             Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
             screen.Save(destPath, useCompactFormat: true);
             ImportedScreenPaths.Add(destPath);

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationCollectionViewModelManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationCollectionViewModelManagerTests.cs
@@ -77,6 +77,69 @@ public class AnimationCollectionViewModelManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void GetElementAnimationsSave_deserializes_ganj_as_json()
+    {
+        // Issue #4595: the path was resolved as .ganj for a JSON project but the file was still
+        // read with the XML deserializer, so a converted project's animations came back empty and
+        // the next save overwrote them.
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        FilePath ganjPath = new FilePath(Path.Combine(_tempDirectory, "FooAnimations.ganj"));
+
+        ElementAnimationsSave toWrite = new ElementAnimationsSave { ElementName = "Foo" };
+        toWrite.Animations.Add(new AnimationSave { Name = "Walk", Loops = true });
+        toWrite.Save(ganjPath.FullPath);
+
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns(ganjPath);
+
+        ElementAnimationsSave? loaded = _manager.GetElementAnimationsSave(element);
+
+        loaded.ShouldNotBeNull();
+        loaded.Animations.Count.ShouldBe(1);
+        loaded.Animations[0].Name.ShouldBe("Walk");
+        loaded.Animations[0].Loops.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SaveElementAnimations_writes_json_when_path_is_ganj()
+    {
+        // The write side of the same bug: XML written to a .ganj path parses in the tool but breaks
+        // the runtime's animation loader, which JSON-deserializes every *Animations.ganj it finds.
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        FilePath ganjPath = new FilePath(Path.Combine(_tempDirectory, "FooAnimations.ganj"));
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns(ganjPath);
+
+        ElementAnimationsSave toWrite = new ElementAnimationsSave { ElementName = "Foo" };
+        toWrite.Animations.Add(new AnimationSave { Name = "Walk" });
+
+        _manager.SaveElementAnimations(element, toWrite);
+
+        File.ReadAllText(ganjPath.FullPath).TrimStart('\uFEFF', ' ', '\r', '\n').ShouldStartWith("{");
+        ElementAnimationsSave.Load(ganjPath.FullPath).Animations[0].Name.ShouldBe("Walk");
+    }
+
+    [Fact]
+    public void SaveElementAnimations_writes_xml_when_path_is_ganx()
+    {
+        ComponentSave element = new ComponentSave { Name = "Foo" };
+        FilePath ganxPath = new FilePath(Path.Combine(_tempDirectory, "FooAnimations.ganx"));
+        _animationFilePathService
+            .Setup(x => x.GetAbsoluteAnimationFileNameFor(It.IsAny<ElementSave>()))
+            .Returns(ganxPath);
+
+        ElementAnimationsSave toWrite = new ElementAnimationsSave { ElementName = "Foo" };
+        toWrite.Animations.Add(new AnimationSave { Name = "Walk" });
+
+        _manager.SaveElementAnimations(element, toWrite);
+
+        File.ReadAllText(ganxPath.FullPath).TrimStart('\uFEFF', ' ', '\r', '\n').ShouldStartWith("<");
+        ElementAnimationsSave.Load(ganxPath.FullPath).Animations[0].Name.ShouldBe("Walk");
+    }
+
+    [Fact]
     public void GetElementAnimationsSave_returns_null_when_file_missing()
     {
         ComponentSave element = new ComponentSave { Name = "Foo" };

--- a/Tools/Gum.Cli/Commands/CheckReferencesCommand.cs
+++ b/Tools/Gum.Cli/Commands/CheckReferencesCommand.cs
@@ -96,28 +96,23 @@ public static class CheckReferencesCommand
         return ExecuteDetect(service, loadResult.Project!, json);
     }
 
-    private static string? GetElementSavePath(string projectDirectory, ElementSave element)
+    private static string? GetElementSavePath(string projectDirectory, ElementSave element, bool isJsonFormat)
     {
-        string subfolder;
-        string extension;
-        switch (element)
+        string subfolder = element switch
         {
-            case ScreenSave:
-                subfolder = ElementReference.ScreenSubfolder;
-                extension = GumProjectSave.ScreenExtension;
-                break;
-            case ComponentSave:
-                subfolder = ElementReference.ComponentSubfolder;
-                extension = GumProjectSave.ComponentExtension;
-                break;
-            case StandardElementSave:
-                subfolder = ElementReference.StandardSubfolder;
-                extension = GumProjectSave.StandardExtension;
-                break;
-            default:
-                return null;
+            ScreenSave => ElementReference.ScreenSubfolder,
+            ComponentSave => ElementReference.ComponentSubfolder,
+            StandardElementSave => ElementReference.StandardSubfolder,
+            _ => null
+        };
+        if (subfolder == null)
+        {
+            return null;
         }
-        return Path.Combine(projectDirectory, subfolder, element.Name + "." + extension);
+        // Extension follows the project's own format - writing .gucx into a .gumj project saves
+        // content the project never loads back (issue #4595).
+        return Path.Combine(projectDirectory, subfolder,
+            element.Name + "." + element.GetFileExtension(isJsonFormat));
     }
 
     private static int ExecuteDetect(IReferencePropagationService service, GumProjectSave project, bool json)
@@ -145,9 +140,10 @@ public static class CheckReferencesCommand
         // element-type subfolder + name + extension.
         string projectDirectory = Path.GetDirectoryName(projectFilePath) ?? "";
         bool useCompact = project.Version >= (int)GumProjectSave.GumxVersions.AttributeVersion;
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(projectFilePath);
         foreach (ElementSave element in modified)
         {
-            string elementPath = GetElementSavePath(projectDirectory, element);
+            string elementPath = GetElementSavePath(projectDirectory, element, isJsonFormat);
             if (!string.IsNullOrEmpty(elementPath))
             {
                 element.Save(elementPath, useCompact);

--- a/Tools/Gum.Presentation/Commands/FileCommands.cs
+++ b/Tools/Gum.Presentation/Commands/FileCommands.cs
@@ -375,13 +375,18 @@ public class FileCommands : IFileCommands
     }
 
     /// <summary>
-    /// Computes the full path to <paramref name="elementSave"/>'s XML file, using
+    /// Computes the full path to <paramref name="elementSave"/>'s file, using
     /// <paramref name="elementSaveName"/> for the file name and Subfolder path. Inlined from the
     /// (Locator-based) <c>ElementSave.GetFullPathXmlFile(string)</c> extension method - that method
     /// resolves <see cref="IProjectManager"/> via <c>Locator</c>, which is a WinForms-tool-only
     /// static and can't be referenced from this headless assembly, so this uses the already-injected
     /// <see cref="_projectManager"/> instead. Behavior is identical. Mirrors the private duplicate in
     /// <c>DragDropManager</c>.
+    /// <para>
+    /// The extension follows the open project's own format, so a .gumj project resolves
+    /// .gusj/.gucj/.gutj. Hardcoding the XML extension here silently wrote element edits to a file
+    /// the project never loads back (issue #4595).
+    /// </para>
     /// </summary>
     private FilePath? GetFullPathXmlFileForElement(ElementSave elementSave, string elementSaveName)
     {
@@ -391,7 +396,7 @@ public class FileCommands : IFileCommands
             return null;
         }
 
-        var extension = elementSave.FileExtension;
+        var extension = elementSave.GetFileExtension(GumProjectSave.IsJsonFormat(gumProject.FullFileName));
 
         var reference =
             gumProject.ScreenReferences.FirstOrDefault(item => item.Name == elementSave.Name) ??
@@ -673,9 +678,14 @@ public class FileCommands : IFileCommands
         var matchingReference = _projectManager.GumProjectSave.BehaviorReferences
             ?.FirstOrDefault(item => item.Name == behaviorName);
 
+        // Same project-format routing as the element overload above (issue #4595): a .gumj project
+        // stores behaviors as .behj, and saving to .behx would write content it never loads back.
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(_projectManager.GumProjectSave.FullFileName);
+
         string relativeFilePath = matchingReference != null
-            ? matchingReference.GetRelativeFilePath()
-            : BehaviorReference.Subfolder + "\\" + behaviorName + "." + BehaviorReference.Extension;
+            ? matchingReference.GetRelativeFilePath(isJsonFormat)
+            : BehaviorReference.Subfolder + "\\" + behaviorName + "." +
+                (isJsonFormat ? BehaviorReference.JsonExtension : BehaviorReference.Extension);
 
         return directory + relativeFilePath;
     }

--- a/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
+++ b/Tools/Gum.Presentation/ImportFromGumx/Services/GumxImportService.cs
@@ -1,6 +1,9 @@
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
 using Gum.DataTypes.Variables;
+using Gum.DataTypes.Serialization;
+using Gum.DataTypes.Serialization.Json;
+using Gum.StateAnimation.SaveClasses;
 using Gum.Commands;
 using Gum.Plugins.ImportPlugin.Manager;
 using Gum.Plugins.ImportPlugin.Services;
@@ -59,7 +62,7 @@ public class GumxImportService : IGumxImportService
         // The set of names is needed downstream regardless of resolution so writers can decide
         // whether to skip the file write (Skip) or skip the IImportLogic registration (Overwrite,
         // since the element is already known in-memory and will refresh on the post-import reload).
-        var conflicts = FindConflictingElements(selections, nameMap, projectDir);
+        var conflicts = FindConflictingElements(selections, nameMap, projectDir, IsDestinationJsonFormat);
         if (conflicts.Count > 0 && conflictResolution == ConflictResolution.Cancel)
         {
             result.ConflictingElements.AddRange(conflicts);
@@ -208,12 +211,12 @@ public class GumxImportService : IGumxImportService
     }
 
     /// <summary>
-    /// Copies the sibling .ganx (or JSON .ganj - issue #4182) state-animation file for each
-    /// element, if one exists in the source. The naming convention is
-    /// {elementName}Animations.ganx/.ganj, located in the same subfolder as the element file
-    /// (e.g. Components/Controls/ButtonAnimations.ganx). Both extensions are attempted - a plain
-    /// byte copy, so there's no format-specific parsing to keep in sync. Silently skips elements
-    /// that have neither file.
+    /// Copies the sibling state-animation file for each element, if one exists in the source. The
+    /// naming convention is {elementName}Animations.ganx/.ganj, located in the same subfolder as
+    /// the element file (e.g. Components/Controls/ButtonAnimations.ganx). Both source extensions
+    /// are attempted, and whichever is found is re-serialized into the destination project's own
+    /// format - a byte copy would put XML inside a .ganj the runtime then fails to parse
+    /// (issue #4595). Silently skips elements that have neither file.
     /// </summary>
     private async Task CopyGanxFilesAsync(
         IEnumerable<ElementSave> elements,
@@ -227,32 +230,49 @@ public class GumxImportService : IGumxImportService
             string sourceName = element.Name;
             string destName = nameMap.TryGetValue(sourceName, out var mapped) ? mapped : sourceName;
 
-            foreach (string extension in new[] { "ganx", "ganj" })
+            string destPath = Path.Combine(projectDir, elementSubfolder,
+                destName + ElementAnimationsSave.GetFileNameSuffix(IsDestinationJsonFormat));
+
+            foreach (bool isSourceJson in new[] { false, true })
             {
-                string relativeSourcePath = $"{elementSubfolder}/{sourceName}Animations.{extension}";
-                string destPath = Path.Combine(projectDir, elementSubfolder, $"{destName}Animations.{extension}");
+                string relativeSourcePath = $"{elementSubfolder}/{sourceName}" +
+                    ElementAnimationsSave.GetFileNameSuffix(isSourceJson);
 
                 byte[]? bytes = await _sourceService.FetchBinaryAsync(relativeSourcePath, sourceBase);
-                if (bytes != null)
+                if (bytes == null)
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-                    await File.WriteAllBytesAsync(destPath, bytes);
+                    continue;
                 }
+
+                string content = System.Text.Encoding.UTF8.GetString(bytes).TrimStart('﻿');
+                ElementAnimationsSave animations = isSourceJson
+                    ? GumAnimationJsonFileSerializer.DeserializeElementAnimations(content)
+                    : FileManager.XmlDeserializeFromStream<ElementAnimationsSave>(new MemoryStream(bytes));
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+                animations.Save(destPath);
+                break;
             }
         }
     }
 
+    /// <summary>
+    /// A conflict is a destination file that already exists, so every path here uses the
+    /// destination project's own format - in a .gumj project the existing file is a .gucj, and
+    /// probing for .gucx would report no conflict and then silently overwrite (issue #4595).
+    /// </summary>
     private static List<string> FindConflictingElements(
         ImportSelections selections,
         Dictionary<string, string> nameMap,
-        string projectDir)
+        string projectDir,
+        bool isJsonFormat)
     {
         var conflicts = new List<string>();
 
         foreach (var component in selections.TransitiveComponents.Concat(selections.DirectComponents))
         {
             string destName = nameMap.TryGetValue(component.Name, out var mapped) ? mapped : component.Name;
-            string destPath = Path.Combine(projectDir, "Components", $"{destName}.{GumProjectSave.ComponentExtension}");
+            string destPath = Path.Combine(projectDir, "Components", destName + "." + ComponentExtension(isJsonFormat));
             if (File.Exists(destPath))
                 conflicts.Add(destName);
         }
@@ -260,14 +280,14 @@ public class GumxImportService : IGumxImportService
         foreach (var screen in selections.DirectScreens)
         {
             string destName = nameMap.TryGetValue(screen.Name, out var mapped) ? mapped : screen.Name;
-            string destPath = Path.Combine(projectDir, "Screens", $"{destName}.{GumProjectSave.ScreenExtension}");
+            string destPath = Path.Combine(projectDir, "Screens", destName + "." + ScreenExtension(isJsonFormat));
             if (File.Exists(destPath))
                 conflicts.Add(destName);
         }
 
         foreach (var behavior in selections.Behaviors)
         {
-            string destPath = Path.Combine(projectDir, "Behaviors", $"{behavior.Name}.{BehaviorReference.Extension}");
+            string destPath = Path.Combine(projectDir, "Behaviors", behavior.Name + "." + BehaviorExtension(isJsonFormat));
             if (File.Exists(destPath))
                 conflicts.Add(behavior.Name);
         }
@@ -339,10 +359,14 @@ public class GumxImportService : IGumxImportService
         string sourceBase,
         string projectDir)
     {
-        string relativeSrc = $"Standards/{standard.Name}.{GumProjectSave.StandardExtension}";
-        string destPath = Path.Combine(projectDir, "Standards", $"{standard.Name}.{GumProjectSave.StandardExtension}");
+        // Source extension follows the SOURCE project's format, destination the destination's -
+        // the two are independent, so this is a re-serialize rather than a copy (issue #4595).
+        bool isSourceJson = GumProjectSave.IsJsonFormat(source.FullFileName ?? "");
+        string relativeSrc = $"Standards/{standard.Name}." + StandardExtension(isSourceJson);
+        string destPath = Path.Combine(projectDir, "Standards",
+            standard.Name + "." + StandardExtension(IsDestinationJsonFormat));
 
-        if (await CopyElementFileAsync(relativeSrc, sourceBase, destPath))
+        if (await CopyElementFileAsync<StandardElementSave>(relativeSrc, sourceBase, destPath))
         {
             // Standards are not imported via IImportLogic — they are loaded on project reload.
             // Ensure the destination directory exists (done inside CopyElementFileAsync).
@@ -379,7 +403,8 @@ public class GumxImportService : IGumxImportService
         {
             // Element is already in the destination project; bypass IImportLogic registration
             // and write the file directly. The post-import save+reload picks up the new content.
-            string destPath = Path.Combine(projectDir, "Components", $"{destName}.{GumProjectSave.ComponentExtension}");
+            string destPath = Path.Combine(projectDir, "Components",
+                destName + "." + ComponentExtension(IsDestinationJsonFormat));
             WriteElementToDisk(clone, destPath);
         }
         else
@@ -413,7 +438,8 @@ public class GumxImportService : IGumxImportService
 
         if (isConflict && conflictResolution == ConflictResolution.Overwrite)
         {
-            string destPath = Path.Combine(projectDir, "Screens", $"{destName}.{GumProjectSave.ScreenExtension}");
+            string destPath = Path.Combine(projectDir, "Screens",
+                destName + "." + ScreenExtension(IsDestinationJsonFormat));
             WriteElementToDisk(clone, destPath);
         }
         else
@@ -534,13 +560,17 @@ public class GumxImportService : IGumxImportService
         bool isConflict = conflictNameSet.Contains(behavior.Name);
         if (isConflict && conflictResolution == ConflictResolution.Skip) { return; }
 
+        // Source extension follows the SOURCE project's format, destination the destination's
+        // (issue #4595).
+        bool isSourceJson = GumProjectSave.IsJsonFormat(source.FullFileName ?? "");
         var matchingReference = source.BehaviorReferences?.FirstOrDefault(item => item.Name == behavior.Name);
         string relativeSrc = matchingReference != null
-            ? matchingReference.GetRelativeFilePath()
-            : $"Behaviors/{behavior.Name}.{BehaviorReference.Extension}";
-        string destPath = Path.Combine(projectDir, "Behaviors", $"{behavior.Name}.{BehaviorReference.Extension}");
+            ? matchingReference.GetRelativeFilePath(isSourceJson)
+            : $"Behaviors/{behavior.Name}." + BehaviorExtension(isSourceJson);
+        string destPath = Path.Combine(projectDir, "Behaviors",
+            behavior.Name + "." + BehaviorExtension(IsDestinationJsonFormat));
 
-        if (await CopyElementFileAsync(relativeSrc, sourceBase, destPath) && !isConflict)
+        if (await CopyBehaviorFileAsync(relativeSrc, sourceBase, destPath) && !isConflict)
         {
             _importLogic.ImportBehavior(new FilePath(destPath), saveProject: false);
         }
@@ -550,13 +580,77 @@ public class GumxImportService : IGumxImportService
     /// Standards path: file-copy preserves the source XML byte-for-byte. Standards are not
     /// renamed during import, so no in-memory mutation is required.
     /// </summary>
-    private async Task<bool> CopyElementFileAsync(string relativeSourcePath, string sourceBase, string destPath)
+    /// <summary>
+    /// Fetches a source element/behavior file and writes it to <paramref name="destPath"/> in the
+    /// destination project's own format. The source and destination formats are independent - a
+    /// .gumx source imported into a .gumj project has to be re-serialized, not byte-copied, or the
+    /// destination gets XML inside a .gucj the project can never load (issue #4595).
+    /// </summary>
+    private async Task<bool> CopyElementFileAsync<T>(string relativeSourcePath, string sourceBase, string destPath)
+        where T : ElementSave, new()
     {
         string? content = await _sourceService.FetchElementTextAsync(relativeSourcePath, sourceBase);
         if (content == null) return false;
 
         Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-        await File.WriteAllTextAsync(destPath, content);
+
+        T? element = DeserializeElementText<T>(relativeSourcePath, content);
+        if (element == null) return false;
+
+        element.Save(destPath, UseCompact);
         return true;
     }
+
+    /// <summary>Behavior counterpart of <see cref="CopyElementFileAsync{T}"/>.</summary>
+    private async Task<bool> CopyBehaviorFileAsync(string relativeSourcePath, string sourceBase, string destPath)
+    {
+        string? content = await _sourceService.FetchElementTextAsync(relativeSourcePath, sourceBase);
+        if (content == null) return false;
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+
+        BehaviorSave? behavior =
+            string.Equals(FileManager.GetExtension(relativeSourcePath), BehaviorReference.JsonExtension,
+                StringComparison.OrdinalIgnoreCase)
+                ? GumJsonFileSerializer.DeserializeBehavior(content)
+                : GumFileSerializer.DeserializeBehaviorSave(content, GumProjectSave.NativeVersion);
+        if (behavior == null) return false;
+
+        behavior.Save(destPath, UseCompact);
+        return true;
+    }
+
+    /// <summary>
+    /// Deserializes element text whose format is decided by <paramref name="relativeSourcePath"/>'s
+    /// own extension - the source project's format, which need not match the destination's.
+    /// </summary>
+    private static T? DeserializeElementText<T>(string relativeSourcePath, string content)
+        where T : ElementSave, new()
+    {
+        string extension = FileManager.GetExtension(relativeSourcePath);
+        string jsonExtension = new T().GetFileExtension(isJsonFormat: true);
+
+        return string.Equals(extension, jsonExtension, StringComparison.OrdinalIgnoreCase)
+            ? GumJsonFileSerializer.DeserializeElement<T>(content)
+            : GumFileSerializer.DeserializeElementSave<T>(content, GumProjectSave.NativeVersion);
+    }
+
+    private static string ComponentExtension(bool isJsonFormat) =>
+        isJsonFormat ? GumProjectSave.ComponentJsonExtension : GumProjectSave.ComponentExtension;
+
+    private static string ScreenExtension(bool isJsonFormat) =>
+        isJsonFormat ? GumProjectSave.ScreenJsonExtension : GumProjectSave.ScreenExtension;
+
+    private static string StandardExtension(bool isJsonFormat) =>
+        isJsonFormat ? GumProjectSave.StandardJsonExtension : GumProjectSave.StandardExtension;
+
+    private static string BehaviorExtension(bool isJsonFormat) =>
+        isJsonFormat ? BehaviorReference.JsonExtension : BehaviorReference.Extension;
+
+    /// <summary>True when the destination project is JSON-formatted (.gumj).</summary>
+    private bool IsDestinationJsonFormat =>
+        GumProjectSave.IsJsonFormat(_projectState.GumProjectSave?.FullFileName ?? "");
+
+    private bool UseCompact =>
+        _projectState.GumProjectSave?.Version >= (int)GumProjectSave.GumxVersions.AttributeVersion;
 }

--- a/Tools/Gum.Presentation/Managers/DragDropManager.cs
+++ b/Tools/Gum.Presentation/Managers/DragDropManager.cs
@@ -412,7 +412,9 @@ public class DragDropManager : IDragDropManager
             return null;
         }
 
-        var extension = elementSave.FileExtension;
+        // Extension follows the open project's own format so a .gumj project resolves
+        // .gusj/.gucj/.gutj (issue #4595).
+        var extension = elementSave.GetFileExtension(GumProjectSave.IsJsonFormat(gumProject.FullFileName));
 
         var reference =
             gumProject.ScreenReferences.FirstOrDefault(item => item.Name == elementSave.Name) ??
@@ -1033,7 +1035,10 @@ public class DragDropManager : IDragDropManager
             var isTargetRootScreenTreeNode = targetTreeNode.IsTopScreenContainerTreeNode();
             foreach (FilePath file in files)
             {
-                if (file.Extension == GumProjectSave.ScreenExtension && isTargetRootScreenTreeNode)
+                // A JSON-format screen file drops the same way its XML counterpart does (issue #4595).
+                bool isScreenFile = file.Extension == GumProjectSave.ScreenExtension
+                    || file.Extension == GumProjectSave.ScreenJsonExtension;
+                if (isScreenFile && isTargetRootScreenTreeNode)
                 {
                     _importLogic.ImportScreen(file);
                 }

--- a/Tools/Gum.Presentation/Managers/ProjectManager.cs
+++ b/Tools/Gum.Presentation/Managers/ProjectManager.cs
@@ -534,7 +534,12 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
 
                 string gumProjectDirectory = FileManager.GetDirectory(gumProjectSave.FullFileName);
 
-                gumProjectSave.SaveStandardElements(gumProjectDirectory);
+                // Both flags must be passed explicitly: the defaults (verbose XML) would recreate
+                // the standard as a .gutx a .gumj project never loads back, and in a compact-format
+                // project would write a verbose file its siblings don't match (issue #4595).
+                gumProjectSave.SaveStandardElements(gumProjectDirectory,
+                    useCompact: gumProjectSave.Version >= (int)GumProjectSave.GumxVersions.AttributeVersion,
+                    isJsonFormat: GumProjectSave.IsJsonFormat(gumProjectSave.FullFileName));
             }
         }
 
@@ -657,7 +662,12 @@ public class ProjectManager : IProjectManager, IDeleteProjectProvider, ICopyPast
                 }
                 catch (UnauthorizedAccessException exception)
                 {
-                    var tempFileName = FileManager.RemoveExtension(GumProjectSave.FullFileName) + DateTime.Now.ToString("s") + "gumx";
+                    // Keep the project's own extension so the fallback copy saves in the same format
+                    // (and stays loadable). "s" formats as 2026-09-03T12:34:56, whose colons are
+                    // illegal in a Windows file name, so use a colon-free stamp (issue #4595).
+                    var tempFileName = FileManager.RemoveExtension(GumProjectSave.FullFileName)
+                        + DateTime.Now.ToString("yyyy-MM-ddTHH-mm-ss")
+                        + "." + FileManager.GetExtension(GumProjectSave.FullFileName);
                     _retryService.TryMultipleTimes(() => GumProjectSave.Save(tempFileName, saveContainedElements));
 
                     string fileName = TryGetFileNameFromException(exception);

--- a/Tools/Gum.Presentation/StateAnimationPlugin/AnimationTabRefreshLogic.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/AnimationTabRefreshLogic.cs
@@ -1,3 +1,4 @@
+using Gum.StateAnimation.SaveClasses;
 using Gum.DataTypes;
 using Gum.DataTypes.Variables;
 using StateAnimationPlugin.Managers;
@@ -19,14 +20,16 @@ public static class AnimationTabRefreshLogic
 {
     /// <summary>
     /// Decides whether an on-disk file change should live-reload the Animations tab (issue #3410):
-    /// true only when <paramref name="changedFile"/> is a <c>.ganx</c> and is the selected element's
-    /// own animation sidecar (<paramref name="selectedElementAnimationFile"/>). Other elements' .ganx
-    /// files reload lazily when that element is next selected, so they are ignored here.
+    /// true only when <paramref name="changedFile"/> is an animation sidecar (<c>.ganx</c> or its
+    /// JSON counterpart <c>.ganj</c>) and is the selected element's own sidecar
+    /// (<paramref name="selectedElementAnimationFile"/>). Other elements' sidecars reload lazily
+    /// when that element is next selected, so they are ignored here.
     /// </summary>
     public static bool ShouldReloadAnimationsForChangedFile(FilePath changedFile,
         FilePath? selectedElementAnimationFile)
     {
-        if (changedFile.Extension != "ganx")
+        if (changedFile.Extension != ElementAnimationsSave.FileExtension &&
+            changedFile.Extension != ElementAnimationsSave.JsonFileExtension)
         {
             return false;
         }

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/AnimationFilePathService.cs
@@ -1,3 +1,4 @@
+using Gum.StateAnimation.SaveClasses;
 using Gum.Commands;
 using Gum.DataTypes;
 using Gum.Managers;
@@ -25,7 +26,7 @@ public class AnimationFilePathService : IAnimationFilePathService
     /// happened to resolve for the element itself.
     /// </summary>
     private string AnimationsFileNameSuffix =>
-        "Animations." + (GumProjectSave.IsJsonFormat(_projectManager.GumProjectSave?.FullFileName ?? "") ? "ganj" : "ganx");
+        ElementAnimationsSave.GetFileNameSuffix(GumProjectSave.IsJsonFormat(_projectManager.GumProjectSave?.FullFileName ?? ""));
 
     /// <inheritdoc/>
     public FilePath? GetAbsoluteAnimationFileNameFor(string elementName)

--- a/Tools/Gum.Presentation/StateAnimationPlugin/Managers/RenameManager.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/Managers/RenameManager.cs
@@ -77,11 +77,15 @@ namespace StateAnimationPlugin.Managers
                 }
                 var projectDirectory = FileManager.GetDirectory(gumProject.FullFileName);
 
-                var oldFile = new FilePath( projectDirectory + elementSave.Subfolder + "/" + oldName + "Animations.ganx");
-                
+                // Suffix follows the open project's own format so a .gumj project moves .ganj
+                // rather than looking for a .ganx that doesn't exist (issue #4595).
+                var suffix = ElementAnimationsSave.GetFileNameSuffix(GumProjectSave.IsJsonFormat(gumProject.FullFileName));
+
+                var oldFile = new FilePath( projectDirectory + elementSave.Subfolder + "/" + oldName + suffix);
+
                 if(oldFile.Exists())
                 {
-                    var newFile = new FilePath(projectDirectory + elementSave.Subfolder + "/" + elementSave.Name + "Animations.ganx");
+                    var newFile = new FilePath(projectDirectory + elementSave.Subfolder + "/" + elementSave.Name + suffix);
 
                     var newDirectory = newFile.GetDirectoryContainingThis();
 
@@ -184,7 +188,7 @@ namespace StateAnimationPlugin.Managers
                 {
                     try
                     {
-                        var animationSave = FileManager.XmlDeserialize<ElementAnimationsSave>(fileName.FullPath);
+                        var animationSave = ElementAnimationsSave.Load(fileName.FullPath);
 
                         var potentialAnimations = animationSave.Animations
                             .SelectMany(item => item.Animations)
@@ -208,7 +212,7 @@ namespace StateAnimationPlugin.Managers
 
                         if(didChange)
                         {
-                            FileManager.XmlSerialize(animationSave, fileName.FullPath);
+                            animationSave.Save(fileName.FullPath);
                         }
                     }
                     catch (Exception e)

--- a/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/SubAnimationSelectionDialogViewModel.cs
@@ -80,7 +80,7 @@ public class SubAnimationSelectionDialogViewModel : DialogViewModel
 
             try
             {
-                save = FileManager.XmlDeserialize<ElementAnimationsSave>(fileName.FullPath);
+                save = ElementAnimationsSave.Load(fileName.FullPath);
             }
             catch (Exception exception)
             {

--- a/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/CodeGenerator.cs
@@ -1,6 +1,7 @@
 using Gum.Converters;
 using Gum.DataTypes;
 using Gum.DataTypes.Behaviors;
+using Gum.DataTypes.Serialization.Json;
 using Gum.DataTypes.Variables;
 using Gum.Localization;
 using Gum.Managers;
@@ -3732,8 +3733,12 @@ public class CodeGenerator
             return null;
         }
 
-        FilePath animationFileName = fullPathXmlForElement.RemoveExtension().FullPath + "Animations.ganx";
-        
+        // Suffix follows the open project's own format so a .gumj project finds .ganj rather than
+        // silently generating code with no animations (issue #4595).
+        bool isJsonFormat = GumProjectSave.IsJsonFormat(ObjectFinder.Self.GumProjectSave?.FullFileName ?? "");
+        FilePath animationFileName = fullPathXmlForElement.RemoveExtension().FullPath +
+            ElementAnimationsSave.GetFileNameSuffix(isJsonFormat);
+
         if (!animationFileName.Exists())
         {
             return null;
@@ -3741,7 +3746,7 @@ public class CodeGenerator
 
         try
         {
-            return FileManager.XmlDeserialize<ElementAnimationsSave>(animationFileName.FullPath);
+            return ElementAnimationsSave.Load(animationFileName.FullPath);
         }
         catch
         {

--- a/Tools/Gum.ProjectServices/CodeGeneration/ElementFilePathHelper.cs
+++ b/Tools/Gum.ProjectServices/CodeGeneration/ElementFilePathHelper.cs
@@ -14,6 +14,15 @@ public static class ElementFilePathHelper
     /// <paramref name="forcedElementName"/> to resolve the path the element had under a different
     /// name, which rename uses to locate files still sitting at the old name.
     /// </summary>
+    /// <remarks>
+    /// The extension is always the XML one - this helper has no access to the project's own file
+    /// name, so it cannot tell a .gumx project from a .gumj one. Every caller today uses the result
+    /// only via <c>RemoveExtension()</c> to reach a sibling file (.codsj settings, the Animations
+    /// sidecar), where the extension is inert. Do NOT use it to read or write the element file
+    /// itself: inside a .gumj project that path points at a file the project never loads back
+    /// (issue #4595). Use <c>IFileCommands.GetFullPathXmlFile</c> (tool) or
+    /// <see cref="ElementSave.GetFileExtension(bool)"/> with the project's format instead.
+    /// </remarks>
     public static FilePath? GetFullPathXmlFile(ElementSave? element, string? projectDirectory,
         string? forcedElementName = null)
     {

--- a/Tools/Gum.ProjectServices/ConvertProjectToJsonService.cs
+++ b/Tools/Gum.ProjectServices/ConvertProjectToJsonService.cs
@@ -151,15 +151,15 @@ public class ConvertProjectToJsonService : IConvertProjectToJsonService
         }
 
         string elementXmlPath = GetElementXmlPath(element, projectDirectory);
-        string animationXmlPath = FileManager.RemoveExtension(elementXmlPath) + "Animations.ganx";
+        string animationXmlPath = FileManager.RemoveExtension(elementXmlPath) + ElementAnimationsSave.GetFileNameSuffix(isJsonFormat: false);
 
         if (!FileManager.FileExists(animationXmlPath))
         {
             return 0;
         }
 
-        ElementAnimationsSave animations = FileManager.XmlDeserialize<ElementAnimationsSave>(animationXmlPath);
-        string animationJsonPath = FileManager.RemoveExtension(elementXmlPath) + "Animations.ganj";
+        ElementAnimationsSave animations = ElementAnimationsSave.Load(animationXmlPath);
+        string animationJsonPath = FileManager.RemoveExtension(elementXmlPath) + ElementAnimationsSave.GetFileNameSuffix(isJsonFormat: true);
         _fileWatchIgnoreList.IgnoreNextChangeUntil(animationJsonPath);
         GumJsonFileSerializer.WriteToFile(animationJsonPath, GumAnimationJsonFileSerializer.SerializeElementAnimations(animations));
 

--- a/Tools/Gum.ProjectServices/FileElementAnimationsProvider.cs
+++ b/Tools/Gum.ProjectServices/FileElementAnimationsProvider.cs
@@ -1,4 +1,5 @@
 using Gum.DataTypes;
+using Gum.DataTypes.Serialization.Json;
 using Gum.ProjectServices.CodeGeneration;
 using Gum.StateAnimation.SaveClasses;
 using System;
@@ -34,7 +35,10 @@ public class FileElementAnimationsProvider : IElementAnimationsProvider
             return null;
         }
 
-        FilePath animationFilePath = elementXmlPath.RemoveExtension() + "Animations.ganx";
+        // Suffix follows the project's own format so a .gumj project finds .ganj rather than
+        // silently reporting no animations (issue #4595).
+        FilePath animationFilePath = elementXmlPath.RemoveExtension() +
+            ElementAnimationsSave.GetFileNameSuffix(GumProjectSave.IsJsonFormat(project.FullFileName));
         if (!animationFilePath.Exists())
         {
             return null;
@@ -48,7 +52,7 @@ public class FileElementAnimationsProvider : IElementAnimationsProvider
             return cached.Animations;
         }
 
-        ElementAnimationsSave animations = FileManager.XmlDeserialize<ElementAnimationsSave>(fullPath);
+        ElementAnimationsSave animations = ElementAnimationsSave.Load(fullPath);
         _cache[fullPath] = new CachedAnimations(lastWriteUtc, animations);
         return animations;
     }

--- a/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
+++ b/Tools/Gum.ProjectServices/HeadlessErrorChecker.cs
@@ -103,7 +103,7 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
         {
             errors.AddRange(GetBehaviorErrorsFor(asComponent, project));
         }
-        errors.AddRange(GetMissingSourceFileErrorsFor(element));
+        errors.AddRange(GetMissingSourceFileErrorsFor(element, project));
         errors.AddRange(GetMissingExternalFileErrorsFor(element, project));
         errors.AddRange(GetMissingElementBaseTypeErrorFor(element));
         errors.AddRange(GetMissingBaseTypeErrorsFor(element));
@@ -525,13 +525,14 @@ public class HeadlessErrorChecker : IHeadlessErrorChecker
     /// comment in ElementReference.ToElementSave), because saving the element is exactly what
     /// recreates the missing file.
     /// </summary>
-    private static List<ErrorResult> GetMissingSourceFileErrorsFor(ElementSave element)
+    private static List<ErrorResult> GetMissingSourceFileErrorsFor(ElementSave element, GumProjectSave project)
     {
         var errors = new List<ErrorResult>();
 
         if (element.IsSourceFileMissing)
         {
-            var expectedRelativePath = $"{element.Subfolder}/{element.Name}.{element.FileExtension}";
+            var expectedRelativePath = $"{element.Subfolder}/{element.Name}." +
+                element.GetFileExtension(GumProjectSave.IsJsonFormat(project?.FullFileName ?? ""));
             errors.Add(new ErrorResult
             {
                 ElementName = element.Name,


### PR DESCRIPTION
Fixes #4595.

Saving a component in a `.gumj` project wrote `Components/Foo.gucx` — XML, at a path the project never loads. The tool reported "Saved" and the edit was gone at the next load. Nine call sites composed paths from the bare XML extension; this routes all of them through the project's format.

**Worst case was the animation sidecar.** Its extension and its serializer were decided in different places: `AnimationFilePathService` resolved `.ganj` correctly (#4182), but the manager still called `FileManager.XmlSerialize`, while the converter wrote real JSON and the runtime's `GumAnimationLoader` JSON-parses every `*Animations.ganj`. On a converted project the Animations tab showed **zero animations** and the next save overwrote them; once the tab had written the file, the tool looked fine but the game failed to load it.

## Fix

The format becomes the single source of truth at each layer: `ElementSave.GetFileExtension(bool)`, `ElementAnimationsSave.Load`/`.Save` (dispatching on the file's own extension, as `ElementSave.Save` already did), and `ElementAnimationsSave.GetFileNameSuffix(bool)`.

Sites corrected: element and behavior save/rename/delete, the tree view, drag/drop of `.gusj`, standard-element recreation (which also dropped `useCompact`), CLI `check-references --fix`, gumx import, codegen and error checking, bundle project resolution, and the read-only-save fallback filename (which also contained colons — illegal on Windows).

Import and copy paths now deserialize and re-save instead of byte-copying: the source project's format is independent of the destination's, so a copy puts XML inside a `.gucj`, or inside a `.ganj` the runtime can't parse.

## Tests

- `ProjectFormatExtensionGuardTests` — source-scan ratchet over bare extension constants and raw animation serializers, with documented baselines for every sanctioned exception. The compiler can't tell a correct extension string from an incorrect one, and this defect had already appeared independently in nine places.
- `JsonProjectFormatRoundTripTests` — save→load for elements, behaviors, and animations in both formats, plus a full convert-to-JSON round trip.
- Targeted pins in `FileCommandsTests`, `AnimationCollectionViewModelManagerTests`, `GumxImportServiceTests`, `CheckReferencesCommandTests`, `AnimationTabRefreshLogicTests`.

Verified the pins catch the regression by temporarily reverting `ElementAnimationsSave.Save` to always-XML — four tests failed, then passed on restore.

Three existing `GumxImportServiceTests` asserted byte-for-byte copies using a synthetic `<Marker>` field that isn't real `BehaviorSave` data. Re-serialization is the intended change, so they now assert round-trippable content; `CopiesJsonAnimationSidecar` pins the corrected normalization (a `.ganj` imported into a `.gumx` project becomes `.ganx`) and gains the mirror case.

Also updated the `gum-tool-save-classes` skill, which claimed Gum is XML-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MT9WBGoqSURZt9Msjk2vNZ