### PR TITLE
Reset Styling.ActiveStyle in FormsUtilities.Uninitialize

### DIFF
--- a/MonoGameGum/Forms/FormsUtilities.cs
+++ b/MonoGameGum/Forms/FormsUtilities.cs
@@ -493,6 +493,13 @@ public class FormsUtilities
         cursor = null;
         keyboard = null;
         Gamepads = new Gum.Input.GamePad[4];
+
+        // Null the backing field (not just leave the instance) so ActiveStyle's lazy getter
+        // (_activeStyle ??= new Styling(null)) rebuilds against the live LoaderManager cache
+        // next access, instead of returning a Styling still pointing at the UISpriteSheet
+        // texture that GumService.Uninitialize's LoaderManager.Self.DisposeAndClear() just
+        // disposed (issue #4626).
+        Gum.Forms.DefaultVisuals.V3.Styling.ActiveStyle = null!;
     }
 
     public static void RegisterFromFileFormRuntimeDefaults()

--- a/Tests/MonoGameGum.Tests.V3/GumServiceUninitializeTests.cs
+++ b/Tests/MonoGameGum.Tests.V3/GumServiceUninitializeTests.cs
@@ -7,6 +7,7 @@ using RenderingLibrary;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using V3Styling = Gum.Forms.DefaultVisuals.V3.Styling;
 
 namespace MonoGameGum.Tests.V3;
 
@@ -257,6 +258,37 @@ public class GumServiceUninitializeTests
             // After Uninitialize, Gamepads is a different array instance of the same length.
             FormsUtilities.Gamepads.ShouldNotBeSameAs(originalGamepads);
             FormsUtilities.Gamepads.Length.ShouldBe(4);
+        }
+        finally
+        {
+            RestoreFormsUtilitiesState(savedCursor, savedPopupRoot, savedModalRoot);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Styling.ActiveStyle — issue #4626, must not survive pointing at a
+    // texture LoaderManager.Self.DisposeAndClear() just disposed.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void FormsUtilities_Uninitialize_ResetsStylingActiveStyle()
+    {
+        ICursor? savedCursor = FormsUtilities.Cursor;
+        InteractiveGue? savedPopupRoot = FrameworkElement.PopupRoot;
+        InteractiveGue? savedModalRoot = FrameworkElement.ModalRoot;
+
+        try
+        {
+            V3Styling sentinel = new(spriteSheet: null, useDefaults: false);
+            V3Styling.ActiveStyle = sentinel;
+
+            FormsUtilities.Uninitialize();
+
+            // The lazy getter (_activeStyle ??= new Styling(null)) only rebuilds when the
+            // backing field is null, so Uninitialize must null it rather than leave the
+            // sentinel (which would still be pointing at the just-disposed sprite sheet
+            // in the real GumService.Uninitialize flow).
+            V3Styling.ActiveStyle.ShouldNotBeSameAs(sentinel);
         }
         finally
         {


### PR DESCRIPTION
Closes #4626

`GumService.Uninitialize` disposes the cached `UISpriteSheet.png` via `LoaderManager.Self.DisposeAndClear()` but left `Styling.ActiveStyle` pointing at the disposed texture. Any surviving `Styling` reference (or a read of `ActiveStyle` between teardown and the next `Initialize`) then draws from a freed texture.

`FormsUtilities.Uninitialize()` now nulls `Styling.ActiveStyle`'s backing field so its lazy getter rebuilds a fresh instance against the live `LoaderManager` cache on next access, instead of returning the stale one.

Checked the issue's other suggestion — `FrameworkElement.DefaultFormsTemplates` already gets `.Clear()`'d in `GumService.Uninitialize`, so no stale visuals/states survive there.

FRB canary: not needed — `FormsUtilities.cs` is not included in `FlatRedBall.Forms.Shared.projitems`.

Manual test: not needed — the new unit test asserts the exact state transition (`ActiveStyle` rebuilds instead of returning the stale instance); no sample/tool flow exercises `Uninitialize` + reuse to observe this by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017krtrJ3WvQKGTUCPwPzs6q
