### PR TITLE
WpfDataUi: generic composite displayer for Vector2/Vector3 properties

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Controls/InlineChannelsDisplayLogicTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/InlineChannelsDisplayLogicTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using Shouldly;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
+using Xunit;
+
+namespace GumToolUnitTests.Controls;
+
+public class InlineChannelsDisplayLogicTests
+{
+    [Fact]
+    public void BuildFieldStates_ShouldReturnOneStatePerChannel_InOrder()
+    {
+        FakeChannelMember x = new("X") { BackingValue = 1f };
+        FakeChannelMember y = new("Y") { BackingValue = 2f };
+
+        InlineChannelFieldState[] states = InlineChannelsDisplayLogic.BuildFieldStates(new List<InstanceMember> { x, y });
+
+        states.Length.ShouldBe(2);
+        states[0].Label.ShouldBe("X");
+        states[0].Text.ShouldBe("1");
+        states[1].Label.ShouldBe("Y");
+        states[1].Text.ShouldBe("2");
+    }
+
+    [Fact]
+    public void BuildFieldStates_ShouldUseDisplayNameAsLabel_WhenCustomDisplayNameSet()
+    {
+        FakeChannelMember x = new("X") { BackingValue = 0f, DisplayName = "Horizontal" };
+
+        InlineChannelFieldState[] states = InlineChannelsDisplayLogic.BuildFieldStates(new List<InstanceMember> { x });
+
+        states[0].Label.ShouldBe("Horizontal");
+    }
+
+    [Fact]
+    public void BuildFieldStates_ShouldCarryIsDefaultAndIsIndeterminate_FromEachChannel()
+    {
+        FakeChannelMember defaultChannel = new("X") { IsDefault = true };
+        FakeChannelMember indeterminateChannel = new("Y") { IsDefault = false, IsIndeterminateOverride = true };
+
+        InlineChannelFieldState[] states = InlineChannelsDisplayLogic.BuildFieldStates(
+            new List<InstanceMember> { defaultChannel, indeterminateChannel });
+
+        states[0].IsDefault.ShouldBeTrue();
+        states[0].IsIndeterminate.ShouldBeFalse();
+        states[1].IsDefault.ShouldBeFalse();
+        states[1].IsIndeterminate.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(1f, "1")]
+    [InlineData(1.5f, "1.5")]
+    [InlineData(1.23456f, "1.2346")]
+    [InlineData(-2f, "-2")]
+    public void FormatChannelValue_ShouldFormatFloats_WithAtMostFourDecimals(float value, string expected)
+    {
+        string result = InlineChannelsDisplayLogic.FormatChannelValue(value);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void FormatChannelValue_ShouldReturnEmptyString_ForNull()
+    {
+        string result = InlineChannelsDisplayLogic.FormatChannelValue(null);
+
+        result.ShouldBe(string.Empty);
+    }
+
+    private class FakeChannelMember : InstanceMember
+    {
+        private bool _isDefault;
+
+        public float BackingValue { get; set; }
+
+        public bool IsIndeterminateOverride { get; set; }
+
+        public override bool IsDefault
+        {
+            get => _isDefault;
+            set => _isDefault = value;
+        }
+
+        public override bool IsIndeterminate => IsIndeterminateOverride;
+
+        public FakeChannelMember(string name) : base(name, null!)
+        {
+            CustomGetEvent += _ => BackingValue;
+            CustomGetTypeEvent += _ => typeof(float);
+            CustomSetPropertyEvent += (_, _) => { };
+        }
+    }
+}

--- a/WpfDataUi/Controls/InlineChannelsDisplay.xaml
+++ b/WpfDataUi/Controls/InlineChannelsDisplay.xaml
@@ -1,0 +1,40 @@
+<UserControl
+    x:Class="WpfDataUi.Controls.InlineChannelsDisplay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <StackPanel>
+        <Grid x:Name="MainGrid">
+            <Grid.ContextMenu>
+                <ContextMenu />
+            </Grid.ContextMenu>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+
+            <Label
+                x:Name="Label"
+                MinWidth="100"
+                VerticalAlignment="Center" />
+
+            <!--  One equal-width labeled field per channel, built in code (RebuildFields) since the
+                  channel count varies per composite type.  -->
+            <UniformGrid
+                x:Name="FieldsPanel"
+                Grid.Column="1"
+                Rows="1" />
+        </Grid>
+
+        <!--  Subtext (e.g. "Exposed as ...") mirrored from InstanceMember.DetailText, like the other displayers.  -->
+        <TextBlock
+            x:Name="HintTextBlock"
+            Margin="0,0,4,4"
+            HorizontalAlignment="Left"
+            FontSize="10"
+            TextWrapping="Wrap"
+            Visibility="Collapsed" />
+    </StackPanel>
+</UserControl>

--- a/WpfDataUi/Controls/InlineChannelsDisplay.xaml.cs
+++ b/WpfDataUi/Controls/InlineChannelsDisplay.xaml.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using WpfDataUi.DataTypes;
+
+namespace WpfDataUi.Controls
+{
+    /// <summary>
+    /// Generic displayer for a <see cref="CompositeInstanceMember"/>: one equal-width labeled numeric
+    /// <see cref="TextBox"/> per <see cref="CompositeInstanceMember.ChannelMembers"/> entry, laid out
+    /// horizontally. Each field commits directly to its own channel member on edit rather than composing
+    /// all fields into one value first, so this control never needs to know the composite's concrete
+    /// type (Vector2, Vector3, ...) - only the descriptor that registers it does. Domain-agnostic sibling
+    /// of the bespoke single-purpose composite displayers (e.g. a color swatch or a corner-radius link
+    /// toggle), which do need to know their composite type because they render more than N plain fields.
+    /// </summary>
+    public partial class InlineChannelsDisplay : UserControl, IDataUi
+    {
+        private readonly List<(TextBox TextBox, InstanceMember Channel)> _fields = new();
+        private InstanceMember? _instanceMember;
+        private bool _isSyncingFromInstance;
+
+        public InstanceMember? InstanceMember
+        {
+            get => _instanceMember;
+            set
+            {
+                bool valueChanged = _instanceMember != value;
+
+                if (_instanceMember != null && valueChanged)
+                {
+                    _instanceMember.PropertyChanged -= HandlePropertyChange;
+                }
+                _instanceMember = value;
+                if (_instanceMember != null && valueChanged)
+                {
+                    _instanceMember.PropertyChanged += HandlePropertyChange;
+                }
+
+                if (valueChanged)
+                {
+                    RebuildFields();
+                }
+
+                Refresh();
+            }
+        }
+
+        public bool SuppressSettingProperty { get; set; }
+
+        public InlineChannelsDisplay()
+        {
+            InitializeComponent();
+        }
+
+        private void RebuildFields()
+        {
+            FieldsPanel.Children.Clear();
+            _fields.Clear();
+
+            if (InstanceMember is not CompositeInstanceMember composite)
+            {
+                return;
+            }
+
+            FieldsPanel.Columns = composite.ChannelMembers.Count;
+
+            foreach (InstanceMember channel in composite.ChannelMembers)
+            {
+                StackPanel fieldPanel = new() { Margin = new Thickness(0, 0, 4, 0) };
+
+                TextBlock label = new()
+                {
+                    Text = channel.DisplayName,
+                    FontSize = 10,
+                    Margin = new Thickness(0, 0, 0, 2)
+                };
+
+                TextBox textBox = new();
+                textBox.LostFocus += (_, _) => Commit(channel, textBox);
+                textBox.KeyDown += (_, e) =>
+                {
+                    if (e.Key == Key.Enter)
+                    {
+                        Commit(channel, textBox);
+                        e.Handled = true;
+                    }
+                };
+
+                fieldPanel.Children.Add(label);
+                fieldPanel.Children.Add(textBox);
+                FieldsPanel.Children.Add(fieldPanel);
+
+                _fields.Add((textBox, channel));
+            }
+        }
+
+        private void Commit(InstanceMember channel, TextBox textBox)
+        {
+            if (_isSyncingFromInstance || SuppressSettingProperty)
+            {
+                return;
+            }
+
+            if (TextBoxDisplayLogic.TryParseNumeric(textBox.Text, channel.PropertyType, out object parsed))
+            {
+                channel.SetValue(parsed, SetPropertyCommitType.Full);
+                channel.CallAfterSetByUi();
+            }
+        }
+
+        public void Refresh(bool forceRefreshEvenIfFocused = false)
+        {
+            if (InstanceMember is not CompositeInstanceMember composite)
+            {
+                return;
+            }
+
+            Label.Content = InstanceMember.DisplayName;
+            IsEnabled = !InstanceMember.IsReadOnly;
+            RefreshHintText();
+
+            _isSyncingFromInstance = true;
+            try
+            {
+                InlineChannelFieldState[] states = InlineChannelsDisplayLogic.BuildFieldStates(composite.ChannelMembers);
+                for (int i = 0; i < _fields.Count; i++)
+                {
+                    (TextBox textBox, InstanceMember channel) = _fields[i];
+                    if (forceRefreshEvenIfFocused || !textBox.IsKeyboardFocused)
+                    {
+                        textBox.Text = states[i].Text;
+                    }
+                    textBox.IsEnabled = !channel.IsReadOnly;
+                    ApplyBackground(textBox, states[i]);
+                }
+            }
+            finally
+            {
+                _isSyncingFromInstance = false;
+            }
+
+            this.RefreshContextMenu(MainGrid.ContextMenu);
+        }
+
+        /// <summary>
+        /// Deferred like <c>CornerRadiusDisplay.RefreshBackgrounds</c>: <see cref="DataUiGrid.OverridesIsDefaultStylingProperty"/>
+        /// is an inherited attached property, and a pooled control isn't necessarily re-parented into the
+        /// grid's visual tree yet when Refresh runs, so reading it synchronously here can see the
+        /// pre-inheritance default (false).
+        /// </summary>
+        private void ApplyBackground(TextBox textBox, InlineChannelFieldState state)
+        {
+            Dispatcher.BeginInvoke(() =>
+            {
+                if (DataUiGrid.GetOverridesIsDefaultStyling(textBox))
+                {
+                    return;
+                }
+
+                if (state.IsDefault)
+                {
+                    textBox.Background = TextBoxDisplayLogic.DefaultValueBackground;
+                }
+                else if (state.IsIndeterminate)
+                {
+                    textBox.Background = TextBoxDisplayLogic.IndeterminateValueBackground;
+                }
+                else if (textBox.TryFindResource("Frb.Brushes.Field.Background") is Brush themed)
+                {
+                    textBox.Background = themed;
+                }
+                else
+                {
+                    textBox.ClearValue(TextBox.BackgroundProperty);
+                }
+            });
+        }
+
+        private void RefreshHintText()
+        {
+            string? detailText = InstanceMember?.DetailText;
+            HintTextBlock.Text = detailText;
+            HintTextBlock.Visibility = string.IsNullOrEmpty(detailText) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Unused: fields commit directly to their own channel member (see <see cref="Commit"/>), not
+        /// through a single composed value - see the class summary for why.
+        /// </summary>
+        public ApplyValueResult TrySetValueOnUi(object valueOnInstance) => ApplyValueResult.NotSupported;
+
+        /// <inheritdoc cref="TrySetValueOnUi"/>
+        public ApplyValueResult TryGetValueOnUi(out object? value)
+        {
+            value = null;
+            return ApplyValueResult.NotSupported;
+        }
+
+        private void HandlePropertyChange(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(InstanceMember.Value) || e.PropertyName == nameof(InstanceMember.DetailText))
+            {
+                Refresh();
+            }
+        }
+    }
+}

--- a/WpfDataUi/Controls/InlineChannelsDisplayLogic.cs
+++ b/WpfDataUi/Controls/InlineChannelsDisplayLogic.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using WpfDataUi.DataTypes;
+
+namespace WpfDataUi.Controls
+{
+    /// <summary>
+    /// Display state for one field of an <see cref="InlineChannelsDisplay"/> composite row: the channel's
+    /// label, its formatted text, and its default/indeterminate state.
+    /// </summary>
+    public readonly struct InlineChannelFieldState
+    {
+        public string Label { get; }
+        public string Text { get; }
+        public bool IsDefault { get; }
+        public bool IsIndeterminate { get; }
+
+        public InlineChannelFieldState(string label, string text, bool isDefault, bool isIndeterminate)
+        {
+            Label = label;
+            Text = text;
+            IsDefault = isDefault;
+            IsIndeterminate = isIndeterminate;
+        }
+    }
+
+    /// <summary>
+    /// Pure, WPF-control-agnostic logic behind <see cref="InlineChannelsDisplay"/>: given a composite
+    /// member's channels, decides what each field's label, formatted text, and default/indeterminate
+    /// state should be. Kept separate from the control so it is testable without a WPF UserControl.
+    /// </summary>
+    public static class InlineChannelsDisplayLogic
+    {
+        public static InlineChannelFieldState[] BuildFieldStates(IReadOnlyList<InstanceMember> channelMembers)
+        {
+            InlineChannelFieldState[] states = new InlineChannelFieldState[channelMembers.Count];
+
+            for (int i = 0; i < channelMembers.Count; i++)
+            {
+                InstanceMember channel = channelMembers[i];
+                states[i] = new InlineChannelFieldState(
+                    channel.DisplayName,
+                    FormatChannelValue(channel.Value),
+                    channel.IsDefault,
+                    channel.IsIndeterminate);
+            }
+
+            return states;
+        }
+
+        public static string FormatChannelValue(object? value)
+        {
+            return value switch
+            {
+                null => string.Empty,
+                float floatValue => floatValue.ToString("0.####", CultureInfo.InvariantCulture),
+                double doubleValue => doubleValue.ToString("0.####", CultureInfo.InvariantCulture),
+                decimal decimalValue => decimalValue.ToString("0.####", CultureInfo.InvariantCulture),
+                _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+            };
+        }
+    }
+}

--- a/WpfDataUi/SampleProject/SampleProject/MainWindow.xaml.cs
+++ b/WpfDataUi/SampleProject/SampleProject/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -49,6 +50,8 @@ namespace SampleProject
             CreateTwiceXMember(character, category);
 
             CreateYAsAngle(character, category);
+
+            CreatePositionAsInlineChannels(character, category);
 
             SetHealthDisplayToUseSlider(character, DataGrid);
 
@@ -123,6 +126,42 @@ namespace SampleProject
             category.Members.Add(member);
         }
 
+        /// <summary>
+        /// Demonstrates <see cref="InlineChannelsDisplay"/>: a generic composite displayer for a
+        /// vector-shaped value, here composing character.X/Y/Z into a System.Numerics.Vector3. The
+        /// same pattern applies to any other vector type (e.g. Microsoft.Xna.Framework.Vector2/3) -
+        /// only the Compose/Decompose delegates below need to know the concrete type.
+        /// </summary>
+        private void CreatePositionAsInlineChannels(Character character, MemberCategory category)
+        {
+            InstanceMember xMember = new("X", character);
+            xMember.CustomGetEvent += (_) => character.X;
+            xMember.CustomSetEvent += (_, value) => character.X = (float)value;
+            xMember.CustomGetTypeEvent += (_) => typeof(float);
 
+            InstanceMember yMember = new("Y", character);
+            yMember.CustomGetEvent += (_) => character.Y;
+            yMember.CustomSetEvent += (_, value) => character.Y = (float)value;
+            yMember.CustomGetTypeEvent += (_) => typeof(float);
+
+            InstanceMember zMember = new("Z", character);
+            zMember.CustomGetEvent += (_) => character.Z;
+            zMember.CustomSetEvent += (_, value) => character.Z = (float)value;
+            zMember.CustomGetTypeEvent += (_) => typeof(float);
+
+            CompositeInstanceMember positionMember = new(
+                "Position",
+                new List<InstanceMember> { xMember, yMember, zMember },
+                typeof(Vector3),
+                channels => new Vector3((float)channels[0]!, (float)channels[1]!, (float)channels[2]!),
+                value =>
+                {
+                    Vector3 vector = (Vector3)value;
+                    return new object?[] { vector.X, vector.Y, vector.Z };
+                });
+            positionMember.PreferredDisplayer = typeof(InlineChannelsDisplay);
+
+            category.Members.Add(positionMember);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `InlineChannelsDisplay` (`WpfDataUi/Controls/`) — a generic `IDataUi` displayer for a `CompositeInstanceMember`: one equal-width labeled numeric TextBox per channel, laid out horizontally. Each field commits directly to its own channel member on edit, so the control never needs to know the composite's concrete type (Vector2, Vector3, XNA equivalents, ...).
- Extracts `InlineChannelsDisplayLogic` (label/formatted-text/default-state per field) as pure, testable logic, mirroring `ColorDisplayLogic`.
- Wires context-menu (Make Default, expose/un-expose) and default/indeterminate background tinting, matching `CornerRadiusDisplay`'s pattern — both are opt-in per displayer and easy to silently miss (see `gum-tool-variable-grid` skill).
- Demonstrates the control in WpfDataUi's own `SampleProject` by composing `Character.X/Y/Z` into a `System.Numerics.Vector3`, since there's no existing WPF sample inside the Gum tool solution to hang this on.

## Deliberately not in scope
- **No `CompositeMemberDescriptor` registered in Gum's `CompositeMemberRegistry` for Vector2/Vector3.** No Vector2/Vector3-typed `VariableSave` exists in Gum's data model today, so a registered descriptor would have no real channels to group (`CompositeMemberLogic.GroupTriples` needs matching `VariableSave`s in the same category) — it would be untestable, unreachable code. This PR is the reusable building block; wiring an actual Gum property to it is separate, future work once such a property exists.
- Label-drag scrub (click-and-drag a field's label to scrub its value) — exists on `TextBoxDisplay`/`CornerRadiusDisplay` and is copy-adaptable, but adds complexity beyond this first pass.

Closes #4660.

## Test plan
- [x] `InlineChannelsDisplayLogicTests` (new, TDD red→green) covers label/text/default/indeterminate derivation and float formatting.
- [x] Full `GumToolUnitTests` suite green (1348 passed, 0 failed, pre-existing 2 skips).
- [x] `WpfDataUi.csproj` builds standalone (net8.0-windows) with 0 errors, 0 new warnings.
- [x] `GumFull.sln` builds with 0 errors, 0 new warnings.
- Manual test: needed — opened `WpfDataUi/SampleProject/SampleProject.sln` in Visual Studio (`Start-Process`) for a visual check of the new "Position" composite row (X/Y/Z fields backed by `System.Numerics.Vector3`). Note: `SampleProject.csproj` targets legacy .NET Framework 4.5.2 and fails to build via both `dotnet build` and VS's own `MSBuild.exe` on this machine ("reference assemblies ... were not found", even though the targeting pack is present on disk) — a pre-existing environment gap unrelated to this change, not something this PR introduces or is expected to fix.
- FRB canary: not needed — WpfDataUi is WPF/Windows-only tool code, not included in any FRB1-shared `.projitems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J78HnzHq52c5PADRS7CbvZ
