### PR TITLE
Allow deleting a referenced component variable, cascading undoably

### DIFF
--- a/.claude/skills/gum-tool-delete-logic/SKILL.md
+++ b/.claude/skills/gum-tool-delete-logic/SKILL.md
@@ -82,7 +82,8 @@ Do not call `IDeleteLogic` methods directly from UI code — always go through `
 | `Tools/Gum.Presentation/Managers/IDeleteLogic.cs` | Interface for pure data-mutation operations |
 | `Tools/Gum.Presentation/Managers/DeleteLogic.cs` | Data mutation + delete-dialog orchestration via `IDeleteDialogService` |
 | `Gum/Services/Dialogs/DeleteDialogService.cs` | WPF shell: creates/shows `DeleteOptionsWindow`, calls the concrete `PluginManager` |
-| `Gum/Logic/RenameLogic.cs` | `ElementReferences` class; `GetDeleteImpactDetails()` and `ExcludeContainersBeingDeleted()` used to build impact warnings in the delete dialog |
+| `Tools/Gum.Presentation/Logic/ReferenceTypes.cs` | `ElementReferences` class; `GetDeleteImpactDetails()` and `ExcludeContainersBeingDeleted()` used to build impact warnings in the delete dialog |
+| `Tools/Gum.Presentation/Logic/ReferenceFinder.cs` | `GetReferencesToVariable()` — enumerates every instance-level assignment of a variable project-wide, including through the inheritance chain; used by `DeleteVariableService.GetIfCanDeleteVariable` to block variable deletes today |
 | `Gum/Plugins/InternalPlugins/Delete/DeleteObjectPlugin.cs` | Contributes "Delete XML?" and "Delete children?" to DeleteOptionsWindow |
 | `Gum/Plugins/InternalPlugins/StatePlugin/StateTreeViewRightClickService.cs` | State/category right-click menu; calls AskTo* methods |
 | `Gum/Plugins/InternalPlugins/TreeView/ElementTreeViewManager.RightClick.cs` | Element tree right-click; calls DeleteSelection |

--- a/.claude/skills/gum-tool-file-watch/SKILL.md
+++ b/.claude/skills/gum-tool-file-watch/SKILL.md
@@ -48,6 +48,19 @@ A second `PeriodicUiTimer` at 200ms drives the File Watch debug panel UI only â€
 
 `RefreshRootDirectory()` is called on project load and whenever a variable that `IsFile == true` changes value.
 
+## Saving Edits Back to Disk
+
+Edits are written out through `IFileCommands.TryAutoSaveElement(ElementSave)` /
+`TryAutoSaveCurrentElement()` / `TryAutoSaveObject(object)` in
+`Tools/Gum.Presentation/Commands/FileCommands.cs`, each of which no-ops unless
+`IProjectManager.AutoSave` is true (`ProjectManager.cs`, backed by `GeneralSettingsFile`,
+user-toggleable in Project Properties).
+
+**Landmine:** "the element is edited" does not imply "the file on disk changed" â€” with AutoSave off,
+in-memory changes sit unsaved until an explicit save. Code that mutates an element other than the
+currently-selected one (e.g. a cascading delete affecting other elements' instances) should call
+`TryAutoSaveElement` for that element, not assume it needs saving unconditionally.
+
 ## Ignore Mechanism
 
 `IgnoreNextChangeUntil(FilePath, DateTime?)` suppresses the next detected change for a file until the given time. Default is **5 seconds** from now.

--- a/.claude/skills/gum-tool-undo/SKILL.md
+++ b/.claude/skills/gum-tool-undo/SKILL.md
@@ -14,6 +14,8 @@ Gum has a snapshot-based undo/redo system scoped per-element. Undo history is di
 ### Per-Element Scoping
 Undo history is stored separately for each open element (Screen, Component, or StandardElement). Switching between elements does not share or merge history — each element maintains its own independent undo stack.
 
+**Narrow exception — cross-element variable removals (ADR 0016 / #4658).** An action that removes an instance-level variable assignment on OTHER elements (e.g. deleting a component variable that instances elsewhere had set) can attach those removals to the initiating element's own action via `IUndoManager.AttachCrossElementVariableRemovals`. The entry still lives only in the initiating element's history; undo/redo replays the attached `CrossElementVariableChange` list against the other elements directly (tolerating an instance or state deleted since recording), saving each one via the normal `TryAutoSaveElement` and firing the same `VariableSet` plugin event a live edit would. This works only because Gum has no tabs — at most one element has an active `RecordState` baseline at a time, so the replay can never collide with another element's own capture. See `DeleteVariableService` for the only current caller.
+
 ### No Selection Tracking
 Undos do not record or restore the user's selection state. After undoing or redoing an operation, the selected object in the tree view or canvas may not match what was selected when the change was originally made.
 
@@ -84,19 +86,22 @@ Consequence: after an undo, `_selectedState.SelectedInstance` may point to a sta
 
 | File | Purpose |
 |------|---------|
-| `Gum/Undo/UndoManager.cs` | Core undo/redo logic; per-element history with `Dictionary<ElementSave, ElementHistory>` |
+| `Tools/Gum.Presentation/Undo/UndoManager.cs` | Orchestrator; delegates to `ElementUndoStrategy` (per-element history, `Dictionary<ElementSave, ElementHistory>`) and `BehaviorUndoStrategy` |
+| `Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs` | Element undo/redo track: capture/diff/apply, plus cross-element variable removal attach + replay |
 | `Gum/Undo/UndoPlugin.cs` | Event handlers that call `RecordState()` / `RecordUndo()` |
-| `Gum/Undo/UndoSnapshot.cs` | Snapshot structure and diff/comparison logic (`UndoComparison`) |
+| `Tools/Gum.Presentation/Undo/UndoSnapshot.cs` | Snapshot structure and diff/comparison logic (`UndoComparison`) |
+| `Tools/Gum.Presentation/Undo/ElementHistory.cs` | `HistoryAction` (undo/redo snapshot pair + optional `CrossElementVariableRemovals`) and `ElementHistory` |
+| `Tools/Gum.Presentation/Undo/CrossElementVariableChange.cs` | One instance-level variable removal on another element, attached to an action for undo/redo replay |
 | `Gum/Plugins/InternalPlugins/Undos/UndosViewModel.cs` | History tab display and description generation |
 | `Gum/Plugins/InternalPlugins/Undos/UndoDisplay.xaml` | WPF ListBox UI for the History tab |
 | `Gum/Plugins/InternalPlugins/Undos/UndoItemViewModel.cs` | Individual history item (display text + undo/redo direction) |
-| `Tool/Tests/GumToolUnitTests/Managers/UndoManagerTests.cs` | Unit tests for undo behavior |
+| `Tests/Gum.Presentation.Tests/UndoManagerTests.cs` | Unit tests for undo behavior |
 
 ## Known Limitations Summary
 
 | Limitation | Details |
 |------------|---------|
-| No global undo | Each element has its own undo stack; cross-element changes are not grouped |
+| No general cross-element undo | Undo stacks are per-element; the only cross-element case handled is instance-level variable removal attached via `AttachCrossElementVariableRemovals` (see above) — everything else stays ungrouped |
 | No selection restore | Selection state is not captured or restored on undo/redo |
 | No persistence | History is cleared on project load or app close |
 | No element-deletion undo | Deleting an element removes its history permanently |

--- a/.claude/skills/gum-tool-variable-grid/SKILL.md
+++ b/.claude/skills/gum-tool-variable-grid/SKILL.md
@@ -53,6 +53,12 @@ Numeric drag-scrub reports every intermediate tick as `VariablePropertyCommitTyp
 
 ---
 
+## Deleting a Custom Variable
+
+`DeleteVariableService` (`Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs`) handles the right-click delete. It still blocks when the variable is referenced through a `VariableReferences` binding, or through an inheriting element's own exposed-name entry — those aren't a simple "restore this value" case. A plain instance-level value override elsewhere in the project (the common case) is instead cascaded: removed from that instance too, and recorded via `IUndoManager.AttachCrossElementVariableRemovals` so undo restores it there as well. See ADR 0016 and the `gum-tool-undo` skill's cross-element exception.
+
+---
+
 ## Non-Obvious Behaviors
 
 ### SetCategories Expansion Preservation

