### PR TITLE
Defer font realization for per-instance layout suspension, fixing ApplyState font staleness

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2564,30 +2564,32 @@ public partial class CustomSetPropertyOnRenderable
         // reached via SetProperty -> SetPropertyOnRenderable -> TrySetPropertyOnText.
         // The direct-property-setter path goes through GraphicalUiElement.UpdateToFontValues() instead.
         //
-        // KNOWN GAP: the two paths handle suspension differently:
-        //   - GUE.UpdateToFontValues() defers for BOTH IsAllLayoutSuspended and IsLayoutSuspended.
-        //   - This static method only defers for IsAllLayoutSuspended (see reason below).
-        //   This means that when fonts are set by string during ApplyState (which uses instance-level
-        //   SuspendLayout, not IsAllLayoutSuspended), those font loads still happen immediately.
-        //   Fixing that gap requires resolving the cascading-layout issue described below.
+        // Both paths now defer identically, for BOTH IsAllLayoutSuspended and the per-instance
+        // IsLayoutSuspended (#4567). Previously this static method only deferred for the global flag,
+        // so a state applied via ApplyState -- which suspends per-instance, not globally -- realized
+        // each font-affecting property (Font, FontSize, IsBold, ...) immediately as it was set, one at
+        // a time, using whatever the OTHER properties currently held. Since ApplyState applies a
+        // state's variables alphabetically, "Font" is realized before "FontSize"/"IsBold" are even
+        // applied, producing spurious font-cache lookups for combinations that were never the state's
+        // actual final values (and could poison the LoaderManager cache with a fallback font under that
+        // combination's filename, silently serving it to a later, unrelated request for the exact same
+        // combo). Deferring here instead means ApplyState's single SuspendLayout/ResumeLayout pair
+        // around its whole variable loop now also covers font realization: only the FINAL, fully
+        // applied combination is ever looked up, via the existing resume-time flush below.
         //
-        // January 28, 2025 - why we cannot simply early-return for IsLayoutSuspended:
-        // If we defer here, bitmap values are not assigned until layout is later resumed via
-        // ResumeLayoutUpdateIfDirtyRecursive. At that point mIsLayoutSuspended is already false,
-        // so when UpdateFontRecursive assigns the BitmapFont to a Text with Width or Height
-        // RelativeToChildren, it triggers UpdateLayout which cascades up through parents that have
-        // already completed their own layout pass. This causes redundant layout calls throughout
-        // a list box or any deeply nested stack. Solving this would require suppressing that
-        // UpdateLayout call inside UpdateToFontValues when called from UpdateFontRecursive, or
-        // performing a single top-down layout pass at the end rather than cascading bottom-up.
+        // The cascading-UpdateLayout concern this early-return used to be withheld over (the resume-time
+        // flush's own layout, running after mIsLayoutSuspended is already cleared, re-entering already
+        // laid-out parents) is the same one the direct-setter path already solves via
+        // SuppressLayoutFromFontChange during ResumeLayoutUpdateIfDirtyRecursive -- see the "Layout
+        // Suspension / Font Batching" tests in FontServiceTests.cs. That machinery is shared, not
+        // path-specific, so extending the defer to this path inherits the same protection.
         //
