### PR TITLE
Copied error text now names its element

### DIFF
--- a/Gum/Managers/ErrorChecker.cs
+++ b/Gum/Managers/ErrorChecker.cs
@@ -48,6 +48,8 @@ public class ErrorChecker : IErrorChecker
                     vm.HelpUrl = _errorDocsRegistry.GetUrl(vm.Code);
                 }
             }
+
+            ApplyDefaultElementName(list, element);
         }
 
         return list.ToArray();
@@ -68,9 +70,25 @@ public class ErrorChecker : IErrorChecker
             {
                 ObjectFinder.Self.DisableCache();
             }
+
+            ApplyDefaultElementName(list, element);
         }
 
         return list.ToArray();
+    }
+
+    // Plugin-contributed errors don't always know which element they belong to (e.g. a check that
+    // isn't scoped to the selected element). Falling back to the selected element keeps every row
+    // in the tab equally useful to copy, even when the plugin itself set no ElementName.
+    private static void ApplyDefaultElementName(List<ErrorViewModel> list, ElementSave element)
+    {
+        foreach (var vm in list)
+        {
+            if (string.IsNullOrEmpty(vm.ElementName))
+            {
+                vm.ElementName = element.Name;
+            }
+        }
     }
 
     private ErrorViewModel ToViewModel(ErrorResult errorResult)
@@ -78,7 +96,8 @@ public class ErrorChecker : IErrorChecker
         ErrorViewModel vm = new ErrorViewModel
         {
             Message = errorResult.Message,
-            Code = errorResult.Code
+            Code = errorResult.Code,
+            ElementName = errorResult.ElementName
         };
         if (errorResult.Code != null)
         {

--- a/Tests/Gum.Presentation.Tests/ErrorViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/ErrorViewModelTests.cs
@@ -52,6 +52,27 @@ public class ErrorViewModelTests
     }
 
     [Fact]
+    public void ClipboardText_IncludesElementName_WhenSet()
+    {
+        ErrorViewModel viewModel = new()
+        {
+            ElementName = "MyComponent",
+            Code = "GUM0003",
+            Message = "self-referential state"
+        };
+
+        viewModel.ClipboardText.ShouldBe("MyComponent: GUM0003: self-referential state");
+    }
+
+    [Fact]
+    public void ClipboardText_OmitsElementName_WhenNotSet()
+    {
+        ErrorViewModel viewModel = new() { Message = "some message" };
+
+        viewModel.ClipboardText.ShouldBe("some message");
+    }
+
+    [Fact]
     public void OwnerPlugin_ComparesByReference()
     {
         object owner = new();

--- a/Tests/Gum.Presentation.Tests/OrphanCodeFileReporterTests.cs
+++ b/Tests/Gum.Presentation.Tests/OrphanCodeFileReporterTests.cs
@@ -45,6 +45,7 @@ public class OrphanCodeFileReporterTests : BaseTestClass
         errors[0].Message.ShouldContain("DeletedScreen.Generated.cs");
         errors[0].Code.ShouldBe("GUM0005");
         errors[0].HasAction.ShouldBeTrue();
+        errors[0].ElementName.ShouldBe("DeletedScreen");
     }
 
     [Fact]

--- a/Tool/Tests/GumToolUnitTests/Managers/ErrorCheckerTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Managers/ErrorCheckerTests.cs
@@ -33,6 +33,7 @@ public class ErrorCheckerTests : BaseTestClass
 
         errors.Length.ShouldBe(1);
         errors[0].Message.ShouldContain("NonExistentBase");
+        errors[0].ElementName.ShouldBe("DerivedComponent");
     }
 
     [Fact]
@@ -61,5 +62,29 @@ public class ErrorCheckerTests : BaseTestClass
 
         errors.Length.ShouldBe(1);
         errors[0].Message.ShouldContain("NonExistentType");
+    }
+
+    [Fact]
+    public void GetErrorsFor_ShouldDefaultElementName_WhenPluginErrorHasNone()
+    {
+        GumProjectSave project = new GumProjectSave();
+        ObjectFinder.Self.GumProjectSave = project;
+
+        ComponentSave component = new ComponentSave { Name = "SomeComponent" };
+        project.Components.Add(component);
+
+        ITypeResolver typeResolver = new DefaultTypeResolver();
+        IHeadlessErrorChecker headlessErrorChecker = new HeadlessErrorChecker(typeResolver);
+        Mock<IPluginManager> mockPluginManager = new Mock<IPluginManager>();
+        mockPluginManager
+            .Setup(m => m.FillWithErrors(It.IsAny<List<ErrorViewModel>>(), It.IsAny<object?>()))
+            .Callback<List<ErrorViewModel>, object?>(
+                (list, _) => list.Add(new ErrorViewModel { Message = "plugin error" }));
+        IErrorDocsRegistry errorDocsRegistry = new ErrorDocsRegistry();
+        ErrorChecker sut = new ErrorChecker(headlessErrorChecker, mockPluginManager.Object, errorDocsRegistry);
+
+        ErrorViewModel[] errors = sut.GetErrorsFor(component, project);
+
+        errors.ShouldContain(e => e.Message == "plugin error" && e.ElementName == "SomeComponent");
     }
 }

--- a/Tools/Gum.Presentation/Managers/ErrorViewModel.cs
+++ b/Tools/Gum.Presentation/Managers/ErrorViewModel.cs
@@ -19,6 +19,12 @@ public class ErrorViewModel : ViewModel
     } = string.Empty;
 
     /// <summary>
+    /// The element this error belongs to, shown in the Errors tab and included in
+    /// <see cref="ClipboardText"/> so a copied error reads with context. Empty when unknown.
+    /// </summary>
+    public string ElementName { get; set; } = string.Empty;
+
+    /// <summary>
     /// Stable error code (e.g. <c>"GUM0001"</c>) for searchability and doc linking.
     /// Null if the error has not been assigned a code.
     /// </summary>
@@ -49,9 +55,17 @@ public class ErrorViewModel : ViewModel
 
     /// <summary>
     /// The error as a single line of plain text, for copying to the clipboard. Matches what the
-    /// Errors tab shows: the code prefixes the message when one is assigned.
+    /// Errors tab shows: the element name and code prefix the message when set, mirroring
+    /// <c>gumcli check</c>'s <c>{ElementName}: {message}</c> shape.
     /// </summary>
-    public string ClipboardText => HasCode ? $"{Code}: {Message}" : Message;
+    public string ClipboardText
+    {
+        get
+        {
+            string codeAndMessage = HasCode ? $"{Code}: {Message}" : Message;
+            return string.IsNullOrEmpty(ElementName) ? codeAndMessage : $"{ElementName}: {codeAndMessage}";
+        }
+    }
 
     /// <summary>
     /// Label for a per-error action button (e.g. "Delete File"). Null when the error has no action.

--- a/Tools/Gum.Presentation/OrphanCodeFiles/OrphanCodeFileReporter.cs
+++ b/Tools/Gum.Presentation/OrphanCodeFiles/OrphanCodeFileReporter.cs
@@ -73,6 +73,7 @@ public class OrphanCodeFileReporter
         _orphans.ToList().Select(orphan => new ErrorViewModel
         {
             Code = ErrorCode,
+            ElementName = orphan.ElementName ?? string.Empty,
             Message = $"Orphaned {GetKindDescription(orphan.Kind)}, no matching element in the project: " +
                 $"{orphan.FilePath.FullPath}",
             ActionName = "Delete File",


### PR DESCRIPTION
## Summary

Copied error text now includes the element it belongs to, matching `gumcli check`'s `{ElementName}: {message}` shape.

- `ErrorViewModel` gains `ElementName`, prefixed onto `ClipboardText` when set.
- `ErrorChecker.ToViewModel` carries `ErrorResult.ElementName` over for core checks.
- `ErrorChecker.GetErrorsFor` defaults any plugin error's blank `ElementName` to the selected element, so future plugin checks get sensible copy text without opting in.
- `OrphanCodeFileReporter` sets its own `ElementName` from the orphan's actual element (its errors aren't scoped to the selected element, so the default would be wrong).

Filed #4648 for unrelated dead code (`AnimationViewModel`/`ElementAnimationsViewModel.GetErrors()`) found while auditing all `ErrorViewModel` construction sites.

Closes #4641

## Test plan
- [x] `Gum.Presentation.Tests` (973 tests) green
- [x] `GumToolUnitTests` (1321 tests) green
- [x] `dotnet build GumFull.sln` — 0 errors, no new warnings
- [x] Manual test: needed — see below

Manual test: open the Errors tab, select an element with an error (e.g. give a component a nonexistent base type), copy the error (Ctrl+C or right-click Copy), and paste — the text now starts with the element's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g43LpkHqnspB3dWZHAAyU