--- a/Direction/decisions/0016-cross-element-undo-transactions-for-cascading-deletes.md
+++ b/Direction/decisions/0016-cross-element-undo-transactions-for-cascading-deletes.md
@@ -1,0 +1,80 @@
+# 0016. Cross-element undo transactions for cascading deletes
+
+- **Status:** Accepted
+- **Date:** 2026-09-09
+- **Deciders:** Victor Chelaru, Claude
+
+## Context
+
+[#4658](https://github.com/vchelaru/Gum/issues/4658) reports that Gum refuses to delete a component
+variable once it has been assigned a value on instances elsewhere in the project
+(`DeleteVariableService.GetIfCanDeleteVariable`,
+`Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs:80`) — even though Gum already
+computes exactly which instances would be affected, since that same enumeration builds the "can't
+delete" message.
+
+The real blocker is undo, not the mutation. `UndoManager` scopes history strictly per element
+(`Dictionary<ElementSave, ElementHistory>`, see the `gum-tool-undo` skill), so there is no existing
+way to record one undo entry that reverts changes spanning multiple `ElementSave`s.
+
+This shape isn't unique to variable deletion. State deletion (an instance elsewhere set to a state
+that no longer exists) and instance deletion raise the same problem: a delete on one element needs
+to mutate data on other elements, and undoing it needs to reverse all of that atomically. Whole-element
+deletion already has a related, narrower precedent: it is accepted as non-undoable, discarding its
+undo history along with it. Whether to extend that precedent to cascading deletes, or build real
+cross-element undo, is the question this decision resolves.
+
+## Decision
+
+We will build a cross-element undo transaction primitive and use it — starting with variable
+deletion — instead of leaving cascading deletes non-undoable.
+
+- **Ownership.** The undo entry belongs to the element that initiated the delete (the component whose
+  variable was removed), not to the elements whose instances were mutated. It appears only in that
+  element's History tab.
+- **Reuse the existing impact enumeration.** Replay is driven by the same lookup the delete-block
+  message already uses: `ReferenceFinder.GetReferencesToVariable`
+  (`Tools/Gum.Presentation/Logic/ReferenceFinder.cs:421`, called via
+  `RenameLogic.GetChangesForRenamedVariable`). It already walks every element in the project plus the
+  inheritance chain (`ObjectFinder.Self.GetElementsInheritingFrom`) to find every instance-level
+  assignment of a variable, so the delete flow's block-vs-remove behavior converges on one
+  enumeration instead of growing a second one.
+- **Snapshot timing.** The affected-instance list is captured at delete time. Replay tolerates
+  instances or elements that no longer exist by the time undo/redo fires — skip them silently rather
+  than erroring. Instances added after the delete were never affected and need no handling.
+- **Persistence.** Replay mutates each affected element directly and saves it through the same path a
+  normal edit uses: `IFileCommands.TryAutoSaveElement`, gated by `IProjectManager.AutoSave` (see the
+  `gum-tool-file-watch` skill's "Saving Edits Back to Disk" section) — never an unconditional
+  force-save.
+- **Plugin/event parity.** Replay fires the same variable-changed plugin events a normal edit fires,
+  so codegen and other listeners stay consistent regardless of whether the change came from direct
+  editing or from an undo/redo replay.
+- **Conflict handling.** If the user hand-edits an affected instance's value between undo and redo,
+  redo overwrites it — last-write-wins, no merge/conflict resolution.
+- **Why direct mutation of other elements is safe.** Gum has no concept of multiple simultaneously
+  open elements — there are no tabs, only one element is selected at a time — so only one element can
+  have an active `RecordState` undo baseline at any moment. A cross-element replay can never collide
+  with another element's captured baseline, which is what makes mutating other elements' data directly
+  safe without having to re-baseline them.
+
+## Consequences
+
+Variable deletion (#4658) can ship as a real, undoable operation instead of staying blocked or
+shipping as a silent, non-undoable delete. The same primitive is available for state deletion and
+instance deletion, which share the identical shape.
+
+What's deferred: this is not a general-purpose cross-element merge/rebase system — only a
+deterministic "apply this frozen list of instance-level changes, atomically, tolerating
+already-deleted targets" transaction. Anything requiring live re-diffing or conflict resolution across
+elements is out of scope and would need its own decision if it comes up.
+
+## Alternatives considered
+
+- **Ship the cascading delete as non-undoable**, following the whole-element-deletion precedent.
+  Rejected: the use case is broader than one issue — state deletion, instance deletion, and
+  inheritance fan-out all need the same mechanism — so building the primitive once pays for itself
+  across all of them rather than accepting permanent undo data loss on each.
+- **Build a fully general cross-element undo/transaction framework** with open-ended merge/rebase
+  support for speculative future cases. Rejected as premature scope: the known cases share one
+  concrete shape (frozen affected-set, atomic apply/revert, no live conflict resolution), and a general
+  framework would solve problems nobody has hit yet.

--- a/Direction/decisions/README.md
+++ b/Direction/decisions/README.md
@@ -35,3 +35,5 @@ re-litigating it.
 | [0012](0012-converge-backends-on-one-shared-render-walk.md) | Converge every backend on one shared render walk, including render-target bakes | Accepted | 2026-07-31 |
 | [0013](0013-adopt-json-project-format-for-native-aot.md) | Adopt JSON as an AOT-safe project file format, phased in alongside XML | Accepted | 2026-07-31 |
 | [0014](0014-clarify-engine-scope-cost-to-integrate-not-owns-ui.md) | Clarify the engine-scope boundary: cost-to-integrate, not "ships its own UI" | Accepted | 2026-09-04 |
+| [0015](0015-treat-dispatcher-merge-as-incremental-goal.md) | Treat the Skia/core dispatcher merge as an incremental long-term goal, not a rejected option | Accepted | 2026-09-04 |
+| [0016](0016-cross-element-undo-transactions-for-cascading-deletes.md) | Cross-element undo transactions for cascading deletes | Accepted | 2026-09-09 |

--- a/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
@@ -103,12 +103,18 @@ public class DeleteVariableService : IDeleteVariableService
     }
 
     /// <summary>
-    /// Instance-level value overrides on other elements (<see cref="VariableChange.Variable"/> with a
-    /// non-null <c>SourceObject</c>) are cascaded rather than blocking - they're returned via
-    /// <paramref name="cascadingInstanceOverrides"/> for the caller to remove and record for undo.
-    /// Anything else that reuses the same rename-impact lookup - a VariableReferences binding, or an
-    /// inheriting element's own exposed-name entry - still blocks: those aren't a simple "restore this
-    /// value" case, so silently deleting through them would leave a dangling reference. See ADR 0016.
+    /// Plain instance-level value overrides on other elements are cascaded rather than blocking -
+    /// they're returned via <paramref name="cascadingInstanceOverrides"/> for the caller to remove and
+    /// record for undo. Anything else that reuses the same rename-impact lookup - a VariableReferences
+    /// binding, or an inheriting element's own exposed-name entry - still blocks: those aren't a simple
+    /// "restore this value" case, so silently deleting through them would leave a dangling reference or
+    /// destroy an unrelated exposed-variable declaration. See ADR 0016.
+    ///
+    /// The discriminator is <see cref="VariableSave.ExposedAsName"/>, not <see cref="VariableSave.SourceObject"/>:
+    /// an exposed variable's own <c>Name</c> is itself instance-qualified (e.g. "InnerButton.X" exposed
+    /// as "Variable1"), so it has a non-null SourceObject too - SourceObject alone can't tell a plain
+    /// override apart from an exposed-name entry. Confirmed by
+    /// ReferenceFinderTests.GetReferencesToVariable_ExposedNameOnInheritingElement_IsDetected_AndHasNonNullSourceObject.
     /// </summary>
     private GeneralResponse GetIfCanDeleteVariable(VariableSave variable, IStateContainer stateContainer,
         out List<VariableChange> cascadingInstanceOverrides)
@@ -134,7 +140,7 @@ public class DeleteVariableService : IDeleteVariableService
 
         var renames = _renameLogic.GetChangesForRenamedVariable(stateContainer, variable.Name, variable.GetRootName());
 
-        var blockingChanges = renames.VariableChanges.Where(c => c.Variable.SourceObject == null).ToList();
+        var blockingChanges = renames.VariableChanges.Where(c => !string.IsNullOrEmpty(c.Variable.ExposedAsName)).ToList();
 
         if (blockingChanges.Count > 0 || renames.VariableReferenceChanges.Count > 0)
         {
@@ -146,7 +152,7 @@ public class DeleteVariableService : IDeleteVariableService
                 $"Cannot delete variable {variable.Name} because it is referenced by other elements.\n\n{blockingResponse.GetChangesDetails()}");
         }
 
-        cascadingInstanceOverrides = renames.VariableChanges.Where(c => c.Variable.SourceObject != null).ToList();
+        cascadingInstanceOverrides = renames.VariableChanges.Where(c => string.IsNullOrEmpty(c.Variable.ExposedAsName)).ToList();
 
         return GeneralResponse.SuccessfulResponse;
     }

--- a/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/DeleteVariableService.cs
@@ -46,20 +46,19 @@ public class DeleteVariableService : IDeleteVariableService
 
     public void DeleteVariable(VariableSave variable, IStateContainer stateContainer)
     {
-
-
-
-        var response = GetIfCanDeleteVariable(variable, stateContainer);
+        var response = GetIfCanDeleteVariable(variable, stateContainer, out var cascadingInstanceOverrides);
 
         if(response.Succeeded == false)
         {
             _dialogService.ShowMessage(response.Message);
+            return;
         }
-        else
-        {
 
-            using var undoLock = _undoManager.RequestLock();
-            var elementSave = stateContainer as ElementSave;
+        var elementSave = stateContainer as ElementSave;
+        var crossElementRemovals = new List<CrossElementVariableChange>();
+
+        using (_undoManager.RequestLock())
+        {
             if(elementSave != null)
             {
                 elementSave.DefaultState.Variables.Remove(variable);
@@ -71,14 +70,51 @@ public class DeleteVariableService : IDeleteVariableService
                 _fileCommands.TryAutoSaveObject(behavior);
             }
 
-            _guiCommands.RefreshVariables(force: true);
+            // Instance-level value overrides elsewhere in the project are cascaded (removed, and
+            // recorded so undo/redo can restore/re-remove them). See ADR 0016.
+            foreach (var change in cascadingInstanceOverrides)
+            {
+                if (change.Container is ElementSave changeElement &&
+                    changeElement.GetInstance(change.Variable.SourceObject) is { } instance)
+                {
+                    change.State.Variables.Remove(change.Variable);
+                    _fileCommands.TryAutoSaveElement(changeElement);
+                    _pluginManager.VariableSet(changeElement, instance, change.Variable.GetRootName(), null);
 
-            _pluginManager.VariableDelete(elementSave, variable.Name);
+                    crossElementRemovals.Add(new CrossElementVariableChange
+                    {
+                        Container = changeElement,
+                        Instance = instance,
+                        State = change.State,
+                        Variable = change.Variable
+                    });
+                }
+            }
         }
+
+        if (crossElementRemovals.Count > 0)
+        {
+            _undoManager.AttachCrossElementVariableRemovals(crossElementRemovals);
+        }
+
+        _guiCommands.RefreshVariables(force: true);
+
+        _pluginManager.VariableDelete(elementSave, variable.Name);
     }
 
-    private GeneralResponse GetIfCanDeleteVariable(VariableSave variable, IStateContainer stateContainer)
+    /// <summary>
+    /// Instance-level value overrides on other elements (<see cref="VariableChange.Variable"/> with a
+    /// non-null <c>SourceObject</c>) are cascaded rather than blocking - they're returned via
+    /// <paramref name="cascadingInstanceOverrides"/> for the caller to remove and record for undo.
+    /// Anything else that reuses the same rename-impact lookup - a VariableReferences binding, or an
+    /// inheriting element's own exposed-name entry - still blocks: those aren't a simple "restore this
+    /// value" case, so silently deleting through them would leave a dangling reference. See ADR 0016.
+    /// </summary>
+    private GeneralResponse GetIfCanDeleteVariable(VariableSave variable, IStateContainer stateContainer,
+        out List<VariableChange> cascadingInstanceOverrides)
     {
+        cascadingInstanceOverrides = new List<VariableChange>();
+
         var isVariableContained = false;
 
         if (stateContainer is ElementSave elementSave)
@@ -98,12 +134,19 @@ public class DeleteVariableService : IDeleteVariableService
 
         var renames = _renameLogic.GetChangesForRenamedVariable(stateContainer, variable.Name, variable.GetRootName());
 
-        var changesDetails = renames.GetChangesDetails();
-        if (!string.IsNullOrEmpty(changesDetails))
+        var blockingChanges = renames.VariableChanges.Where(c => c.Variable.SourceObject == null).ToList();
+
+        if (blockingChanges.Count > 0 || renames.VariableReferenceChanges.Count > 0)
         {
+            var blockingResponse = new VariableChangeResponse();
+            blockingResponse.VariableChanges.AddRange(blockingChanges);
+            blockingResponse.VariableReferenceChanges.AddRange(renames.VariableReferenceChanges);
+
             return GeneralResponse.UnsuccessfulWith(
-                $"Cannot delete variable {variable.Name} because it is referenced by other elements.\n\n{changesDetails}");
+                $"Cannot delete variable {variable.Name} because it is referenced by other elements.\n\n{blockingResponse.GetChangesDetails()}");
         }
+
+        cascadingInstanceOverrides = renames.VariableChanges.Where(c => c.Variable.SourceObject != null).ToList();
 
         return GeneralResponse.SuccessfulResponse;
     }

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -1262,4 +1262,70 @@ public class UndoManagerTests : BaseTestClass
         _undoManager.PerformRedo();
         component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(3f);
     }
