### PR TITLE
Remove dead AnimationViewModel/ElementAnimationsViewModel.GetErrors()

### DIFF
--- a/Tests/Gum.Presentation.Tests/AnimatedKeyframeViewModelTests.cs
+++ b/Tests/Gum.Presentation.Tests/AnimatedKeyframeViewModelTests.cs
@@ -6,9 +6,8 @@ namespace Gum.Presentation.Tests;
 /// <summary>
 /// Pins <see cref="AnimatedKeyframeViewModel.IsMissingReference"/>, the flag the keyframe-list
 /// icon uses to mark a keyframe that references a state/animation which no longer exists (issue
-/// #3386). Mirrors the broken-keyframe logic in <c>AnimationViewModel.GetErrors</c>: a keyframe is
-/// broken only when it points at a state/animation (not a named event) and its reference is invalid.
-/// Relocated out of GumToolUnitTests into headless Gum.Presentation.Tests once
+/// #3386): a keyframe is broken only when it points at a state/animation (not a named event) and
+/// its reference is invalid. Relocated out of GumToolUnitTests into headless Gum.Presentation.Tests once
 /// AnimatedKeyframeViewModel's dead WPF BitmapFrame plumbing was removed (ADR-0005, issue #3754).
 /// </summary>
 public class AnimatedKeyframeViewModelTests

--- a/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/StateAnimationPlugin/AnimationStateRenameErrorTests.cs
@@ -11,18 +11,17 @@ using StateAnimationPlugin;
 using StateAnimationPlugin.Managers;
 using StateAnimationPlugin.ViewModels;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace GumToolUnitTests.Plugins.StateAnimationPlugin;
 
 /// <summary>
 /// Characterizes how the animation view models detect missing-state errors (<c>RefreshErrors</c> →
-/// <c>GetErrors</c>) and how a state rename propagates to animation keyframes. Companion to
-/// <see cref="RenameManagerTests"/>: those pin the keyframe-mutating overloads in isolation, these
-/// pin the resulting error state — the same error the tree "!" indicator and the Errors tab surface
-/// (issue #3293), and that a rename must rewrite the keyframe before recomputing so it leaves no
-/// stale error (issue #3383).
+/// <see cref="AnimatedKeyframeViewModel.IsMissingReference"/>) and how a state rename propagates to
+/// animation keyframes. Companion to <see cref="RenameManagerTests"/>: those pin the
+/// keyframe-mutating overloads in isolation, these pin the resulting error state — the same error
+/// the tree "!" indicator and the Errors tab surface (issue #3293), and that a rename must rewrite
+/// the keyframe before recomputing so it leaves no stale error (issue #3383).
 ///
 /// These were the behaviors repeatedly mis-read while reasoning about #3293/#3383; they are pinned
 /// here so future changes start from executable ground truth rather than speculation.
@@ -47,7 +46,7 @@ public class AnimationStateRenameErrorTests : BaseTestClass
         viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("Cat/Walk");
 
         viewModel.RefreshErrors(element);
-        viewModel.GetErrors().ShouldBeEmpty();
+        viewModel.Animations[0].Keyframes[0].IsMissingReference.ShouldBeFalse();
     }
 
     [Fact]
@@ -79,8 +78,9 @@ public class AnimationStateRenameErrorTests : BaseTestClass
 
         viewModel.RefreshErrors(element);
 
-        viewModel.GetErrors().Count().ShouldBe(1);
-        viewModel.GetErrors().Single().Message.ShouldContain("Cat/Missing");
+        AnimatedKeyframeViewModel keyframe = viewModel.Animations[0].Keyframes[0];
+        keyframe.IsMissingReference.ShouldBeTrue();
+        keyframe.MissingReferenceMessage.ShouldContain("Missing");
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class AnimationStateRenameErrorTests : BaseTestClass
 
         viewModel.RefreshErrors(element);
 
-        viewModel.GetErrors().ShouldBeEmpty();
+        viewModel.Animations[0].Keyframes[0].IsMissingReference.ShouldBeFalse();
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class AnimationStateRenameErrorTests : BaseTestClass
             RenameManagerFor(element), viewModel, element, idle, "Idle");
 
         viewModel.Animations[0].Keyframes[0].StateName.ShouldBe("Cat/Walk");
-        viewModel.GetErrors().ShouldBeEmpty();
+        viewModel.Animations[0].Keyframes[0].IsMissingReference.ShouldBeFalse();
     }
 
     private static ComponentSave ElementWithCategorizedState(string categoryName, string stateName)

--- a/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/AnimatedKeyframeViewModel.cs
@@ -168,8 +168,7 @@ public class AnimatedKeyframeViewModel : ViewModel, IComparable
     /// <summary>
     /// True when this keyframe points at a state or animation whose reference is missing
     /// (<see cref="HasValidState"/> is false). Named events are never considered broken. Drives the
-    /// broken-keyframe icon in the keyframe list (issue #3386); mirrors the broken-keyframe condition
-    /// in <c>AnimationViewModel.GetErrors</c>.
+    /// broken-keyframe icon in the keyframe list (issue #3386).
     /// </summary>
     [DependsOn(nameof(HasValidState))]
     [DependsOn(nameof(StateName))]

--- a/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/AnimationViewModel.cs
@@ -64,8 +64,7 @@ public partial class AnimationViewModel : ViewModel
 
     /// <summary>
     /// True when any keyframe references a missing state or animation. Drives the animation-list
-    /// error icon (issue #3401); mirrors <see cref="GetErrors"/> and
-    /// <see cref="AnimatedKeyframeViewModel.IsMissingReference"/>.
+    /// error icon (issue #3401); mirrors <see cref="AnimatedKeyframeViewModel.IsMissingReference"/>.
     /// </summary>
     public bool HasBrokenKeyframe => Keyframes.Any(keyframe => keyframe.IsMissingReference);
 
@@ -402,30 +401,6 @@ public partial class AnimationViewModel : ViewModel
             _selectedState.CustomCurrentStateSave = stateToSet;
             _selectedState.SelectedStateSave = null;
             _wireframeObjectManager.RootGue?.ApplyState(stateToSet);
-        }
-    }
-
-    public IEnumerable<ErrorViewModel> GetErrors()
-    {
-        foreach(var keyframe in this.Keyframes)
-        {
-            if(!keyframe.HasValidState)
-            {
-                if (!string.IsNullOrEmpty(keyframe.StateName))
-                {
-                    yield return new ErrorViewModel()
-                    {
-                        Message = $"{this.Name} Keyframe at time {keyframe.Time} references a state {keyframe.StateName} which does not exist."
-                    };
-                }
-                else if (!string.IsNullOrEmpty(keyframe.AnimationName))
-                {
-                    yield return new ErrorViewModel()
-                    {
-                        Message = $"{this.Name} Keyframe at time {keyframe.Time} references an animation {keyframe.AnimationName} which does not exist."
-                    };
-                }
-            }
         }
     }
 

--- a/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
+++ b/Tools/Gum.Presentation/StateAnimationPlugin/ViewModels/ElementAnimationsViewModel.cs
@@ -771,18 +771,6 @@ public partial class ElementAnimationsViewModel : ViewModel
         }
     }
 
-    public IEnumerable<ErrorViewModel> GetErrors()
-    {
-        List<ErrorViewModel> toReturn = new List<ErrorViewModel>();
-        foreach(var animation in Animations)
-        {
-            var animationErrors = animation.GetErrors();
-            toReturn.AddRange(animationErrors);
-        }
-        return toReturn;
-    }
-
-
     [RelayCommand]
     private void ToggleInterpolationClamping()
     {


### PR DESCRIPTION
Closes #4648

Deletes `AnimationViewModel.GetErrors()` and `ElementAnimationsViewModel.GetErrors()` — dead code left over from the headless-checker migration (#3293); only their own unit tests called them, nothing in production.

Rewrote `AnimationStateRenameErrorTests` (and a stray doc-comment in `AnimatedKeyframeViewModelTests`) to assert on the live path (`AnimatedKeyframeViewModel.IsMissingReference`/`MissingReferenceMessage` after `RefreshErrors`) instead of deleting the tests outright — they pin real rename-propagation behavior (RenameManager + RefreshErrors ordering), not just the dead `GetErrors()` call.

Manual test: not needed — behavior-preserving dead-code removal, covered by unit tests + compilation.
FRB canary: not needed — no FRB1-shared source touched (StateAnimationPlugin/Gum.Presentation are tool-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9cNKR12LyivSYEm6JzjGR
