### PR TITLE
Add Samples/StrideGum/StrideGumSample (#4609)

### DIFF
--- a/.claude/skills/gum-samples/SKILL.md
+++ b/.claude/skills/gum-samples/SKILL.md
@@ -15,7 +15,7 @@ The "**big three**" refers to the three backends below (Silk.NET/Skia, raylib, M
 |---|---|---|---|
 | MonoGameGumInCode | MonoGame (XNA) | `Samples/MonoGameGumInCode/MonoGameGumInCode/` | `FrameworkElement`; nav button in `Game1.BuildNavStrip` |
 | raylib gallery | raylib | `Samples/raylib/` | `FrameworkElement`; nav button in `Program.BuildNavStrip` (`Examples.Shapes` namespace) |
-| SilkNetGum | SkiaSharp via Silk.NET | `Samples/SilkNetGum/SilkNetGum/` | `FrameworkElement`; factory in `Program.codeScreenFactories`, keyboard nav |
+| SilkNetGum | SkiaSharp via Silk.NET | `Samples/SilkNetGum/SilkNetGumSample/` | `FrameworkElement`; factory in `Program.codeScreenFactories`, keyboard nav |
 
 Each has a `Screens/` folder with one `*Screen.cs` per feature (`SpriteScreen`, `NineSliceScreen`, …). **MonoGameGumInCode is the reference** — mirror its screen section-for-section in the other two so the same screen can be opened side by side and any per-backend rendering difference stands out as a backend bug. The existing screen headers say exactly this ("Raylib mirror of …", "Mirror of MonoGameGumInCode.Screens…").
 
@@ -52,3 +52,5 @@ raylib and Skia render shapes natively. MonoGame's shape rendering comes from th
 These samples exist for visual confirmation; they have no automated assertions. After adding a screen, build the sample and tell the user to run it and eyeball the new screen. Behavioral correctness still gets a unit test in the matching `Tests/*` project (see [[tdd]]) — the sample is the visual complement, not a replacement.
 
 A brand-new standalone sample project (not one of the "big three") still ships a `.sln` alongside its `.csproj`, mirroring `FontPlayground.MonoGame.sln` — the user opens and runs these in Visual Studio, not via `dotnet run`.
+
+That `.sln` also enrolls the sample in CI automatically: `build-samples.yaml` runs `.github/scripts/build-all.ps1 -Path Samples`, which globs every `.sln`/`.slnx` under `Samples/` and builds it on a `windows-latest` runner. A sample that can't restore or build there (a Mac-only head, a hand-cloned dependency) has to be added to that script's `$excludeLeafNames`.

--- a/Samples/StrideGum/StrideGumSample.sln
+++ b/Samples/StrideGum/StrideGumSample.sln
@@ -1,0 +1,49 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35323.107
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrideGumSample", "StrideGumSample\StrideGumSample.csproj", "{03BD334E-6E27-4BF8-94C0-A4F75FE6B247}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StrideGum", "..\..\Runtimes\StrideGum\StrideGum.csproj", "{0FBE1A2C-E811-48D6-8D73-2AE10D823E05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkiaGum", "..\..\Runtimes\SkiaGum\SkiaGum.csproj", "{C8415A14-F48F-47E3-914D-79C44434CB77}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LibraryProjects", "LibraryProjects", "{269E6100-C1A6-41C2-971C-7C5B32987775}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GumCommon", "..\..\GumCommon\GumCommon.csproj", "{2ABFB42D-954D-4429-8B01-397581BC8C9D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{03BD334E-6E27-4BF8-94C0-A4F75FE6B247}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03BD334E-6E27-4BF8-94C0-A4F75FE6B247}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03BD334E-6E27-4BF8-94C0-A4F75FE6B247}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03BD334E-6E27-4BF8-94C0-A4F75FE6B247}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FBE1A2C-E811-48D6-8D73-2AE10D823E05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FBE1A2C-E811-48D6-8D73-2AE10D823E05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FBE1A2C-E811-48D6-8D73-2AE10D823E05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FBE1A2C-E811-48D6-8D73-2AE10D823E05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8415A14-F48F-47E3-914D-79C44434CB77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8415A14-F48F-47E3-914D-79C44434CB77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8415A14-F48F-47E3-914D-79C44434CB77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8415A14-F48F-47E3-914D-79C44434CB77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ABFB42D-954D-4429-8B01-397581BC8C9D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0FBE1A2C-E811-48D6-8D73-2AE10D823E05} = {269E6100-C1A6-41C2-971C-7C5B32987775}
+		{C8415A14-F48F-47E3-914D-79C44434CB77} = {269E6100-C1A6-41C2-971C-7C5B32987775}
+		{2ABFB42D-954D-4429-8B01-397581BC8C9D} = {269E6100-C1A6-41C2-971C-7C5B32987775}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C8399387-D5EE-457B-AE02-EDBF36C880B9}
+	EndGlobalSection
+EndGlobal