+
+    [Fact]
+    public void PerformUndoAndRedo_WithTwoConsecutiveCascadingDeletes_ShouldKeepEachActionsCrossElementDataIsolated()
+    {
+        // AttachCrossElementVariableRemovals always attaches to "the most recently recorded action."
+        // A second cascading delete must attach to its OWN action, not overwrite or bleed into the
+        // first one's - each undo/redo step must only touch the element it was actually recorded for.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var variable1 = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 1f };
+        var variable2 = new VariableSave { Name = "Variable2", Type = "float", IsCustomVariable = true, Value = 2f };
+        component.DefaultState.Variables.Add(variable1);
+        component.DefaultState.Variables.Add(variable2);
+
+        var screenA = new ScreenSave { Name = "ScreenA" };
+        screenA.States.Add(new StateSave { Name = "Default", ParentContainer = screenA });
+        var instanceA = new InstanceSave { Name = "InstanceA", BaseType = "Component1", ParentContainer = screenA };
+        screenA.Instances.Add(instanceA);
+        var variableA = new VariableSave { Name = "InstanceA.Variable1", Type = "float", Value = 10f };
+        screenA.DefaultState.Variables.Add(variableA);
+
+        var screenB = new ScreenSave { Name = "ScreenB" };
+        screenB.States.Add(new StateSave { Name = "Default", ParentContainer = screenB });
+        var instanceB = new InstanceSave { Name = "InstanceB", BaseType = "Component1", ParentContainer = screenB };
+        screenB.Instances.Add(instanceB);
+        var variableB = new VariableSave { Name = "InstanceB.Variable2", Type = "float", Value = 20f };
+        screenB.DefaultState.Variables.Add(variableB);
+
+        // Action 1: delete Variable1, cascading to ScreenA only.
+        _undoManager.RecordState();
+        component.DefaultState.Variables.Remove(variable1);
+        screenA.DefaultState.Variables.Remove(variableA);
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = screenA, Instance = instanceA, State = screenA.DefaultState, Variable = variableA }
+        });
+
+        // Action 2: delete Variable2, cascading to ScreenB only.
+        component.DefaultState.Variables.Remove(variable2);
+        screenB.DefaultState.Variables.Remove(variableB);
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = screenB, Instance = instanceB, State = screenB.DefaultState, Variable = variableB }
+        });
+
+        // Undo action 2: only ScreenB's variable comes back, ScreenA's stays removed.
+        _undoManager.PerformUndo();
+        screenB.DefaultState.Variables.ShouldContain(variableB);
+        screenA.DefaultState.Variables.ShouldNotContain(variableA);
+
+        // Undo action 1: ScreenA's variable now comes back too; ScreenB's remains restored (untouched).
+        _undoManager.PerformUndo();
+        screenA.DefaultState.Variables.ShouldContain(variableA);
+        screenB.DefaultState.Variables.ShouldContain(variableB);
+
+        // Redo action 1: only ScreenA's variable is removed again.
+        _undoManager.PerformRedo();
+        screenA.DefaultState.Variables.ShouldNotContain(variableA);
+        screenB.DefaultState.Variables.ShouldContain(variableB);
+
+        // Redo action 2: ScreenB's variable is removed again too.
+        _undoManager.PerformRedo();
+        screenA.DefaultState.Variables.ShouldNotContain(variableA);
+        screenB.DefaultState.Variables.ShouldNotContain(variableB);
+    }
 }

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -957,6 +957,35 @@ public class UndoManagerTests : BaseTestClass
     }
 
     [Fact]
+    public void AttachCrossElementVariableRemovals_WithEmptyList_ShouldBeANoOp()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 10f);
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 11f);
+        _undoManager.RecordUndo();
+
+        Should.NotThrow(() => _undoManager.AttachCrossElementVariableRemovals(System.Array.Empty<CrossElementVariableChange>()));
+
+        _undoManager.CurrentElementHistory.Actions.Single().CrossElementVariableRemovals.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AttachCrossElementVariableRemovals_WithNoRecordedActionYet_ShouldBeANoOp()
+    {
+        // Guards against attaching data that would silently land on the wrong (unrelated, previous)
+        // action if a future caller invoked this before anything was actually recorded.
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        Should.NotThrow(() => _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        }));
+
+        _undoManager.CanUndo().ShouldBeFalse();
+    }
+
+    [Fact]
     public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldRestoreVariableOnOtherElement()
     {
         ComponentSave component = _selectedState.Object.SelectedComponent!;

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -929,4 +929,134 @@ public class UndoManagerTests : BaseTestClass
 
         _undoManager.CanUndo().ShouldBeFalse();
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Cross-element undo transactions (ADR 0016 / #4658). Deleting a variable that's assigned on
+    // instances elsewhere removes those assignments too; the removals are attached to the deleting
+    // element's own undo action via AttachCrossElementVariableRemovals so undo/redo replay them on
+    // the other elements without those elements needing their own undo entries.
+    // ---------------------------------------------------------------------------------------------
+
+    private (ScreenSave Screen, InstanceSave Instance, VariableSave Variable) SetUpOtherElementWithAssignedVariable()
+    {
+        var otherScreen = new ScreenSave { Name = "Screen1" };
+        otherScreen.States.Add(new StateSave { Name = "Default", ParentContainer = otherScreen });
+
+        var instance = new InstanceSave
+        {
+            Name = "Variable1Instance",
+            BaseType = "Component1",
+            ParentContainer = otherScreen
+        };
+        otherScreen.Instances.Add(instance);
+
+        var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        otherScreen.DefaultState.Variables.Add(instanceVariable);
+
+        return (otherScreen, instance, instanceVariable);
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldRestoreVariableOnOtherElement()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        _undoManager.PerformUndo();
+
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+    }
+
+    [Fact]
+    public void PerformRedo_WithAttachedCrossElementVariableRemoval_ShouldRemoveVariableAgain()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        _undoManager.PerformUndo();
+        _undoManager.PerformRedo();
+
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldSkipInstanceRemovedSinceRecording()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        // Simulate the instance itself being deleted after the cascading delete was recorded.
+        otherScreen.Instances.Remove(instance);
+
+        Should.NotThrow(() => _undoManager.PerformUndo());
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldSaveOtherElementAndNotifyPlugin()
+    {
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        _undoManager.PerformUndo();
+
+        _fileCommands.Verify(x => x.TryAutoSaveElement(otherScreen), Times.Once);
+        _pluginNotifier.Verify(x => x.VariableSet(otherScreen, instance, "Variable1", null), Times.Once);
+    }
 }

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -1059,4 +1059,178 @@ public class UndoManagerTests : BaseTestClass
         _fileCommands.Verify(x => x.TryAutoSaveElement(otherScreen), Times.Once);
         _pluginNotifier.Verify(x => x.VariableSet(otherScreen, instance, "Variable1", null), Times.Once);
     }
