### PR TITLE
Fix dropdown default-value background to match text field styling

### DIFF
--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ComboBoxDisplayDefaultBackgroundTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/ComboBoxDisplayDefaultBackgroundTests.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Shouldly;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+/// <summary>
+/// FlatRedBall#1755: a default-valued combo box variable should get the same green
+/// background <see cref="TextBoxDisplayLogic"/> uses for a default text field, not a
+/// green foreground.
+/// </summary>
+public class ComboBoxDisplayDefaultBackgroundTests : BaseTestClass
+{
+    private enum SampleEnum
+    {
+        Alpha,
+        Beta
+    }
+
+    [StaFact]
+    public void ComboBoxDisplay_InstanceMemberIsDefault_SetsGreenBackground()
+    {
+        ComboBoxDisplay display = new ComboBoxDisplay();
+        DefaultableInstanceMember member = MakeMember(isDefault: true);
+
+        display.InstanceMember = member;
+        PumpDispatcher();
+
+        ComboBox comboBox = GetComboBox(display);
+        // Reference-equality via a bool, not ShouldBe(brush): Shouldly's failure-message
+        // formatter calls Brush.ToString(), which throws off the owning thread.
+        ReferenceEquals(comboBox.Background, TextBoxDisplayLogic.DefaultValueBackground).ShouldBeTrue();
+    }
+
+    [StaFact]
+    public void ComboBoxDisplay_InstanceMemberNotDefault_DoesNotSetGreenBackground()
+    {
+        ComboBoxDisplay display = new ComboBoxDisplay();
+        DefaultableInstanceMember member = MakeMember(isDefault: false);
+
+        display.InstanceMember = member;
+        PumpDispatcher();
+
+        ComboBox comboBox = GetComboBox(display);
+        ReferenceEquals(comboBox.Background, TextBoxDisplayLogic.DefaultValueBackground).ShouldBeFalse();
+    }
+
+    private static DefaultableInstanceMember MakeMember(bool isDefault)
+    {
+        DefaultableInstanceMember member = new DefaultableInstanceMember
+        {
+            Name = "TestMember",
+            ForcedIsDefault = isDefault
+        };
+        member.CustomGetTypeEvent += _ => typeof(SampleEnum);
+        member.CustomGetEvent += _ => SampleEnum.Alpha;
+        return member;
+    }
+
+    private static ComboBox GetComboBox(ComboBoxDisplay display)
+    {
+        PropertyInfo? property = typeof(ComboBoxDisplay).GetProperty(
+            "ComboBox",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        property.ShouldNotBeNull();
+        ComboBox? comboBox = (ComboBox?)property!.GetValue(display);
+        comboBox.ShouldNotBeNull();
+        return comboBox!;
+    }
+
+    /// <summary>
+    /// Pumps the calling thread's Dispatcher once so a pending
+    /// <see cref="Dispatcher.BeginInvoke(System.Delegate)"/> callback (e.g. the
+    /// background-color sync in <c>ComboBoxDisplay</c>) runs before assertions.
+    /// </summary>
+    private static void PumpDispatcher()
+    {
+        DispatcherFrame frame = new DispatcherFrame();
+        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => frame.Continue = false));
+        Dispatcher.PushFrame(frame);
+    }
+
+    private sealed class DefaultableInstanceMember : InstanceMember
+    {
+        public bool ForcedIsDefault { get; set; }
+
+        public override bool IsDefault => ForcedIsDefault;
+    }
+}

--- a/WpfDataUi/Controls/ComboBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/ComboBoxDisplay.xaml.cs
@@ -58,8 +58,8 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
             if (instanceMemberChanged)
             {
                 this.RefreshAllContextMenus(force: true);
-                // Clear stale green foreground from a previous pooled use.
-                ComboBox.ClearValue(Control.ForegroundProperty);
+                // Clear stale green background from a previous pooled use.
+                ComboBox.ClearValue(Control.BackgroundProperty);
             }
 
             Refresh();
@@ -275,7 +275,7 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
         HintTextBlock.Visibility = !string.IsNullOrEmpty(InstanceMember?.DetailText) ? Visibility.Visible : Visibility.Collapsed;
         HintTextBlock.Text = InstanceMember?.DetailText;
 
-        SyncForegroundWithState();
+        SyncBackgroundWithState();
 
         RefreshAllContextMenus();
         
@@ -333,7 +333,7 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
         }
         this.SuppressSettingProperty = false;
 
-        SyncForegroundWithState();
+        SyncBackgroundWithState();
 
         return ApplyValueResult.Success;
     }
@@ -528,10 +528,10 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
         // problem: https://github.com/vchelaru/Gum/issues/676.
         this.TrySetValueOnInstance();
 
-        SyncForegroundWithState();
+        SyncBackgroundWithState();
     }
 
-    private void SyncForegroundWithState()
+    private void SyncBackgroundWithState()
     {
         Dispatcher.BeginInvoke(() =>
         {
@@ -540,13 +540,19 @@ public class ComboBoxDisplay : UserControl, IDataUi, INotifyPropertyChanged
                 return;
             }
 
+            // Green background for a default value, matching TextBoxDisplayLogic (FlatRedBall#1755).
             if (InstanceMember?.IsDefault == true)
             {
-                ComboBox.Foreground = Brushes.Green;
+                ComboBox.Background = TextBoxDisplayLogic.DefaultValueBackground;
+            }
+            else if (ComboBox.TryFindResource("Frb.Brushes.Field.Background") != null)
+            {
+                ComboBox.SetResourceReference(Control.BackgroundProperty,
+                    "Frb.Brushes.Field.Background");
             }
             else
             {
-                ComboBox.ClearValue(Control.ForegroundProperty);
+                ComboBox.ClearValue(Control.BackgroundProperty);
             }
         });
 


### PR DESCRIPTION
## Problem

Restoring a default-valued dropdown variable (e.g. a state category) in the Gum tool's variable grid highlighted it with green *text*, while restoring a default-valued text field (e.g. a float) highlights it with a green *background* (`TextBoxDisplayLogic.DefaultValueBackground`). The two controls disagreed on how "this is at its default" is shown.

## Fix

`ComboBoxDisplay.SyncBackgroundWithState` (renamed from `SyncForegroundWithState`) now sets the same `DefaultValueBackground` brush `TextBoxDisplayLogic` uses, and otherwise falls back to the `Frb.Brushes.Field.Background` theme resource — mirroring `TextBoxDisplayLogic.RefreshBackgroundColor` exactly (both branches, same resource key).

## Testing

Added `ComboBoxDisplayDefaultBackgroundTests` (STA, pumps the dispatcher) covering the default and non-default cases; confirmed red without the fix, green with it. `dotnet build GumFull.sln` and the full `GumToolUnitTests` combo-box suite are clean.

**Manual test: not needed** — covered by the new unit tests plus a build/rebuild of the theme resource lookup (`Frb.Brushes.Field.Background`, verified defined in both `Frb.Brushes.Light.xaml` and `Frb.Brushes.Dark.xaml`).

Fixes vchelaru/FlatRedBall#1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