-        // IsAllLayoutSuspended is safe to defer because:
-        //   a) WireframeObjectManager calls RootGue.UpdateFontRecursive() before RootGue.UpdateLayout(),
-        //      so any per-element UpdateLayout calls triggered by font assignment are immediately
-        //      superseded by the full UpdateLayout pass.
-        //   b) mIsLayoutSuspended is always false during IsAllLayoutSuspended (ApplyState skips
-        //      SuspendLayout when the global flag is set), so there is no cascading risk.
-        if (GraphicalUiElement.IsAllLayoutSuspended)
+        // GraphicalUiElement.ApplyState's own suspend/resume was made reentrancy-safe alongside this
+        // change: a state's Variables can include a category-state assignment (e.g.
+        // "ButtonCategoryState" = "Highlighted"), which triggers a NESTED ApplyState call on the same
+        // instance mid-loop. ApplyState now skips re-suspending when the instance is already suspended,
+        // so the nested call's own resume doesn't prematurely flush before the outer call finishes.
+        if (GraphicalUiElement.IsAllLayoutSuspended || graphicalUiElement.IsLayoutSuspended)
         {
             graphicalUiElement.IsFontDirty = true;
             return;

--- a/GumRuntime/GraphicalUiElement.cs
+++ b/GumRuntime/GraphicalUiElement.cs
@@ -6824,7 +6824,15 @@ public partial class GraphicalUiElement : IRenderableIpso, IVisible, INotifyProp
         else
         {
             bool didSuspend = false;
-            if (GraphicalUiElement.IsAllLayoutSuspended == false)
+            // Also check this.IsLayoutSuspended: a state's own Variables can include a category-state
+            // assignment (e.g. "ButtonCategoryState" = "Highlighted"), which TrySetValueOnThis resolves
+            // by calling ApplyState AGAIN on this same instance, nested inside this loop. Without this
+            // check, that nested call would see IsAllLayoutSuspended still false, suspend/resume on its
+            // own, and its ResumeLayout would prematurely clear mIsLayoutSuspended -- and flush any
+            // deferred font load -- before THIS (outer) call finishes applying its own remaining
+            // variables (#4567). Skipping suspend/resume when already suspended lets the nested call's
+            // variables apply under the outer suspension, so only the outermost ApplyState flushes.
+            if (GraphicalUiElement.IsAllLayoutSuspended == false && this.IsLayoutSuspended == false)
             {
                 didSuspend = true;
                 this.SuspendLayout(true);

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -1,3 +1,4 @@
+using Gum.DataTypes.Variables;
 using Gum.Wireframe;
 using Gum.GueDeriving;
 using Microsoft.Xna.Framework.Graphics;
@@ -374,15 +375,13 @@ public class FontServiceTests : BaseTestClass
     }
 
     [Fact]
-    public void StringSetPath_ShouldNotDeferFontGeneration_WhenOnlyInstanceLayoutSuspended()
+    public void StringSetPath_ShouldDeferFontGeneration_WhenOnlyInstanceLayoutSuspended()
     {
-        // Documents the "KNOWN GAP" in CustomSetPropertyOnRenderable.UpdateToFontValues:
-        // the string-set path only defers for IsAllLayoutSuspended, not for the
-        // per-instance suspension flag. ApplyState (which uses SetProperty) will
-        // therefore load fonts immediately even if the user has called SuspendLayout
-        // on the instance. The gap is intentional — see the comment block in
-        // CustomSetPropertyOnRenderable.UpdateToFontValues for why fixing it would
-        // require resolving a cascading-layout issue.
+        // Was pinned as a "KNOWN GAP" (#4567): the string-set path used to defer only for
+        // IsAllLayoutSuspended, not the per-instance suspension flag, so ApplyState (which uses
+        // SetProperty under instance-level SuspendLayout, not the global flag) loaded fonts
+        // immediately. CustomSetPropertyOnRenderable.UpdateToFontValues now defers for both flags,
+        // matching the direct-property-setter path.
         TextRuntime textRuntime = new();
         var capturedCalls = StartCapturingFontCalls();
 
@@ -390,7 +389,15 @@ public class FontServiceTests : BaseTestClass
         textRuntime.SetProperty("Font", "Consolas");
         textRuntime.SetProperty("FontSize", 24);
 
-        capturedCalls.Count.ShouldBe(2);
+        capturedCalls.Count.ShouldBe(0);
+        textRuntime.IsFontDirty.ShouldBeTrue();
+
+        textRuntime.ResumeLayout(recursive: true);
+
+        capturedCalls.Count.ShouldBe(1);
+        capturedCalls[0].FontName.ShouldBe("Consolas");
+        capturedCalls[0].FontSize.ShouldBe(24);
+        textRuntime.IsFontDirty.ShouldBeFalse();
     }
 
     [Fact]
@@ -679,6 +686,174 @@ public class FontServiceTests : BaseTestClass
         textRuntime.UpdateLayout();
 
         textRuntime.IsFontDirty.ShouldBeFalse();   // cleared — no per-layout retry
+    }
+
+    #endregion
+
+    #region Order-Dependent Property Application (issue #4567)
+
+    [Fact]
+    public void ApplyState_ShouldNotRequestStalePropertyCombo_WhenFontSortsAlphabeticallyBeforeFontSizeAndIsBold()
+    {
+        // Repro for #4567. ApplyState (GraphicalUiElement.ApplyState) applies a state's variables
+        // one SetProperty call at a time, in the order StateSaveExtensionMethods.Initialize() sorts
+        // state.Variables into -- alphabetical. "Font" sorts before both "FontSize" and "IsBold", so
+        // setting Font fires an immediate UpdateToFontValues call (see the KNOWN GAP comment on
+        // CustomSetPropertyOnRenderable.UpdateToFontValues) using FontSize/IsBold's still-default
+        // values (TextRuntime.DefaultFontSize = 18, IsBold = false) instead of this state's actual
+        // FontSize=15/IsBold=true. That transient combo doesn't match anything gumcli fonts
+        // pre-generates, so it logs a "no usable font" warning even though the text is ultimately
+        // rendered correctly once FontSize and IsBold are applied moments later.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        StateSave state = new StateSave { Name = "Default" };
+        state.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = "Fonts/Baloo2-Bold.ttf", SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+        textRuntime.ApplyState(state);
+
+        // Currently captures 3 calls: (FontSize=18, IsBold=false) when Font is set, then
+        // (FontSize=15, IsBold=false) when FontSize is set, then (FontSize=15, IsBold=true) once
+        // IsBold itself is finally set -- only the last one reflects the state's actual values.
+        capturedCalls.ShouldNotBeEmpty();
+        capturedCalls.ShouldAllBe(bmfc => bmfc.FontSize == 15 && bmfc.IsBold,
+            "every font request during this ApplyState call should reflect the state's actual " +
+            "FontSize/IsBold, not a stale default caught mid-way through applying the state");
+    }
+
+    [Fact]
+    public void ApplyState_ShouldNotFlushFontPrematurely_WhenStateAppliesNestedCategoryState()
+    {
+        // Gap test found while scoping a fix for #4567. A state's own Variables can include a
+        // category-state assignment (e.g. "ButtonCategoryState" = "Highlighted"). GraphicalUiElement
+        // resolves that by calling ApplyState AGAIN, on the same instance, nested inside the outer
+        // ApplyState's own variable-application loop. "ButtonCategoryState" sorts alphabetically
+        // before "Font"/"FontSize"/"IsBold", so the nested call fires before the outer state's own
+        // font properties are applied. Any fix that makes font realization defer-until-resume for a
+        // single ApplyState call must also make that defer reentrancy-safe across this nesting --
+        // otherwise the nested call's own resume flushes a font using the not-yet-applied outer
+        // values, reintroducing #4567's staleness through a different door.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        StateSaveCategory category = new StateSaveCategory { Name = "ButtonCategory" };
+        StateSave highlightedState = new StateSave { Name = "Highlighted" };
+        highlightedState.Variables.Add(new VariableSave { Type = "int", Name = "OutlineThickness", Value = 2, SetsValue = true });
+        category.States.Add(highlightedState);
+        textRuntime.AddCategory(category);
+
+        StateSave outerState = new StateSave { Name = "Default" };
+        outerState.Variables.Add(new VariableSave { Type = "string", Name = "ButtonCategoryState", Value = "Highlighted", SetsValue = true });
+        outerState.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = "Fonts/Baloo2-Bold.ttf", SetsValue = true });
+        outerState.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+        outerState.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+        textRuntime.ApplyState(outerState);
+
+        capturedCalls.ShouldNotBeEmpty();
+        capturedCalls.ShouldAllBe(bmfc => bmfc.FontSize == 15 && bmfc.IsBold && bmfc.OutlineThickness == 2,
+            "no font request during this ApplyState call -- including one triggered by the nested " +
+            "category-state ApplyState -- should reflect anything other than the final, fully " +
+            "applied combination (outer Font/FontSize/IsBold plus the nested category's OutlineThickness)");
+    }
+
+    [Fact]
+    public void ApplyState_ShouldDeferUntilGlobalResume_WhenCalledWhileGloballySuspended()
+    {
+        // Must-stay-green pin: the pre-existing global-suspend defer/flush path (unrelated to
+        // #4567's per-instance gap) must keep working once ApplyState's own suspend condition is
+        // touched to close that gap.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        StateSave state = new StateSave { Name = "Default" };
+        state.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = "Fonts/Baloo2-Bold.ttf", SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+        try
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = true;
+            textRuntime.ApplyState(state);
+
+            capturedCalls.ShouldBeEmpty();
+            textRuntime.IsFontDirty.ShouldBeTrue();
+        }
+        finally
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = false;
+        }
+
+        textRuntime.UpdateFontRecursive();
+
+        capturedCalls.Count.ShouldBe(1);
+        capturedCalls[0].FontSize.ShouldBe(15);
+        capturedCalls[0].IsBold.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ApplyState_AppliedTwiceInSequence_ShouldEachResolveItsOwnFinalCombo_NotLeftoversFromThePrevious()
+    {
+        // Worse-than-expected discovery while writing this gap test: a SECOND, unrelated ApplyState
+        // call can silently get served a WRONG font from cache, with no warning at all, because of
+        // #4567's staleness in a PRIOR call. The Default state's own #4567 staleness (see the first
+        // test in this region) makes a transient, never-rendered lookup for (FontSize=15,
+        // IsBold=false) during its OWN application -- that lookup fails to resolve a real font,
+        // silently caches Text.DefaultBitmapFont under that filename in LoaderManager (same shape as
+        // RaylibGum.Tests' font-cache-poisoning regression), and never calls CreateFontIfNecessary
+        // again. So when Disabled later legitimately asks for that exact (15, IsBold=false) combo,
+        // it is served the poisoned cache entry directly -- CreateFontIfNecessary is never invoked,
+        // and the mock captures nothing. `ShouldNotBeEmpty()` below is what should be true (a real
+        // font lookup must happen for Disabled's own combo); today it is false because the poisoned
+        // cache from Default's OWN #4567 staleness swallows it first.
+        TextRuntime textRuntime = new();
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        StateSave defaultState = new StateSave { Name = "Default" };
+        defaultState.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = "Fonts/Baloo2-Bold.ttf", SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+        defaultState.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+        StateSave disabledState = new StateSave { Name = "Disabled" };
+        disabledState.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = false, SetsValue = true });
+
+        textRuntime.ApplyState(defaultState);
+        capturedCalls.Clear();
+
+        textRuntime.ApplyState(disabledState);
+
+        capturedCalls.ShouldNotBeEmpty(
+            "Disabled's own (FontSize=15, IsBold=false) combo must trigger a real font lookup, not " +
+            "silently reuse a cache entry poisoned by Default's own #4567 staleness");
+        capturedCalls.ShouldAllBe(bmfc => bmfc.FontSize == 15 && bmfc.IsBold == false,
+            "the second ApplyState call should resolve Font/FontSize carried over from the first " +
+            "call plus its own IsBold override -- not a stale combination from mid-way through either call");
+    }
+
+    [Fact]
+    public void ApplyState_OnStackedChild_ShouldNotRequestStalePropertyCombo()
+    {
+        // Extends the base #4567 repro onto a stacking parent's child, since UpdateLayout cascading
+        // through a stack is a documented tricky area for font realization (see the "Layout
+        // Suspension / Font Batching" region above) -- confirms the fix holds in that topology too.
+        ContainerRuntime parent = new();
+        parent.ChildrenLayout = Gum.Managers.ChildrenLayout.TopToBottomStack;
+        TextRuntime childText = new();
+        parent.AddChild(childText);
+        List<BmfcSave> capturedCalls = StartCapturingFontCalls();
+
+        StateSave state = new StateSave { Name = "Highlighted" };
+        state.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = "Fonts/Baloo2-Bold.ttf", SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+        state.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+        childText.ApplyState(state);
+
+        capturedCalls.ShouldNotBeEmpty();
+        capturedCalls.ShouldAllBe(bmfc => bmfc.FontSize == 15 && bmfc.IsBold,
+            "a stacked child's ApplyState call must resolve the same final combo as an unstacked one");
     }
 
     #endregion

