### PR TITLE
StrideGum: render via zero-copy D3D11/ANGLE GPU path

### DIFF
--- a/Runtimes/StrideGum/GumService.Stride.cs
+++ b/Runtimes/StrideGum/GumService.Stride.cs
@@ -9,6 +9,9 @@ using Gum.Forms.Controls;
 using Gum.Input;
 using Gum.Wireframe;
 using RenderingLibrary;
+#if STRIDE_GPU_ANGLE
+using SkiaGameRendering.Stride.D3D11;
+#endif
 using SkiaSharp;
 using Stride.CommunityToolkit.Engine;
 using Stride.Core.Mathematics;
@@ -46,18 +49,44 @@ public class GumService : GumServiceSkiaBase, IGumService
     private InputManager? _inputManager;
     private GraphicsDevice? _graphicsDevice;
 
-    // Owns the Skia-to-Stride bridge: Gum renders into _skSurface (CPU-side), which is copied into
-    // _skiaTexture each frame and blitted into the composited frame via _spriteBatch. GumService owns
-    // this state (not GumSceneRenderer) so Initialize can create it synchronously -- Root is usable
-    // immediately after Initialize returns, matching every other runtime's Initialize-then-build-UI
-    // pattern, rather than deferring setup until Stride's own SceneRendererBase.InitializeCore fires.
+    // Owns the Skia-to-Stride bridge, one of two ways (#4617):
+    // - D3D11, net10.0-windows7.0 builds only: _gpuTarget renders straight into its own Stride
+    //   Texture via ANGLE (zero-copy) and composites itself on End -- see
+    //   SkiaGameRendering.Stride.D3D11.SkiaStrideRenderTarget2D. That package only ships
+    //   net10.0-windows7.0 (see StrideGum.csproj's TargetFrameworks/STRIDE_GPU_ANGLE remarks), so this
+    //   whole path is compiled out of the plain net10.0 build -- there _useGpuPath is always false.
+    // - Everything else (Vulkan/D3D12/Null, or any net10.0 consumer): the original CPU path -- Gum
+    //   renders into _skSurface (CPU raster), which is copied into _skiaTexture each frame and
+    //   blitted into the composited frame via _spriteBatch.
+    // GumService owns this state (not GumSceneRenderer) so Initialize can create it synchronously --
+    // Root is usable immediately after Initialize returns, matching every other runtime's
+    // Initialize-then-build-UI pattern, rather than deferring setup until Stride's own
+    // SceneRendererBase.InitializeCore fires.
+    private bool _useGpuPath;
+#if STRIDE_GPU_ANGLE
+    private SkiaStrideRenderTarget2D? _gpuTarget;
+#endif
     private SKSurface? _skSurface;
     private Texture? _skiaTexture;
     private SpriteBatch? _spriteBatch;
+    // The canvas SystemManagers.Default.Canvas is pointed at -- _skSurface.Canvas (CPU path) or
+    // _gpuTarget.Canvas (GPU path). Stable across frames on both paths even though the GPU target's
+    // own Canvas getter is only accessible while a Begin/End pass is open: RecreateSurface captures it
+    // once via a throwaway Begin/EndWithoutDrawing, since SkiaStrideTarget's underlying SKSurface (and
+    // therefore its Canvas) is allocated once in its constructor and does not change between passes.
+    private SKCanvas? _canvas;
     private int _surfaceWidth;
     private int _surfaceHeight;
 
     private readonly Stopwatch _clock = new();
+
+    /// <summary>
+    /// <see langword="true"/> once <see cref="Initialize"/> has picked the zero-copy GPU render path
+    /// (D3D11 via ANGLE, only available in <c>net10.0-windows7.0</c> builds); <see langword="false"/>
+    /// when running the CPU raster-and-upload fallback (#4617), including on every non-D3D11 backend
+    /// and every net10.0 (non-Windows-TFM) build.
+    /// </summary>
+    public bool IsUsingGpuPath => _useGpuPath;
 
     /// <summary>
     /// Gets the default cursor, which represents the mouse.
@@ -135,7 +164,7 @@ public class GumService : GumServiceSkiaBase, IGumService
         var backBuffer = game.GraphicsDevice.Presenter.BackBuffer;
         RecreateSurface(backBuffer.Width, backBuffer.Height);
 
-        InitializeCore(_skSurface!.Canvas, game.Input, _surfaceWidth, _surfaceHeight, gumProjectFile);
+        InitializeCore(_canvas!, game.Input, _surfaceWidth, _surfaceHeight, gumProjectFile);
 
         if (registerSceneRenderer)
         {
@@ -163,6 +192,13 @@ public class GumService : GumServiceSkiaBase, IGumService
         base.Initialize(canvas, width, height, gumProjectFile);
     }
 
+    /// <summary>
+    /// Decides which of the two render paths (see the class's <c>_useGpuPath</c> remarks) a
+    /// <see cref="GraphicsDevice"/> should use. Only D3D11 has a <c>SkiaGameRendering.Stride.D3D11</c>
+    /// adapter today (#4617); every other backend keeps the CPU raster-and-upload path.
+    /// </summary>
+    internal static bool ShouldUseGpuPath(GraphicsPlatform platform) => platform == GraphicsPlatform.Direct3D11;
+
     private void RecreateSurface(int width, int height)
     {
         if (width <= 0 || height <= 0 || _graphicsDevice == null) return;
@@ -170,11 +206,36 @@ public class GumService : GumServiceSkiaBase, IGumService
         _surfaceWidth = width;
         _surfaceHeight = height;
 
+#if STRIDE_GPU_ANGLE
+        _gpuTarget?.Dispose();
+        _gpuTarget = null;
+#endif
         _skSurface?.Dispose();
+        _skSurface = null;
         _skiaTexture?.Dispose();
+        _skiaTexture = null;
+
+#if STRIDE_GPU_ANGLE
+        _useGpuPath = ShouldUseGpuPath(GraphicsDevice.Platform);
+        if (_useGpuPath)
+        {
+            _gpuTarget = new SkiaStrideRenderTarget2D(_graphicsDevice, width, height);
+
+            // SkiaStrideRenderTarget2D.Canvas only reads while a pass is open; capture the reference
+            // once here (see the class's _canvas remarks for why the reference itself stays valid
+            // after End) rather than reopening a pass on every SystemManagers.Default.Canvas read.
+            _gpuTarget.Begin();
+            _canvas = _gpuTarget.Canvas;
+            _gpuTarget.EndWithoutDrawing();
+            return;
+        }
+#else
+        _useGpuPath = false;
+#endif
 
         var info = new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
         _skSurface = SKSurface.Create(info);
+        _canvas = _skSurface.Canvas;
 
         _skiaTexture = Texture.New2D(
             _graphicsDevice,
@@ -201,18 +262,34 @@ public class GumService : GumServiceSkiaBase, IGumService
         if (backBuffer.Width != _surfaceWidth || backBuffer.Height != _surfaceHeight)
         {
             RecreateSurface(backBuffer.Width, backBuffer.Height);
-            SystemManagers.Default.Canvas = _skSurface!.Canvas;
+            SystemManagers.Default.Canvas = _canvas!;
             HandleResize(_surfaceWidth, _surfaceHeight);
         }
+
+        if (_canvas == null) return;
+
+#if STRIDE_GPU_ANGLE
+        if (_useGpuPath)
+        {
+            if (_gpuTarget == null) return;
+
+            _gpuTarget.Begin();
+            Update(_clock.Elapsed.TotalSeconds);
+            Draw();
+            // Flushes Skia's GPU work, restores Stride's D3D11 state, and composites the target onto
+            // the backbuffer via its own SpriteBatch -- no manual blit needed on this path.
+            _gpuTarget.End(drawContext.GraphicsContext);
+            return;
+        }
+#endif
 
         if (_skSurface == null || _skiaTexture == null || _spriteBatch == null) return;
 
         Update(_clock.Elapsed.TotalSeconds);
 
-        var canvas = _skSurface.Canvas;
-        canvas.Clear(SKColors.Empty);
+        _canvas.Clear(SKColors.Empty);
         Draw();
-        canvas.Flush();
+        _canvas.Flush();
 
         SKPixmap pixmap = _skSurface.PeekPixels();
         IntPtr pixelPointer = pixmap.GetPixels();
@@ -232,6 +309,9 @@ public class GumService : GumServiceSkiaBase, IGumService
 
     internal void DisposeStrideResources()
     {
+#if STRIDE_GPU_ANGLE
+        _gpuTarget?.Dispose();
+#endif
         _skSurface?.Dispose();
         _skiaTexture?.Dispose();
         _spriteBatch?.Dispose();

--- a/Runtimes/StrideGum/StrideGum.csproj
+++ b/Runtimes/StrideGum/StrideGum.csproj
@@ -27,8 +27,14 @@
 		<!-- Overrides RuntimePackage.props' shared net8.0: Stride's own packages (Stride.Input,
 		     Stride.CommunityToolkit) only ship net10.0(+platform)-targeted builds. A net10.0 project
 		     referencing the net8.0 GumCommon/SkiaGum is fine (same modern .NET family, no
-		     netstandard-style compat gap). -->
-		<TargetFramework>net10.0</TargetFramework>
+		     netstandard-style compat gap).
+		     Two TFMs (#4617): SkiaGameRendering.Stride.D3D11 (the zero-copy GPU path) only ships
+		     net10.0-windows7.0, so it's referenced only under that TFM below; non-Windows/other-API
+		     consumers still get a net10.0 build with the CPU raster-and-upload path. Clearing the
+		     singular TargetFramework the import above set is required: the SDK only multi-targets off
+		     TargetFrameworks when TargetFramework is empty. -->
+		<TargetFramework></TargetFramework>
+		<TargetFrameworks>net10.0;net10.0-windows7.0</TargetFrameworks>
 		<!-- GumService.Stride.cs's texture upload does an unsafe pointer read off the Skia surface's
 		     pixel buffer (SKPixmap.GetPixels()). -->
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -50,6 +56,19 @@
 		<DefineConstants>TRACE;SKIA;STRIDE</DefineConstants>
 	</PropertyGroup>
 
+	<!-- Selects the zero-copy GPU path's source in GumService.Stride.cs (#4617), gated to the TFM
+	     that actually references SkiaGameRendering.Stride.D3D11 above. -->
+	<PropertyGroup Condition="'$(TargetFramework)'=='net10.0-windows7.0'">
+		<DefineConstants>$(DefineConstants);STRIDE_GPU_ANGLE</DefineConstants>
+		<!-- TargetPlatformIdentifier/Version/SupportedOSPlatformVersion all correctly resolve to
+		     Windows/7.0 for this inner build (verified via -getProperty), which per CA1416's own docs
+		     should suppress it; the analyzer still fires on every windows7.0-only API (Keys,
+		     SkiaStrideRenderTarget2D) here, a known limitation with multi-targeted (TargetFrameworks,
+		     not TargetFramework) projects mixing a platform-neutral and a platform-specific TFM. Not
+		     an actual platform risk: this whole TFM only builds/ships for Windows. -->
+		<NoWarn>$(NoWarn);CA1416</NoWarn>
+	</PropertyGroup>
+
 	<!-- ScreenBase is NOT file-linked here (unlike RaylibGum/SokolGum, which are self-contained and
 	     need their own copy): this project ProjectReferences SkiaGum.csproj below, which already
 	     compiles Forms/ScreenBase.cs. See SilkNetGum.csproj's identical comment for the full
@@ -67,7 +86,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SkiaSharp" Version="3.119.1" />
+		<!-- 3.119.4, not SkiaGum.csproj's 3.119.1: SkiaGameRendering.Stride.D3D11 (below, windows7.0
+		     only) pins SkiaSharp 3.119.4 exactly, and NuGet flags anything lower in this project's own
+		     graph as a downgrade. Different projects in the same solution resolving different patch
+		     versions is normal (see StrideGum.csproj's TargetFrameworks remarks for why the two
+		     packages can't just share a version file: SkiaGameRendering isn't a Gum-managed csproj). -->
+		<PackageReference Include="SkiaSharp" Version="3.119.4" />
 		<PackageReference Include="SkiaSharp.Extended" Version="3.0.0" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="3.119.1" />
 		<PackageReference Include="Svg.Skia" Version="1.0.0.19" />
@@ -84,6 +108,14 @@
 		<!-- Stride's runtime (unlike its WPF GameStudio editor) exposes no clipboard API; this is the
 		     cross-platform fallback for Gum.Input.StrideGumClipboard. -->
 		<PackageReference Include="TextCopy" Version="6.2.1" />
+	</ItemGroup>
+
+	<!-- Zero-copy GPU path for the D3D11 backend (#4617): Skia renders straight into the Stride
+	     Texture via ANGLE, no CPU rasterize-and-upload. Only ships net10.0-windows7.0, so it's scoped
+	     to that TFM; net10.0 consumers (Linux/macOS, or Windows on Vulkan/D3D12) keep the CPU
+	     SKSurface path below unconditionally. -->
+	<ItemGroup Condition="'$(TargetFramework)'=='net10.0-windows7.0'">
+		<PackageReference Include="SkiaGameRendering.Stride.D3D11" Version="0.15.0-beta" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/StrideGum/StrideGumSample/Program.cs
+++ b/Samples/StrideGum/StrideGumSample/Program.cs
@@ -64,4 +64,14 @@ void BuildDemoUi()
         listBox.Items!.Add("Item " + i);
     }
     stackPanel.AddChild(listBox);
+
+    // Surfaces which render path GumService picked (#4617) so this is visible without a GPU
+    // profiler: GPU path on D3D11 (this sample's TFM), CPU fallback everywhere else.
+    var renderPathLabel = new Label
+    {
+        Text = GumService.Default.IsUsingGpuPath
+            ? "Render path: GPU (D3D11 via ANGLE)"
+            : "Render path: CPU (raster + upload)",
+    };
+    stackPanel.AddChild(renderPathLabel);
 }

--- a/Samples/StrideGum/StrideGumSample/StrideGumSample.csproj
+++ b/Samples/StrideGum/StrideGumSample/StrideGumSample.csproj
@@ -2,8 +2,12 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<!-- net10.0 matches Runtimes/StrideGum: Stride's own packages only ship net10.0 builds. -->
-		<TargetFramework>net10.0</TargetFramework>
+		<!-- net10.0-windows7.0, not the plain net10.0 Runtimes/StrideGum also ships (#4617): this
+		     sample already depends on Stride.CommunityToolkit.Windows below, so it's Windows-only in
+		     practice already, and targeting the windows7.0 TFM is what actually pulls in
+		     Gum.Stride's zero-copy GPU path (SkiaGameRendering.Stride.D3D11) instead of silently
+		     falling back to the CPU path this sample would otherwise still exercise. -->
+		<TargetFramework>net10.0-windows7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<!-- Stride.CommunityToolkit.Windows drags in Stride's editor-side package manager, whose own

--- a/Tests/StrideGum.Tests/GumServiceGpuPathTests.cs
+++ b/Tests/StrideGum.Tests/GumServiceGpuPathTests.cs
@@ -1,0 +1,29 @@
+using Gum;
+using Shouldly;
+using Stride.Graphics;
+
+namespace StrideGum.Tests;
+
+/// <summary>
+/// Pins <see cref="GumService.ShouldUseGpuPath"/>: the platform check that decides whether
+/// <see cref="GumService"/> renders through the zero-copy ANGLE/D3D11 GPU path
+/// (<c>SkiaGameRendering.Stride.D3D11</c>) or falls back to the CPU raster-and-upload path (issue
+/// #4617). D3D11 is the only backend with an adapter; everything else must fall back.
+/// </summary>
+public class GumServiceGpuPathTests
+{
+    [Fact]
+    public void ShouldUseGpuPath_ReturnsTrue_ForDirect3D11()
+    {
+        GumService.ShouldUseGpuPath(GraphicsPlatform.Direct3D11).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(GraphicsPlatform.Vulkan)]
+    [InlineData(GraphicsPlatform.Direct3D12)]
+    [InlineData(GraphicsPlatform.Null)]
+    public void ShouldUseGpuPath_ReturnsFalse_ForNonDirect3D11Platforms(GraphicsPlatform platform)
+    {
+        GumService.ShouldUseGpuPath(platform).ShouldBeFalse();
+    }
+}

--- a/Tests/StrideGum.Tests/StrideGum.Tests.csproj
+++ b/Tests/StrideGum.Tests/StrideGum.Tests.csproj
@@ -21,8 +21,12 @@
     <!-- SKSurface for the in-memory raster canvas; Stride.Input types (InputManager / IMouseDevice /
          IKeyboardDevice / IGamePadDevice / Keys) for mocking input in the Cursor/Keyboard/GamePad
          tests. -->
-    <PackageReference Include="SkiaSharp" VersionOverride="3.119.1" />
+    <!-- Matches Gum.Stride's own bump: SkiaGameRendering.Stride.D3D11 pins 3.119.4 exactly. -->
+    <PackageReference Include="SkiaSharp" VersionOverride="3.119.4" />
     <PackageReference Include="Stride.Input" VersionOverride="4.4.0-beta5" />
+    <!-- GraphicsPlatform, for GumServiceGpuPathTests. Not otherwise pulled in transitively by
+         Stride.Input. -->
+    <PackageReference Include="Stride.Graphics" VersionOverride="4.4.0-beta5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/code/getting-started/setup/adding-initializing-gum/stride.md
+++ b/docs/code/getting-started/setup/adding-initializing-gum/stride.md
@@ -34,11 +34,54 @@ dotnet add package Gum.Stride --prerelease
 <PackageReference Include="Stride.CommunityToolkit.Windows" Version="1.0.0-preview.63" />
 ```
 
-Your project must target `net10.0`, since Stride's own packages ship `net10.0` builds only.
+Your project must target `net10.0` at minimum, since Stride's own packages ship `net10.0` builds only. Targeting `net10.0-windows7.0` instead unlocks GPU-accelerated rendering on Direct3D11; see [Skia Render Path](#skia-render-path) below.
 
 {% hint style="warning" %}
 Don't name your project `StrideGum`, that's the assembly name inside the `Gum.Stride` package. A same-named project produces a same-named output DLL that silently overwrites the runtime's copy in your `bin` folder, causing a `TypeLoadException` at runtime with no build warning. Gum's build now catches this for you: if your `AssemblyName` collides, the build fails with an error telling you to change it.
 {% endhint %}
+
+## Skia Render Path
+
+{% hint style="info" %}
+Available in October 2026, or now if building Gum from source.
+{% endhint %}
+
+Gum renders Stride's UI through SkiaSharp, and it can hand that drawing to the GPU two different ways. Which one you get depends on the graphics API your Stride project already builds against, chosen independently of Gum through Stride's own `StrideGraphicsApi` property (`Direct3D11` is Stride's Windows default):
+
+{% tabs %}
+{% tab title="Direct3D11" %}
+Gum renders directly into a GPU texture, with no CPU round trip. To use it, target `net10.0-windows7.0` instead of plain `net10.0`:
+
+```xml
+<TargetFramework>net10.0-windows7.0</TargetFramework>
+```
+
+That TFM change is the only setup step. The `Gum.Stride` NuGet package brings in the GPU renderer automatically; you don't add a separate package reference.
+{% endtab %}
+
+{% tab title="Direct3D12" %}
+Gum rasterizes with Skia on the CPU and uploads the result to a GPU texture every frame. There's no GPU-direct render path for Direct3D12 yet, and no TFM change unlocks one, so stay on plain `net10.0`.
+{% endtab %}
+
+{% tab title="Vulkan" %}
+Gum rasterizes with Skia on the CPU and uploads the result to a GPU texture every frame, the same as Direct3D12. A GPU-direct render path for Vulkan exists but isn't wired into Gum yet. Stay on plain `net10.0`, which Vulkan on Linux and macOS requires anyway, since `net10.0-windows7.0` is a Windows-only TFM.
+{% endtab %}
+{% endtabs %}
+
+Check `GumService.Default.IsUsingGpuPath` at runtime to confirm which path is active:
+
+```csharp
+// Initialize
+GumService.Default.Initialize(game);
+
+var renderPathLabel = new Label
+{
+    Text = GumService.Default.IsUsingGpuPath ? "GPU path" : "CPU path",
+};
+renderPathLabel.AddToRoot();
+```
+
+`Label` comes from `Gum.Forms.Controls`.
 
 ## Adding Source (Optional)
 


### PR DESCRIPTION
Closes #4617

## Summary
- `Gum.Stride` now renders via `SkiaGameRendering.Stride.D3D11` (zero-copy ANGLE/D3D11 GPU path) when `GraphicsDevice.Platform == GraphicsPlatform.Direct3D11`; every other backend keeps the existing CPU raster-and-upload path unchanged.
- `SkiaGameRendering.Stride.D3D11` only ships `net10.0-windows7.0`, so `StrideGum.csproj` now multi-targets `net10.0;net10.0-windows7.0` — the GPU path (package ref + `STRIDE_GPU_ANGLE` source) is scoped to the windows7.0 TFM only; non-Windows/other-API consumers still get a plain net10.0 build with the CPU path.
- Colorspace/MSAA correctness (raised in the issue's comment thread) is handled by the adapter itself — it owns a non-MSAA texture and reads `GraphicsDevice.ColorSpace` internally — no extra work needed on Gum's side.
- New `GumService.IsUsingGpuPath` and `StrideGumSample` now shows which path is active.
- `ShouldUseGpuPath(GraphicsPlatform)` is unit-tested (the only part of this testable without a real D3D11 device).

## Test plan
- [x] `dotnet test Tests/StrideGum.Tests/StrideGum.Tests.csproj` — 29/29 passing
- [x] `dotnet build Runtimes/StrideGum/StrideGum.csproj -f net10.0` and `-f net10.0-windows7.0` — both clean, 0 errors, no new warnings
- [x] `dotnet build Samples/StrideGum/StrideGumSample/StrideGumSample.csproj` (now `net10.0-windows7.0`) — clean
- [ ] Manual: run `StrideGumSample` on Windows/D3D11, confirm the UI renders and the label reads "Render path: GPU (D3D11 via ANGLE)"

FRB canary: not needed — no FRB1-shared source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C35Bfw5c9rorLiKd3AHYfZ
