### PR TITLE
Add Ctrl+E to focus the Variables tab filter box (#4633)

### DIFF
--- a/Gum/Commands/GuiCommands.cs
+++ b/Gum/Commands/GuiCommands.cs
@@ -131,6 +131,12 @@ public class GuiCommands : IGuiCommands
     }
 
     /// <inheritdoc/>
+    public void FocusVariableFilter()
+    {
+        _pluginManager.FocusVariableFilter();
+    }
+
+    /// <inheritdoc/>
     public ISpinner ShowSpinner() => _spinnerFactory.Create();
 
     /// <inheritdoc/>

--- a/Gum/Managers/KeyCombinationExtensions.cs
+++ b/Gum/Managers/KeyCombinationExtensions.cs
@@ -18,9 +18,13 @@ public static class KeyCombinationExtensions
 
     public static bool IsPressed(this KeyCombination kc, KeyEventArgs args)
     {
-        if (kc.IsCtrlDown && (args.Modifiers & Keys.Control) != Keys.Control) return false;
-        if (kc.IsShiftDown && (args.Modifiers & Keys.Shift) != Keys.Shift) return false;
-        if (kc.IsAltDown && (args.Modifiers & Keys.Alt) != Keys.Alt) return false;
+        if (!kc.ModifiersMatch(
+                (args.Modifiers & Keys.Control) == Keys.Control,
+                (args.Modifiers & Keys.Shift) == Keys.Shift,
+                (args.Modifiers & Keys.Alt) == Keys.Alt))
+        {
+            return false;
+        }
 
         return kc.Key == null || args.KeyCode == ToWinFormsKey(kc.Key.Value);
     }
@@ -31,9 +35,15 @@ public static class KeyCombinationExtensions
 
     public static bool IsPressed(this KeyCombination kc, System.Windows.Input.KeyEventArgs args)
     {
-        if (kc.IsCtrlDown && (args.KeyboardDevice.Modifiers & System.Windows.Input.ModifierKeys.Control) != System.Windows.Input.ModifierKeys.Control) return false;
-        if (kc.IsShiftDown && (args.KeyboardDevice.Modifiers & System.Windows.Input.ModifierKeys.Shift) != System.Windows.Input.ModifierKeys.Shift) return false;
-        if (kc.IsAltDown && (args.KeyboardDevice.Modifiers & System.Windows.Input.ModifierKeys.Alt) != System.Windows.Input.ModifierKeys.Alt) return false;
+        System.Windows.Input.ModifierKeys modifiers = args.KeyboardDevice.Modifiers;
+
+        if (!kc.ModifiersMatch(
+                (modifiers & System.Windows.Input.ModifierKeys.Control) == System.Windows.Input.ModifierKeys.Control,
+                (modifiers & System.Windows.Input.ModifierKeys.Shift) == System.Windows.Input.ModifierKeys.Shift,
+                (modifiers & System.Windows.Input.ModifierKeys.Alt) == System.Windows.Input.ModifierKeys.Alt))
+        {
+            return false;
+        }
 
         if (kc.Key == null)
         {

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
@@ -65,7 +65,7 @@
           VerticalContentAlignment="Center"
           PreviewKeyDown="HandleVariableFilterPreviewKeyDown"
           Text="{Binding VariableFilterText, UpdateSourceTrigger=PropertyChanged}"
-          ToolTip="Show only variables whose name contains this text. Press Escape to clear." />
+          ToolTip="Show only variables whose name contains this text. Press Ctrl+E to focus, Escape to clear." />
         <TextBlock
           Grid.Column="1"
           Margin="5,0,0,0"

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml
@@ -74,6 +74,16 @@
           IsHitTestVisible="False"
           Text="Filter variables"
           Visibility="{Binding IsFilterWatermarkVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
+        <!--  Shares the right-hand slot with the clear button, which has the opposite visibility.  -->
+        <TextBlock
+          Grid.Column="1"
+          Margin="0,0,4,0"
+          HorizontalAlignment="Right"
+          VerticalAlignment="Center"
+          Foreground="{DynamicResource Frb.Brushes.Foreground.Subtle}"
+          IsHitTestVisible="False"
+          Text="Ctrl+E"
+          Visibility="{Binding IsFilterWatermarkVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
         <Button
           Grid.Column="1"
           Margin="0,0,2,0"

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainPropertyGrid.xaml.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace Gum
 {
@@ -81,6 +82,22 @@ namespace Gum
             {
                 RefreshVariableFilter();
             }
+        }
+
+        /// <summary>
+        /// Puts the caret in the filter box with any existing filter selected, so typing replaces it.
+        /// Called by <see cref="Gum.Plugins.InternalPlugins.VariableGrid.PropertyGridManager"/> in
+        /// response to the focus-filter hotkey.
+        /// </summary>
+        public void FocusVariableFilter()
+        {
+            // Dispatched at Loaded priority: the caller may have just brought a hidden Variables tab
+            // forward, and a TextBox that hasn't been laid out yet refuses focus.
+            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() =>
+            {
+                VariableFilterTextBox.Focus();
+                VariableFilterTextBox.SelectAll();
+            }));
         }
 
         private void HandleClearVariableFilterClicked(object? sender, RoutedEventArgs e)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/MainVariableGridPlugin.cs
@@ -52,6 +52,12 @@ public class MainVariableGridPlugin : PriorityPlugin
         this.RefreshVariableView += HandleRefreshVariableView;
         this.AfterUndo += HandleAfterUndo;
         this.VariableSet += HandleVariableSet;
+        this.FocusVariableFilter += HandleFocusVariableFilter;
+    }
+
+    private void HandleFocusVariableFilter()
+    {
+        _propertyGridManager.FocusVariableFilter();
     }
 
     private void HandleElementRenamed(ElementSave save, string arg2)

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -57,6 +57,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
 
     WpfDataUi.DataUiGrid mVariablesDataGrid;
     MainPropertyGrid mainControl;
+    private IPluginTab? _variablesTab;
 
     ElementSaveDisplayer mPropertyGridDisplayer;
 
@@ -195,7 +196,7 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         // Plugin-scoped and dependency-free, so it is created here rather than registered app-wide.
         mainControl = new Gum.MainPropertyGrid(new VariableFilterService());
 
-        _tabManager.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
+        _variablesTab = _tabManager.AddControl(mainControl, "Variables", TabLocation.CenterBottom);
 
         mVariablesDataGrid = mainControl.DataGrid;
 
@@ -204,6 +205,22 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
         mainControl.DataContext = VariableViewModel;
         mainControl.SelectedBehaviorVariableChanged += HandleBehaviorVariableSelected;
         mainControl.AddVariableClicked += HandleAddVariable;
+    }
+
+    /// <summary>
+    /// Brings the Variables tab forward and puts the caret in its filter box, so the hotkey works
+    /// from anywhere in the app rather than only when the tab already happens to be showing.
+    /// </summary>
+    public void FocusVariableFilter()
+    {
+        if (_variablesTab != null)
+        {
+            // Show as well as select: the tab may have been closed rather than merely unselected.
+            _variablesTab.Show();
+            _variablesTab.IsSelected = true;
+        }
+
+        mainControl?.FocusVariableFilter();
     }
 
     private void HandleBehaviorVariableSelected(object? sender, EventArgs e)

--- a/Gum/Plugins/PluginManager.cs
+++ b/Gum/Plugins/PluginManager.cs
@@ -706,6 +706,9 @@ public class PluginManager : IPluginManager, IUndoPluginNotifier, IDeletePluginN
     public void FocusSearch() =>
         CallMethodOnPlugin(plugin => plugin.CallFocusSearch());
 
+    public void FocusVariableFilter() =>
+        CallMethodOnPlugin(plugin => plugin.CallFocusVariableFilter());
+
     public bool ShouldExclude(VariableSave defaultVariable, RecursiveVariableFinder rvf)
     {
         bool shouldExclude = false;

--- a/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/HotkeyManagerTests.cs
@@ -196,6 +196,32 @@ public class HotkeyManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void PreviewKeyDownAppWide_CtrlE_InvokesFocusVariableFilterAndSetsHandled()
+    {
+        GumKeyEventArgs e = new() { Key = GumKey.E, IsCtrlDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeTrue();
+        e.Handled.ShouldBeTrue();
+        _guiCommands.Verify(g => g.FocusVariableFilter(), Times.Once);
+    }
+
+    [Fact]
+    public void PreviewKeyDownAppWide_AltGrE_IsLeftForTheFocusedControl()
+    {
+        // Windows reports AltGr as Ctrl+Alt, and AltGr+E is the Euro sign on several European
+        // layouts, so the Ctrl+E hotkey must not swallow it.
+        GumKeyEventArgs e = new() { Key = GumKey.E, IsCtrlDown = true, IsAltDown = true };
+
+        bool handled = _hotkeyManager.PreviewKeyDownAppWide(e);
+
+        handled.ShouldBeFalse();
+        e.Handled.ShouldBeFalse();
+        _guiCommands.Verify(g => g.FocusVariableFilter(), Times.Never);
+    }
+
+    [Fact]
     public void PreviewKeyDownAppWide_CtrlZ_InvokesPerformUndo()
     {
         GumKeyEventArgs e = new() { Key = GumKey.Z, IsCtrlDown = true };

--- a/Tool/Tests/GumToolUnitTests/Managers/KeyCombinationExtensionsTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/KeyCombinationExtensionsTests.cs
@@ -42,4 +42,26 @@ public class KeyCombinationExtensionsTests : BaseTestClass
 
         combo.IsPressed(args).ShouldBeTrue();
     }
+
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_KeyedCombinationWithUnrequestedModifierDown_ReturnsFalse()
+    {
+        // Windows reports AltGr as Ctrl+Alt, so a Ctrl shortcut that ignored the extra Alt would
+        // swallow every AltGr character a non-US layout types (AltGr+E is the Euro sign).
+        KeyCombination combo = KeyCombination.Ctrl(GumKey.E);
+        GumKeyEventArgs args = new() { Key = GumKey.E, IsCtrlDown = true, IsAltDown = true };
+
+        combo.IsPressed(args).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsPressed_GumKeyEventArgs_NoKeyOnCombinationWithExtraModifierDown_StillMatches()
+    {
+        // A modifier-only combination qualifies a mouse gesture rather than naming a shortcut, so
+        // holding something else alongside it must not stop it matching.
+        KeyCombination combo = KeyCombination.Shift();
+        GumKeyEventArgs args = new() { Key = GumKey.Up, IsShiftDown = true, IsCtrlDown = true };
+
+        combo.IsPressed(args).ShouldBeTrue();
+    }
 }

--- a/Tools/Gum.Presentation/Commands/IGuiCommands.cs
+++ b/Tools/Gum.Presentation/Commands/IGuiCommands.cs
@@ -14,6 +14,11 @@ public interface IGuiCommands
     void FocusSearch();
 
     /// <summary>
+    /// Shows the Variables tab and puts the caret in its filter box.
+    /// </summary>
+    void FocusVariableFilter();
+
+    /// <summary>
     /// Shows a progress spinner and returns it as a framework-neutral <see cref="ISpinner"/>.
     /// </summary>
     ISpinner ShowSpinner();

--- a/Tools/Gum.Presentation/Input/GumKey.cs
+++ b/Tools/Gum.Presentation/Input/GumKey.cs
@@ -21,6 +21,7 @@ public enum GumKey
     Down = 0x28,
 
     C = 0x43,
+    E = 0x45,
     F = 0x46,
     V = 0x56,
     X = 0x58,

--- a/Tools/Gum.Presentation/Managers/HotkeyManager.cs
+++ b/Tools/Gum.Presentation/Managers/HotkeyManager.cs
@@ -37,6 +37,11 @@ public class HotkeyManager : IHotkeyManager
     public KeyCombination ReorderDown { get; private set; } = KeyCombination.Alt(GumKey.Down);
     public KeyCombination GoToDefinition { get; private set; } = KeyCombination.Pressed(GumKey.F12);
     public KeyCombination Search { get; private set; } = KeyCombination.Ctrl(GumKey.F);
+
+    // Ctrl+F stays the tree search everywhere, so the variable filter gets Ctrl+E - the Windows
+    // convention for focusing a search field.
+    public KeyCombination FocusVariableFilter { get; private set; } = KeyCombination.Ctrl(GumKey.E);
+
     public KeyCombination NudgeUp { get; private set; } = KeyCombination.Pressed(GumKey.Up);
     public KeyCombination NudgeDown { get; private set; } = KeyCombination.Pressed(GumKey.Down);
     public KeyCombination NudgeRight { get; private set; } = KeyCombination.Pressed(GumKey.Right);
@@ -145,6 +150,7 @@ public class HotkeyManager : IHotkeyManager
         Action? match = true switch
         {
             _ when Search.IsPressed(e)  => _guiCommands.FocusSearch,
+            _ when FocusVariableFilter.IsPressed(e) => _guiCommands.FocusVariableFilter,
             _ when RedoAlt.IsPressed(e) || Redo.IsPressed(e) => _undoManager.PerformRedo,
             _ when Undo.IsPressed(e) => _undoManager.PerformUndo,
             _ when NavigateBack.IsPressed(e) => _selectionHistory.NavigateBack,

--- a/Tools/Gum.Presentation/Managers/IHotkeyManager.cs
+++ b/Tools/Gum.Presentation/Managers/IHotkeyManager.cs
@@ -17,6 +17,7 @@ public interface IHotkeyManager
     KeyCombination ReorderDown { get; }
     KeyCombination GoToDefinition { get; }
     KeyCombination Search { get; }
+    KeyCombination FocusVariableFilter { get; }
     KeyCombination NudgeUp { get; }
     KeyCombination NudgeDown { get; }
     KeyCombination NudgeRight { get; }

--- a/Tools/Gum.Presentation/Managers/KeyCombination.cs
+++ b/Tools/Gum.Presentation/Managers/KeyCombination.cs
@@ -19,6 +19,31 @@ public class KeyCombination
     public static KeyCombination Alt(GumKey? key = null) => new KeyCombination { Key = key, IsAltDown = true };
     public static KeyCombination Shift(GumKey? key = null) => new KeyCombination { Key = key, IsShiftDown = true };
 
+    /// <summary>
+    /// Whether the held modifiers satisfy this combination. Shared by every framework-specific
+    /// <c>IsPressed</c> overload, which adds only the key comparison on top.
+    /// </summary>
+    /// <remarks>
+    /// A combination naming a <see cref="Key"/> requires the modifiers to match exactly, so a
+    /// modifier it did not ask for blocks it. That keeps AltGr - which Windows reports as Ctrl+Alt -
+    /// from triggering a Ctrl shortcut and swallowing the character the user meant to type.
+    /// A combination with no <see cref="Key"/> qualifies a mouse gesture (hold Shift to constrain a
+    /// drag) rather than naming a shortcut, so it asks only about the modifiers it lists.
+    /// </remarks>
+    public bool ModifiersMatch(bool isCtrlDown, bool isShiftDown, bool isAltDown)
+    {
+        if (Key == null)
+        {
+            return (!IsCtrlDown || isCtrlDown)
+                && (!IsShiftDown || isShiftDown)
+                && (!IsAltDown || isAltDown);
+        }
+
+        return IsCtrlDown == isCtrlDown
+            && IsShiftDown == isShiftDown
+            && IsAltDown == isAltDown;
+    }
+
     public override string ToString()
     {
         string toReturn = "";

--- a/Tools/Gum.Presentation/Managers/KeyCombinationGumEventArgsExtensions.cs
+++ b/Tools/Gum.Presentation/Managers/KeyCombinationGumEventArgsExtensions.cs
@@ -14,9 +14,7 @@ public static class KeyCombinationGumEventArgsExtensions
 {
     public static bool IsPressed(this KeyCombination kc, GumKeyEventArgs args)
     {
-        if (kc.IsCtrlDown && !args.IsCtrlDown) return false;
-        if (kc.IsShiftDown && !args.IsShiftDown) return false;
-        if (kc.IsAltDown && !args.IsAltDown) return false;
+        if (!kc.ModifiersMatch(args.IsCtrlDown, args.IsShiftDown, args.IsAltDown)) return false;
 
         return kc.Key == null || args.Key == kc.Key;
     }

--- a/Tools/Gum.Presentation/Plugins/BaseClasses/PluginBase.cs
+++ b/Tools/Gum.Presentation/Plugins/BaseClasses/PluginBase.cs
@@ -152,6 +152,7 @@ public abstract class PluginBase : IPlugin
     public event Func<ITreeNode?>? GetTreeNodeOver;
     public event Func<IEnumerable<ITreeNode>>? GetSelectedNodes;
     public event Action? FocusSearch;
+    public event Action? FocusVariableFilter;
 
     public event Action<BehaviorSave?>? BehaviorSelected;
     public event Action<BehaviorSave>? BehaviorCreated;
@@ -471,6 +472,8 @@ public abstract class PluginBase : IPlugin
     }
 
     public void CallFocusSearch() => FocusSearch?.Invoke();
+
+    public void CallFocusVariableFilter() => FocusVariableFilter?.Invoke();
 
     public ITreeNode? CallGetTreeNodeOver() => GetTreeNodeOver?.Invoke();
 

--- a/Tools/Gum.Presentation/Plugins/IPluginManager.cs
+++ b/Tools/Gum.Presentation/Plugins/IPluginManager.cs
@@ -144,6 +144,7 @@ public interface IPluginManager
     void FillTopLevelNames(ElementSave element, List<TopLevelName> names);
     bool GetIfShouldSuppressRemoveEditorHighlight();
     void FocusSearch();
+    void FocusVariableFilter();
     bool ShouldExclude(VariableSave defaultVariable, RecursiveVariableFinder rvf);
 
     // Widened for #3753: MainBehaviorsPlugin/MainEditorTabPlugin previously took the concrete

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/Hotkey/ViewModels/HotkeyViewModel.cs
@@ -29,6 +29,7 @@ namespace Gum.Plugins.InternalPlugins.Hotkey.ViewModels
             Add(_hotkeyManager.ReorderDown, "Reorder Down");
             Add(_hotkeyManager.GoToDefinition, "Go to Definition");
             Add(_hotkeyManager.Search, "Search");
+            Add(_hotkeyManager.FocusVariableFilter, "Filter Variables");
             
             Add(_hotkeyManager.NudgeUp, "Nudge Up");
             Add(_hotkeyManager.NudgeUp5, "Nudge Up 5");

--- a/docs/gum-tool/variables/README.md
+++ b/docs/gum-tool/variables/README.md
@@ -6,6 +6,14 @@ The Variables tab displays the variables for the currently-selected element, ins
 
 <figure><img src="../../.gitbook/assets/VariablesTab.png" alt=""><figcaption><p>Variables for the ExitButton instance</p></figcaption></figure>
 
+## Filtering Variables
+
+An element can have more variables than fit on screen, so a filter box sits above the variable list. Type in it and the tab shows only the variables whose name contains what you typed. Matching ignores capitalization, so typing `vis` finds `Visible`.
+
+Matching variables stay inside their own categories, which means a filter also shows you where a variable lives. Categories holding no matches hide while you are filtering, and clearing the filter restores every category, including which ones you had expanded.
+
+Press `Ctrl+E` from anywhere in Gum to bring the **Variables** tab forward and put the cursor in the filter box. Press `Escape` to clear the filter and move focus back to the variable list, or click the **X** button at the right of the box.
+
 ## Default and Explicitly Set Values
 
 Gum helps you visualize which variables are explicitly set at the current selection level. If a variable is not explicitly set, then it inherits the value from the next level down.


### PR DESCRIPTION
Closes #4633

`Ctrl+F` stays the element tree search everywhere. The Variables tab filter box gets `Ctrl+E`, the Windows convention for focusing a search field, routed through the same plugin broadcast `FocusSearch` already uses. Pressed from anywhere it brings the Variables tab forward and selects it before focusing, so it works when the tab is hidden or unselected, and it selects any existing filter text so typing replaces it.

The issue's option 1 (scope `Ctrl+F` to the focused tab) was rejected: users treat `Ctrl+F` as a global search, and a tab-scoped `InputBinding` could not have won anyway, since `MainWindow`'s tunneling `PreviewKeyDown` reaches the window before any focused element and marks the key handled.

## Also: keyed hotkeys now require an exact modifier match

`KeyCombination` matching ignored modifiers a combination did not ask for, so `Ctrl+E` would also have matched `Ctrl+Alt+E`. Windows reports AltGr as Ctrl+Alt, and AltGr+E is the Euro sign on German, French, Spanish, Italian and Portuguese layouts, so the new hotkey would have swallowed `€` in every text field in the tool. `Ctrl+F`/`Z`/`Y`/`C`/`V`/`X` escaped this only because none of those letters carry an AltGr character.

Fixed at the root rather than special-casing `Ctrl+E`: a combination naming a key now requires the modifiers to match exactly, while a modifier-only combination (`Shift()` to constrain a drag) still asks only about the modifiers it lists. `HandleNudge` had already been hand-rolling this guard for the arrow keys. Side effects are all corrections in the same direction, e.g. `Ctrl+Shift+Z` no longer also matches Undo, `Shift+Delete` no longer deletes.

## Testing

- Ctrl+E dispatches to the new command; AltGr+E is left for the focused control; keyed and modifier-only matching each pinned.
- `GumFull.sln` builds with 0 errors and no new warnings. GumToolUnitTests 1319/1319, Gum.Presentation.Tests 969/969.
- FRB canary: not needed, no FRB1-shared source touched.

Also documents the filter box in `docs/gum-tool/variables/README.md`, which #4632 left undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBdSckHwGyXs9Ue2LJZAty