--- a/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
+++ b/Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs
@@ -1,4 +1,5 @@
-﻿using Gum.GueDeriving;
+﻿using Gum.DataTypes.Variables;
+using Gum.GueDeriving;
 using Gum.Wireframe;
 using RaylibGum.Renderables;
 using RenderingLibrary.Content;
@@ -308,14 +309,14 @@ public class TextRuntimeTests : BaseTestClass
         });
     }
 
-    // Documents (and pins on Raylib) the intentional KNOWN GAP described in the comment block now shared
-    // verbatim with the MonoGame copy of UpdateToFontValues: the static string path defers ONLY for the
-    // global IsAllLayoutSuspended flag, NOT for per-instance SuspendLayout. So a string set under instance
-    // suspension still loads eagerly. Mirrors MonoGame's
-    // StringSetPath_ShouldNotDeferFontGeneration_WhenOnlyInstanceLayoutSuspended — proving the copied
-    // comment's claim is true on Raylib, not just transcribed.
+    // Was pinned (#4567) as the intentional KNOWN GAP shared verbatim with the MonoGame copy of
+    // UpdateToFontValues: the static string path used to defer ONLY for the global
+    // IsAllLayoutSuspended flag, not per-instance SuspendLayout. UpdateToFontValues now defers for
+    // both, matching the direct-property-setter path. Mirrors MonoGame's
+    // StringSetPath_ShouldDeferFontGeneration_WhenOnlyInstanceLayoutSuspended — proving the fix
+    // holds on Raylib too, not just transcribed.
     [Fact]
