### PR TITLE
Let users copy errors from the Errors tab

### DIFF
--- a/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml
+++ b/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml
@@ -14,6 +14,32 @@
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
             ItemsSource="{Binding Errors}"
             SelectedItem="{Binding SelectedItem}">
+            <ListBox.InputBindings>
+                <KeyBinding
+                    Command="{Binding CopySelectedErrorCommand}"
+                    Gesture="Ctrl+C" />
+                <KeyBinding
+                    Command="{Binding CopyAllErrorsCommand}"
+                    Gesture="Ctrl+Shift+C" />
+            </ListBox.InputBindings>
+            <ListBox.ContextMenu>
+                <ContextMenu>
+                    <MenuItem
+                        Command="{Binding CopySelectedErrorCommand}"
+                        Header="_Copy"
+                        InputGestureText="Ctrl+C" />
+                    <MenuItem
+                        Command="{Binding CopyAllErrorsCommand}"
+                        Header="Copy _All Errors"
+                        InputGestureText="Ctrl+Shift+C" />
+                </ContextMenu>
+            </ListBox.ContextMenu>
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <!--  Right-clicking a row does not select it in WPF, so the context menu would otherwise act on whatever was selected before.  -->
+                    <EventSetter Event="PreviewMouseRightButtonDown" Handler="HandleItemPreviewMouseRightButtonDown" />
+                </Style>
+            </ListBox.ItemContainerStyle>
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <local:ErrorListEntry />

--- a/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml
+++ b/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml
@@ -35,7 +35,7 @@
                 </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemContainerStyle>
-                <Style TargetType="ListBoxItem">
+                <Style BasedOn="{StaticResource {x:Type ListBoxItem}}" TargetType="{x:Type ListBoxItem}">
                     <!--  Right-clicking a row does not select it in WPF, so the context menu would otherwise act on whatever was selected before.  -->
                     <EventSetter Event="PreviewMouseRightButtonDown" Handler="HandleItemPreviewMouseRightButtonDown" />
                 </Style>

--- a/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/Errors/ErrorDisplay.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Gum.Plugins.Errors
 {
@@ -10,6 +11,14 @@ namespace Gum.Plugins.Errors
         public ErrorDisplay()
         {
             InitializeComponent();
+        }
+
+        private void HandleItemPreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is ListBoxItem item)
+            {
+                item.IsSelected = true;
+            }
         }
     }
 }

--- a/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/Errors/MainErrorsPlugin.cs
@@ -27,20 +27,23 @@ public class MainErrorsPlugin : PriorityPlugin
     PluginTab tabPage;
     private ErrorTabHeader _tabPageHeader;
     private readonly ISelectedState _selectedState;
+    private readonly IClipboardService _clipboardService;
 
     #endregion
 
     [ImportingConstructor]
