### PR TITLE
Collapse the Texture2D #if blocks behind GetOrLoadEmbeddedTexture2d (#4451)

### DIFF
--- a/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
@@ -66,7 +66,11 @@ public class Styling
 
         // Get-or-load rather than load: Styling is constructed per default-visual class, so loading
         // here would decode (and on raylib, upload) a duplicate sprite sheet every time.
-        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+        // SystemManagers.Default is null before Initialize and after Uninitialize, and ActiveStyle's
+        // lazy getter can construct a Styling in either state, so fall back to an unset sheet
+        // instead of throwing.
+        Texture2D? loaded = SystemManagers.Default?.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+        this.SpriteSheet = spriteSheet ?? loaded ?? default!;
 
         // Set the backing field directly rather than going through the ActiveStyle property:
         // ActiveStyle's getter lazily constructs a Styling(null) when unset, and re-entering that

--- a/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
+++ b/MonoGameGum/Forms/DefaultVisuals/V3/Styling.cs
@@ -64,22 +64,9 @@ public class Styling
         NineSlice = new();
         Icons = new();
 
-#if XNALIKE
-        if (spriteSheet == null)
-        {
-            this.SpriteSheet = (Texture2D)global::RenderingLibrary.Content.LoaderManager.Self.GetDisposable($"EmbeddedResource.{SystemManagers.AssemblyPrefix}.UISpriteSheet.png");
-        }
-        else
-        {
-            this.SpriteSheet = spriteSheet;
-        }
-#elif RAYLIB
-        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!.Value;
-#elif SOKOL
-        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
-#elif SKIA
-        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
-#endif
+        // Get-or-load rather than load: Styling is constructed per default-visual class, so loading
+        // here would decode (and on raylib, upload) a duplicate sprite sheet every time.
+        this.SpriteSheet = spriteSheet ?? SystemManagers.Default.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
 
         // Set the backing field directly rather than going through the ActiveStyle property:
         // ActiveStyle's getter lazily constructs a Styling(null) when unset, and re-entering that

--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -95,14 +95,10 @@ public class FormsUtilities
                 "You must call this method after initializing SystemManagers.Default, or you must explicitly specify a SystemsManager instance");
         }
 
-        // Written as an exclusion rather than an enumeration of every backend so a new runtime
-        // linking this file gets a compiling default instead of an undeclared-variable error:
-        // raylib alone returns a nullable value type here, everything else a nullable reference.
-#if RAYLIB
-        Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png").Value;
-#else
-        Texture2D uiSpriteSheet = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!;
-#endif
+        // Each backend's GetOrLoadEmbeddedTexture2d returns its own texture type non-nullable, so
+        // this needs no per-backend branch even though raylib's Texture2D is a struct and every
+        // other backend's is a class.
+        Texture2D uiSpriteSheet = systemManagers.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
 
         // DefaultVisualsVersion has only one member (V3, aliased as Newest), so no switch is needed
         // here -- this used to also register V1/V2 legacy default visuals, removed in #4447.

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -362,6 +362,26 @@ public partial class SystemManagers : ISystemManagers
     }
 
     /// <summary>
+    /// Returns the embedded texture cached under <paramref name="embeddedTexture2dName"/>, loading
+    /// and caching it via <see cref="LoadEmbeddedTexture2d"/> on the first call. Prefer this over
+    /// <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested more than
+    /// once, so the callers share one texture instead of each getting a fresh copy.
+    /// </summary>
+    public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
+    {
+        var cacheName = $"EmbeddedResource.{AssemblyPrefix}.{embeddedTexture2dName}";
+
+        if (Content.LoaderManager.Self.GetDisposable(cacheName) is Texture2D cached)
+        {
+            return cached;
+        }
+
+        // Null when there's no graphics device, which unit tests rely on; the callers assign to a
+        // non-nullable local and already tolerated that from LoadEmbeddedTexture2d.
+        return LoadEmbeddedTexture2d(embeddedTexture2dName)!;
+    }
+
+    /// <summary>
     /// Performs every-frame activity for all contained systems in the SystemManager.
     /// </summary>
     /// <param name="currentTime">The amount of time that has passed since the game started.</param>

--- a/RenderingLibrary/SystemManagers.cs
+++ b/RenderingLibrary/SystemManagers.cs
@@ -367,6 +367,13 @@ public partial class SystemManagers : ISystemManagers
     /// <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested more than
     /// once, so the callers share one texture instead of each getting a fresh copy.
     /// </summary>