-    public void StringSetPath_ShouldNotDeferFontLoad_WhenOnlyInstanceLayoutSuspended()
+    public void StringSetPath_ShouldDeferFontLoad_WhenOnlyInstanceLayoutSuspended()
     {
         string uniqueFontName = NewUniqueFontName();
         WithFontLoadRecording(uniqueFontName, fontRequestCount =>
@@ -325,7 +326,13 @@ public class TextRuntimeTests : BaseTestClass
             textRuntime.SuspendLayout();
             textRuntime.SetProperty("Font", uniqueFontName);
 
+            fontRequestCount().ShouldBe(0);
+            textRuntime.IsFontDirty.ShouldBeTrue();
+
+            textRuntime.ResumeLayout(recursive: true);
+
             fontRequestCount().ShouldBeGreaterThan(0);
+            textRuntime.IsFontDirty.ShouldBeFalse();
         });
     }
 
@@ -360,6 +367,83 @@ public class TextRuntimeTests : BaseTestClass
             };
 
             body(() => fontRequestCount);
+        }
+        finally
+        {
+            GraphicalUiElement.IsAllLayoutSuspended = savedSuspended;
+            LoaderManager.Self.CacheTextures = savedCacheTextures;
+            FileManager.RelativeDirectory = savedRelativeDirectory;
+            FileManager.CustomGetStreamFromFile = savedHook;
+        }
+    }
+
+    // Mirrors MonoGame's FontServiceTests.ApplyState_ShouldNotFlushFontPrematurely_WhenStateAppliesNestedCategoryState
+    // (#4567 gap audit). Raylib compiles the literal same Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+    // and GumRuntime/GraphicalUiElement.cs, so the nested-ApplyState-via-category-state reentrancy hazard
+    // -- a fix that defers font realization for a suspended instance must not let a NESTED ApplyState
+    // call (triggered by a category-state variable like "ButtonCategoryState") resume/flush before the
+    // OUTER ApplyState call finishes applying its own remaining font-affecting variables -- applies here
+    // identically. Unlike WithFontLoadRecording's plain count, this records every requested PATH so we
+    // can assert none of them reflect a stale, partially-applied combo (wrong size or missing the
+    // BmfcSave "_Bold" filename suffix).
+    [Fact]
+    public void ApplyState_ShouldNotFlushFontPrematurely_WhenStateAppliesNestedCategoryState()
+    {
+        string uniqueFontName = NewUniqueFontName();
+        WithFontLoadRecordingPaths(uniqueFontName, requestedPaths =>
+        {
+            TextRuntime textRuntime = new();
+
+            StateSaveCategory category = new StateSaveCategory { Name = "ButtonCategory" };
+            StateSave highlightedState = new StateSave { Name = "Highlighted" };
+            highlightedState.Variables.Add(new VariableSave { Type = "int", Name = "OutlineThickness", Value = 2, SetsValue = true });
+            category.States.Add(highlightedState);
+            textRuntime.AddCategory(category);
+
+            StateSave outerState = new StateSave { Name = "Default" };
+            outerState.Variables.Add(new VariableSave { Type = "string", Name = "ButtonCategoryState", Value = "Highlighted", SetsValue = true });
+            outerState.Variables.Add(new VariableSave { Type = "string", Name = "Font", Value = uniqueFontName, SetsValue = true });
+            outerState.Variables.Add(new VariableSave { Type = "int", Name = "FontSize", Value = 15, SetsValue = true });
+            outerState.Variables.Add(new VariableSave { Type = "bool", Name = "IsBold", Value = true, SetsValue = true });
+
+            textRuntime.ApplyState(outerState);
+
+            List<string> paths = requestedPaths();
+            paths.ShouldNotBeEmpty();
+            paths.ShouldAllBe(p => p.Contains("Font15", StringComparison.OrdinalIgnoreCase)
+                    && p.Contains("_Bold", StringComparison.OrdinalIgnoreCase),
+                "no requested font-cache path -- including one triggered by the nested category-state " +
+                "ApplyState -- should reflect anything other than the final, fully applied combination " +
+                $"(FontSize=15, IsBold=true): {string.Join(", ", paths)}");
+        });
+    }
+
+    // Same isolation strategy as WithFontLoadRecording, but records every requested path (not just a
+    // count) so a caller can assert on the SHAPE of each request (e.g. size/bold suffix), not just how
+    // many happened.
+    private static void WithFontLoadRecordingPaths(string uniqueFontName, Action<Func<List<string>>> body)
+    {
+        bool savedCacheTextures = LoaderManager.Self.CacheTextures;
+        string savedRelativeDirectory = FileManager.RelativeDirectory;
+        Func<string, Stream>? savedHook = FileManager.CustomGetStreamFromFile;
+        bool savedSuspended = GraphicalUiElement.IsAllLayoutSuspended;
+        try
+        {
+            LoaderManager.Self.CacheTextures = false;
+            FileManager.RelativeDirectory = Path.Combine(Path.GetTempPath(),
+                "GumRaylibDeferFontTest_" + Guid.NewGuid().ToString("N")).Replace('\\', '/') + "/";
+
+            List<string> requestedPaths = new();
+            FileManager.CustomGetStreamFromFile = incomingPath =>
+            {
+                if (incomingPath.Contains(uniqueFontName, StringComparison.OrdinalIgnoreCase))
+                {
+                    requestedPaths.Add(incomingPath);
+                }
+                return null!;
+            };
+
+            body(() => requestedPaths);
         }
         finally
         {


### PR DESCRIPTION
Closes #4567

## Root cause

`ApplyState` applies a state's variables one `SetProperty` call at a time, alphabetically (`StateSaveExtensionMethods.Initialize()` sorts them). "Font" sorts before "FontSize"/"IsBold", so each font-affecting property (Font, FontSize, IsBold, OutlineThickness, ...) fired an immediate `UpdateToFontValues` call using whatever the *other* properties still held. Setting `Font` fired before `FontSize`/`IsBold` were applied, producing a transient lookup for `Font18<Name>` (still-default `FontSize=18`) or a missing-bold-suffix combo — matching both the Font18 warnings in the issue body and the Bold-suffix warning in the comment. Worse: that stale lookup could cache a fallback font under the wrong combination's filename, silently serving it to a later, unrelated, legitimate request for the exact same combo.

## Fix

`CustomSetPropertyOnRenderable.UpdateToFontValues` (the string-set path `ApplyState` uses) now defers for per-instance layout suspension, matching the direct-property-setter path — closing a previously-documented "KNOWN GAP". Since `ApplyState` already wraps its whole variable loop in instance-level suspend/resume, this makes every font-affecting property set during one `ApplyState` call batch into a single flush with the state's actual final values, reusing the already-tested `SuppressLayoutFromFontChange` flush machinery.

`GraphicalUiElement.ApplyState`'s own suspend/resume was made reentrancy-safe alongside this: a state's Variables can include a category-state assignment (e.g. `ButtonCategoryState = "Highlighted"`), which triggers a *nested* `ApplyState` call on the same instance mid-loop. Without the fix, the nested call's own resume would prematurely flush before the outer call finished applying its remaining variables, reintroducing the same staleness through a different door. `ApplyState` now skips re-suspending when the instance is already suspended.

## Testing

- 5 new tests in `MonoGameGum.Tests/Runtimes/FontServiceTests.cs` pin the bug (including the nested-ApplyState hazard and a cache-poisoning scenario found while writing them) and now pass.
- 1 mirrored to `Tests/RaylibGum.Tests/Runtimes/TextRuntimeTests.cs` (shares the literal same source file) — confirms the hazard and fix on Raylib too.
- 2 pre-existing tests that pinned the "KNOWN GAP" as intentional (`StringSetPath_ShouldNotDeferFontGeneration_WhenOnlyInstanceLayoutSuspended` on MonoGame and Raylib) were flipped to assert the new correct (deferred) behavior.
- Full suites green: MonoGameGum.Tests (2271), RaylibGum.Tests (635), SkiaGum.Tests (437, unaffected fork — see #4602), MonoGameGum.Tests.V3 (154), GumToolUnitTests (1296).
- FRB canary: pass (both net6.0 and net8.0 targets, 0 errors).
- Real-world verification: `gumcli screenshot` on both `Meadow/DemoScreenGum` and `Meadow/Controls/Button` (the issue's exact repro) now logs zero font-resolution warnings, where it previously logged 4 and 1 respectively.

Manual test: not needed — the bug only ever produced spurious warnings/cache pollution with no visible rendering difference (confirmed by the gumcli screenshot verification above and the full test suite asserting on the exact resolved font values).

FRB canary: pass.

Filed #4602 separately to track unifying SkiaGum's forked copy of `CustomSetPropertyOnRenderable.cs`, which this fix doesn't reach.