+
+    [Fact]
+    public void PerformUndo_WithMultipleAttachedCrossElementVariableRemovals_ShouldRestoreAllOfThem()
+    {
+        // The realistic case: instances of Component1 exist in more than one other element (and/or
+        // more than once in the same element). One delete must restore every one of them on undo.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (screenA, instanceA, variableA) = SetUpOtherElementWithAssignedVariable();
+
+        var screenB = new ScreenSave { Name = "Screen2" };
+        screenB.States.Add(new StateSave { Name = "Default", ParentContainer = screenB });
+        var instanceB1 = new InstanceSave { Name = "Instance1", BaseType = "Component1", ParentContainer = screenB };
+        var instanceB2 = new InstanceSave { Name = "Instance2", BaseType = "Component1", ParentContainer = screenB };
+        screenB.Instances.Add(instanceB1);
+        screenB.Instances.Add(instanceB2);
+        var variableB1 = new VariableSave { Name = "Instance1.Variable1", Type = "float", Value = 1f };
+        var variableB2 = new VariableSave { Name = "Instance2.Variable1", Type = "float", Value = 2f };
+        screenB.DefaultState.Variables.Add(variableB1);
+        screenB.DefaultState.Variables.Add(variableB2);
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        screenA.DefaultState.Variables.Remove(variableA);
+        screenB.DefaultState.Variables.Remove(variableB1);
+        screenB.DefaultState.Variables.Remove(variableB2);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = screenA, Instance = instanceA, State = screenA.DefaultState, Variable = variableA },
+            new CrossElementVariableChange { Container = screenB, Instance = instanceB1, State = screenB.DefaultState, Variable = variableB1 },
+            new CrossElementVariableChange { Container = screenB, Instance = instanceB2, State = screenB.DefaultState, Variable = variableB2 }
+        });
+
+        _undoManager.PerformUndo();
+
+        screenA.DefaultState.Variables.ShouldContain(variableA);
+        screenB.DefaultState.Variables.ShouldContain(variableB1);
+        screenB.DefaultState.Variables.ShouldContain(variableB2);
+
+        _undoManager.PerformRedo();
+
+        screenA.DefaultState.Variables.ShouldNotContain(variableA);
+        screenB.DefaultState.Variables.ShouldNotContain(variableB1);
+        screenB.DefaultState.Variables.ShouldNotContain(variableB2);
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldSkipStateRemovedSinceRecording()
+    {
+        // Mirrors the instance-removed-since-recording tolerance test, for the other half of the
+        // skip condition: the state itself (e.g. a category state) no longer belongs to the element.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        // Simulate the state itself being deleted after the cascading delete was recorded.
+        otherScreen.States.Remove(otherScreen.DefaultState);
+
+        Should.NotThrow(() => _undoManager.PerformUndo());
+        otherScreen.DefaultState.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PerformRedo_WithAttachedCrossElementVariableRemoval_ShouldClobberManualEditMadeAfterUndo()
+    {
+        // ADR 0016's explicit conflict-handling call: if the user hand-edits the restored value between
+        // undo and redo, redo still removes it - last write wins, no merge.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        _undoManager.PerformUndo();
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+
+        // The user edits the restored value by hand before redoing.
+        instanceVariable.Value = 99f;
+
+        _undoManager.PerformRedo();
+
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+    }
+
+    [Fact]
+    public void PerformUndoAndRedo_InterleavedWithUnrelatedOwnerEdits_ShouldKeepCrossElementReplayInSync()
+    {
+        // The cross-element entry sits in the middle of an otherwise-ordinary undo stack. Walking back
+        // past it and forward again must not desync the owner's plain edits from the other element's
+        // restored/removed variable.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        component.DefaultState.SetValue("X", 1f);
+
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        // Action 1: plain edit on the owner.
+        _undoManager.RecordState();
+        component.DefaultState.SetValue("X", 2f);
+        _undoManager.RecordUndo();
+
+        // Action 2: the cascading delete.
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        // Action 3: another plain edit on the owner.
+        component.DefaultState.SetValue("X", 3f);
+        _undoManager.RecordUndo();
+
+        // Undo action 3 (plain edit): X reverts, cross-element removal untouched.
+        _undoManager.PerformUndo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(2f);
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+
+        // Undo action 2 (the cascading delete): X untouched, the other element's variable comes back.
+        _undoManager.PerformUndo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(2f);
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+
+        // Undo action 1 (plain edit): X reverts to its original value, cross-element restore untouched.
+        _undoManager.PerformUndo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(1f);
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+
+        // Redo action 1: X moves forward, cross-element restore still untouched.
+        _undoManager.PerformRedo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(2f);
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+
+        // Redo action 2: the cascading delete replays - the other element's variable is removed again.
+        _undoManager.PerformRedo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(2f);
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+
+        // Redo action 3: X moves to its final value.
+        _undoManager.PerformRedo();
+        component.DefaultState.GetValueOrDefault<float>("X").ShouldBe(3f);
+    }
 }

--- a/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
+++ b/Tests/Gum.Presentation.Tests/UndoManagerTests.cs
@@ -26,6 +26,8 @@ public class UndoManagerTests : BaseTestClass
     private readonly Mock<IMessenger> _messenger;
     private readonly Mock<IUndoPluginNotifier> _pluginNotifier;
     private readonly FakeAnimationUndoProvider _animationUndoProvider;
+    private readonly Mock<IReferenceFinderProjectProvider> _projectProvider;
+    private readonly GumProjectSave _project;
     private readonly UndoManager _undoManager;
 
     /// <summary>
@@ -63,6 +65,9 @@ public class UndoManagerTests : BaseTestClass
         _messenger = new Mock<IMessenger>();
         _pluginNotifier = new Mock<IUndoPluginNotifier>();
         _animationUndoProvider = new FakeAnimationUndoProvider();
+        _project = new GumProjectSave();
+        _projectProvider = new Mock<IReferenceFinderProjectProvider>();
+        _projectProvider.Setup(x => x.GumProjectSave).Returns(_project);
 
         ComponentSave component = new();
         component.States.Add(new Gum.DataTypes.Variables.StateSave
@@ -91,7 +96,8 @@ public class UndoManagerTests : BaseTestClass
             _fileCommands.Object,
             _messenger.Object,
             _pluginNotifier.Object,
-            _animationUndoProvider
+            _animationUndoProvider,
+            _projectProvider.Object
             );
     }
 
@@ -953,6 +959,8 @@ public class UndoManagerTests : BaseTestClass
         var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
         otherScreen.DefaultState.Variables.Add(instanceVariable);
 
+        _project.Screens.Add(otherScreen);
+
         return (otherScreen, instance, instanceVariable);
     }
 
@@ -1110,6 +1118,7 @@ public class UndoManagerTests : BaseTestClass
         var variableB2 = new VariableSave { Name = "Instance2.Variable1", Type = "float", Value = 2f };
         screenB.DefaultState.Variables.Add(variableB1);
         screenB.DefaultState.Variables.Add(variableB2);
+        _project.Screens.Add(screenB);
 
         _undoManager.RecordState();
 
@@ -1166,6 +1175,109 @@ public class UndoManagerTests : BaseTestClass
 
         Should.NotThrow(() => _undoManager.PerformUndo());
         otherScreen.DefaultState.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldSkipElementDeletedFromProjectSinceRecording()
+    {
+        // Whole-element deletion is a separate, non-undoable action (its own undo history is
+        // discarded with it) - the ScreenSave object can still be referenced here even after being
+        // removed from the project, so this must be checked explicitly or undoing an earlier
+        // cascading delete would resurrect a file for a screen the user already deleted.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        // Simulate whole-element-deleting the screen after the cascading delete was recorded.
+        _project.Screens.Remove(otherScreen);
+
+        Should.NotThrow(() => _undoManager.PerformUndo());
+
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+        _fileCommands.Verify(x => x.TryAutoSaveElement(otherScreen), Times.Never);
+    }
+
+    [Fact]
+    public void PerformRedo_WithAttachedCrossElementVariableRemoval_ShouldRemoveByNameEvenIfTheVariableObjectWasReplaced()
+    {
+        // StateSave.SetValue creates a NEW VariableSave when none exists under that name. If the user
+        // re-assigns the instance override (after undo restored it) through the normal edit path
+        // rather than mutating the captured object directly, redo must still find and remove it by
+        // name - a reference-based Remove would silently miss the replacement object and leave a
+        // dangling override.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        _undoManager.PerformUndo();
+        otherScreen.DefaultState.Variables.ShouldContain(instanceVariable);
+
+        // The user re-assigns the value through the normal edit path (StateSave.SetValue), which
+        // replaces the restored VariableSave with a brand-new object of the same Name.
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+        var replacement = otherScreen.DefaultState.SetValue(instanceVariable.Name, 42f, instanceVariable.Type);
+
+        _undoManager.PerformRedo();
+
+        otherScreen.DefaultState.Variables.ShouldNotContain(replacement);
+        otherScreen.DefaultState.Variables.Any(v => v.Name == instanceVariable.Name).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PerformUndo_WithAttachedCrossElementVariableRemoval_ShouldNotDuplicateIfSameNamedVariableAlreadyExists()
+    {
+        // Mirror of the redo-side replacement case: if a same-named override already exists on undo
+        // (e.g. the user re-created it independently), restoring must not add a second VariableSave
+        // with the same Name.
+        ComponentSave component = _selectedState.Object.SelectedComponent!;
+        var ownerVariable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        component.DefaultState.Variables.Add(ownerVariable);
+
+        var (otherScreen, instance, instanceVariable) = SetUpOtherElementWithAssignedVariable();
+
+        _undoManager.RecordState();
+
+        component.DefaultState.Variables.Remove(ownerVariable);
+        otherScreen.DefaultState.Variables.Remove(instanceVariable);
+
+        _undoManager.RecordUndo();
+        _undoManager.AttachCrossElementVariableRemovals(new[]
+        {
+            new CrossElementVariableChange { Container = otherScreen, Instance = instance, State = otherScreen.DefaultState, Variable = instanceVariable }
+        });
+
+        // The user independently re-creates a same-named override before undoing.
+        var recreated = otherScreen.DefaultState.SetValue(instanceVariable.Name, 42f, instanceVariable.Type);
+
+        _undoManager.PerformUndo();
+
+        otherScreen.DefaultState.Variables.Count(v => v.Name == instanceVariable.Name).ShouldBe(1);
     }
 
     [Fact]
@@ -1288,6 +1400,9 @@ public class UndoManagerTests : BaseTestClass
         screenB.Instances.Add(instanceB);
         var variableB = new VariableSave { Name = "InstanceB.Variable2", Type = "float", Value = 20f };
         screenB.DefaultState.Variables.Add(variableB);
+
+        _project.Screens.Add(screenA);
+        _project.Screens.Add(screenB);
 
         // Action 1: delete Variable1, cascading to ScreenA only.
         _undoManager.RecordState();

--- a/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
+++ b/Tests/Gum.Presentation.Tests/VariableCategoryCopyPasteUndoTests.cs
@@ -78,7 +78,8 @@ public class VariableCategoryCopyPasteUndoTests : BaseTestClass
             new Mock<IFileCommands>().Object,
             new Mock<IMessenger>().Object,
             new Mock<IUndoPluginNotifier>().Object,
-            new NoAnimationUndoProvider());
+            new NoAnimationUndoProvider(),
+            new Mock<IReferenceFinderProjectProvider>().Object);
     }
 
     /// <summary>

