### PR TITLE
Converge raylib SystemManagers.Initialize() gaps from #4577 (missing-file behavior, dead-flag mirroring)

### DIFF
--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -39,7 +39,12 @@ namespace RenderingLibrary;
 public partial class SystemManagers : ISystemManagers
 {
     int mPrimaryThreadId;
+#if !RAYLIB
+    // Feeds Renderer.NotifyHostFrameAdvanced() below, which doesn't exist on raylib's own Renderer.
+    // Mirrored as dead code in raylib's SystemManagers.cs so the two files stay line-for-line
+    // comparable; porting this to raylib is tracked separately (#4598).
     private double _lastActivityTime = double.NaN;
+#endif
 
     static bool IsMobile =>
         System.OperatingSystem.IsAndroid() ||
@@ -216,6 +221,10 @@ public partial class SystemManagers : ISystemManagers
 
         mPrimaryThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
 
+        // Recreated on every Initialize() call (e.g. graphics-device-loss recovery). raylib has no
+        // such concept and instead creates its Renderer once in its constructor, never recreating it
+        // here - not unified for now; revisit only if raylib ever needs to re-run Initialize() on an
+        // existing instance (#4577).
         Renderer = new Renderer();
         Renderer.Initialize(graphicsDevice, this);
 
@@ -266,7 +275,14 @@ public partial class SystemManagers : ISystemManagers
 
             GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
             GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
+
+#if !RAYLIB
+            // Currently has no reader (SpriteRenderer.cs's check is commented out) - kept live here
+            // for parity with the flag's original intent, but not ported to raylib, whose Renderer has
+            // no equivalent member. Mirrored as dead code in raylib's SystemManagers.cs so the two
+            // files stay line-for-line comparable (#4577).
             Renderer.ApplyCameraZoomOnWorldTranslation = true;
+#endif
 
             Renderer.Camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
 
@@ -274,9 +290,18 @@ public partial class SystemManagers : ISystemManagers
 
             StandardElementsManager.Self.Initialize();
 
+#if !RAYLIB
+            // raylib's Text class has no equivalent member - mirrored as dead code in raylib's
+            // SystemManagers.cs so the two files stay line-for-line comparable (#4577).
             Text.RenderBoundaryDefault = false;
+#endif
 
+#if !RAYLIB
+            // raylib apps commonly use their own resources folder; defaulting this here would be an
+            // unwarranted assumption for raylib, so this stays XNA/KNI/FNA-only. Mirrored as dead code
+            // in raylib's SystemManagers.cs so the two files stay line-for-line comparable (#4577).
             ToolsUtilities.FileManager.RelativeDirectory = "Content/";
+#endif
 
             RegisterComponentRuntimeInstantiations();
 
@@ -343,11 +368,13 @@ public partial class SystemManagers : ISystemManagers
     /// <exception cref="InvalidOperationException">Exception thrown if the SystemManagers hasn't yet been initialized.</exception>
     public void Activity(double currentTime)
     {
+#if !RAYLIB
         if (currentTime != _lastActivityTime)
         {
             _lastActivityTime = currentTime;
             Renderer.NotifyHostFrameAdvanced();
         }
+#endif
 
 #if !RAYLIB
 #if FULL_DIAGNOSTICS

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -22,6 +22,12 @@ namespace RenderingLibrary;
 public partial class SystemManagers : ISystemManagers
 {
     int mPrimaryThreadId;
+#if !RAYLIB
+    // Mirrors RenderingLibrary/SystemManagers.cs's _lastActivityTime, which feeds
+    // Renderer.NotifyHostFrameAdvanced() - not ported here since raylib's own Renderer has no
+    // equivalent member. Dead in this build; kept for cross-file diff parity. Tracked separately (#4598).
+    private double _lastActivityTime = double.NaN;
+#endif
 
     static bool IsMobile =>
     System.OperatingSystem.IsAndroid() ||
@@ -104,6 +110,10 @@ public partial class SystemManagers : ISystemManagers
 
     public SystemManagers()
     {
+        // Unlike XNA/KNI/FNA's Initialize() (which recreates Renderer on every call), raylib creates
+        // its Renderer once here and Initialize() never touches it - raylib doesn't have MonoGame's
+        // graphics-device-loss concept that motivated the XNA behavior. Not unified for now; revisit
+        // only if raylib ever needs to re-run Initialize() on an existing instance (#4577).
         Renderer = new Renderer();
     }
 
@@ -115,11 +125,11 @@ public partial class SystemManagers : ISystemManagers
         // (MonoGame/KNI/FNA) line-for-line wherever raylib has an equivalent, so the two files
         // stay easy to diff against each other as they converge (#4576: raylib's copy had
         // silently dropped the LocalizationService/ThrowExceptionsForMissingFiles wiring below
-        // because nothing kept the two in sync). Steps XNA has that raylib genuinely cannot
-        // (embedded font preloading, Renderer.ApplyCameraZoomOnWorldTranslation,
-        // Text.RenderBoundaryDefault, GraphicalUiElement.MissingFileBehavior - none of those
-        // members exist on raylib's own Renderer/Text) are intentionally omitted rather than
-        // stubbed out; tracked as remaining convergence gaps in #4577.
+        // because nothing kept the two in sync). Embedded font preloading has no raylib equivalent
+        // and is intentionally omitted. Renderer.ApplyCameraZoomOnWorldTranslation and
+        // Text.RenderBoundaryDefault don't exist on raylib's own Renderer/Text at all, and the
+        // Content/-folder default is intentionally XNA/KNI/FNA-only - all three are mirrored below
+        // as dead #if !RAYLIB code so the two files stay line-for-line comparable (#4577).
         if(fullInstantiation)
         {
             LoaderManager.Self.ContentLoader = new ContentLoader();
@@ -138,18 +148,27 @@ public partial class SystemManagers : ISystemManagers
             GraphicalUiElement.AddRenderableToManagers = CustomSetPropertyOnRenderable.AddRenderableToManagers;
             GraphicalUiElement.RemoveRenderableFromManagers = CustomSetPropertyOnRenderable.RemoveRenderableFromManagers;
 
+#if !RAYLIB
+            Renderer.ApplyCameraZoomOnWorldTranslation = true;
+#endif
+
             Renderer.Camera.CameraCenterOnScreen = CameraCenterOnScreen.TopLeft;
 
             ElementSaveExtensions.CustomCreateGraphicalComponentFunc = RenderableCreator.HandleCreateGraphicalComponent;
 
             StandardElementsManager.Self.Initialize();
 
-            // raylib seems to use a resources folder, but I don't think we should make any
-            // assumptions (unlike MonoGame/KNI/FNA, which default ToolsUtilities.FileManager.RelativeDirectory
-            // to "Content/" here - see #4577).
-            //ToolsUtilities.FileManager.RelativeDirectory = "Content/";
+#if !RAYLIB
+            Text.RenderBoundaryDefault = false;
+#endif
+
+#if !RAYLIB
+            ToolsUtilities.FileManager.RelativeDirectory = "Content/";
+#endif
 
             RegisterComponentRuntimeInstantiations();
+
+            GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ThrowException;
         }
     }
 
@@ -200,6 +219,14 @@ public partial class SystemManagers : ISystemManagers
     /// <exception cref="InvalidOperationException">Exception thrown if the SystemManagers hasn't yet been initialized.</exception>
     public void Activity(double currentTime)
     {
+#if !RAYLIB
+        if (currentTime != _lastActivityTime)
+        {
+            _lastActivityTime = currentTime;
+            Renderer.NotifyHostFrameAdvanced();
+        }
+#endif
+
 #if !RAYLIB
 #if FULL_DIAGNOSTICS
         if (SpriteManager == null)

--- a/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
+++ b/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
@@ -91,6 +91,28 @@ public class GumServiceInitializeTests
     }
 
     [Fact]
+    public void Initialize_ShouldSetMissingFileBehaviorToThrowException()
+    {
+        // Same shape as Initialize_ShouldAssignThrowExceptionsForMissingFilesDelegate above:
+        // MonoGame/KNI/FNA's SystemManagers.Initialize() sets this to ThrowException, but raylib's
+        // never did, leaving raylib on the shared ConsumeSilently default (#4577).
+        Gum.GumService.Default.Uninitialize();
+        GraphicalUiElement.MissingFileBehavior = MissingFileBehavior.ConsumeSilently;
+
+        try
+        {
+            Gum.GumService.Default.Initialize(DefaultVisualsVersion.V3);
+
+            GraphicalUiElement.MissingFileBehavior.ShouldBe(MissingFileBehavior.ThrowException);
+        }
+        finally
+        {
+            Gum.GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
     public void Initialize_RegistersRootPopupRootAndModalRootInMainLayer()
     {
         // Tear down the assembly-wide state so we can observe a cold init.

--- a/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
+++ b/Tests/RaylibGum.Tests/GumServiceInitializeTests.cs
@@ -8,6 +8,7 @@ using RenderingLibrary;
 using RenderingLibrary.Graphics;
 using Shouldly;
 using System.Linq;
+using ToolsUtilities;
 
 namespace RaylibGum.Tests;
 
@@ -109,6 +110,54 @@ public class GumServiceInitializeTests
         {
             Gum.GumService.Default.Uninitialize();
             TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldNotChangeRelativeDirectory()
+    {
+        // Unlike MonoGame/KNI/FNA's SystemManagers.Initialize() (which defaults
+        // ToolsUtilities.FileManager.RelativeDirectory to "Content/"), raylib intentionally leaves it
+        // alone: raylib apps commonly use their own resources folder, and defaulting this would be an
+        // unwarranted assumption (#4577).
+        Gum.GumService.Default.Uninitialize();
+        FileManager.RelativeDirectory = System.IO.Path.GetTempPath();
+        string sentinel = FileManager.RelativeDirectory;
+
+        try
+        {
+            Gum.GumService.Default.Initialize(DefaultVisualsVersion.V3);
+
+            FileManager.RelativeDirectory.ShouldBe(sentinel);
+        }
+        finally
+        {
+            Gum.GumService.Default.Uninitialize();
+            TestAssemblyInitialize.ApplyDefaultTestState();
+        }
+    }
+
+    [Fact]
+    public void Initialize_ShouldNotRecreateRenderer()
+    {
+        // Unlike MonoGame/KNI/FNA's SystemManagers.Initialize() (which recreates Renderer on every
+        // call, e.g. to recover from graphics-device loss), raylib creates its Renderer once in its
+        // constructor and Initialize() never touches it (#4577).
+        var sut = new SystemManagers();
+        var rendererBeforeInitialize = sut.Renderer;
+
+        try
+        {
+            sut.Initialize();
+
+            sut.Renderer.ShouldBeSameAs(rendererBeforeInitialize);
+        }
+        finally
+        {
+            // Initialize() re-points the static component-instantiation registry (Polygon/Rectangle/
+            // Text) at whichever SystemManagers instance called it - restore it to SystemManagers.Default
+            // so later tests don't construct runtimes bound to this throwaway instance.
+            SystemManagers.Default.Initialize();
         }
     }
 


### PR DESCRIPTION
Resolves 4 of #4577's 5 decision points (the 5th, `NotifyHostFrameAdvanced`, is split into #4598 since it needs new raylib `Renderer` plumbing).

## Changes

- **`MissingFileBehavior`**: raylib's `Initialize()` now sets `GraphicalUiElement.MissingFileBehavior = ThrowException`, matching XNA/KNI/FNA.
- **Content folder default, `ApplyCameraZoomOnWorldTranslation`, `RenderBoundaryDefault`**: stay XNA-only. Each is now mirrored as dead `#if !RAYLIB` code in raylib's `SystemManagers.cs` (and matching `#if !RAYLIB` added around the XNA copy's lines), so the two files stay line-for-line comparable per the incremental-convergence approach from #4576.
- **Renderer creation timing**: raylib creates `Renderer` once in its constructor; XNA recreates it every `Initialize()` call. Left as-is, with a comment on both sides explaining why (raylib has no graphics-device-loss concept to recover from).

## Testing

- New test: `Initialize_ShouldSetMissingFileBehaviorToThrowException` (red without the fix, green with it).
- Full `RaylibGum.Tests`: 635/635 pass (confirms the global default flip doesn't break any raylib test relying on silent missing-file handling).
- Full `MonoGameGum.Tests`: 2266/2266 pass.
- `KniGum` builds clean.
- FRB canary: pass (0 errors, no new warnings).

Closes #4577
