### PR TITLE
Open a .gumx/.gumj dropped anywhere on the Gum window

### DIFF
--- a/Gum/CommandLine/CommandLineManager.cs
+++ b/Gum/CommandLine/CommandLineManager.cs
@@ -111,12 +111,7 @@ namespace Gum.CommandLine
                             // The containing project may itself be XML or JSON-formatted (issue #4182) -
                             // whichever project file sits next to the element wins.
                             GlueProjectToLoad = System.IO.Directory.GetFiles(gluxDirectory)
-                                .FirstOrDefault(item =>
-                                {
-                                    string lowerItem = item.ToLowerInvariant();
-                                    return lowerItem.EndsWith("." + GumProjectSave.ProjectExtension) ||
-                                        lowerItem.EndsWith("." + GumProjectSave.ProjectJsonExtension);
-                                });
+                                .FirstOrDefault(GumProjectSave.IsProjectFile);
                         }
 
                     }

--- a/Gum/MainWindow.xaml.cs
+++ b/Gum/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindow
         IMessenger messenger,
         IHotkeyManager hotkeyManager,
         ISelectionHistory selectionHistory,
+        IProjectFileDropLogic projectFileDropLogic,
         IWritableOptions<LayoutSettings> layoutSettings
         )
     {
@@ -52,11 +53,40 @@ public partial class MainWindow : WindowChromeWindow, IRecipient<CloseMainWindow
             e.Handled = keyArgs.Handled;
         };
         this.PreviewMouseDown += OnPreviewMouseDown;
+
+        // Dropping a project file anywhere in the window opens it, the same as File > Load Project.
+        // Tunneling handlers, so the drop wins over the wireframe canvas and the element tree, which
+        // both accept file drops of their own but reject a .gumx/.gumj.
+        this.AllowDrop = true;
+        DragEventHandler acceptProjectDrag = (_, e) =>
+        {
+            if (projectFileDropLogic.GetProjectFileToOpen(GetDroppedFiles(e)) != null)
+            {
+                e.Effects = DragDropEffects.Copy;
+                e.Handled = true;
+            }
+        };
+        // DragEnter as well as DragOver, so the wireframe never gets to report the drag as rejected.
+        this.PreviewDragEnter += acceptProjectDrag;
+        this.PreviewDragOver += acceptProjectDrag;
+        this.PreviewDrop += (_, e) =>
+        {
+            if (projectFileDropLogic.TryOpenDroppedProject(GetDroppedFiles(e)))
+            {
+                e.Handled = true;
+            }
+        };
+
         this.Loaded += (_, _) =>
         {
             mainWindowViewModel.LoadWindowSettings(layoutSettings.CurrentValue.MainWindow);
         };
     }
+
+    private static string[]? GetDroppedFiles(DragEventArgs e) =>
+        e.Data?.GetDataPresent(DataFormats.FileDrop) == true
+            ? e.Data.GetData(DataFormats.FileDrop) as string[]
+            : null;
 
     private void OnPreviewMouseDown(object sender, MouseButtonEventArgs e)
     {

--- a/Gum/Services/Builder.cs
+++ b/Gum/Services/Builder.cs
@@ -212,6 +212,7 @@ file static class ServiceCollectionExtensions
         services.AddSingleton<IExposeVariableService, ExposeVariableService>();
         services.AddSingleton<IStateEditingIndicatorService, StateEditingIndicatorService>();
         services.AddSingleton<IDragDropManager, DragDropManager>();
+        services.AddSingleton<IProjectFileDropLogic, ProjectFileDropLogic>();
         services.AddSingleton<MenuStripManager>();
         services.AddSingleton<IScreenImportService, ScreenImportService>();
         services.AddSingleton<ImportLogic>();

--- a/GumDataTypes/GumProjectSave.cs
+++ b/GumDataTypes/GumProjectSave.cs
@@ -853,6 +853,18 @@ public class GumProjectSave
     public static bool IsJsonFormat(string fileName) =>
         string.Equals(FileManager.GetExtension(fileName), ProjectJsonExtension, StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// True when <paramref name="fileName"/> is a Gum project file in either format -
+    /// <see cref="ProjectExtension"/> or <see cref="ProjectJsonExtension"/>, case-insensitive.
+    /// Use this rather than hand-rolling the pair of extension comparisons.
+    /// </summary>
+    public static bool IsProjectFile(string fileName)
+    {
+        string extension = FileManager.GetExtension(fileName);
+        return string.Equals(extension, ProjectExtension, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ProjectJsonExtension, StringComparison.OrdinalIgnoreCase);
+    }
+
 #if NET5_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026",
         Justification = "Serializes this GumProjectSave instance, which GumCommon's ILLink.Descriptors.xml preserves in full (preserve=\"all\").")]