--- a/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
@@ -846,5 +846,39 @@ public class ReferenceFinderTests : BaseTestClass
         result.VariableChanges[0].Variable.SourceObject.ShouldNotBeNull();
     }
 
+    [Fact]
+    public void GetReferencesToVariable_WithBehaviorOwner_ShouldNotMatchElementInstanceOverrides()
+    {
+        // Regression guard: cascading delete (DeleteVariableService) is currently only reachable for
+        // ElementSave owners. The instance-override scan gates on `owner as ElementSave`, so a
+        // BehaviorSave owner must never produce a VariableChanges match here even when an unrelated
+        // element instance happens to have an override with a matching root name - if this ever started
+        // matching, DeleteVariableService would cascade-remove it while AttachCrossElementVariableRemovals
+        // (which only knows about the currently selected ElementSave) would silently misattach the data.
+        var behavior = new BehaviorSave { Name = "MyBehavior" };
+        var requiredVariable = new VariableSave { Name = "RequiredVar", Type = "float" };
+        behavior.RequiredVariables.Variables.Add(requiredVariable);
+
+        ComponentSave someComponent = new ComponentSave { Name = "SomeComponent" };
+        someComponent.States.Add(new StateSave { Name = "Default", ParentContainer = someComponent });
+        _project.Components.Add(someComponent);
+
+        ScreenSave screen1 = new ScreenSave { Name = "Screen1" };
+        StateSave defaultStateScreen = new StateSave { Name = "Default", ParentContainer = screen1 };
+        screen1.States.Add(defaultStateScreen);
+        InstanceSave instance = new InstanceSave { Name = "RequiredVarInstance", BaseType = "SomeComponent", ParentContainer = screen1 };
+        screen1.Instances.Add(instance);
+        VariableSave instanceVariable = new VariableSave { Name = "RequiredVarInstance.RequiredVar", Type = "float", Value = 7f };
+        defaultStateScreen.Variables.Add(instanceVariable);
+        _project.Screens.Add(screen1);
+
+        VariableChangeResponse result = _referenceFinder.GetReferencesToVariable(
+            behavior,
+            oldFullName: "RequiredVar",
+            oldStrippedOrExposedName: "RequiredVar");
+
+        result.VariableChanges.ShouldBeEmpty();
+    }
+
     #endregion
 }

--- a/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
@@ -813,5 +813,38 @@ public class ReferenceFinderTests : BaseTestClass
         result.VariableChanges[0].Variable.ShouldBe(instanceVariable);
     }
 
+    [Fact]
+    public void GetReferencesToVariable_ExposedNameOnInheritingElement_IsDetected_AndHasNonNullSourceObject()
+    {
+        // Component2 inherits from Component1 and exposes its own inner instance's property AS
+        // "Variable1" - shadowing/re-declaring the same name, not overriding an instance value.
+        // DeleteVariableService must keep this case blocking (ADR 0016), not cascade it: the
+        // exposed VariableSave's own Name is "InnerButton.X" (an instance-qualified reference), so it
+        // has a non-null SourceObject just like a plain instance override does. A filter that uses
+        // "SourceObject != null" alone to decide cascade-vs-block cannot tell the two apart.
+        ComponentSave component1 = new ComponentSave { Name = "Component1" };
+        component1.States.Add(new StateSave { Name = "Default", ParentContainer = component1 });
+        _project.Components.Add(component1);
+
+        ComponentSave component2 = new ComponentSave { Name = "Component2", BaseType = "Component1" };
+        StateSave defaultStateComponent2 = new StateSave { Name = "Default", ParentContainer = component2 };
+        component2.States.Add(defaultStateComponent2);
+        InstanceSave innerInstance = new InstanceSave { Name = "InnerButton", BaseType = "Button", ParentContainer = component2 };
+        component2.Instances.Add(innerInstance);
+        VariableSave exposedVariable = new VariableSave { Name = "InnerButton.X", Type = "float", ExposedAsName = "Variable1" };
+        defaultStateComponent2.Variables.Add(exposedVariable);
+        _project.Components.Add(component2);
+
+        VariableChangeResponse result = _referenceFinder.GetReferencesToVariable(
+            component1,
+            oldFullName: "Variable1",
+            oldStrippedOrExposedName: "Variable1");
+
+        result.VariableChanges.Count.ShouldBe(1);
+        result.VariableChanges[0].Container.ShouldBe(component2);
+        result.VariableChanges[0].Variable.ShouldBe(exposedVariable);
+        result.VariableChanges[0].Variable.SourceObject.ShouldNotBeNull();
+    }
+
     #endregion
 }

--- a/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Logic/ReferenceFinderTests.cs
@@ -749,5 +749,69 @@ public class ReferenceFinderTests : BaseTestClass
         result.VariableReferenceChanges[0].ChangedSide.ShouldBe(SideOfEquals.Right);
     }
 
+    [Fact]
+    public void GetReferencesToVariable_InstanceValueOverride_IsDetected()
+    {
+        // Component1 has a custom variable Variable1. Screen1 has an instance of Component1 with
+        // Variable1 explicitly assigned. This is the plain-override case #4658/ADR 0016 cascades on
+        // delete: it must be found as a VariableChange (not a VariableReferenceChange).
+        ComponentSave component1 = new ComponentSave { Name = "Component1" };
+        component1.States.Add(new StateSave { Name = "Default", ParentContainer = component1 });
+        _project.Components.Add(component1);
+
+        ScreenSave screen1 = new ScreenSave { Name = "Screen1" };
+        StateSave defaultStateScreen = new StateSave { Name = "Default", ParentContainer = screen1 };
+        screen1.States.Add(defaultStateScreen);
+        InstanceSave instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component1", ParentContainer = screen1 };
+        screen1.Instances.Add(instance);
+        VariableSave instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        defaultStateScreen.Variables.Add(instanceVariable);
+        _project.Screens.Add(screen1);
+
+        VariableChangeResponse result = _referenceFinder.GetReferencesToVariable(
+            component1,
+            oldFullName: "Variable1",
+            oldStrippedOrExposedName: "Variable1");
+
+        result.VariableChanges.Count.ShouldBe(1);
+        result.VariableChanges[0].Container.ShouldBe(screen1);
+        result.VariableChanges[0].State.ShouldBe(defaultStateScreen);
+        result.VariableChanges[0].Variable.ShouldBe(instanceVariable);
+        result.VariableReferenceChanges.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetReferencesToVariable_InstanceValueOverride_OnInstanceOfInheritingElement_IsDetected()
+    {
+        // Component2 inherits from Component1 (which declares Variable1). Screen1 has an instance of
+        // Component2 (not Component1 directly) with Variable1 overridden. The inheritance fan-out this
+        // ADR relies on: deleting Component1.Variable1 must still find and cascade this override.
+        ComponentSave component1 = new ComponentSave { Name = "Component1" };
+        component1.States.Add(new StateSave { Name = "Default", ParentContainer = component1 });
+        _project.Components.Add(component1);
+
+        ComponentSave component2 = new ComponentSave { Name = "Component2", BaseType = "Component1" };
+        component2.States.Add(new StateSave { Name = "Default", ParentContainer = component2 });
+        _project.Components.Add(component2);
+
+        ScreenSave screen1 = new ScreenSave { Name = "Screen1" };
+        StateSave defaultStateScreen = new StateSave { Name = "Default", ParentContainer = screen1 };
+        screen1.States.Add(defaultStateScreen);
+        InstanceSave instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component2", ParentContainer = screen1 };
+        screen1.Instances.Add(instance);
+        VariableSave instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        defaultStateScreen.Variables.Add(instanceVariable);
+        _project.Screens.Add(screen1);
+
+        VariableChangeResponse result = _referenceFinder.GetReferencesToVariable(
+            component1,
+            oldFullName: "Variable1",
+            oldStrippedOrExposedName: "Variable1");
+
+        result.VariableChanges.Count.ShouldBe(1);
+        result.VariableChanges[0].Container.ShouldBe(screen1);
+        result.VariableChanges[0].Variable.ShouldBe(instanceVariable);
+    }
+
     #endregion
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
@@ -51,6 +51,22 @@ public class DeleteVariableServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void DeleteVariable_WhenNoReferencesExist_ShouldNotAttachCrossElementRemovals()
+    {
+        // The most common case: nobody references the variable at all. This must delete plainly and
+        // must never call AttachCrossElementVariableRemovals with an empty/pointless entry.
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse());
+
+        _service.DeleteVariable(variable, owner);
+
+        owner.DefaultState.Variables.ShouldNotContain(variable);
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(It.IsAny<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>()), Times.Never);
+    }
+
+    [Fact]
     public void DeleteVariable_WhenReferencedOnlyByInstanceValueOverride_ShouldRemoveFromBothElements()
     {
         var (owner, variable) = MakeOwnerWithCustomVariable();

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
@@ -135,4 +135,82 @@ public class DeleteVariableServiceTests : BaseTestClass
         owner.DefaultState.Variables.ShouldContain(variable);
         _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Once);
     }
