### PR TITLE
Fix stale raylib growth caveat, document BmfcSave character ranges

### DIFF
--- a/docs/code/files-and-fonts/advanced-font-effects.md
+++ b/docs/code/files-and-fonts/advanced-font-effects.md
@@ -167,6 +167,10 @@ BitmapFont bitmapFont = CreateBitmapFont(result, GraphicsDevice);
 
 A tightly-subsetted atlas can be dramatically smaller than the default ASCII set — useful for a HUD font that only ever shows numbers, or a CJK font where you've pre-scanned your localization tables.
 
+{% hint style="info" %}
+This replaces the character set entirely. To extend the default set instead on `TextRuntime`'s property-driven path, see [Character Ranges](font-strategies.md#character-ranges).
+{% endhint %}
+
 ## Custom Glyphs
 
 `CustomGlyphs` lets you inject raw pixel data for specific codepoints — handy for inserting button-prompt icons (gamepad face buttons, key glyphs) into a normal text run so they flow inline with the surrounding text:

--- a/docs/code/files-and-fonts/font-automatic-growth.md
+++ b/docs/code/files-and-fonts/font-automatic-growth.md
@@ -5,7 +5,7 @@
 A font only has the characters you baked into it. If your game shows text you didn't plan for ahead of time — a player's name, a localized string with an accented letter, a currency symbol — a character missing from the font quietly falls back to a blank space. Automatic glyph growth fixes this: when `Text` is assigned a character the current font doesn't have, Gum adds that character to the live font's texture on the spot, and the text renders it immediately.
 
 {% hint style="info" %}
-Works on MonoGame, KNI, and FNA. Raylib is not supported yet.
+Works on MonoGame, KNI, FNA, and Raylib.
 {% endhint %}
 
 ## Enabling Automatic Growth
@@ -13,13 +13,25 @@ Works on MonoGame, KNI, and FNA. Raylib is not supported yet.
 You need two things, the same shape as [Font Oversampling](font-oversampling.md):
 
 1. Turn on the flag: `TextRuntime.UseAutomaticFontGrowth = true`. One `static` switch for the whole game, off by default.
-2. Give Gum a way to build and grow fonts while the game runs. KernSmith's `KernSmithFontCreator` supports this — see [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation).
+2. Give Gum a way to build and grow fonts while the game runs. KernSmith's `IGrowableFontCreator`/`IGrowableRaylibFontCreator` implementations support this, see [Dynamic KernSmith Generation](font-strategies.md#dynamic-kernsmith-generation).
 
+{% tabs %}
+{% tab title="MonoGame" %}
 ```csharp
 TextRuntime.UseAutomaticFontGrowth = true;
 CustomSetPropertyOnRenderable.InMemoryFontCreator =
     new KernSmithFontCreator(GraphicsDevice);
 ```
