### PR TITLE
Consolidate the two GumShapes csprojs into their shared Directory.Build.props

### DIFF
--- a/.claude/skills/gum-cross-platform-unification/SKILL.md
+++ b/.claude/skills/gum-cross-platform-unification/SKILL.md
@@ -13,7 +13,7 @@ Reference implementations: `TextRuntime.cs` (#2509, #2510) and `ContainerRuntime
 
 ### Apos.Shapes ↔ SkiaGum shape runtime pair
 
-Shape runtimes that exist on the Apos.Shapes side (`MonoGameGumShapes` / `KniGumShapes`) and SkiaGum — `RoundedRectangleRuntime`, `ArcRuntime`, `ColoredCircleRuntime`, `LineRuntime` — follow the same source-sharing pattern but with a different canonical home: **`Runtimes/SkiaGum/GueDeriving/`** rather than `MonoGameGum/GueDeriving/`. The Apos csprojs file-link via `<Compile Include="..\SkiaGum\GueDeriving\FooRuntime.cs" Link="GueDeriving\FooRuntime.cs" />`.
+Shape runtimes that exist on the Apos.Shapes side (`MonoGameGumShapes` / `KniGumShapes`) and SkiaGum — `RoundedRectangleRuntime`, `ArcRuntime`, `ColoredCircleRuntime`, `LineRuntime` — follow the same source-sharing pattern but with a different canonical home: **`Runtimes/SkiaGum/GueDeriving/`** rather than `MonoGameGum/GueDeriving/`. The Apos csprojs file-link via `<Compile Include="..\SkiaGum\GueDeriving\FooRuntime.cs" Link="GueDeriving\FooRuntime.cs" />`, declared once in `Runtimes/GumShapes/Directory.Build.props` rather than in either csproj.
 
 Why a different home: these runtimes wrap Skia-specific renderables on one side and Apos.Shapes-specific renderables on the other. Neither platform's renderable surface aligns with the MonoGame/Raylib/Sokol axis, so putting the canonical file in `MonoGameGum/GueDeriving/` would be misleading. Reference implementation: `RoundedRectangleRuntime.cs`. Platform divergence uses `#if SKIA` (no `RAYLIB` / `XNALIKE` involved on this pair).
 

--- a/Runtimes/GumShapes/Directory.Build.props
+++ b/Runtimes/GumShapes/Directory.Build.props
@@ -3,8 +3,68 @@
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition="'$(MSBuildProjectName)' == 'KniGumShapes'">obj\KNI\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition="'$(MSBuildProjectName)' == 'KniGumShapes'">bin\KNI\</BaseOutputPath>
-    
+
     <BaseIntermediateOutputPath Condition="'$(MSBuildProjectName)' == 'MonoGameGumShapes'">obj\MonoGame\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition="'$(MSBuildProjectName)' == 'MonoGameGumShapes'">bin\MonoGame\</BaseOutputPath>
+
+    <!--
+      Both projects live in this one folder, so each one's default item globs would otherwise
+      pick up the OTHER one's generated sources. The SDK's own DefaultItemExcludes only covers
+      the project's own BaseOutputPath/BaseIntermediateOutputPath, which the redirects above
+      have narrowed to bin\KNI\ + obj\KNI\ (or bin\MonoGame\ + obj\MonoGame\) — so e.g.
+      obj\KNI\Debug\net8.0\KniGumShapes.AssemblyInfo.cs is not excluded from MonoGameGumShapes
+      and would compile into it as a duplicate assembly attribute. Exclude bin and obj wholesale.
+    -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;obj\**</DefaultItemExcludes>
   </PropertyGroup>
+
+  <!--
+    Shared NuGet package metadata for the two Apos.Shapes-backed shape packages
+    (Gum.Shapes.MonoGame / Gum.Shapes.KNI). They are a coupled pair — released together and
+    bumped in lockstep in every commit since they were split — so Version lives here too.
+    PackageId and the platform PackageReferences stay in each csproj.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>2026.4.5.1</Version>
+    <NoWarn>1591</NoWarn>
+
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      One version for both packages: MonoGameGumShapes references Apos.Shapes and KniGumShapes
+      references Apos.Shapes.KNI, but the two must stay on the same version — the shared runtime
+      sources linked below are written against one shader/API generation.
+
+      As of Apos.Shapes 0.7.2 the shader is precompiled and embedded in the assembly — no content
+      pipeline, no buildTransitive content, no PrivateAssets blocking needed (see issue #4020).
+      The precompiled apos-shapes.xnb workaround these csprojs used to ship is gone; consumers
+      just reference the package.
+
+      Bumped from 0.7.10 to 0.8.1 for issue #4473 (RectangleRuntime crashed on macOS/Linux GL
+      drivers under the pinned 0.7.10 shader). 0.7.11's DrawRing second-radius semantics change
+      (rings would render 2x thicker) is compensated for in Arc.cs's DrawRing call — see
+      AposShapeGeometryTests for the pixel-level regression guard.
+    -->
+    <AposShapesVersion>0.8.1</AposShapesVersion>
+  </PropertyGroup>
+
+  <!--
+    Shape runtimes shared with SkiaGum. SkiaGum is the canonical home for the Apos-specific
+    shape runtimes; see the gum-cross-platform-unification skill.
+  -->
+  <ItemGroup>
+    <Compile Include="..\SkiaGum\CustomSetPropertyOnRenderable.cs" Link="CustomSetPropertyOnRenderable.cs" />
+    <Compile Include="..\SkiaGum\GueDeriving\ArcRuntime.cs" Link="GueDeriving\ArcRuntime.cs" />
+    <Compile Include="..\SkiaGum\GueDeriving\LineRuntime.cs" Link="GueDeriving\LineRuntime.cs" />
+    <Compile Include="..\SkiaGum\GueDeriving\RoundedRectangleRuntime.cs" Link="GueDeriving\RoundedRectangleRuntime.cs" />
+  </ItemGroup>
 </Project>

--- a/Runtimes/GumShapes/KniGumShapes.csproj
+++ b/Runtimes/GumShapes/KniGumShapes.csproj
@@ -1,53 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+	<!-- Shared metadata, item excludes, and the SkiaGum source links live in Directory.Build.props. -->
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
 		<PackageId>Gum.Shapes.KNI</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-
-		<Version>2026.4.5.1</Version>
-		<NoWarn>1591</NoWarn>
-
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Compile Remove="bin\**" />
-		<Compile Remove="obj\**" />
-		<Compile Remove="XnbTest\**" />
-		<EmbeddedResource Remove="bin\**" />
-		<EmbeddedResource Remove="obj\**" />
-		<EmbeddedResource Remove="XnbTest\**" />
-		<None Remove="bin\**" />
-		<None Remove="obj\**" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Include="..\SkiaGum\CustomSetPropertyOnRenderable.cs" Link="CustomSetPropertyOnRenderable.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\ArcRuntime.cs" Link="GueDeriving\ArcRuntime.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\LineRuntime.cs" Link="GueDeriving\LineRuntime.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\RoundedRectangleRuntime.cs" Link="GueDeriving\RoundedRectangleRuntime.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<!--
-			As of Apos.Shapes.KNI 0.7.2 the shader is precompiled and embedded in the assembly —
-			no content pipeline, no buildTransitive content, no PrivateAssets blocking needed
-			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
-			ship is gone; consumers just reference the package.
-
-			Bumped from 0.7.10 to 0.8.1 for issue #4473 (RectangleRuntime crashed on macOS/Linux
-			GL drivers under the pinned 0.7.10 shader). 0.7.11's DrawRing second-radius semantics
-			change (rings would render 2x thicker) is compensated for in Arc.cs's DrawRing call —
-			see AposShapeGeometryTests for the pixel-level regression guard.
-		-->
-		<PackageReference Include="Apos.Shapes.KNI" Version="0.8.1" />
+		<PackageReference Include="Apos.Shapes.KNI" Version="$(AposShapesVersion)" />
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Content" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" PrivateAssets="All" />
@@ -58,27 +17,12 @@
 		<PackageReference Include="nkast.Xna.Framework.Devices" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.Storage" Version="4.2.9001" PrivateAssets="All" />
 		<PackageReference Include="nkast.Xna.Framework.XR" Version="4.2.9001" PrivateAssets="All" />