+    /// <returns>
+    /// The texture, or null when there is no graphics device (headless unit tests). Declared
+    /// non-nullable so the shared Forms sources can call this with no per-backend branch: raylib's
+    /// Texture2D is a struct and every other backend's is a class, so a nullable return needs
+    /// <c>.Value</c> on one and <c>!</c> on the others. Null-check the result before using it if you
+    /// may run without a graphics device.
+    /// </returns>
     public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
     {
         var cacheName = $"EmbeddedResource.{AssemblyPrefix}.{embeddedTexture2dName}";
@@ -376,8 +383,6 @@ public partial class SystemManagers : ISystemManagers
             return cached;
         }
 
-        // Null when there's no graphics device, which unit tests rely on; the callers assign to a
-        // non-nullable local and already tolerated that from LoadEmbeddedTexture2d.
         return LoadEmbeddedTexture2d(embeddedTexture2dName)!;
     }
 

--- a/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/RaylibGum/RenderingLibrary/SystemManagers.cs
@@ -205,9 +205,32 @@ public partial class SystemManagers : ISystemManagers
 
         //Texture2D texture = Texture2D.FromStream(Renderer.GraphicsDevice, stream);
 
-        var resourceName = $"{AssemblyPrefix}.{embeddedTexture2dName}";
-        // raylib textures aren't disposable...
-        //Content.LoaderManager.Self.AddDisposable($"EmbeddedResource.{resourceName}", texture);
+        // Deliberately uncached: this always uploads a fresh texture. Use
+        // GetOrLoadEmbeddedTexture2d below to share one.
+        return texture;
+    }
+
+    /// <summary>
+    /// Returns the embedded texture cached under <paramref name="embeddedTexture2dName"/>, loading
+    /// and caching it via <see cref="LoadEmbeddedTexture2d"/> on the first call. Prefer this over
+    /// <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested more than
+    /// once, so the callers share one GPU texture instead of each uploading a fresh copy.
+    /// </summary>
+    public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
+    {
+        var cacheName = $"EmbeddedResource.{AssemblyPrefix}.{embeddedTexture2dName}";
+
+        if (Content.LoaderManager.Self.GetDisposable(cacheName) is ManagedTexture cached)
+        {
+            return cached.Texture;
+        }
+
+        var texture = LoadEmbeddedTexture2d(embeddedTexture2dName)!.Value;
+
+        // raylib's Texture2D is a struct, so it reaches the IDisposable cache through
+        // ManagedTexture, the same wrapper ContentLoader uses for file-loaded textures.
+        Content.LoaderManager.Self.AddDisposable(cacheName, new ManagedTexture(texture),
+            Content.LoaderManager.ExistingContentBehavior.Replace);
 
         return texture;
     }

--- a/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
+++ b/Runtimes/SkiaGum/RenderingLibrary/SystemManagers.cs
@@ -291,5 +291,23 @@ namespace RenderingLibrary
 
             return texture;
         }
+
+        /// <summary>
+        /// Returns the embedded texture cached under <paramref name="embeddedTexture2dName"/>,
+        /// loading and caching it via <see cref="LoadEmbeddedTexture2d"/> on the first call. Prefer
+        /// this over <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested
+        /// more than once, so the callers share one bitmap instead of each decoding a fresh copy.
+        /// </summary>
+        public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
+        {
+            var cacheName = $"EmbeddedResource.{AssemblyPrefix}.{embeddedTexture2dName}";
+
+            if (Content.LoaderManager.Self.GetDisposable(cacheName) is Texture2D cached)
+            {
+                return cached;
+            }
+
+            return LoadEmbeddedTexture2d(embeddedTexture2dName)!;
+        }
     }
 }

--- a/Runtimes/SokolGum/SystemManagers.cs
+++ b/Runtimes/SokolGum/SystemManagers.cs
@@ -173,6 +173,10 @@ public sealed class SystemManagers : ISystemManagers, IDisposable
     /// <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested more than
     /// once, so the callers share one texture instead of each decoding a fresh copy.
     /// </summary>
+    /// <returns>
+    /// The texture, or null when the embedded resource is missing or fails to decode. Declared
+    /// non-nullable so the shared Forms sources can call this with no per-backend branch.
+    /// </returns>
     public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
     {
         var cacheName = $"EmbeddedResource.SokolGum.Content.{embeddedTexture2dName}";
@@ -182,11 +186,17 @@ public sealed class SystemManagers : ISystemManagers, IDisposable
             return cached;
         }
 
-        var texture = LoadEmbeddedTexture2d(embeddedTexture2dName)!;
-        LoaderManager.Self.AddDisposable(cacheName, texture,
-            LoaderManager.ExistingContentBehavior.Replace);
+        var texture = LoadEmbeddedTexture2d(embeddedTexture2dName);
 