+
+    [Fact]
+    public void DeleteVariable_WhenBothInstanceOverrideAndVariableReferenceBindingExist_ShouldBlockEntirelyRatherThanPartiallyDelete()
+    {
+        // A mix of a cascadable override and a still-blocking VariableReferences binding must fail
+        // closed: nothing gets removed anywhere, not just the binding's own instance.
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var screenWithOverride = new ScreenSave { Name = "Screen1" };
+        screenWithOverride.States.Add(new StateSave { Name = "Default", ParentContainer = screenWithOverride });
+        var instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component1", ParentContainer = screenWithOverride };
+        screenWithOverride.Instances.Add(instance);
+        var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        screenWithOverride.DefaultState.Variables.Add(instanceVariable);
+
+        var screenWithBinding = new ScreenSave { Name = "Screen2" };
+        var variableReferenceList = new VariableListSave<string> { Name = "VariableReferences" };
+        variableReferenceList.ValueAsIList.Add("SomeInstance.X = Components/Component1.Variable1");
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = screenWithOverride, State = screenWithOverride.DefaultState, Variable = instanceVariable }
+                },
+                VariableReferenceChanges =
+                {
+                    new VariableReferenceChange { Container = screenWithBinding, VariableReferenceList = variableReferenceList, LineIndex = 0, ChangedSide = SideOfEquals.Right }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        owner.DefaultState.Variables.ShouldContain(variable);
+        screenWithOverride.DefaultState.Variables.ShouldContain(instanceVariable);
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(It.IsAny<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>()), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenReferencedByMultipleInstanceOverrides_ShouldCascadeAndAttachAllOfThem()
+    {
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var screenA = new ScreenSave { Name = "Screen1" };
+        screenA.States.Add(new StateSave { Name = "Default", ParentContainer = screenA });
+        var instanceA = new InstanceSave { Name = "InstanceA", BaseType = "Component1", ParentContainer = screenA };
+        screenA.Instances.Add(instanceA);
+        var variableA = new VariableSave { Name = "InstanceA.Variable1", Type = "float", Value = 1f };
+        screenA.DefaultState.Variables.Add(variableA);
+
+        var screenB = new ScreenSave { Name = "Screen2" };
+        screenB.States.Add(new StateSave { Name = "Default", ParentContainer = screenB });
+        var instanceB = new InstanceSave { Name = "InstanceB", BaseType = "Component1", ParentContainer = screenB };
+        screenB.Instances.Add(instanceB);
+        var variableB = new VariableSave { Name = "InstanceB.Variable1", Type = "float", Value = 2f };
+        screenB.DefaultState.Variables.Add(variableB);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = screenA, State = screenA.DefaultState, Variable = variableA },
+                    new VariableChange { Container = screenB, State = screenB.DefaultState, Variable = variableB }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        screenA.DefaultState.Variables.ShouldNotContain(variableA);
+        screenB.DefaultState.Variables.ShouldNotContain(variableB);
+
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(
+            It.Is<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>(removals =>
+                System.Linq.Enumerable.Count(removals) == 2)),
+            Times.Once);
+    }
 }

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
@@ -1,0 +1,138 @@
+using Gum.Commands;
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+using Gum.Logic;
+using Gum.Plugins;
+using Gum.Plugins.InternalPlugins.VariableGrid;
+using Gum.Services;
+using Gum.Services.Dialogs;
+using Gum.Undo;
+using Moq;
+using Shouldly;
+
+namespace GumToolUnitTests.Plugins.InternalPlugins.VariableGrid;
+
+public class DeleteVariableServiceTests : BaseTestClass
+{
+    private readonly Mock<IUndoManager> _undoManager;
+    private readonly Mock<IFileCommands> _fileCommands;
+    private readonly Mock<IGuiCommands> _guiCommands;
+    private readonly Mock<IRenameLogic> _renameLogic;
+    private readonly Mock<IDialogService> _dialogService;
+    private readonly Mock<IPluginManager> _pluginManager;
+    private readonly DeleteVariableService _service;
+
+    public DeleteVariableServiceTests()
+    {
+        _undoManager = new Mock<IUndoManager>();
+        _undoManager.Setup(x => x.RequestLock()).Returns(new UndoLock(() => { }));
+        _fileCommands = new Mock<IFileCommands>();
+        _guiCommands = new Mock<IGuiCommands>();
+        _renameLogic = new Mock<IRenameLogic>();
+        _dialogService = new Mock<IDialogService>();
+        _pluginManager = new Mock<IPluginManager>();
+
+        _service = new DeleteVariableService(
+            _undoManager.Object,
+            _fileCommands.Object,
+            _guiCommands.Object,
+            _renameLogic.Object,
+            _dialogService.Object,
+            _pluginManager.Object);
+    }
+
+    private static (ComponentSave Owner, VariableSave Variable) MakeOwnerWithCustomVariable()
+    {
+        var owner = new ComponentSave { Name = "Component1" };
+        owner.States.Add(new StateSave { Name = "Default", ParentContainer = owner });
+        var variable = new VariableSave { Name = "Variable1", Type = "float", IsCustomVariable = true, Value = 5f };
+        owner.DefaultState.Variables.Add(variable);
+        return (owner, variable);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenReferencedOnlyByInstanceValueOverride_ShouldRemoveFromBothElements()
+    {
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var otherScreen = new ScreenSave { Name = "Screen1" };
+        otherScreen.States.Add(new StateSave { Name = "Default", ParentContainer = otherScreen });
+        var instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component1", ParentContainer = otherScreen };
+        otherScreen.Instances.Add(instance);
+        var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        otherScreen.DefaultState.Variables.Add(instanceVariable);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = otherScreen, State = otherScreen.DefaultState, Variable = instanceVariable }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        owner.DefaultState.Variables.ShouldNotContain(variable);
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenReferencedOnlyByInstanceValueOverride_ShouldAttachCrossElementRemovalForUndo()
+    {
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var otherScreen = new ScreenSave { Name = "Screen1" };
+        otherScreen.States.Add(new StateSave { Name = "Default", ParentContainer = otherScreen });
+        var instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component1", ParentContainer = otherScreen };
+        otherScreen.Instances.Add(instance);
+        var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        otherScreen.DefaultState.Variables.Add(instanceVariable);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = otherScreen, State = otherScreen.DefaultState, Variable = instanceVariable }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(
+            It.Is<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>(removals =>
+                System.Linq.Enumerable.Single(removals).Container == otherScreen &&
+                System.Linq.Enumerable.Single(removals).Instance == instance &&
+                System.Linq.Enumerable.Single(removals).Variable == instanceVariable)),
+            Times.Once);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenReferencedByVariableReferenceBinding_ShouldStillBlock()
+    {
+        // A VariableReferences binding pointing at the deleted variable is a different, harder problem
+        // than a plain instance value override (ADR 0016 scopes it out) - it must keep blocking rather
+        // than silently leaving a dangling reference.
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var otherScreen = new ScreenSave { Name = "Screen1" };
+        var variableReferenceList = new VariableListSave<string> { Name = "VariableReferences" };
+        variableReferenceList.ValueAsIList.Add("SomeInstance.X = Components/Component1.Variable1");
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableReferenceChanges =
+                {
+                    new VariableReferenceChange { Container = otherScreen, VariableReferenceList = variableReferenceList, LineIndex = 0, ChangedSide = SideOfEquals.Right }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        owner.DefaultState.Variables.ShouldContain(variable);
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Once);
+    }
+}

--- a/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Plugins/InternalPlugins/VariableGrid/DeleteVariableServiceTests.cs
@@ -137,6 +137,39 @@ public class DeleteVariableServiceTests : BaseTestClass
     }
 
     [Fact]
+    public void DeleteVariable_WhenReferencedByExposedNameOnInheritingElement_ShouldStillBlock()
+    {
+        // Regression test: an exposed variable's own Name is itself instance-qualified (e.g.
+        // "InnerButton.X" exposed as "Variable1"), so it has a non-null SourceObject just like a plain
+        // instance override does (confirmed by ReferenceFinderTests). A filter keyed on SourceObject
+        // alone would misclassify this as cascadable and delete the derived element's exposed-variable
+        // declaration outright instead of blocking. The real discriminator is ExposedAsName.
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var derivedComponent = new ComponentSave { Name = "Component2", BaseType = "Component1" };
+        var defaultStateDerived = new StateSave { Name = "Default", ParentContainer = derivedComponent };
+        derivedComponent.States.Add(defaultStateDerived);
+        var exposedVariable = new VariableSave { Name = "InnerButton.X", Type = "float", ExposedAsName = "Variable1" };
+        defaultStateDerived.Variables.Add(exposedVariable);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = derivedComponent, State = defaultStateDerived, Variable = exposedVariable }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        owner.DefaultState.Variables.ShouldContain(variable);
+        defaultStateDerived.Variables.ShouldContain(exposedVariable);
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Once);
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(It.IsAny<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>()), Times.Never);
+    }
+
+    [Fact]
     public void DeleteVariable_WhenBothInstanceOverrideAndVariableReferenceBindingExist_ShouldBlockEntirelyRatherThanPartiallyDelete()
     {
         // A mix of a cascadable override and a still-blocking VariableReferences binding must fail
@@ -212,5 +245,78 @@ public class DeleteVariableServiceTests : BaseTestClass
             It.Is<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>(removals =>
                 System.Linq.Enumerable.Count(removals) == 2)),
             Times.Once);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenOverrideIsInANonDefaultState_ShouldCascadeInThatState()