-
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
+		<ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />
 	</ItemGroup>
 
-	<!--
-		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
-		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
-		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
-		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
-		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
-		present, so source-only builds keep working with zero impact.
-	-->
-	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
-	  <None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
-		    Pack="true"
-		    PackagePath="analyzers/dotnet/cs/"
-		    Visible="false" />
-	</ItemGroup>
-
+	<Import Project="..\RuntimePackage.Analyzers.props" />
 
 </Project>

--- a/Runtimes/GumShapes/MonoGameGumShapes.csproj
+++ b/Runtimes/GumShapes/MonoGameGumShapes.csproj
@@ -1,53 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+	<!-- Shared metadata, item excludes, and the SkiaGum source links live in Directory.Build.props. -->
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		
 		<PackageId>Gum.Shapes.MonoGame</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		
-		<Version>2026.4.5.1</Version>
-		<NoWarn>1591</NoWarn>
-
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <Compile Remove="bin\**" />
-	  <Compile Remove="obj\**" />
-	  <Compile Remove="XnbTest\**" />
-	  <EmbeddedResource Remove="bin\**" />
-	  <EmbeddedResource Remove="obj\**" />
-	  <EmbeddedResource Remove="XnbTest\**" />
-	  <None Remove="bin\**" />
-	  <None Remove="obj\**" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Include="..\SkiaGum\CustomSetPropertyOnRenderable.cs" Link="CustomSetPropertyOnRenderable.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\ArcRuntime.cs" Link="GueDeriving\ArcRuntime.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\LineRuntime.cs" Link="GueDeriving\LineRuntime.cs" />
-		<Compile Include="..\SkiaGum\GueDeriving\RoundedRectangleRuntime.cs" Link="GueDeriving\RoundedRectangleRuntime.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<!--
-			As of Apos.Shapes 0.7.2 the shader is precompiled and embedded in the assembly —
-			no content pipeline, no buildTransitive content, no PrivateAssets blocking needed
-			(see issue #4020). The precompiled apos-shapes.xnb workaround this csproj used to
-			ship is gone; consumers just reference the package.
-
-			Bumped from 0.7.10 to 0.8.1 for issue #4473 (RectangleRuntime crashed on macOS/Linux
-			GL drivers under the pinned 0.7.10 shader). 0.7.11's DrawRing second-radius semantics
-			change (rings would render 2x thicker) is compensated for in Arc.cs's DrawRing call —
-			see AposShapeGeometryTests for the pixel-level regression guard.
-		-->
-		<PackageReference Include="Apos.Shapes" Version="0.8.1" />
+		<PackageReference Include="Apos.Shapes" Version="$(AposShapesVersion)" />
 		<PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" PrivateAssets="All" />
 	</ItemGroup>
 
@@ -55,20 +14,6 @@
 		<ProjectReference Include="..\..\MonoGameGum\MonoGameGum.csproj" />
 	</ItemGroup>
 
-	<!--
-		Bundle the Gum.Analyzers Roslyn analyzer DLL into this package so NuGet consumers
-		get GUM001 namespace-migration warnings + code fixes. This is NOT a ProjectReference
-		because we do not want source-linkers' .sln files to require Tools/Gum.Analyzers/
-		to build. The analyzer is built independently (e.g. via AllLibraries.sln /
-		GumFull.sln) and the Exists() guard makes this include a no-op if the DLL is not
-		present, so source-only builds keep working with zero impact.
-	-->
-	<ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
-		<None Include="..\..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"
-			  Pack="true"
-			  PackagePath="analyzers/dotnet/cs/"
-			  Visible="false" />
-	</ItemGroup>
-
+	<Import Project="..\RuntimePackage.Analyzers.props" />
 
 </Project>

--- a/Runtimes/RuntimePackage.Analyzers.props
+++ b/Runtimes/RuntimePackage.Analyzers.props
@@ -6,8 +6,8 @@
     AllLibraries.sln / GumFull.sln); the Exists() guard makes this a no-op when the DLL is absent,
     so source-only builds keep working with zero impact.
 
