### PR TITLE
Grant GumStride InternalsVisibleTo on SkiaGum

### DIFF
--- a/Runtimes/SkiaGum/SkiaGum.csproj
+++ b/Runtimes/SkiaGum/SkiaGum.csproj
@@ -174,6 +174,10 @@
 		     the assembly boundary — SilkNetGum references this project for GumServiceSkiaBase
 		     instead of file-linking FormsUtilities.cs (issue #4452 phase 2). -->
 		<InternalsVisibleTo Include="SilkNetGum" />
+		<!-- Same reason, for the Stride runtime host prototype (issue #4600): GumStride is the
+		     external project name (Skia_GumUi_Stride/GumStride.csproj) before extraction into
+		     Runtimes/StrideGum. -->
+		<InternalsVisibleTo Include="GumStride" />
 	</ItemGroup>
 
 	<Import Project="..\RuntimePackage.Analyzers.props" />


### PR DESCRIPTION
## Summary

Adds `GumStride` to `SkiaGum.csproj`'s `InternalsVisibleTo`, mirroring the existing `SilkNetGum` entry. Unblocks a Stride runtime host prototype (`GumStride`, an external project at `Skia_GumUi_Stride`, modeled on `SilkNetGum` per issue #4600) — its `CursorExtensions.cs` (file-linked from `MonoGameGum/Input`) needs `FormsUtilities.LastEventRoots` (internal) across the assembly boundary, the same way `SilkNetGum` already does.

Does not close #4600 — this only unblocks the external prototype's build; the in-repo `Runtimes/StrideGum` extraction is still future work.

## Test plan
- `dotnet build Runtimes/SkiaGum/SkiaGum.csproj` — 0 warnings, 0 errors.
- Built the external `GumStride` prototype project against this branch: 0 errors.

Manual test: not needed — `InternalsVisibleTo` addition only, no runtime behavior change.
FRB canary: not needed — csproj-only change, not FRB1-shared source.