--- a/Tests/Gum.Presentation.Tests/ProjectFileDropLogicTests.cs
+++ b/Tests/Gum.Presentation.Tests/ProjectFileDropLogicTests.cs
@@ -1,0 +1,72 @@
+using Gum.Commands;
+using Gum.Managers;
+using Moq;
+using Shouldly;
+using System.Collections.Generic;
+
+namespace Gum.Presentation.Tests;
+
+public class ProjectFileDropLogicTests
+{
+    private readonly Mock<IFileCommands> _fileCommands = new();
+    private readonly ProjectFileDropLogic _logic;
+
+    public ProjectFileDropLogicTests()
+    {
+        _logic = new ProjectFileDropLogic(_fileCommands.Object);
+    }
+
+    [Theory]
+    [InlineData(@"C:\Projects\MyGame\MyGame.gumx")]
+    [InlineData(@"C:\Projects\MyGame\MyGame.gumj")]
+    // Windows Explorer hands over whatever casing is on disk, so the check can't be ordinal.
+    [InlineData(@"C:\Projects\MyGame\MyGame.GUMX")]
+    public void TryOpenDroppedProject_ProjectFile_LoadsIt(string droppedFile)
+    {
+        _logic.TryOpenDroppedProject(new List<string> { droppedFile }).ShouldBeTrue();
+
+        _fileCommands.Verify(f => f.LoadProject(droppedFile), Times.Once);
+    }
+
+    [Fact]
+    public void TryOpenDroppedProject_NonProjectFiles_LoadsNothing()
+    {
+        List<string> dropped = new() { @"C:\Art\Icon.png", @"C:\Projects\MyGame\Screens\Main.gusx" };
+
+        _logic.TryOpenDroppedProject(dropped).ShouldBeFalse();
+
+        _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void TryOpenDroppedProject_MixedDrop_LoadsOnlyTheProject()
+    {
+        List<string> dropped = new() { @"C:\Art\Icon.png", @"C:\Projects\MyGame\MyGame.gumx" };
+
+        _logic.TryOpenDroppedProject(dropped).ShouldBeTrue();
+
+        _fileCommands.Verify(f => f.LoadProject(@"C:\Projects\MyGame\MyGame.gumx"), Times.Once);
+        _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void TryOpenDroppedProject_NoFiles_LoadsNothing()
+    {
+        // A drag of something that isn't a file at all (a tree node, a Standards-palette chip)
+        // carries no file list.
+        _logic.TryOpenDroppedProject(null).ShouldBeFalse();
+        _logic.TryOpenDroppedProject(new List<string>()).ShouldBeFalse();
+
+        _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void GetProjectFileToOpen_DoesNotLoad()
+    {
+        // The drag-over decision runs on every mouse move; it must stay a pure query.
+        _logic.GetProjectFileToOpen(new List<string> { @"C:\Projects\MyGame\MyGame.gumx" })
+            .ShouldBe(@"C:\Projects\MyGame\MyGame.gumx");
+
+        _fileCommands.Verify(f => f.LoadProject(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/Tools/Gum.Presentation/Managers/ProjectFileDropLogic.cs
+++ b/Tools/Gum.Presentation/Managers/ProjectFileDropLogic.cs
@@ -1,0 +1,53 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gum.Managers;
+
+/// <summary>
+/// Decides whether a set of dropped files is a request to open a Gum project, and opens it. Backs
+/// the app-wide drop handler on the main window, so dropping a .gumx/.gumj anywhere in the tool
+/// behaves like File &gt; Load Project.
+/// </summary>
+public interface IProjectFileDropLogic
+{
+    /// <summary>
+    /// The project file that a drop of <paramref name="droppedFiles"/> would open, or null if the
+    /// drop carries no project file. A pure query - safe to call repeatedly while dragging.
+    /// </summary>
+    string? GetProjectFileToOpen(IEnumerable<string>? droppedFiles);
+
+    /// <summary>
+    /// Opens the project among <paramref name="droppedFiles"/>, if there is one. Returns true when
+    /// the drop was consumed, so the caller can stop it from reaching the control underneath.
+    /// </summary>
+    bool TryOpenDroppedProject(IEnumerable<string>? droppedFiles);
+}
+
+/// <inheritdoc cref="IProjectFileDropLogic"/>
+public class ProjectFileDropLogic : IProjectFileDropLogic
+{
+    private readonly IFileCommands _fileCommands;
+
+    public ProjectFileDropLogic(IFileCommands fileCommands)
+    {
+        _fileCommands = fileCommands;
+    }
+
+    /// <inheritdoc/>
+    public string? GetProjectFileToOpen(IEnumerable<string>? droppedFiles) =>
+        droppedFiles?.FirstOrDefault(GumProjectSave.IsProjectFile);
+
+    /// <inheritdoc/>
+    public bool TryOpenDroppedProject(IEnumerable<string>? droppedFiles)
+    {
+        if (GetProjectFileToOpen(droppedFiles) is not { } projectFile)
+        {
+            return false;
+        }
+
+        _fileCommands.LoadProject(projectFile);
+        return true;
+    }
+}


### PR DESCRIPTION
Dropping a `.gumx` or `.gumj` anywhere on the Gum window now opens it, same as File > Load Project.

`MainWindow` sets `AllowDrop` and hands the dropped paths to a new `ProjectFileDropLogic` (headless, in `Gum.Presentation`), which loads via `IFileCommands.LoadProject` — the same call the recent-files menu makes. Handlers are tunneling (`PreviewDragEnter`/`Over`/`Drop`) so the wireframe canvas and element tree, which accept file drops of their own but reject project files, never see the drag.

Dropping onto the `.exe` already worked via the command-line path; this covers the running window.

Boyscout: added `GumProjectSave.IsProjectFile` for the `.gumx`/`.gumj` pair check and used it to replace `CommandLineManager`'s hand-rolled lowercase `EndsWith`.

Closes #4593
