### PR TITLE
Consolidate runtime package csproj boilerplate into shared props

### DIFF
--- a/Runtimes/RaylibGum/RaylibGum.csproj
+++ b/Runtimes/RaylibGum/RaylibGum.csproj
@@ -1,23 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<Import Project="..\RuntimePackage.props" />
+
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>disable</ImplicitUsings>
-		<Nullable>enable</Nullable>
 		<!-- Building the raylib Font struct from a parsed .fnt requires writing its
 		     Recs/Glyphs pointer arrays (see ContentLoader bitmap-font stream loading, #3037). -->
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.raylib</PackageId>
 		<Version>2026.4.5.1</Version>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
-
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -251,20 +243,7 @@
 		<ProjectReference Include="..\..\GumCommon\GumCommon.csproj" />
 	</ItemGroup>
 
-	<!--
-		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
-		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
-		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
-		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
-		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
-		present, so source-only builds keep working with zero impact.
-	-->
-	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
-		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs/"
-			  Visible="false" />
-	</ItemGroup>
+	<Import Project="..\RuntimePackage.Analyzers.props" />
 
 	<ItemGroup>
 		<Folder Include="Forms\Data\" />
@@ -280,13 +259,10 @@
 	</ItemGroup>
 
 	<!--
-		Guards against a consumer whose own AssemblyName collides with this package's assembly
-		name (RaylibGum), which silently overwrites the runtime DLL in the shared output folder.
-		NuGet auto-imports buildTransitive\Gum.raylib.targets into every consumer; it imports the
-		shared check packed alongside it. See #4311.
+		Gum.raylib.targets (per-package name, so it stays local) imports the shared
+		AssemblyNameCollisionGuard.targets check from RuntimePackage.props. See #4311.
 	-->
 	<ItemGroup>
-		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
 		<None Include="build\Gum.raylib.targets" Pack="true" PackagePath="buildTransitive\Gum.raylib.targets" Visible="false" />
 	</ItemGroup>
 

--- a/Runtimes/RuntimePackage.Analyzers.props
+++ b/Runtimes/RuntimePackage.Analyzers.props
@@ -1,0 +1,18 @@
+<Project>
+  <!--
+    Bundles the Gum.Analyzers Roslyn analyzer DLL into the package so NuGet consumers get GUM001
+    namespace-migration warnings + code fixes. Not a ProjectReference: source-linkers' .sln files
+    must not require Tools/Gum.Analyzers/ to build. The analyzer builds independently (e.g. via
+    AllLibraries.sln / GumFull.sln); the Exists() guard makes this a no-op when the DLL is absent,
+    so source-only builds keep working with zero impact.
+
+    Imported by RaylibGum, SkiaGum, and SilkNetGum. SokolGum does not currently bundle the
+    analyzer — a pre-existing gap this consolidation preserves rather than silently changes.
+  -->
+  <ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('$(MSBuildThisFileDirectory)..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
+    <None Include="$(MSBuildThisFileDirectory)..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/"
+          Visible="false" />
+  </ItemGroup>
+</Project>

--- a/Runtimes/RuntimePackage.props
+++ b/Runtimes/RuntimePackage.props
@@ -1,0 +1,29 @@
+<Project>
+  <!--
+    Shared NuGet package metadata for Gum's runtime host packages (RaylibGum, SokolGum, SkiaGum,
+    SilkNetGum, and any future host package, e.g. a Stride adapter). Each project imports this and
+    layers on its own PackageId, Version, DefineConstants, and item groups. Extracted from four
+    independently copy-pasted csproj blocks (#4601) so a new runtime package doesn't start life as
+    a 5th copy-paste.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
+  </PropertyGroup>
+
+  <!--
+    Guards against a consumer whose own AssemblyName collides with this package's assembly name,
+    which would silently overwrite the runtime DLL in the shared output folder. Each package still
+    declares its own buildTransitive\Gum.<name>.targets locally (filename/PackagePath are
+    package-specific), which imports this shared check. See #4311.
+  -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
+  </ItemGroup>
+</Project>

--- a/Runtimes/SilkNetGum/SilkNetGum.csproj
+++ b/Runtimes/SilkNetGum/SilkNetGum.csproj
@@ -6,31 +6,19 @@
 		SKCanvas + an IInputContext (view.CreateInput()), so this project references
 		Silk.NET.Input only (never Silk.NET.Windowing) and makes no SDL-vs-GLFW commitment.
 
-		It is SELF-CONTAINED like RaylibGum / SokolGum: it references GumCommon only and file-links
-		the shared render + Forms + input source, rather than ProjectReferencing SkiaGum. Splitting
-		the input stack (Cursor / CursorExtensions) from FormsUtilities across an assembly boundary
-		fails to compile — CursorExtensions reaches FormsUtilities' internal LastEventRoots and the
-		concrete GumService — so everything must live in one assembly, the pattern every other
-		runtime already uses. The link set is SkiaGum's render half (its local Renderables /
-		GueDeriving / RenderingLibrary / Helpers / Content source, globbed, plus the same shared
-		GueDeriving / Animation / V3-DefaultVisuals / FormsUtilities links SkiaGum.csproj carries)
-		PLUS the input stack SkiaGum omits because it is render-only.
+		It ProjectReferences SkiaGum.csproj for the render/Forms source and GumServiceSkiaBase
+		(issue #4452 phase 2 — see the ItemGroup comment further down); it is no longer
+		self-contained like RaylibGum/SokolGum. What stays file-linked locally is only the input
+		host half SkiaGum omits because it is render-only (Cursor/CursorExtensions/FormsUtilities'
+		input seam).
 	-->
+	<Import Project="..\RuntimePackage.props" />
+
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.SilkNet</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Version>2026.4.5.1</Version>
-
 		<NoWarn>1591</NoWarn>
-
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
 	</PropertyGroup>
 
 	<!--
@@ -114,29 +102,17 @@
 		<ProjectReference Include="..\SkiaGum\SkiaGum.csproj" />
 	</ItemGroup>
 
-	<!--
-		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers get
-		GUM001 namespace-migration warnings + code fixes. Mirrors SkiaGum/RaylibGum: not a
-		ProjectReference (source-linkers must not require Tools/Gum.Analyzers/ to build), and the
-		Exists() guard makes it a no-op when the DLL is absent.
-	-->
-	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
-		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs/"
-			  Visible="false" />
-	</ItemGroup>
+	<Import Project="..\RuntimePackage.Analyzers.props" />
 
 	<!--
 		Guards against a consumer whose own AssemblyName collides with this package's assembly
 		name (SilkNetGum), which silently overwrites the runtime DLL in the shared output folder
 		(the exact failure this project's own sample worked around - see
-		Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj). NuGet auto-imports
-		buildTransitive\Gum.SilkNet.targets into every consumer; it imports the shared check
-		packed alongside it. See #4311.
+		Samples/SilkNetGum/SilkNetGumSample/SilkNetGumSample.csproj). Gum.SilkNet.targets
+		(per-package name, so it stays local) imports the shared AssemblyNameCollisionGuard.targets
+		check from RuntimePackage.props. See #4311.
 	-->
 	<ItemGroup>
-		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
 		<None Include="build\Gum.SilkNet.targets" Pack="true" PackagePath="buildTransitive\Gum.SilkNet.targets" Visible="false" />
 	</ItemGroup>
 

--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -1,19 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<Import Project="..\RuntimePackage.props" />
+
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.SkiaSharp</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Version>2026.4.5.1</Version>
-
 		<NoWarn>1591</NoWarn>
-
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -184,20 +176,7 @@
 		<InternalsVisibleTo Include="SilkNetGum" />
 	</ItemGroup>
 
-	<!--
-		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
-		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
-		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
-		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
-		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
-		present, so source-only builds keep working with zero impact.
-	-->
-	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
-		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs/"
-			  Visible="false" />
-	</ItemGroup>
+	<Import Project="..\RuntimePackage.Analyzers.props" />
 
 	<ItemGroup>
 		<Folder Include="Xna\" />
@@ -210,13 +189,10 @@
 	</ItemGroup>
 
 	<!--
-		Guards against a consumer whose own AssemblyName collides with this package's assembly
-		name (SkiaGum), which silently overwrites the runtime DLL in the shared output folder.
-		NuGet auto-imports buildTransitive\Gum.SkiaSharp.targets into every consumer; it imports
-		the shared check packed alongside it. See #4311.
+		Gum.SkiaSharp.targets (per-package name, so it stays local) imports the shared
+		AssemblyNameCollisionGuard.targets check from RuntimePackage.props. See #4311.
 	-->
 	<ItemGroup>
-		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
 		<None Include="build\Gum.SkiaSharp.targets" Pack="true" PackagePath="buildTransitive\Gum.SkiaSharp.targets" Visible="false" />
 	</ItemGroup>
 

--- a/Runtimes/SokolGum/SokolGum.csproj
+++ b/Runtimes/SokolGum/SokolGum.csproj
@@ -1,21 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+	<Import Project="..\RuntimePackage.props" />
+
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<RootNamespace>SokolGum</RootNamespace>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Gum.sokol</PackageId>
 		<Version>2026.4.17.1</Version>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Configurations>Debug;Release;Release_No_Diagnostics</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -195,13 +188,10 @@
 	</ItemGroup>
 
 	<!--
-		Guards against a consumer whose own AssemblyName collides with this package's assembly
-		name (SokolGum), which silently overwrites the runtime DLL in the shared output folder.
-		NuGet auto-imports buildTransitive\Gum.sokol.targets into every consumer; it imports the
-		shared check packed alongside it. See #4311.
+		Gum.sokol.targets (per-package name, so it stays local) imports the shared
+		AssemblyNameCollisionGuard.targets check from RuntimePackage.props. See #4311.
 	-->
 	<ItemGroup>
-		<None Include="..\..\AssemblyNameCollisionGuard.targets" Pack="true" PackagePath="buildTransitive\AssemblyNameCollisionGuard.targets" Visible="false" />
 		<None Include="build\Gum.sokol.targets" Pack="true" PackagePath="buildTransitive\Gum.sokol.targets" Visible="false" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
- Extracts the boilerplate `RaylibGum.csproj`/`SokolGum.csproj`/`SkiaGum.csproj`/`SilkNetGum.csproj` each copy-pasted (package metadata PropertyGroup, `AssemblyNameCollisionGuard.targets` wiring) into `Runtimes/RuntimePackage.props`, imported by all four.
- Splits the Gum.Analyzers bundling `ItemGroup` into `Runtimes/RuntimePackage.Analyzers.props`, imported by Raylib/Skia/SilkNet only — SokolGum never had this block, so importing it there unchanged rather than silently adding new behavior.
- Boyscout: fixed a stale comment at the top of `SilkNetGum.csproj` claiming the project is "SELF-CONTAINED... rather than ProjectReferencing SkiaGum" — it does ProjectReference SkiaGum.csproj since #4452 phase 2; the comment directly contradicted a later comment in the same file.
- Genuinely differing settings (`ImplicitUsings`, `AllowUnsafeBlocks`, `PackageId`, `Version`, `GenerateAssemblyInfo`, `NoWarn`) were left per-project, not silently unified.

## Test plan
- `dotnet build` on RaylibGum.csproj, SkiaGum.csproj, SilkNetGum.csproj: 0 errors, same warning counts as before the change.
- Verified the packed `.nupkg` for all three still contains `buildTransitive/AssemblyNameCollisionGuard.targets` at the correct path.
- SokolGum.csproj: confirmed the props import parses (build fails only on the pre-existing, unrelated "Sokol.NET not cloned" errors — expected per repo convention, unverified build not a blocker).

Manual test: not needed — build-file-only change, no runtime behavior; proven by green builds + unchanged package contents.
FRB canary: not needed — no FRB-shared source touched (`Runtimes/*.csproj` only).

Follow-up filed: #4603 (GumShapes csproj duplication + SokolGum's missing analyzer bundling, left out of this PR's scope).

Closes #4601
