### PR TITLE
Make VariableGridEntry.StateSave genuinely nullable

### DIFF
--- a/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/StateReferencingInstanceMember.cs
@@ -106,7 +106,8 @@ public class StateReferencingInstanceMember : InstanceMember
         set => _entry.StateSaveCategory = value;
     }
 
-    public StateSave StateSave => _entry.StateSave;
+    /// <inheritdoc cref="Gum.Plugins.InternalPlugins.VariableGrid.VariableGridEntry.StateSave"/>
+    public StateSave? StateSave => _entry.StateSave;
 
     public InstanceSave? InstanceSave => _entry.InstanceSave;
 
@@ -262,7 +263,10 @@ public class StateReferencingInstanceMember : InstanceMember
     /// (built by the relocated <c>ElementSaveDisplayer</c>) into the real WPF row the live grid needs.
     /// </summary>
     public StateReferencingInstanceMember(VariableGridEntry entry) :
-        base(entry.Name, entry.StateSave)
+        // entry.StateSave is genuinely null for a behavior's required-instance entries (Name/BaseType
+        // only). InstanceMember.Instance already tolerates a null Instance elsewhere in its own logic
+        // (see its "Instance != null" checks), so this is a real, accepted null - not an assertion.
+        base(entry.Name, entry.StateSave!)
     {
         _entry = entry;
 

--- a/Tests/Gum.Presentation.Tests/VariableGridEntryTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableGridEntryTests.cs
@@ -114,6 +114,30 @@ public class VariableGridEntryTests : BaseTestClass
     }
 
     [Fact]
+    public void GetValue_ShouldReturnNull_WhenIsVariableFalseAndStateSaveIsNull()
+    {
+        // Issue #4643: entries built for a behavior's required instance pass a null StateSave.
+        // isVariable=false (VariableList-backed) entries must not crash if that ever happens.
+        ComponentSave component = CreateComponent("MyComponent");
+        VariableGridEntry sut = CreateSut("SomeList", stateSave: null!, component, isVariable: false);
+
+        object? value = sut.GetValue(component);
+
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SetValue_ShouldNotThrow_WhenIsVariableFalseAndStateSaveIsNull()
+    {
+        // Issue #4643: the isVariable=false write path dereferenced the (nullable-in-practice)
+        // StateSave unguarded; assert it degrades to a no-op instead of throwing.
+        ComponentSave component = CreateComponent("MyComponent");
+        VariableGridEntry sut = CreateSut("SomeList", stateSave: null!, component, isVariable: false);
+
+        Should.NotThrow(() => sut.SetValue(component, new List<string> { "a" }, VariablePropertyCommitType.Full));
+    }
+
+    [Fact]
     public void ResetToDefault_ShouldRemoveVariableAndRecordUndo_WhenElementIsNotStandardElement()
     {
         ComponentSave component = CreateComponent("MyComponent");

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ElementSaveDisplayerFormsPropertiesTests.cs
@@ -590,4 +590,27 @@ public class ElementSaveDisplayerFormsPropertiesTests : BaseTestClass
         member.ShouldNotBeNull();
         member.GetValueType(member.Instance!).ShouldBe(typeof(Gum.Forms.Controls.ResizeBehavior?));
     }
+
+    [Fact]
+    public void GetCategories_BehaviorRequiredInstance_SetNameAndBaseType_DoesNotThrow()
+    {
+        // Issue #4643: GetCategories(BehaviorSave, InstanceSave) builds its Name/BaseType entries
+        // with a null StateSave (CreateEntryFromPropertyData(null, instance, null, null, item)).
+        // Reproduces "select a required instance under a behavior, edit Name/BaseType" to check
+        // whether that null StateSave is ever actually dereferenced unguarded.
+        BehaviorInstanceSave requiredInstance = new BehaviorInstanceSave
+        {
+            Name = "RequiredButton",
+            BaseType = "Controls/ButtonStandard"
+        };
+        _buttonBehavior.RequiredInstances.Add(requiredInstance);
+
+        List<VariableCategoryDescriptor> categories = _displayer.GetCategories(_buttonBehavior, requiredInstance);
+
+        VariableGridEntry nameEntry = categories.SelectMany(c => c.Members).Single(m => m.Name.EndsWith(".Name"));
+        VariableGridEntry baseTypeEntry = categories.SelectMany(c => c.Members).Single(m => m.Name.EndsWith(".BaseType"));
+
+        Should.NotThrow(() => nameEntry.SetValue(requiredInstance, "RenamedButton", VariablePropertyCommitType.Full));
+        Should.NotThrow(() => baseTypeEntry.SetValue(requiredInstance, "Controls/OtherButton", VariablePropertyCommitType.Full));
+    }
 }

--- a/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
+++ b/Tools/Gum.Presentation/Plugins/InternalPlugins/VariableGrid/VariableGridEntry.cs
@@ -47,7 +47,7 @@ public class VariableGridEntry
     private readonly IClipboardService _clipboardService;
 
     private readonly IStateContainer _stateListCategoryContainer;
-    private readonly StateSave _stateSave;
+    private readonly StateSave? _stateSave;
     private readonly string _variableName;
     private readonly bool _isVariable;
     private readonly bool _isReadOnlyFromDescriptor;
@@ -62,8 +62,13 @@ public class VariableGridEntry
     /// <summary>The category this variable belongs to, if any (drives the "part of a category" reset/remove rules).</summary>
     public StateSaveCategory? StateSaveCategory { get; set; }
 
-    /// <summary>The state this entry reads/writes non-recursively (see <see cref="GetValue"/>).</summary>
-    public StateSave StateSave => _stateSave;
+    /// <summary>
+    /// The state this entry reads/writes non-recursively (see <see cref="GetValue"/>). Null for
+    /// entries built from a behavior's required instance (Name/BaseType only - see
+    /// <c>ElementSaveDisplayer.GetCategories(BehaviorSave, InstanceSave)</c>), which has no
+    /// <see cref="Gum.DataTypes.Variables.StateSave"/> to read/write against.
+    /// </summary>
+    public StateSave? StateSave => _stateSave;
 
     /// <summary>The selected instance this entry belongs to, or null when it belongs to the element/behavior itself.</summary>
     public InstanceSave? InstanceSave { get; }
@@ -283,7 +288,7 @@ public class VariableGridEntry
         bool isReadOnly,
         bool isAssignedByReference,
         bool isVariable,
-        StateSave stateSave,
+        StateSave? stateSave,
         StateSaveCategory? stateSaveCategory,
         string variableName,
         InstanceSave? instanceSave,
@@ -550,7 +555,7 @@ public class VariableGridEntry
         else
         {
             var effectiveVariableName = VariableSave?.Name ?? _variableName;
-            return _stateSave.GetValueRecursive(effectiveVariableName);
+            return _stateSave?.GetValueRecursive(effectiveVariableName);
         }
     }
 
@@ -659,7 +664,9 @@ public class VariableGridEntry
 
             var existingVariableList = elementSave != null ? GetVariableListFromThisOrBase(elementSave, Name) : null;
             var type = existingVariableList?.Type ?? TryGetTypeFromVariableListSave()?.ToString();
-            _stateSave.SetValue(_variableName, newValue, instanceSave, type);
+            // _stateSave is null for entries built from a behavior's required instance (Name/BaseType
+            // only), which never reach this VariableList write path - guard anyway rather than trust that.
+            _stateSave?.SetValue(_variableName, newValue, instanceSave, type);
 
             return NotifyVariableLogic(gumElementOrInstanceSaveAsObject, commitType, trySave: commitType == VariablePropertyCommitType.Full);
         }
@@ -921,7 +928,10 @@ public class VariableGridEntry
                 var instanceInElement = elementSave.Instances
                     .FirstOrDefault(item => item.Name == sourceObjectName);
 
-                if (instanceInElement != null)
+                // StateSave is null for entries built from a behavior's required instance, but those
+                // are never ElementSave-typed, so this branch never actually sees that case - guard
+                // anyway rather than assert it away with a null-forgiving StateSave!.
+                if (instanceInElement != null && StateSave != null)
                 {
                     handledByExposedVariable = true;
 


### PR DESCRIPTION
## Summary

`VariableGridEntry._stateSave` was declared non-nullable `StateSave`, but `ElementSaveDisplayer.GetCategories(BehaviorSave, InstanceSave)` (selecting a behavior's required instance) constructs entries with a literal `null` for it - the annotation lied, so the compiler couldn't flag the two places that dereferenced it unguarded.

- Made `_stateSave` / the ctor param / the `StateSave` property genuinely nullable.
- Guarded the two flagged dereferences (`GetValue`'s and `SetValue`'s `isVariable=false` branches).
- Rebuilding surfaced one more unguarded use in `NotifyVariableLogic`'s exposed-variable-tunneling branch; guarded it too rather than assert it away with `!`.
- Propagated the nullability one layer out to `StateReferencingInstanceMember.StateSave` (the WPF adapter), which had the same lie.

Verified the issue's crash claim didn't actually reproduce today: the behavior path only ever builds Name/BaseType entries, and both are special-cased before reaching the unguarded lines. Added a reproduction test proving that, plus direct tests pinning the new nullable-safe behavior (red before the fix, green after).

Zero new compiler warnings (diffed against baseline per-file).

## Test plan

- [x] `Gum.Presentation.Tests` (971 tests) green
- [x] `GumToolUnitTests` VariableGrid/PropertyGridHelpers suites (221 tests) green
- [x] `GumFull.sln` builds with 0 errors, 0 new warnings
- Manual test: not needed - the two previously-unguarded paths are unreachable from any current call site (traced exhaustively and confirmed with a reproduction test); this is a nullability-accuracy/hardening fix with no observable behavior change.
- FRB canary: not needed - `VariableGridEntry.cs`/`StateReferencingInstanceMember.cs` are tool-only, not in any FRB-shared `.projitems`.

Closes #4643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpXjJ41QMUzxNyBhRwydsc