--- a/Samples/StrideGum/StrideGumSample/Program.cs
+++ b/Samples/StrideGum/StrideGumSample/Program.cs
@@ -1,0 +1,67 @@
+using Gum;
+using Gum.Forms.Controls;
+using Stride.CommunityToolkit.Bepu;
+using Stride.CommunityToolkit.Engine;
+using Stride.CommunityToolkit.Rendering.Compositing;
+using Stride.Engine;
+
+using var game = new Game();
+
+game.Run(start: Start);
+
+void Start(Scene rootScene)
+{
+    // A GraphicsCompositor must already exist when Initialize runs: Stride drives rendering
+    // through that pipeline, so Initialize registers Gum's own scene renderer into it. From
+    // here on Stride ticks Gum's Update/Draw every frame -- unlike every other Gum runtime,
+    // there is nothing for this sample to call per frame.
+    game.AddGraphicsCompositor().AddCleanUIStage();
+    GumService.Default.Initialize(game);
+
+    BuildDemoUi();
+
+    game.Add3DCamera().Add3DCameraController();
+    game.AddDirectionalLight();
+    game.Add3DGround();
+}
+
+void BuildDemoUi()
+{
+    var stackPanel = new StackPanel();
+    stackPanel.AddToRoot();
+    stackPanel.X = 100;
+    stackPanel.Y = 100;
+    stackPanel.Spacing = 5;
+
+    var label = new Label
+    {
+        Text = "Hello from Gum on Stride!",
+    };
+    stackPanel.AddChild(label);
+
+    var button = new Button
+    {
+        Text = "Click me",
+    };
+    button.Click += (_, _) => label.Text = "Clicked!";
+    stackPanel.AddChild(button);
+
+    var textBox = new TextBox
+    {
+        Placeholder = "Type here",
+    };
+    stackPanel.AddChild(textBox);
+
+    var checkBox = new CheckBox
+    {
+        Text = "Check me"
+    };
+    stackPanel.AddChild(checkBox);
+
+    var listBox = new ListBox();
+    for (int i = 0; i < 10; i++)
+    {
+        listBox.Items!.Add("Item " + i);
+    }
+    stackPanel.AddChild(listBox);
+}

--- a/Samples/StrideGum/StrideGumSample/StrideGumSample.csproj
+++ b/Samples/StrideGum/StrideGumSample/StrideGumSample.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<!-- net10.0 matches Runtimes/StrideGum: Stride's own packages only ship net10.0 builds. -->
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<!-- Stride.CommunityToolkit.Windows drags in Stride's editor-side package manager, whose own
+		     transitive SSH.NET has a published advisory (NU1903). Nothing here can pick a different
+		     version, and this sample ships no binaries, so audit only what this project references
+		     directly. -->
+		<NuGetAuditMode>direct</NuGetAuditMode>
+	</PropertyGroup>
+
+	<!--
+		Two warnings this project emits are Stride's, not Gum's, and neither is suppressible from
+		here: CS0162 "Unreachable code detected" against a temp file, which is the inline C# task
+		Stride's _StrideCollectUpToDateCheckInputDesignTime target compiles; and "[AssetCompiler]
+		Could not find game settings asset at location [GameSettings]", which Stride's asset
+		compiler emits for any code-only game with no asset folder. Both are expected here.
+	-->
+
+
+	<ItemGroup>
+		<!-- The window/host backend and physics are a consuming game's choice, which is why
+		     Runtimes/StrideGum references neither. Bepu supplies Add3DGround. -->
+		<PackageReference Include="Stride.CommunityToolkit.Bepu" Version="1.0.0-preview.63" />
+		<PackageReference Include="Stride.CommunityToolkit.Windows" Version="1.0.0-preview.63" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\Runtimes\StrideGum\StrideGum.csproj" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds `Samples/StrideGum/StrideGumSample`, mirroring `Samples/SilkNetGum`'s layout: a standalone `.sln` next to the project (not in `AllLibraries.sln`/`GumFull.sln`), referencing `Runtimes/StrideGum` directly. Demonstrates `Label`, `Button`, `TextBox`, `CheckBox` and `ListBox` in a `StackPanel` over a 3D scene.

Stride needs no per-frame call — `GumService.Default.Initialize(game)` registers Gum's scene renderer into the `GraphicsCompositor`, which drives Update/Draw from there.

Two things worth knowing:

- **CI picks this up with no workflow change.** `build-samples.yaml` runs `build-all.ps1 -Path Samples`, which globs every `.sln`/`.slnx` under `Samples/`. Recorded in the `gum-samples` skill, along with a fix for its stale SilkNetGum sample path.
- **`NuGetAuditMode=direct`.** `Stride.CommunityToolkit.Windows` drags in Stride's editor-side package manager, whose transitive SSH.NET has a published advisory (NU1903). Nothing here can pick a different version and this sample ships no binaries. Filed separately to revisit when Stride updates.

Two remaining build warnings are Stride's own and unsuppressible from a consuming project (CS0162 in an inline MSBuild task, and the asset compiler's missing-`GameSettings` note for a code-only game) — documented in the csproj.

Manual test: needed — run `StrideGumSample` and confirm the Gum controls render and respond over the 3D ground.
FRB canary: not needed — no FRB1-shared source touched.

Closes #4609