-    Imported by RaylibGum, SkiaGum, and SilkNetGum. SokolGum does not currently bundle the
-    analyzer — a pre-existing gap this consolidation preserves rather than silently changes.
+    Imported by RaylibGum, SkiaGum, SilkNetGum, MonoGameGumShapes, and KniGumShapes. SokolGum
+    does not bundle the analyzer — a deliberate gap while that runtime is dormant (#4603).
   -->
   <ItemGroup Condition="'$(IncludeAnalyzers)' != 'false' AND Exists('$(MSBuildThisFileDirectory)..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll')">
     <None Include="$(MSBuildThisFileDirectory)..\Tools\Gum.Analyzers\bin\$(Configuration)\netstandard2.0\Gum.Analyzers.dll"


### PR DESCRIPTION
`MonoGameGumShapes` and `KniGumShapes` duplicated package metadata, the item excludes, the four SkiaGum source links, and the `Gum.Analyzers` bundling block. All of it moves into the `Directory.Build.props` already sitting in that folder. Each csproj keeps only its `PackageId`, its platform `PackageReference`s, and its `ProjectReference` — 19 and 28 lines, down from 74 and 84.

Three things beyond a straight move:

- **`$(AposShapesVersion)` is now one shared property.** `Apos.Shapes` and `Apos.Shapes.KNI` have to move together (the linked SkiaGum sources target one shader/API generation), and two independent literals made it possible to bump one and miss the other.
- **The `bin`/`obj` excludes become a `DefaultItemExcludes` property, with a comment explaining why they're needed at all.** They look redundant against the SDK defaults but aren't: both projects share one folder, and the `BaseOutputPath` redirects narrow each project's default excludes to its own `bin\<Platform>\` subfolder, so `KniGumShapes`' generated `AssemblyInfo.cs` isn't excluded from `MonoGameGumShapes` without them. The `XnbTest` excludes are dropped — that folder no longer exists.
- **`Runtimes/RuntimePackage.props` is deliberately *not* imported.** It would switch on `GeneratePackageOnBuild`, add `Release_No_Diagnostics` to `Configurations`, and pack an `AssemblyNameCollisionGuard.targets` that's inert without a per-package `buildTransitive` targets file these two don't have. Only `RuntimePackage.Analyzers.props` is a real drop-in, and both now import it.

The analyzer import stays in each csproj rather than moving to `Directory.Build.props`: its `Exists()` guard reads `$(Configuration)`, which isn't set yet that early in evaluation, so the guard would silently go false and drop the analyzer from both packages.

The issue's second half — `SokolGum` not bundling the analyzer — is closed as answered rather than changed. Sokol is dormant; the comment in `RuntimePackage.Analyzers.props` is updated to record that as deliberate instead of "pre-existing".

## Verification

Packed both projects before and after the change: identical nuspec metadata, identical package contents, `analyzers/dotnet/cs/Gum.Analyzers.dll` present in both. Identical warning profile (rebuild, warning-code histogram unchanged). `MonoGameGum.Shapes.Tests` 241/241.

Closes #4603