+    {
+        // CrossElementVariableChange.State documents that the override isn't necessarily in the
+        // default state - a category state override must cascade (and later restore) in that same
+        // state, not DefaultState.
+        var (owner, variable) = MakeOwnerWithCustomVariable();
+
+        var otherScreen = new ScreenSave { Name = "Screen1" };
+        otherScreen.States.Add(new StateSave { Name = "Default", ParentContainer = otherScreen });
+        var category = new StateSaveCategory { Name = "MyCategory" };
+        var categoryState = new StateSave { Name = "On", ParentContainer = otherScreen };
+        category.States.Add(categoryState);
+        otherScreen.Categories.Add(category);
+
+        var instance = new InstanceSave { Name = "Variable1Instance", BaseType = "Component1", ParentContainer = otherScreen };
+        otherScreen.Instances.Add(instance);
+        var instanceVariable = new VariableSave { Name = "Variable1Instance.Variable1", Type = "float", Value = 7f };
+        categoryState.Variables.Add(instanceVariable);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(owner, variable.Name, variable.GetRootName()))
+            .Returns(new VariableChangeResponse
+            {
+                VariableChanges =
+                {
+                    new VariableChange { Container = otherScreen, State = categoryState, Variable = instanceVariable }
+                }
+            });
+
+        _service.DeleteVariable(variable, owner);
+
+        categoryState.Variables.ShouldNotContain(instanceVariable);
+        otherScreen.DefaultState.Variables.ShouldNotContain(instanceVariable);
+
+        _undoManager.Verify(x => x.AttachCrossElementVariableRemovals(
+            It.Is<System.Collections.Generic.IEnumerable<CrossElementVariableChange>>(removals =>
+                System.Linq.Enumerable.Single(removals).State == categoryState)),
+            Times.Once);
+    }
+
+    [Fact]
+    public void DeleteVariable_OnBehavior_ShouldStillRemoveTheRequiredVariable()
+    {
+        // Regression check: restructuring DeleteVariable/GetIfCanDeleteVariable around the new
+        // cascade must not disturb the (unrelated, un-cascaded) BehaviorSave path.
+        var behavior = new Gum.DataTypes.Behaviors.BehaviorSave { Name = "MyBehavior" };
+        var requiredVariable = new VariableSave { Name = "RequiredVar", Type = "float", IsCustomVariable = true };
+        behavior.RequiredVariables.Variables.Add(requiredVariable);
+
+        _renameLogic.Setup(x => x.GetChangesForRenamedVariable(behavior, requiredVariable.Name, requiredVariable.GetRootName()))
+            .Returns(new VariableChangeResponse());
+
+        _service.DeleteVariable(requiredVariable, behavior);
+
+        behavior.RequiredVariables.Variables.ShouldNotContain(requiredVariable);
+        _fileCommands.Verify(x => x.TryAutoSaveObject(behavior), Times.Once);
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Never);
+    }
+
+    [Fact]
+    public void DeleteVariable_WhenVariableIsNotContainedInTarget_ShouldBlockAndNotTouchUndo()
+    {
+        var (owner, _) = MakeOwnerWithCustomVariable();
+        var variableNotInOwner = new VariableSave { Name = "NotThere", Type = "float", IsCustomVariable = true };
+
+        _service.DeleteVariable(variableNotInOwner, owner);
+
+        _dialogService.Verify(x => x.ShowMessage(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<MessageDialogStyle?>()), Times.Once);
+        _undoManager.Verify(x => x.RequestLock(), Times.Never);
+        _renameLogic.Verify(x => x.GetChangesForRenamedVariable(
+            It.IsAny<IStateContainer>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 }

--- a/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
+++ b/Tool/Tests/GumToolUnitTests/VariableGrid/CompositeMemberLogicApplyTests.cs
@@ -43,7 +43,7 @@ public class CompositeMemberLogicApplyTests : BaseTestClass
         _nameVerifier = new Mock<INameVerifier>();
         _clipboardService = new Mock<IClipboardService>();
 
-        _realUndoManager = new UndoManager(null!, null!, null!, null!, null!, null!, null!);
+        _realUndoManager = new UndoManager(null!, null!, null!, null!, null!, null!, null!, null!);
         _undoManager = new Mock<IUndoManager>();
         _undoManager.Setup(x => x.RequestLock()).Returns(() => _realUndoManager.RequestLock());
 

--- a/Tools/Gum.Presentation/Undo/CrossElementVariableChange.cs
+++ b/Tools/Gum.Presentation/Undo/CrossElementVariableChange.cs
@@ -1,0 +1,25 @@
+using Gum.DataTypes;
+using Gum.DataTypes.Variables;
+
+namespace Gum.Undo;
+
+/// <summary>
+/// One instance-level variable assignment removed from an element other than the one that owns the
+/// undo entry it's attached to - for example, deleting Component1.Variable1 also removes
+/// MyButton.Variable1 wherever some other element has an instance of Component1 with that value
+/// assigned. Captured at delete time so the owning element's undo entry can restore it on undo and
+/// remove it again on redo, without that other element needing its own undo entry. See ADR 0016.
+/// </summary>
+public class CrossElementVariableChange
+{
+    public ElementSave Container { get; set; } = null!;
+    public InstanceSave Instance { get; set; } = null!;
+
+    /// <summary>
+    /// The state the variable lives in - not necessarily <see cref="Container"/>'s default state, since
+    /// an instance-level override can be assigned inside any category state.
+    /// </summary>
+    public StateSave State { get; set; } = null!;
+
+    public VariableSave Variable { get; set; } = null!;
+}

--- a/Tools/Gum.Presentation/Undo/ElementHistory.cs
+++ b/Tools/Gum.Presentation/Undo/ElementHistory.cs
@@ -8,6 +8,13 @@ public class HistoryAction
     public UndoSnapshot UndoState { get; set; }
     public UndoSnapshot RedoState { get; set; }
 
+    /// <summary>
+    /// Instance-level variable assignments on OTHER elements that this action's owning element caused
+    /// to be removed (e.g. deleting a variable that instances elsewhere had assigned). Null when this
+    /// action has none. Undo restores each entry; redo removes it again. See ADR 0016.
+    /// </summary>
+    public List<CrossElementVariableChange>? CrossElementVariableRemovals { get; set; }
+
     public override string ToString()
     {
         return $"Undo:{UndoState}";

--- a/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
+++ b/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
@@ -28,6 +28,7 @@ public class ElementUndoStrategy : IUndoStrategy
     private readonly IMessenger _messenger;
     private readonly IUndoPluginNotifier _pluginNotifier;
     private readonly IAnimationUndoProvider _animationUndoProvider;
+    private readonly IReferenceFinderProjectProvider _projectProvider;
     private readonly Func<bool> _areUndoLocksActive;
     private readonly Action<UndoOperation> _raiseUndosChanged;
 
@@ -63,6 +64,7 @@ public class ElementUndoStrategy : IUndoStrategy
         IMessenger messenger,
         IUndoPluginNotifier pluginNotifier,
         IAnimationUndoProvider animationUndoProvider,
+        IReferenceFinderProjectProvider projectProvider,
         Func<bool> areUndoLocksActive,
         Action<UndoOperation> raiseUndosChanged)
     {
@@ -73,6 +75,7 @@ public class ElementUndoStrategy : IUndoStrategy
         _messenger = messenger;
         _pluginNotifier = pluginNotifier;
         _animationUndoProvider = animationUndoProvider;
+        _projectProvider = projectProvider;
         _areUndoLocksActive = areUndoLocksActive;
         _raiseUndosChanged = raiseUndosChanged;
     }
@@ -611,9 +614,9 @@ public class ElementUndoStrategy : IUndoStrategy
 
     /// <summary>
     /// Restores (undo, <paramref name="restoring"/> true) or re-removes (redo, false) each cross-element
-    /// variable removal attached to an action, tolerating an instance or element deleted since the
-    /// action was recorded by skipping it. Mirrors a normal edit: saves each element it touches and
-    /// notifies plugins via the same VariableSet event a live edit fires.
+    /// variable removal attached to an action, tolerating an instance, state, or whole element deleted
+    /// since the action was recorded by skipping it. Mirrors a normal edit: saves each element it
+    /// touches and notifies plugins via the same VariableSet event a live edit fires.
     /// </summary>
     private void ReplayCrossElementVariableRemovals(List<CrossElementVariableChange>? removals, bool restoring)
     {
@@ -624,17 +627,30 @@ public class ElementUndoStrategy : IUndoStrategy
 
         foreach (var removal in removals)
         {
-            if (!removal.Container.Instances.Contains(removal.Instance) ||
+            // Whole-element deletion is a separate, non-undoable action (its own history is discarded
+            // with it) - the deleted element's object can still be referenced here since C# references
+            // don't get cleared by removing it from the project's element lists, so this must be
+            // checked explicitly or a stale reference resurrects a file for a screen/component the
+            // user already deleted.
+            if (_projectProvider.GumProjectSave?.AllElements.Contains(removal.Container) != true ||
+                !removal.Container.Instances.Contains(removal.Instance) ||
                 !removal.Container.AllStates.Contains(removal.State))
             {
                 continue;
             }
 
             var variables = removal.State.Variables;
+
+            // Match by name, not by the captured object reference: StateSave.SetValue creates a NEW
+            // VariableSave when none exists under that name, so a value re-assigned after the cascade
+            // removed the original is a different object with the same Name - and VariableSave has no
+            // value-equality override, so reference-based Contains/Remove would silently miss it.
+            var existing = variables.FirstOrDefault(v => v.Name == removal.Variable.Name);
+
             bool changed;
             if (restoring)
             {
-                changed = !variables.Contains(removal.Variable);
+                changed = existing == null;
                 if (changed)
                 {
                     variables.Add(removal.Variable);
@@ -642,7 +658,11 @@ public class ElementUndoStrategy : IUndoStrategy
             }
             else
             {
-                changed = variables.Remove(removal.Variable);
+                changed = existing != null;
+                if (changed)
+                {
+                    variables.Remove(existing!);
+                }
             }
 
             if (changed)

--- a/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
+++ b/Tools/Gum.Presentation/Undo/ElementUndoStrategy.cs
@@ -409,6 +409,8 @@ public class ElementUndoStrategy : IUndoStrategy
                 out bool shouldRefreshStateTreeView,
                 out bool shouldRefreshBehaviorView);
 
+            ReplayCrossElementVariableRemovals(undoSnapshot.CrossElementVariableRemovals, restoring: true);
+
             //if (undoSnapshot.UndoState.CategoryName != _selectedState.SelectedStateCategorySave?.Name ||
             //    undoSnapshot.UndoState.StateName != _selectedState.SelectedStateSave?.Name)
             //{
@@ -513,29 +515,26 @@ public class ElementUndoStrategy : IUndoStrategy
         return false;
     }
 
-    private UndoSnapshot? GetRedoSnapshot(ElementHistory elementHistory)
+    private UndoSnapshot? GetRedoSnapshot(ElementHistory elementHistory) => GetActionToRedo(elementHistory)?.RedoState;
+
+    private HistoryAction? GetActionToRedo(ElementHistory? elementHistory)
     {
-        UndoSnapshot? redoSnapshot = null;
-
-        if (elementHistory != null)
+        if (elementHistory == null)
         {
-            var indexToApply = elementHistory.UndoIndex + 1;
-
-
-            if (indexToApply < elementHistory.Actions.Count)
-            {
-                redoSnapshot = elementHistory.Actions[indexToApply].RedoState;
-            }
+            return null;
         }
 
-        return redoSnapshot;
+        var indexToApply = elementHistory.UndoIndex + 1;
+
+        return indexToApply < elementHistory.Actions.Count ? elementHistory.Actions[indexToApply] : null;
     }
 
     public void PerformRedo()
     {
         var elementHistory = GetValidUndosForElement(_selectedState.SelectedElement);
 
-        UndoSnapshot? redoSnapshot = GetRedoSnapshot(elementHistory);
+        var actionToRedo = GetActionToRedo(elementHistory);
+        UndoSnapshot? redoSnapshot = actionToRedo?.RedoState;
 
         //////////////////////////////////////Early Out//////////////////////////////////////////
         if (!CanRedo(elementHistory, redoSnapshot))
@@ -554,6 +553,8 @@ public class ElementUndoStrategy : IUndoStrategy
                 out bool shouldRefreshWireframe,
                 out bool shouldRefreshStateTreeView,
                 out bool shouldRefreshBehaviorView);
+
+            ReplayCrossElementVariableRemovals(actionToRedo!.CrossElementVariableRemovals, restoring: false);
 
             if (redoSnapshot.CategoryName != _selectedState.SelectedStateCategorySave?.Name ||
                 redoSnapshot.StateName != _selectedState.SelectedStateSave?.Name)
@@ -584,6 +585,72 @@ public class ElementUndoStrategy : IUndoStrategy
     public void ApplyUndoSnapshotToElement(UndoSnapshot undoSnapshot, ElementSave toApplyTo, bool propagateNameChanges)
     {
         ApplyUndoSnapshotToElement(undoSnapshot, toApplyTo, propagateNameChanges, out bool _, out bool _, out bool _);
+    }
+
+    /// <summary>
+    /// Attaches instance-level variable removals made on other elements to the most recently recorded
+    /// action for the currently selected element (the owner). Must be called after the RequestLock
+    /// that performed the removals has disposed, so TryRecord has already appended the owner's own
+    /// action to attach to. See ADR 0016.
+    /// </summary>
+    public void AttachCrossElementVariableRemovals(IEnumerable<CrossElementVariableChange> removals)
+    {
+        var list = removals as IReadOnlyCollection<CrossElementVariableChange> ?? removals.ToList();
+        if (list.Count == 0 || _selectedState.SelectedElement == null)
+        {
+            return;
+        }
+
+        if (!mUndos.TryGetValue(_selectedState.SelectedElement, out var history) || history.Actions.Count == 0)
+        {
+            return;
+        }
+
+        history.Actions[history.Actions.Count - 1].CrossElementVariableRemovals = list.ToList();
+    }
+
+    /// <summary>
+    /// Restores (undo, <paramref name="restoring"/> true) or re-removes (redo, false) each cross-element
+    /// variable removal attached to an action, tolerating an instance or element deleted since the
+    /// action was recorded by skipping it. Mirrors a normal edit: saves each element it touches and
+    /// notifies plugins via the same VariableSet event a live edit fires.
+    /// </summary>
+    private void ReplayCrossElementVariableRemovals(List<CrossElementVariableChange>? removals, bool restoring)
+    {
+        if (removals == null)
+        {
+            return;
+        }
+
+        foreach (var removal in removals)
+        {
+            if (!removal.Container.Instances.Contains(removal.Instance) ||
+                !removal.Container.AllStates.Contains(removal.State))
+            {
+                continue;
+            }
+
+            var variables = removal.State.Variables;
+            bool changed;
+            if (restoring)
+            {
+                changed = !variables.Contains(removal.Variable);
+                if (changed)
+                {
+                    variables.Add(removal.Variable);
+                }
+            }
+            else
+            {
+                changed = variables.Remove(removal.Variable);
+            }
+
+            if (changed)
+            {
+                _fileCommands.TryAutoSaveElement(removal.Container);
+                _pluginNotifier.VariableSet(removal.Container, removal.Instance, removal.Variable.GetRootName(), null);
+            }
+        }
     }
 
     private AddedAndRemovedInstances? ApplyUndoSnapshotToElement(UndoSnapshot undoSnapshot, ElementSave toApplyTo,

--- a/Tools/Gum.Presentation/Undo/IUndoManager.cs
+++ b/Tools/Gum.Presentation/Undo/IUndoManager.cs
@@ -35,6 +35,14 @@ public interface IUndoManager
 
     void ApplyUndoSnapshotToElement(UndoSnapshot undoSnapshot, ElementSave toApplyTo, bool propagateNameChanges);
 
+    /// <summary>
+    /// Attaches instance-level variable removals made on OTHER elements to the most recently recorded
+    /// undo action for the currently selected element. Call after the RequestLock that performed those
+    /// removals has been disposed (so the owning element's own action already exists to attach to).
+    /// See ADR 0016.
+    /// </summary>
+    void AttachCrossElementVariableRemovals(IEnumerable<CrossElementVariableChange> removals);
+
     void PerformUndo();
 
     void PerformRedo();

--- a/Tools/Gum.Presentation/Undo/IUndoPluginNotifier.cs
+++ b/Tools/Gum.Presentation/Undo/IUndoPluginNotifier.cs
@@ -18,4 +18,6 @@ public interface IUndoPluginNotifier
     void InstancesDelete(ElementSave elementSave, InstanceSave[] instances);
 
     void BehaviorSelected(BehaviorSave? behaviorSave);
+
+    void VariableSet(ElementSave parentElement, InstanceSave? instance, string unqualifiedChangedMemberName, object? oldValue);
 }

--- a/Tools/Gum.Presentation/Undo/UndoManager.cs
+++ b/Tools/Gum.Presentation/Undo/UndoManager.cs
@@ -55,7 +55,8 @@ public class UndoManager : IUndoManager
         IFileCommands fileCommands,
         IMessenger messenger,
         IUndoPluginNotifier pluginNotifier,
-        IAnimationUndoProvider animationUndoProvider)
+        IAnimationUndoProvider animationUndoProvider,
+        IReferenceFinderProjectProvider projectProvider)
     {
         UndoLocks = new ObservableCollection<UndoLock>();
         UndoLocks.CollectionChanged += HandleUndoLockChanged;
@@ -63,7 +64,7 @@ public class UndoManager : IUndoManager
         bool AreUndoLocksActive() => UndoLocks.Count > 0;
 
         _elementStrategy = new ElementUndoStrategy(selectedState, renameLogic, guiCommands, fileCommands,
-            messenger, pluginNotifier, animationUndoProvider, AreUndoLocksActive, InvokeUndosChanged);
+            messenger, pluginNotifier, animationUndoProvider, projectProvider, AreUndoLocksActive, InvokeUndosChanged);
         _behaviorStrategy = new BehaviorUndoStrategy(selectedState, guiCommands, fileCommands,
             messenger, pluginNotifier, AreUndoLocksActive, InvokeUndosChanged);
 

--- a/Tools/Gum.Presentation/Undo/UndoManager.cs
+++ b/Tools/Gum.Presentation/Undo/UndoManager.cs
@@ -104,6 +104,9 @@ public class UndoManager : IUndoManager
     public void ApplyUndoSnapshotToElement(UndoSnapshot undoSnapshot, ElementSave toApplyTo, bool propagateNameChanges)
         => _elementStrategy.ApplyUndoSnapshotToElement(undoSnapshot, toApplyTo, propagateNameChanges);
 
+    public void AttachCrossElementVariableRemovals(IEnumerable<CrossElementVariableChange> removals)
+        => _elementStrategy.AttachCrossElementVariableRemovals(removals);
+
     public UndoLock RequestLock()
     {
         // UndoLock lives in the headless Gum.Presentation assembly and can no longer reach back


### PR DESCRIPTION
## Summary
- Deleting a custom component variable no longer blocks just because instances elsewhere have overridden it. That override is removed too, and the delete is now undoable across both elements.
- Still blocks when the reference is a `VariableReferences` binding or an inheriting element's own exposed-name entry - those aren't a simple restore-this-value case (ADR 0016).
- New `IUndoManager.AttachCrossElementVariableRemovals` primitive: an undo entry owned by the deleting element can carry removals made on other elements, replayed on undo/redo, saved and plugin-notified the same way a live edit is. State deletion and instance deletion can reuse it later - see `Direction/decisions/0016-*.md`.
- **Three real bugs found and fixed via test coverage** (two by the author, one flagged by an independent fresh-context review agent asked to audit test coverage, then verified against source before fixing):
  1. The block/cascade filter keyed on `VariableSave.SourceObject != null`, but an exposed variable's own `Name` is itself instance-qualified, so it also has a non-null `SourceObject`. Deleting a base variable would have silently deleted a derived component's exposed-variable declaration instead of blocking. Fixed by keying on `ExposedAsName` instead.
  2. Cross-element replay matched by `VariableSave` object reference, not by name. `StateSave.SetValue` creates a new object when none exists under a name - exactly the state right after a cascade removes one - so re-assigning the value through the normal edit path (not by mutating the captured object) left redo unable to find and remove it, and undo able to create a duplicate. Fixed by matching on `Name`.
  3. The skip-guard never checked whether the affected element was still part of the project. Whole-element deletion only removes it from the project's own lists - the object survives as long as the cross-element undo data references it - so undoing an earlier cascading delete after that element was since whole-element-deleted (itself non-undoable) would resurrect a stray `.gusx`/`.gucx` file. Fixed by checking `GumProjectSave.AllElements` via the same project-provider port `ReferenceFinder` already uses.
- Bundled: fixed stale file-path pointers and added a cross-element-undo note to the `gum-tool-undo` skill, a save-path note to `gum-tool-file-watch`, and a short pointer in `gum-tool-variable-grid`.

## Test plan
- [x] `dotnet test Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj` - 989 passed
- [x] `dotnet test Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj` - 1339 passed, 2 pre-existing skips
- [x] `dotnet build GumFull.sln` - 0 errors, no new warnings
- [ ] Manual: delete a component variable that's assigned on an instance elsewhere, undo, redo (see #4658 for exact repro)

Manual test: needed - Visual Studio is open in the worktree for it.
FRB canary: not needed - no FRB1-shared source touched (`Tools/Gum.Presentation/Undo`, `Gum/Plugins/InternalPlugins/VariableGrid` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhnMGNKAuxXwynKZ1wAvCN