### PR TITLE
gum-issue-creation: state the title-should-be-phrased-as-should rule

### DIFF
--- a/.claude/skills/gum-issue-creation/SKILL.md
+++ b/.claude/skills/gum-issue-creation/SKILL.md
@@ -50,6 +50,6 @@ Keep it scannable for a future implementer:
 - **Reach** — how a user lands on the broken code path, and whether that path is the recommended route or a legacy corner the tool never produces on its own. A defect reachable only through hand-authored input is near-zero impact; say so instead of letting it read like an ordinary bug.
 
 ## Title
-Specific and self-describing — names the feature area and the gap (e.g. `Animation keyframe "Could not find state or animation" error should name the missing reference`), not a generic summary.
+Specific and self-describing, phrased as what should be true (`X should Y`) rather than a description of the current problem, e.g. `Animation keyframe "Could not find state or animation" error should name the missing reference`, not a generic summary.
 
 After creating, report the issue URL back to the user.


### PR DESCRIPTION
## Summary
- Makes the `gum-issue-creation` skill's title rule explicit: issue titles should be phrased as `X should Y`, not a description of the current problem. The existing example already followed this, but the rule itself wasn't stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSwaWKPsbwJCzW65WDjMvr
