### PR TITLE
Fix ListBoxDisplay crash from stale IndexEditing on a pooled/first-bound control

### DIFF
--- a/Tool/Tests/GumToolUnitTests/Controls/ListBoxDisplayIndexEditingTests.cs
+++ b/Tool/Tests/GumToolUnitTests/Controls/ListBoxDisplayIndexEditingTests.cs
@@ -1,0 +1,74 @@
+using Shouldly;
+using WpfDataUi.Controls;
+using WpfDataUi.DataTypes;
+
+namespace GumToolUnitTests.Controls;
+
+/// <summary>
+/// A pooled ListBoxDisplay (see gum-tool-variable-grid: SingleDataUiContainer recycles
+/// displayer controls across InstanceMembers) must not carry a stale "editing index" from
+/// a previous bind into a new one - and the very first bind is itself such a transition,
+/// since the backing field starts at -1 rather than null. Either case previously made the
+/// very next "Add" go through the edit-in-place branch instead of appending, indexing a
+/// list that doesn't have that many entries yet.
+/// </summary>
+public class ListBoxDisplayIndexEditingTests : BaseTestClass
+{
+    [StaFact]
+    public void HandleAddTextItem_ShouldAppend_OnFreshlyConstructedDisplay()
+    {
+        var backingValue = new List<int>();
+        var display = new ListBoxDisplay();
+        display.InstanceMember = MakeIntListMember(() => backingValue, v => backingValue = (List<int>)v);
+
+        InvokeHandleAddTextItem(display, "5");
+
+        backingValue.ShouldBe(new List<int> { 5 });
+    }
+
+    [StaFact]
+    public void HandleAddTextItem_ShouldAppend_AfterRebindingToADifferentShorterList()
+    {
+        // Simulates SingleDataUiContainer pooling: this ListBoxDisplay was previously used to
+        // edit index 2 of some other (longer) list-typed InstanceMember, then got reassigned
+        // to a new, shorter list without the user ever confirming or cancelling that edit.
+        var firstBackingValue = new List<int> { 1, 2, 3 };
+        var display = new ListBoxDisplay();
+        display.InstanceMember = MakeIntListMember(() => firstBackingValue, v => firstBackingValue = (List<int>)v);
+        SetIndexEditing(display, 2);
+
+        var secondBackingValue = new List<int>();
+        display.InstanceMember = MakeIntListMember(() => secondBackingValue, v => secondBackingValue = (List<int>)v);
+
+        InvokeHandleAddTextItem(display, "9");
+
+        secondBackingValue.ShouldBe(new List<int> { 9 });
+    }
+
+    private static InstanceMember MakeIntListMember(Func<object?> get, Action<object> set)
+    {
+        var member = new InstanceMember { Name = "TestListMember" };
+        member.CustomGetTypeEvent += _ => typeof(List<int>);
+        member.CustomGetEvent += _ => get();
+        member.CustomSetPropertyEvent += (_, args) => set(args.Value!);
+        return member;
+    }
+
+    private static void InvokeHandleAddTextItem(ListBoxDisplay display, string text)
+    {
+        var method = typeof(ListBoxDisplay).GetMethod(
+            "HandleAddTextItem",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        method.ShouldNotBeNull();
+        method!.Invoke(display, new object[] { text });
+    }
+
+    private static void SetIndexEditing(ListBoxDisplay display, int index)
+    {
+        var field = typeof(ListBoxDisplay).GetField(
+            "indexEditing",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        field.ShouldNotBeNull();
+        field!.SetValue(display, (int?)index);
+    }
+}

--- a/WpfDataUi/Controls/ListBoxDisplay.xaml.cs
+++ b/WpfDataUi/Controls/ListBoxDisplay.xaml.cs
@@ -51,6 +51,13 @@ public partial class ListBoxDisplay : UserControl, IDataUi
             {
                 // Clear stale green background from a previous pooled use.
                 this.ListBox.ClearValue(ListBox.BackgroundProperty);
+                // A pooled instance (or this control's very first bind, since the backing
+                // field starts at -1 rather than null) may not be "not editing" for this
+                // InstanceMember. Reset so the next Add appends instead of indexing an
+                // in-progress edit position that may not exist in the new list.
+                NewEntryGrid.Visibility = Visibility.Collapsed;
+                NotEditingEntryStackPanel.Visibility = Visibility.Visible;
+                IndexEditing = null;
             }
 
             Refresh();


### PR DESCRIPTION
**Required by [vchelaru/FlatRedBall#2260](https://github.com/vchelaru/FlatRedBall/pull/2260) (int/float array CustomVariables) — that PR does not work without this merged first (or together). Do not merge #2260 alone.**

Found while manually testing that FlatRedBall PR: adding the first item to a fresh int-list variable crashed with `ArgumentOutOfRangeException`.

Root cause: `ListBoxDisplay.IndexEditing` starts at `-1` (not `null`), and is only ever reset to `null` after a completed edit or an explicit Cancel - never on `InstanceMember` reassignment. `SingleDataUiContainer` pools `ListBoxDisplay` instances across different `InstanceMember`s, and a brand-new instance's very first bind goes through that same reassignment path. Either way, `HandleAddTextItem`'s `if (IndexEditing == null)` check is false, so the very next "Add" writes into `list[IndexEditing.Value]` instead of appending - indexing a list that doesn't have that many entries yet. Reproducible for any list type (`List<string>`/`List<int>`/`List<float>`/`List<Vector2>`), not just the new numeric ones, but numeric lists make it trivial to hit since every one starts empty.

Fix: reset `IndexEditing` (and the add/edit entry UI) whenever `InstanceMember` changes, matching the pooled-control cleanup contract other displayers already follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNUWgENyYL5kFxEosf3FEY