-    public MainErrorsPlugin(IErrorChecker errorChecker, IMessenger messenger, ISelectedState selectedState)
+    public MainErrorsPlugin(IErrorChecker errorChecker, IMessenger messenger, ISelectedState selectedState,
+        IClipboardService clipboardService)
     {
         this.errorChecker = errorChecker;
         _messenger = messenger;
         _selectedState = selectedState;
+        _clipboardService = clipboardService;
     }
 
     public override void StartUp()
     {
-        viewModel = new AllErrorsViewModel();
+        viewModel = new AllErrorsViewModel(_clipboardService);
 
         _messenger.Register<RequestErrorRefreshMessage>(
             this,

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -878,13 +878,14 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
 
             // Medium-tier plugin ctor drains (cheapest-first batch): MainHideShowToolsPlugin
             // (MainPanelViewModel), MainVariableGridPlugin (PropertyGridManager,
-            // IVariableReferenceLogic), MainErrorsPlugin (IErrorChecker, IMessenger),
+            // IVariableReferenceLogic), MainErrorsPlugin (IErrorChecker, IMessenger, IClipboardService),
             // MainFileWatchPlugin (FileWatchLogic, PeriodicUiTimer). PeriodicUiTimer is
             // transient; this bridges the single instance MainFileWatchPlugin consumes.
             batch.AddExportedValue<MainPanelViewModel>(Locator.GetRequiredService<MainPanelViewModel>());
             batch.AddExportedValue<PropertyGridManager>(Locator.GetRequiredService<PropertyGridManager>());
             batch.AddExportedValue<IVariableReferenceLogic>(Locator.GetRequiredService<IVariableReferenceLogic>());
             batch.AddExportedValue<IErrorChecker>(Locator.GetRequiredService<IErrorChecker>());
+            batch.AddExportedValue<IClipboardService>(Locator.GetRequiredService<IClipboardService>());
             batch.AddExportedValue<IMessenger>(Locator.GetRequiredService<IMessenger>());
             batch.AddExportedValue<FileWatchLogic>(Locator.GetRequiredService<FileWatchLogic>());
             batch.AddExportedValue<PeriodicUiTimer>(Locator.GetRequiredService<PeriodicUiTimer>());

--- a/Tests/Gum.Presentation.Tests/AllErrorsViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AllErrorsViewModelTests.cs
@@ -133,4 +133,17 @@ public class AllErrorsViewModelTests
         viewModel.CopySelectedErrorCommand.CanExecute(null).ShouldBeTrue();
         viewModel.CopyAllErrorsCommand.CanExecute(null).ShouldBeTrue();
     }
+
+    [Fact]
+    public void CopyCommands_CannotExecute_WhenEveryErrorIsBlank()
+    {
+        // Clipboard.SetText throws on empty text, so a blank error must not reach it.
+        AllErrorsViewModel viewModel = CreateViewModel();
+        ErrorViewModel blank = new();
+        viewModel.Errors.Add(blank);
+        viewModel.SelectedItem = blank;
+
+        viewModel.CopySelectedErrorCommand.CanExecute(null).ShouldBeFalse();
+        viewModel.CopyAllErrorsCommand.CanExecute(null).ShouldBeFalse();
+    }
 }

--- a/Tests/Gum.Presentation.Tests/AllErrorsViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AllErrorsViewModelTests.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using Gum.Managers;
 using Gum.Plugins.Errors;
+using Gum.Services;
+using Moq;
 using Shouldly;
 
 namespace Gum.Presentation.Tests;
@@ -12,10 +15,14 @@ namespace Gum.Presentation.Tests;
 /// </summary>
 public class AllErrorsViewModelTests
 {
+    private readonly Mock<IClipboardService> _clipboardService = new();
+
+    private AllErrorsViewModel CreateViewModel() => new(_clipboardService.Object);
+
     [Fact]
     public void CountDescription_PluralizesForMultipleErrors()
     {
-        AllErrorsViewModel viewModel = new();
+        AllErrorsViewModel viewModel = CreateViewModel();
 
         viewModel.Errors.Add(new ErrorViewModel { Message = "first" });
         viewModel.Errors.Add(new ErrorViewModel { Message = "second" });
@@ -26,7 +33,7 @@ public class AllErrorsViewModelTests
     [Fact]
     public void CountDescription_ReflectsSingleError()
     {
-        AllErrorsViewModel viewModel = new();
+        AllErrorsViewModel viewModel = CreateViewModel();
 
         viewModel.Errors.Add(new ErrorViewModel { Message = "only" });
 
@@ -36,7 +43,7 @@ public class AllErrorsViewModelTests
     [Fact]
     public void CountDescription_ReflectsZeroErrors_WhenConstructed()
     {
-        AllErrorsViewModel viewModel = new();
+        AllErrorsViewModel viewModel = CreateViewModel();
 
         viewModel.CountDescription.ShouldBe("0 Errors");
     }
@@ -44,7 +51,7 @@ public class AllErrorsViewModelTests
     [Fact]
     public void Errors_Add_RaisesCountDescriptionPropertyChanged()
     {
-        AllErrorsViewModel viewModel = new();
+        AllErrorsViewModel viewModel = CreateViewModel();
         List<string?> changedProperties = new();
         viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
 
@@ -56,7 +63,7 @@ public class AllErrorsViewModelTests
     [Fact]
     public void SelectedItem_Set_RaisesPropertyChanged()
     {
-        AllErrorsViewModel viewModel = new();
+        AllErrorsViewModel viewModel = CreateViewModel();
         ErrorViewModel item = new() { Message = "boom" };
         List<string?> changedProperties = new();
         viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
@@ -65,5 +72,65 @@ public class AllErrorsViewModelTests
 
         viewModel.SelectedItem.ShouldBe(item);
         changedProperties.ShouldContain(nameof(AllErrorsViewModel.SelectedItem));
+    }
+
+    [Fact]
+    public void CopySelectedError_CopiesCodeAndMessage()
+    {
+        AllErrorsViewModel viewModel = CreateViewModel();
+        ErrorViewModel error = new()
+        {
+            Code = "GUM0003",
+            Message = "Category state references itself"
+        };
+        viewModel.Errors.Add(error);
+        viewModel.SelectedItem = error;
+
+        viewModel.CopySelectedErrorCommand.Execute(null);
+
+        _clipboardService.Verify(x => x.SetText("GUM0003: Category state references itself"), Times.Once);
+    }
+
+    [Fact]
+    public void CopySelectedError_CopiesMessageOnly_WhenErrorHasNoCode()
+    {
+        AllErrorsViewModel viewModel = CreateViewModel();
+        ErrorViewModel error = new() { Message = "Missing base type" };
+        viewModel.Errors.Add(error);
+        viewModel.SelectedItem = error;
+
+        viewModel.CopySelectedErrorCommand.Execute(null);
+
+        _clipboardService.Verify(x => x.SetText("Missing base type"), Times.Once);
+    }
+
+    [Fact]
+    public void CopyAllErrors_CopiesEveryErrorOnItsOwnLine()
+    {
+        AllErrorsViewModel viewModel = CreateViewModel();
+        viewModel.Errors.Add(new ErrorViewModel { Code = "GUM0001", Message = "First problem" });
+        viewModel.Errors.Add(new ErrorViewModel { Message = "Second problem" });
+
+        viewModel.CopyAllErrorsCommand.Execute(null);
+
+        _clipboardService.Verify(
+            x => x.SetText("GUM0001: First problem" + Environment.NewLine + "Second problem"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void CopyCommands_CannotExecute_WhenThereIsNothingToCopy()
+    {
+        AllErrorsViewModel viewModel = CreateViewModel();
+
+        viewModel.CopySelectedErrorCommand.CanExecute(null).ShouldBeFalse();
+        viewModel.CopyAllErrorsCommand.CanExecute(null).ShouldBeFalse();
+
+        ErrorViewModel error = new() { Message = "Missing base type" };
+        viewModel.Errors.Add(error);
+        viewModel.SelectedItem = error;
+
+        viewModel.CopySelectedErrorCommand.CanExecute(null).ShouldBeTrue();
+        viewModel.CopyAllErrorsCommand.CanExecute(null).ShouldBeTrue();
     }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/PluginBridgedServiceTypes.cs
@@ -73,6 +73,7 @@ internal static class PluginBridgedServiceTypes
         typeof(PropertyGridManager),
         typeof(IVariableReferenceLogic),
         typeof(IErrorChecker),
+        typeof(IClipboardService),
         typeof(IMessenger),
         typeof(FileWatchLogic),
         typeof(PeriodicUiTimer),

--- a/Tools/Gum.Presentation/Managers/ErrorViewModel.cs
+++ b/Tools/Gum.Presentation/Managers/ErrorViewModel.cs
@@ -48,6 +48,12 @@ public class ErrorViewModel : ViewModel
     public bool HasCodeWithoutHelpUrl => HasCode && !HasHelpUrl;
 
     /// <summary>
+    /// The error as a single line of plain text, for copying to the clipboard. Matches what the
+    /// Errors tab shows: the code prefixes the message when one is assigned.
+    /// </summary>
+    public string ClipboardText => HasCode ? $"{Code}: {Message}" : Message;
+
+    /// <summary>
     /// Label for a per-error action button (e.g. "Delete File"). Null when the error has no action.
     /// </summary>
     public string? ActionName { get; set; }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/Errors/AllErrorsViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/Errors/AllErrorsViewModel.cs
@@ -46,7 +46,8 @@ public partial class AllErrorsViewModel : ViewModel
         CopyAllErrorsCommand.NotifyCanExecuteChanged();
     }
 
-    private bool CanCopySelectedError() => SelectedItem != null;
+    // Clipboard.SetText throws on empty text, so blank rows must not reach it.
+    private bool CanCopySelectedError() => !string.IsNullOrEmpty(SelectedItem?.ClipboardText);
 
     [RelayCommand(CanExecute = nameof(CanCopySelectedError))]
     private void CopySelectedError()
@@ -57,7 +58,7 @@ public partial class AllErrorsViewModel : ViewModel
         }
     }
 
-    private bool CanCopyAllErrors() => Errors.Count > 0;
+    private bool CanCopyAllErrors() => Errors.Any(item => !string.IsNullOrEmpty(item.ClipboardText));
 
     [RelayCommand(CanExecute = nameof(CanCopyAllErrors))]
     private void CopyAllErrors()

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/Errors/AllErrorsViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/Errors/AllErrorsViewModel.cs
@@ -1,18 +1,30 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
+using CommunityToolkit.Mvvm.Input;
 using Gum.Managers;
 using Gum.Mvvm;
+using Gum.Services;
 
 namespace Gum.Plugins.Errors;
 
-public class AllErrorsViewModel : ViewModel
+public partial class AllErrorsViewModel : ViewModel
 {
+    private readonly IClipboardService _clipboardService;
+
     public ObservableCollection<ErrorViewModel> Errors { get; } = [];
 
-    public ErrorViewModel SelectedItem
+    public ErrorViewModel? SelectedItem
     {
-        get => Get<ErrorViewModel>();
-        set => Set(value);
+        get => Get<ErrorViewModel?>();
+        set
+        {
+            if (Set(value))
+            {
+                CopySelectedErrorCommand.NotifyCanExecuteChanged();
+            }
+        }
     }
 
     public string CountDescription => Errors.Count switch
@@ -22,13 +34,35 @@ public class AllErrorsViewModel : ViewModel
         _ => $"{Errors.Count} Errors"
     };
 
-    public AllErrorsViewModel()
+    public AllErrorsViewModel(IClipboardService clipboardService)
     {
+        _clipboardService = clipboardService;
         Errors.CollectionChanged += ErrorsOnCollectionChanged;
     }
 
     private void ErrorsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         NotifyPropertyChanged(nameof(CountDescription));
+        CopyAllErrorsCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanCopySelectedError() => SelectedItem != null;
+
+    [RelayCommand(CanExecute = nameof(CanCopySelectedError))]
+    private void CopySelectedError()
+    {
+        if (SelectedItem != null)
+        {
+            _clipboardService.SetText(SelectedItem.ClipboardText);
+        }
+    }
+
+    private bool CanCopyAllErrors() => Errors.Count > 0;
+
+    [RelayCommand(CanExecute = nameof(CanCopyAllErrors))]
+    private void CopyAllErrors()
+    {
+        _clipboardService.SetText(
+            string.Join(Environment.NewLine, Errors.Select(item => item.ClipboardText)));
     }
 }


### PR DESCRIPTION
Errors in the Errors tab could be selected but never yielded their text — Ctrl+C did nothing and there was no copy affordance, so the only way out was a screenshot.

## What changed

- `AllErrorsViewModel` takes `IClipboardService` and exposes `CopySelectedErrorCommand` and `CopyAllErrorsCommand`. Both refuse to run when there's nothing to copy (`Clipboard.SetText` throws on empty text).
- `ErrorViewModel.ClipboardText` formats a row the way the tab renders it: `GUM00XX: message` when a code is assigned, the message alone otherwise.
- The ListBox binds both commands to **Ctrl+C** / **Ctrl+Shift+C** and to a right-click context menu, and selects a row on right-click so the menu acts on the row you clicked rather than whatever was selected before.
- `IClipboardService` is bridged into the plugin MEF container (and mirrored into `PluginBridgedServiceTypes`) so `MainErrorsPlugin` can inject it.

## Decisions

- **Copy All instead of multi-select.** The issue raised multi-select as an option. Copy All covers the reporting case it was aimed at without the attached-behavior machinery WPF needs to bind `ListBox.SelectedItems`.
- **No element name in the copied text.** `ErrorResult.ElementName` exists, but `ToViewModel` drops it and plugin-contributed errors never set one, so the field would be populated for some rows and blank for others in the same list. Filed as #4641.

## Testing

9 view-model tests in `Gum.Presentation.Tests` cover both formats, copy-all, and the can-execute guards. Full `GumToolUnitTests` (1315) and `Gum.Presentation.Tests` (967) suites green; `GumFull.sln` builds with no new warnings.

Closes #4640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpXzrge86KTVSFNREEETSv
