### PR TITLE
Fix FRB build: move dispatched-alpha normalization to shared source

### DIFF
--- a/.claude/skills/frb-build-verification/SKILL.md
+++ b/.claude/skills/frb-build-verification/SKILL.md
@@ -24,6 +24,8 @@ If a shared `.cs` file gains a `using` that resolves through a NuGet package, ad
 
 The most common way a Gum change silently breaks FRB1: a member behind `#if !FRB` (e.g. on `TextRuntime`, which doesn't exist under FRB) gets called from shared, unguarded code. The non-FRB build stays green, so the break is invisible until this skill's canary runs. Whenever you add or move a member behind any platform `#if` (`!FRB`, `!RAYLIB`, `XNALIKE`, etc.), grep every call site — if any lives in unguarded shared source, guard the call site too or provide a same-named shim for the excluded platform (an FRB-only extension method on `GraphicalUiElement` is the established pattern — see `CustomSetPropertyOnRenderable.cs`).
 
+A member needs no `#if` of its own to fall into this trap: FRB compiles none of `MonoGameGum/GueDeriving/*Runtime.cs`, so under `FRB` the `ContainerRuntimeType`/`SpriteRuntimeType` aliases in `CustomSetPropertyOnRenderable.cs` resolve to the small `IContainerRuntime`/`ISpriteRuntime` shim interfaces, and unguarded dispatch code can touch only what those shims declare. Keep the shims describing data (Glue generates the classes that must implement them) and put shared value normalization in FRB-compiled source instead — `InvisibleRenderable.NormalizeDispatchedAlpha` is the pattern.
+
 ## Precondition — skip entirely if absent
 
 This is only doable when a **FlatRedBall checkout exists as a sibling of the Gum repo** (i.e. `<gum-repo>/../FlatRedBall/`). The cross-repo csproj imports are sibling-relative (`..\..\..\..\FlatRedBall\…`), so without that layout the build can't resolve. If the sibling is absent, **skip FRB verification and say so** — it is not a failure; the maintainer/CI covers it. Do not hardcode an absolute path; check for the sibling.

--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -401,7 +401,10 @@ public partial class CustomSetPropertyOnRenderable
                 AssignSourceShaderFileOnContainer(invisibleRenderable, graphicalUiElement, value as string);
                 return true;
             case "Alpha":
-                containerRuntime?.SetAlphaFromDispatch(value);
+                if (containerRuntime != null)
+                {
+                    containerRuntime.Alpha = InvisibleRenderable.NormalizeDispatchedAlpha(value);
+                }
                 return true;
         }
 

--- a/MonoGameGum/GueDeriving/ContainerRuntime.cs
+++ b/MonoGameGum/GueDeriving/ContainerRuntime.cs
@@ -35,29 +35,6 @@ public class ContainerRuntime : InteractiveGue
         }
     }
 
-    /// <summary>
-    /// Assigns <see cref="Alpha"/> from a dispatched string-path property value, which arrives as
-    /// <see cref="int"/> or <see cref="float"/> depending on caller. Shared by the core
-    /// (XNA-like/raylib) and Skia dispatchers so the int/float normalization isn't duplicated in
-    /// each (see <c>TrySetPropertyOnContainer</c> in
-    /// <c>Gum.Wireframe.CustomSetPropertyOnRenderable</c> and <c>SkiaGum.CustomSetPropertyOnRenderable</c>).
-    /// </summary>
-    public void SetAlphaFromDispatch(object value)
-    {
-        if (value is int intValue)
-        {
-            Alpha = intValue;
-        }
-        else if (value is float floatValue)
-        {
-            Alpha = (int)floatValue;
-        }
-        else
-        {
-            Alpha = 255;
-        }
-    }
-
     public bool IsRenderTarget
     {
         get => (RenderableComponent as InvisibleRenderable)?.IsRenderTarget ?? false;

--- a/RenderingLibrary/Graphics/InvisibleRenderable.cs
+++ b/RenderingLibrary/Graphics/InvisibleRenderable.cs
@@ -16,6 +16,29 @@ public class InvisibleRenderable : RenderableBase, ICloneable, IRenderableIpso
 
     int IRenderableIpso.Alpha => (int)this.Alpha;
 
+    /// <summary>
+    /// Normalizes an alpha value arriving from the string-based property dispatch, which is an
+    /// int or a float depending on caller, into the int the Alpha properties expect. Lives here
+    /// (shared, FRB-compiled source) rather than on a GueDeriving runtime so both the core and
+    /// Skia dispatchers - and the FRB build, which compiles no GueDeriving runtimes - can reach
+    /// the same normalization. Unrecognized value types fall back to fully opaque.
+    /// </summary>
+    public static int NormalizeDispatchedAlpha(object value)
+    {
+        if (value is int intValue)
+        {
+            return intValue;
+        }
+        else if (value is float floatValue)
+        {
+            return (int)floatValue;
+        }
+        else
+        {
+            return 255;
+        }
+    }
+
     public override void Render(ISystemManagers managers)
     {
 

--- a/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
+++ b/Runtimes/SkiaGum/CustomSetPropertyOnRenderable.cs
@@ -1062,7 +1062,10 @@ public partial class CustomSetPropertyOnRenderable
                     break;
 #endif
                 case "Alpha":
-                    containerRuntime?.SetAlphaFromDispatch(value);
+                    if (containerRuntime != null)
+                    {
+                        containerRuntime.Alpha = InvisibleRenderable.NormalizeDispatchedAlpha(value);
+                    }
                     handled = true;
                     break;
             }


### PR DESCRIPTION
`TrySetPropertyOnContainer` called `ContainerRuntime.SetAlphaFromDispatch` unguarded, but FRB compiles no `GueDeriving` runtimes — under `FRB` the `ContainerRuntimeType` alias is the `IContainerRuntime` shim, which declares only `Alpha` and `IsRenderTarget`. Every non-FRB build stayed green while FRB1 failed with CS1061 (confirmed in a real game project).

The int/float normalization moves to `InvisibleRenderable.NormalizeDispatchedAlpha`, which is shared into FRB via `GumCoreShared.projitems`. Both the core and Skia dispatchers now assign `containerRuntime.Alpha` directly, so the call site is unguarded again and the shim interface keeps describing data only — Glue's generated runtimes gain no new obligation.

Behavior is unchanged and already pinned by `DataDrivenContainerPropertyTests` (int, float, unsupported type).

Verified: MonoGameGum.Tests, RaylibGum, SkiaGum, KniGum, MonoGameGumShapes all build clean; container tests 6/6. FRB canary (`GumCore.DesktopGlNet6`, net6.0 + net8.0) passes.

Also generalizes the `frb-build-verification` guard-symmetry section: a member needs no `#if` of its own to break FRB — living in `GueDeriving/*Runtime.cs` is enough.

Closes #4625