+{% endtab %}
+
+{% tab title="Raylib" %}
+```csharp
+TextRuntime.UseAutomaticFontGrowth = true;
+CustomSetPropertyOnRenderable.InMemoryFontCreator =
+    new KernSmithRaylibFontCreator();
+```
+{% endtab %}
+{% endtabs %}
 
 After that it runs on its own. Assigning `Text` (or `TextNoTranslate`) checks the new string against the font's known characters; anything missing is added to the live texture before the text wraps and measures, so there is no stale frame where the character is still missing.
 

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -299,6 +299,10 @@ BmfcSave.AddFontRange(BmfcSave.GenerateRangesFromFile("Content/Localisation/loc.
 
 Both `AddFontRange` and `AddCharacters` are static and apply to every `BmfcSave` created afterward, so call them once before creating any `Text`.
 
+{% hint style="info" %}
+`AddFontRange` and `AddCharacters` only add to the default range, they can't replace it. To generate a font from an exact character set instead of extending the default, see [Custom Character Sets](advanced-font-effects.md#custom-character-sets), which replaces the set entirely but requires the manual generation path rather than `TextRuntime`'s font properties.
+{% endhint %}
+
 ### When to Use This Strategy
 
 * You're using Latin, Cyrillic, Greek, or another small-charset script.

--- a/docs/code/files-and-fonts/font-strategies.md
+++ b/docs/code/files-and-fonts/font-strategies.md
@@ -276,12 +276,35 @@ This is KernSmith's behavior, so it covers MonoGame, KNI, FNA, and raylib. SkiaG
 
 KernSmith can also build the style even when a real face exists, which makes every platform render the same letters. `TextRuntime` does not expose that option, so reaching it means calling KernSmith yourself. See [Forcing Synthetic Bold and Italic](advanced-font-effects.md#forcing-synthetic-bold-and-italic) on the Advanced Font Effects page.
 
+### Character Ranges
+
+Every `BmfcSave` starts with `BmfcSave.DefaultRanges`, `32-126,160-255` (ASCII plus Latin-1 Supplement). Extend that default project-wide with `BmfcSave.AddFontRange`, which takes the same comma-separated `start-end`/single-codepoint format, or `BmfcSave.AddCharacters`, which takes literal characters and converts each one to its codepoint:
+
+```csharp
+// Initialize
+BmfcSave.AddFontRange("19968-40959"); // CJK Unified Ideographs
+BmfcSave.AddCharacters("日本語"); // add exact characters instead of a whole block
+```
+
+For a localized game, `BmfcSave.GenerateRangesFromFile` builds the range from your actual localization file instead of guessing a Unicode block:
+
+```csharp
+// Initialize
+BmfcSave.AddFontRange(BmfcSave.GenerateRangesFromFile("Content/Localisation/loc.csv"));
+```
+
+{% hint style="info" %}
+`GenerateRangesFromFile` reads every character in the file. A localization file holding every supported language returns the union of all of them, not just the language your player selected. Split the file per language first for a tighter range.
+{% endhint %}
+
+Both `AddFontRange` and `AddCharacters` are static and apply to every `BmfcSave` created afterward, so call them once before creating any `Text`.
+
 ### When to Use This Strategy
 
 * You're using Latin, Cyrillic, Greek, or another small-charset script.
 * You want to change font, size, style, outline thickness, or baked drop shadow without rebuilding atlases.
 * You don't want to check generated `.fnt` files into source control.
-* For CJK or other large charsets, this strategy still works — but you should pair it with [Font Preloading](font-preloading.md) so the per-atlas generation cost happens on a loading screen rather than during gameplay.
+* For CJK or other large charsets, this strategy still works. Pair it with [Character Ranges](font-strategies.md#character-ranges) to build a range that matches your actual content, and with [Font Preloading](font-preloading.md) so the per-atlas generation cost happens on a loading screen rather than during gameplay.
 * Player-typed or localized text can introduce characters you didn't plan for ahead of time — see [Automatic Glyph Growth](font-automatic-growth.md) to grow the live atlas instead of silently falling back to a blank glyph.
 
 ## Dynamic Generation on SkiaGum


### PR DESCRIPTION
font-automatic-growth.md said raylib wasn't supported for automatic glyph growth. That shipped in #4546/#4557 (`KernSmithRaylibFontCreator` implements `IGrowableRaylibFontCreator`); confirmed by running `TextRuntimeAutomaticFontGrowthTests`/`KernSmithRaylibFontCreatorGrowthTests` (13/13 green, real font + real creator, not mocks).

Also adds a Character Ranges section to font-strategies.md covering `BmfcSave.AddFontRange`, `AddCharacters`, and `GenerateRangesFromFile` — none were documented anywhere. Came up from a CJK support question where the asker was using `GenerateRangesFromFile` against a whole localization file; added a hint about that scanning every language in the file, not just the selected one.

Manual test: not needed, docs-only change.
FRB canary: not needed, no FRB-shared source touched.