-        return texture;
+        // Null when the resource is missing or fails to decode. Caching that would put a null in
+        // LoaderManager's dictionary, which DisposeAndClear dereferences at shutdown.
+        if (texture != null)
+        {
+            LoaderManager.Self.AddDisposable(cacheName, texture,
+                LoaderManager.ExistingContentBehavior.Replace);
+        }
+
+        return texture!;
     }
 
     private static unsafe Texture2D? DecodeRgba8(byte[] bytes, string label)

--- a/Runtimes/SokolGum/SystemManagers.cs
+++ b/Runtimes/SokolGum/SystemManagers.cs
@@ -167,6 +167,28 @@ public sealed class SystemManagers : ISystemManagers, IDisposable
         return DecodeRgba8(fileData, embeddedTexture2dName);
     }
 
+    /// <summary>
+    /// Returns the embedded texture cached under <paramref name="embeddedTexture2dName"/>, loading
+    /// and caching it via <see cref="LoadEmbeddedTexture2d"/> on the first call. Prefer this over
+    /// <see cref="LoadEmbeddedTexture2d"/> anywhere the same texture may be requested more than
+    /// once, so the callers share one texture instead of each decoding a fresh copy.
+    /// </summary>
+    public Texture2D GetOrLoadEmbeddedTexture2d(string embeddedTexture2dName)
+    {
+        var cacheName = $"EmbeddedResource.SokolGum.Content.{embeddedTexture2dName}";
+
+        if (LoaderManager.Self.GetDisposable(cacheName) is Texture2D cached)
+        {
+            return cached;
+        }
+
+        var texture = LoadEmbeddedTexture2d(embeddedTexture2dName)!;
+        LoaderManager.Self.AddDisposable(cacheName, texture,
+            LoaderManager.ExistingContentBehavior.Replace);
+
+        return texture;
+    }
+
     private static unsafe Texture2D? DecodeRgba8(byte[] bytes, string label)
     {
         int width = 0, height = 0, channels = 0;

--- a/Samples/raylib/Program.cs
+++ b/Samples/raylib/Program.cs
@@ -84,7 +84,6 @@ public class BasicShapes
 
         // Demo the auto-fit helpers — flip via the Zoom/Expand radio buttons in the nav strip.
         GumUI.EnableZoomToWindow();
-        var standardTexture = SystemManagers.Default.LoadEmbeddedTexture2d("UISpriteSheet.png");
 
         InitializeStyling();
         BuildNavStrip();

--- a/Tests/RaylibGum.Tests/GetOrLoadEmbeddedTexture2dTests.cs
+++ b/Tests/RaylibGum.Tests/GetOrLoadEmbeddedTexture2dTests.cs
@@ -1,5 +1,6 @@
 using Raylib_cs;
 using RenderingLibrary;
+using RenderingLibrary.Content;
 using Shouldly;
 
 namespace RaylibGum.Tests;
@@ -22,5 +23,36 @@ public class GetOrLoadEmbeddedTexture2dTests : BaseTestClass
 
         first.Id.ShouldBeGreaterThan(0u);
         second.Id.ShouldBe(first.Id);
+    }
+
+    // The other half of the contract: LoadEmbeddedTexture2d is the always-fresh loader, and the
+    // caller owns what it returns. Nothing caches it, so nothing will ever call UnloadTexture on
+    // it either -- which is exactly why Styling and FormsUtilities must use the get-or-load method
+    // instead. Pins both halves so a future "helpful" cache added here doesn't silently hand two
+    // callers the same texture.
+    [Fact]
+    public void LoadEmbeddedTexture2d_CalledTwice_ShouldUploadTwoUnownedTextures()
+    {
+        SystemManagers systemManagers = SystemManagers.Default;
+        string cacheKey = $"EmbeddedResource.{SystemManagers.AssemblyPrefix}.UISpriteSheet.png";
+
+        // Drop just this key if a neighbouring test cached it, so the assertion below is about this
+        // method's own behavior. Scoped to the one entry rather than toggling CacheTextures, which
+        // would dispose the whole shared cache and break tests that run after this one.
+        LoaderManager.Self.Dispose(cacheKey);
+
+        Texture2D first = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!.Value;
+        Texture2D second = systemManagers.LoadEmbeddedTexture2d("UISpriteSheet.png")!.Value;
+
+        try
+        {
+            second.Id.ShouldNotBe(first.Id);
+            LoaderManager.Self.CachedDisposables.ContainsKey(cacheKey).ShouldBeFalse();
+        }
+        finally
+        {
+            Raylib.UnloadTexture(first);
+            Raylib.UnloadTexture(second);
+        }
     }
 }

