### PR TITLE
Reset global suspend flags on the way into a test, not just out (#4613)

### DIFF
--- a/MonoGameGum.Tests/BaseTestClass.cs
+++ b/MonoGameGum.Tests/BaseTestClass.cs
@@ -18,6 +18,15 @@ public class BaseTestClass : IDisposable
 
     public BaseTestClass()
     {
+        // Dispose clears these too, but only for tests that derive from this class. Several test
+        // classes in this project don't, so a global suspend flag one of them leaves set would
+        // otherwise land on whatever runs next -- and both flags make font and layout work silently
+        // no-op rather than fail, so the damage shows up as a confusing assertion somewhere else.
+        // Clearing on the way in as well means a test starts from a known state no matter what ran
+        // before it.
+        GraphicalUiElement.IsAllLayoutSuspended = false;
+        GraphicalUiElement.SuppressFontRegeneration = false;
+
         GumService.Default.InitializeForTesting();
         CreateMockCursor();
     }
@@ -38,6 +47,9 @@ public class BaseTestClass : IDisposable
     public virtual void Dispose()
     {
         GraphicalUiElement.IsAllLayoutSuspended = false;
+        // Paired with IsAllLayoutSuspended: the same "silently skip font work" hazard, and the
+        // tests that set it rely on their own finally alone until now.
+        GraphicalUiElement.SuppressFontRegeneration = false;
         GraphicalUiElement.CanvasWidth = 800;
         GraphicalUiElement.CanvasHeight = 600;
         GraphicalUiElement.GlobalFontScale = 1;


### PR DESCRIPTION
`BaseTestClass.Dispose` already cleared `GraphicalUiElement.IsAllLayoutSuspended`, but only for tests that derive from it — about 14 classes in `MonoGameGum.Tests` don't, so a flag one of those leaves set lands on whatever runs next. Now cleared on construction as well, so a test starts from a known state regardless of what ran before it.

`SuppressFontRegeneration` gets the same treatment in both places. Same hazard, and until now the tests that set it relied on their own `finally` alone. Both flags make font and layout work silently no-op rather than throw, so a leak surfaces as a confusing assertion somewhere unrelated.

**This does not explain the #4613 flake** — that test clears `IsAllLayoutSuspended` itself on the line before the failing assertion, so a leaked `true` was never reachable. This is defense in depth: one fewer candidate the next time it fires. #4613 stays open.

Full suite green, 2271/2271.

Manual test: not needed — test-harness only, no production code touched; the suite is the proof.
FRB canary: not needed — no FRB1-shared source touched.

Part of #4613
