### PR TITLE
Document the required camera in the Stride setup docs

### DIFF
--- a/docs/code/getting-started/setup/adding-initializing-gum/stride.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/stride.md
@@ -62,7 +62,7 @@ Next, add StrideGum as a project reference in your game project. Your project mi
 
 ## Initializing Gum
 
-Stride draws through a `GraphicsCompositor`, and Gum draws as part of that pipeline, so create the compositor before calling `Initialize`:
+Stride draws through a `GraphicsCompositor`, and Gum draws as part of that pipeline, so create the compositor before calling `Initialize`. Stride also renders the scene through a camera, so add one or the window stays empty:
 
 ```csharp
 using Gum;
@@ -77,9 +77,12 @@ game.Run(start: Start);
 void Start(Scene rootScene)
 {
     game.AddGraphicsCompositor().AddCleanUIStage();
+    game.Add2DCamera();
     GumService.Default.Initialize(game);
 }
 ```
+
+`Add2DCamera` suits a UI-only or 2D game. Use `Add3DCamera` instead if your game draws a 3D scene. Gum draws in screen space and ignores the camera, so either one works for the UI.
 
 `Initialize` adds Gum's scene renderer to the compositor, and Stride runs Gum's update and draw every frame from there. Stride is the one runtime where you never call `Update` and `Draw` yourself, so the per-frame calls the other setup pages show have no equivalent here.
 

--- a/docs/code/getting-started/setup/empty-project-before-adding-gum/stride.md
+++ b/docs/code/getting-started/setup/empty-project-before-adding-gum/stride.md
@@ -49,4 +49,6 @@ void Start(Scene rootScene)
 }
 ```
 
+The camera is required. Stride renders the scene through it, so the window stays empty without one. `Add3DCamera` matches the 3D scene above, and `Add2DCamera` is the equivalent for a 2D game.
+
 Next, you can begin adding Gum to your project. For more information see the [Adding/Initializing Gum](../adding-initializing-gum/stride.md) page.


### PR DESCRIPTION
Stride renders the scene through a camera, so a Stride + Gum project shows an empty window without one. Reported by a user following the docs.

- **Adding/Initializing Gum**: the snippet had no camera at all. Adds `game.Add2DCamera()` plus a line on picking `Add2DCamera` vs `Add3DCamera` (Gum blits in screen space and ignores the camera, so either works).
- **Empty Project**: the snippet already had `Add3DCamera()` but never said it was required, or that `Add2DCamera` is the 2D equivalent.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v6fAwsHHRzJBZxvBzbh6P