--- a/Tests/RaylibGum.Tests/GetOrLoadEmbeddedTexture2dTests.cs
+++ b/Tests/RaylibGum.Tests/GetOrLoadEmbeddedTexture2dTests.cs
@@ -1,0 +1,26 @@
+using Raylib_cs;
+using RenderingLibrary;
+using Shouldly;
+
+namespace RaylibGum.Tests;
+
+/// <summary>
+/// Covers <see cref="SystemManagers.GetOrLoadEmbeddedTexture2d"/>'s cache-hit branch. Raylib is the
+/// backend where this matters most: its <c>LoadEmbeddedTexture2d</c> uploads a fresh GPU texture on
+/// every call and caches nothing, so repeated <c>Styling</c> construction leaked one texture per
+/// instance. Issue #4451.
+/// </summary>
+public class GetOrLoadEmbeddedTexture2dTests : BaseTestClass
+{
+    [Fact]
+    public void GetOrLoadEmbeddedTexture2d_CalledTwice_ShouldReturnTheSameTexture()
+    {
+        SystemManagers systemManagers = SystemManagers.Default;
+
+        Texture2D first = systemManagers.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+        Texture2D second = systemManagers.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+
+        first.Id.ShouldBeGreaterThan(0u);
+        second.Id.ShouldBe(first.Id);
+    }
+}

--- a/Tests/SkiaGum.Tests/LoadEmbeddedTexture2dTests.cs
+++ b/Tests/SkiaGum.Tests/LoadEmbeddedTexture2dTests.cs
@@ -21,4 +21,19 @@ public class LoadEmbeddedTexture2dTests
         texture.Width.ShouldBeGreaterThan(0);
         texture.Height.ShouldBeGreaterThan(0);
     }
+
+    // GetOrLoadEmbeddedTexture2d reuses the cached bitmap instead of decoding a fresh one per call,
+    // which is what lets Styling and FormsUtilities share one line across every backend. Issue #4451.
+    [Fact]
+    public void GetOrLoadEmbeddedTexture2d_CalledTwice_ShouldReturnTheSameBitmap()
+    {
+        SystemManagers systemManagers = new SystemManagers();
+        systemManagers.Initialize();
+
+        SKBitmap first = systemManagers.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+        SKBitmap second = systemManagers.GetOrLoadEmbeddedTexture2d("UISpriteSheet.png");
+
+        first.ShouldNotBeNull();
+        second.ShouldBeSameAs(first);
+    }
 }


### PR DESCRIPTION
Closes #4451.

`FormsUtilities.InitializeDefaults` and `Styling`'s constructor each carried a per-backend `#if` for one reason: `Texture2D` is a struct on raylib and a class everywhere else, and the embedded loader returned it nullable, so one backend needed `.Value` and the rest needed `!`.

Each backend's `SystemManagers` now also exposes `GetOrLoadEmbeddedTexture2d`, returning its own texture type non-nullable. Both call sites collapse to a single unconditional line, and no backend-neutral texture wrapper was needed.

Get-or-load rather than load, because `Styling` is constructed once per default-visual class.

## Fixes that fell out

- **raylib leaked a GPU texture per `Styling` instance.** Its embedded loader cached nothing, so every construction uploaded another sprite sheet that nothing ever unloaded. It now caches through `ManagedTexture`, the `IDisposable` wrapper `ContentLoader` already uses for file-loaded raylib textures.
- **`Styling`'s XNALIKE branch read the cache directly** and got null when nothing had primed it. It now falls back to loading, matching every other backend.
- Dropped a dead `LoadEmbeddedTexture2d` call in the raylib sample that uploaded and leaked a second sheet.

## Tests

One per backend that can actually reach the code. `MonoGameGum.Tests` runs with no graphics device, so the loader returns null there and the cache never populates.

- Skia: repeated calls return the same bitmap.
- raylib: repeated calls return the same texture; and the companion pin that `LoadEmbeddedTexture2d` uploads a fresh texture per call and caches nothing, so nothing owns it to free it.

Verified the raylib cache-hit test goes red with the branch disabled. `MonoGameGum.Tests` 2271, `SkiaGum.Tests` 440, `RaylibGum.Tests` 640 green. `GumFull.sln`, KniGum, SilkNetGum, StrideGum, SkiaGum.Wpf and both samples build with no new warnings. SokolGum's source is updated but unverified — it is in no solution and CI does not build it.

Manual test passed: Forms control chrome renders normally in `MonoGameGumInCode`.

FRB canary: pass. `GumCore.DesktopGlNet6` is red, but identically red on the clean base — filed as #4625.

Filed #4626 for a teardown hazard this made uniform across backends: `Uninitialize` disposes the cached sprite sheet without resetting `Styling.ActiveStyle`.
