### PR TITLE
Document why raylib has no host-frame latch (#4598)

### DIFF
--- a/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/Renderer.cs
@@ -218,6 +218,11 @@ public class Renderer : IRenderer
         Draw(systemManagers, _layers);
     }
 
+    // Every frame-boundary step below runs unconditionally, because this Draw is the host frame on
+    // raylib — there is no GumBatch here issuing several Begin/Draw/End cycles per frame. That is
+    // why this Renderer has no BeginFrame/EndFrame/NotifyHostFrameAdvanced and none of the
+    // _*ForHostFrame latch flags the XNA Renderer carries: those exist purely to make this work
+    // happen once across multiple cycles. Deliberate, not a porting gap (#4598).
     private void Draw(SystemManagers managers, List<Layer> layers)
     {
         // Frame-boundary RT sweep — release per-renderable shadow RTs whose owner wasn't drawn

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -23,9 +23,9 @@ public partial class SystemManagers : ISystemManagers
 {
     int mPrimaryThreadId;
 #if !RAYLIB
-    // Mirrors RenderingLibrary/SystemManagers.cs's _lastActivityTime, which feeds
-    // Renderer.NotifyHostFrameAdvanced() - not ported here since raylib's own Renderer has no
-    // equivalent member. Dead in this build; kept for cross-file diff parity. Tracked separately (#4598).
+    // Mirrors RenderingLibrary/SystemManagers.cs's _lastActivityTime, which gates the
+    // Renderer.NotifyHostFrameAdvanced() call in Activity below. Dead in this build; kept for
+    // cross-file diff parity.
     private double _lastActivityTime = double.NaN;
 #endif
 
@@ -220,6 +220,13 @@ public partial class SystemManagers : ISystemManagers
     public void Activity(double currentTime)
     {
 #if !RAYLIB
+        // XNALIKE-only, and intentionally never ported to raylib (#4598). NotifyHostFrameAdvanced()
+        // resets the once-per-host-frame latches on the XNA Renderer (render-target sweep, layer
+        // pre-render, referenced-RT collection, perf-stat reset). Those latches exist only because
+        // GumBatch lets a host run several Begin/Draw/End cycles per frame, so the work behind them
+        // has to be skipped after the first cycle. raylib has no GumBatch: Renderer.Draw runs once
+        // per host frame and does that same work unconditionally at the top of it, so there is
+        // nothing to latch and no member to call here.
         if (currentTime != _lastActivityTime)
         {
             _lastActivityTime = currentTime;


### PR DESCRIPTION
Closes #4598 — as documentation, not as a port. The issue's premise doesn't hold.

`NotifyHostFrameAdvanced()` resets four booleans on the XNA `Renderer`: `_renderTargetSweepCompletedForHostFrame`, `_allLayersPreRenderedForHostFrame`, `_referencedRenderTargetsCollectedForHostFrame`, `_perfStatsResetForHostFrame`. It never touches `BatchKeyGroupedOrderer`, so the issue's "feeds the BatchKeyGroupedOrderer diagnostics/batching work" framing is wrong.

Those latches exist only because MonoGame has `GumBatch` — an immediate-mode Begin/Draw/End path a host can run several times per frame, so once-per-frame work has to be skipped after the first cycle. raylib has no `GumBatch`: `Renderer.Draw` *is* the host frame and does the same sweeps unconditionally at its top, with an existing in-code note saying as much ("raylib bakes all layers in one pass so no per-host-frame caching is needed").

Porting the member would add three no-op parity methods that latch nothing. So instead:

- `SystemManagers.Activity` — the `#if !RAYLIB` block now explains why there's no counterpart, replacing the "not ported / tracked separately (#4598)" note that pointed at what is now a closed issue.
- `Renderer.Draw` — a note above the frame-boundary sweeps saying the absent `BeginFrame`/`EndFrame`/`NotifyHostFrameAdvanced` and `_*ForHostFrame` flags are deliberate.

No behavior change; `RaylibGum.csproj` builds with 0 errors and no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1Z4QsVUbUeABUUY1ajuSR

