### PR TITLE
Make BitmapFont's shadow-sibling probe conditional on HasDropshadow

### DIFF
--- a/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
+++ b/Gum/Wireframe/CustomSetPropertyOnRenderable.cs
@@ -2335,6 +2335,20 @@ public partial class CustomSetPropertyOnRenderable
             return null;
         }
 
+        // Issue #4665: BitmapFont's "-shadow.fnt" sibling probe is opt-in (see
+        // BitmapFont.EnsureShadowChecked doc / the checkForShadowSibling constructor parameter) so it
+        // never runs for a font nobody configured with a dropshadow. Safe to key purely off
+        // HasDropshadow here (rather than deferring): GetFontCacheFileName already bakes dropshadow
+        // into fullFileName (a "_ds{blur}" suffix), so a dropshadow and non-dropshadow request for the
+        // same base font are never the same cache entry/BitmapFont instance to begin with.
+#if FRB
+        // FRB doesn't compile TextRuntime (GueDeriving), so there is no HasDropshadow to read here --
+        // textRuntime is the bare GraphicalUiElement param above.
+        bool wantsDropshadow = false;
+#else
+        bool wantsDropshadow = textRuntime.HasDropshadow;
+#endif
+
         font = loaderManager.GetDisposable(fullFileName) as BitmapFont;
 
         // Attempt to load from Embedded Resource
@@ -2392,7 +2406,7 @@ public partial class CustomSetPropertyOnRenderable
                 try
                 {
                     // this could be running in browser where we don't have File.Exists, so JUST DO IT
-                    font = new BitmapFont(fullFileName);
+                    font = new BitmapFont(fullFileName, checkForShadowSibling: wantsDropshadow);
 
                     loaderManager.AddDisposable(fullFileName, font);
                 }
@@ -2413,7 +2427,7 @@ public partial class CustomSetPropertyOnRenderable
 
                 try
                 {
-                    font = new BitmapFont(fullFileName);
+                    font = new BitmapFont(fullFileName, checkForShadowSibling: wantsDropshadow);
                     loaderManager.AddDisposable(fullFileName, font);
                 }
                 catch (System.Text.DecoderFallbackException exception)

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ToolsUtilities;
 using Xunit;
 
 namespace MonoGameGum.Tests.RenderingLibraries;
@@ -141,6 +142,96 @@ char id=37   x=161   y=0     width=22    height=20    xoffset=1     yoffset=6   
     public void GetShadowSiblingFntPath_ReturnsNull_ForNonFntPath(string fontFile)
     {
         BitmapFont.GetShadowSiblingFntPath(fontFile).ShouldBeNull();
+    }
+
+    // A minimal .fnt with zero pages, so the constructor's ReloadTextures step has nothing to load -
+    // these tests exercise only the shadow-sibling probe, not MonoGame texture loading (which needs
+    // a real GraphicsDevice this test project doesn't set up - see GumService.InitializeForTesting).
+    const string noPagesBMFontFileData =
+@"info face=""Test"" size=-14 bold=0 italic=0 charset="""" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0
+common lineHeight=16 base=12 scaleW=1 scaleH=1 pages=0 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4
+chars count=0
+";
+
+    [Fact]
+    public void Constructor_ShouldNotProbeForShadowSibling_WhenCheckForShadowSiblingIsFalse()
+    {
+        // Issue #4665: the shadow-sibling probe used to run unconditionally in the constructor, on
+        // every font load. checkForShadowSibling makes it opt-in - a caller that already knows the
+        // font was never configured with a dropshadow (e.g. CustomSetPropertyOnRenderable, from
+        // TextRuntime.HasDropshadow) can skip the probe entirely.
+        bool shadowProbed = false;
+        Func<string, System.IO.Stream>? previousHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            FileManager.CustomGetStreamFromFile = path =>
+            {
+                // EndsWith (not Contains) - the absolute path is rooted under this test run's working
+                // directory, which can itself legitimately contain the substring "-shadow" (e.g. a
+                // worktree folder name), so only the actual "-shadow.fnt" suffix counts as a probe.
+                if (path.EndsWith("-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    shadowProbed = true;
+                }
+                if (path.EndsWith(".fnt"))
+                {
+                    return new System.IO.MemoryStream(Encoding.UTF8.GetBytes(noPagesBMFontFileData));
+                }
+                throw new System.IO.FileNotFoundException();
+            };
+
+            BitmapFont font = new BitmapFont("NoShadowCheck.fnt", checkForShadowSibling: false);
+
+            shadowProbed.ShouldBeFalse();
+            font.ShadowFont.ShouldBeNull();
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = previousHook;
+        }
+    }
+
+    [Fact]
+    public void Constructor_ShouldProbeForShadowSibling_WhenCheckForShadowSiblingIsTrue()
+    {
+        // Companion to the above: when a caller DOES want the check (the default, and what every
+        // other existing caller of the single-argument constructor still gets), it must still run.
+        bool shadowProbed = false;
+        Func<string, System.IO.Stream>? previousHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            FileManager.CustomGetStreamFromFile = path =>
+            {
+                // The resolved shadow font's own constructor also checks for a "-shadow.fnt" sibling
+                // of ITS OWN path (GetShadowSiblingFntPath doesn't special-case this - in practice no
+                // such doubly-nested file is ever generated, so FileExists naturally returns false on
+                // a real disk). Simulate that here so the fixture doesn't recurse forever.
+                if (path.EndsWith("-shadow-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new System.IO.FileNotFoundException();
+                }
+                // EndsWith (not Contains) - the absolute path is rooted under this test run's working
+                // directory, which can itself legitimately contain the substring "-shadow" (e.g. a
+                // worktree folder name), so only the actual "-shadow.fnt" suffix counts as a probe.
+                if (path.EndsWith("-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    shadowProbed = true;
+                }
+                if (path.EndsWith(".fnt"))
+                {
+                    return new System.IO.MemoryStream(Encoding.UTF8.GetBytes(noPagesBMFontFileData));
+                }
+                throw new System.IO.FileNotFoundException();
+            };
+
+            BitmapFont font = new BitmapFont("ShouldCheckShadow.fnt");
+
+            shadowProbed.ShouldBeTrue();
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = previousHook;
+        }
     }
 
     [Fact]

--- a/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
+++ b/MonoGameGum.Tests/RenderingLibraries/BitmapFontTests.cs
@@ -192,10 +192,13 @@ chars count=0
     }
 
     [Fact]
-    public void Constructor_ShouldProbeForShadowSibling_WhenCheckForShadowSiblingIsTrue()
+    public void Constructor_ShouldAttachShadowFont_WhenCheckForShadowSiblingIsTrueAndSiblingExists()
     {
         // Companion to the above: when a caller DOES want the check (the default, and what every
-        // other existing caller of the single-argument constructor still gets), it must still run.
+        // other existing caller of the single-argument constructor still gets), it must still run -
+        // and pins the actual positive outcome (issue #4665's "can you still ask for a shadow font"
+        // question): a genuinely-present "-shadow.fnt" sibling must end up attached as ShadowFont,
+        // not just probed-for.
         bool shadowProbed = false;
         Func<string, System.IO.Stream>? previousHook = FileManager.CustomGetStreamFromFile;
         try
@@ -227,6 +230,7 @@ chars count=0
             BitmapFont font = new BitmapFont("ShouldCheckShadow.fnt");
 
             shadowProbed.ShouldBeTrue();
+            font.ShadowFont.ShouldNotBeNull("a real '-shadow.fnt' sibling was present and should have been attached");
         }
         finally
         {

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -1103,5 +1103,51 @@ public class FontServiceTests : BaseTestClass
         }
     }
 
+    [Fact]
+    public void FontResolution_ShouldAttachShadowFont_WhenHasDropshadowIsTrueAndSiblingExists()
+    {
+        // Positive companion to the above: not just "was it checked" but "does asking for a
+        // dropshadow actually still work end-to-end" - a genuinely-present "-shadow.fnt" sibling
+        // must end up attached to the Text this TextRuntime wraps.
+        TextRuntime textRuntime = new();
+        textRuntime.HasDropshadow = true;
+
+        const string zeroPageFntContent =
+            "info face=\"GumFontResolutionTest4665Positive\" size=-14 bold=0 italic=0 charset=\"\" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0\n" +
+            "common lineHeight=16 base=12 scaleW=1 scaleH=1 pages=0 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4\n" +
+            "chars count=0\n";
+
+        var previousHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            FileManager.CustomGetStreamFromFile = path =>
+            {
+                // As in BitmapFontTests: the shadow font's own constructor also probes for ITS OWN
+                // "-shadow.fnt" sibling. Reject only that doubly-nested case so the fixture doesn't
+                // recurse forever, while every real (single) request - primary or shadow - succeeds.
+                if (path.EndsWith("-shadow-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new System.IO.FileNotFoundException();
+                }
+                if (path.EndsWith(".fnt"))
+                {
+                    return new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(zeroPageFntContent));
+                }
+                throw new System.IO.FileNotFoundException();
+            };
+
+            textRuntime.Font = "GumFontResolutionTest4665Positive";
+
+            Text underlyingText = (Text)textRuntime.RenderableComponent;
+            underlyingText.BitmapFont.ShouldNotBeNull();
+            underlyingText.BitmapFont.ShadowFont.ShouldNotBeNull(
+                "HasDropshadow was true and a real shadow sibling existed - it should be attached");
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = previousHook;
+        }
+    }
+
     #endregion
 }

--- a/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
+++ b/MonoGameGum.Tests/Runtimes/FontServiceTests.cs
@@ -1012,4 +1012,96 @@ public class FontServiceTests : BaseTestClass
     }
 
     #endregion
+
+    #region Lazy Shadow-Sibling Probe (issue #4665)
+
+    [Fact]
+    public void FontResolution_ShouldNotProbeForShadow_WhenHasDropshadowIsFalse()
+    {
+        // Issue #4665: BitmapFont's shadow-sibling probe used to run unconditionally on every font
+        // load, even for fonts nobody ever configured with a dropshadow. Font resolution should now
+        // only check for a shadow when the resolving Text actually wants one.
+        TextRuntime textRuntime = new();
+
+        int shadowProbeCount = 0;
+        var previousHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            FileManager.CustomGetStreamFromFile = path =>
+            {
+                // EndsWith (not Contains) - the absolute path is rooted under this test run's working
+                // directory, which can itself legitimately contain the substring "-shadow" (e.g. a
+                // worktree folder name), so only the actual "-shadow.fnt" suffix counts as a probe.
+                if (path.EndsWith("-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    shadowProbeCount++;
+                }
+                throw new System.IO.FileNotFoundException();
+            };
+
+            // "Arial"/18 is TextRuntime's own default, resolved via the embedded resource (or the
+            // cache LoaderManager already seeded from it) - no disk I/O for the primary font, so any
+            // probe counted here can only be the shadow-sibling check.
+            textRuntime.Font = "Arial";
+            textRuntime.FontSize = 18;
+
+            shadowProbeCount.ShouldBe(0, "no dropshadow was requested, so the shadow-sibling probe should never fire");
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = previousHook;
+        }
+    }
+
+    [Fact]
+    public void FontResolution_ShouldProbeForShadow_WhenHasDropshadowIsTrue()
+    {
+        // Companion to the above: resolving a font that isn't the embedded default goes through
+        // CustomSetPropertyOnRenderable.GetOrCreateBakedFont's disk-load path, which now decides
+        // whether to check for a "-shadow.fnt" sibling based on TextRuntime.HasDropshadow. A
+        // zero-page .fnt keeps this test out of MonoGame texture loading (no real GraphicsDevice is
+        // set up by GumService.InitializeForTesting).
+        TextRuntime textRuntime = new();
+        textRuntime.HasDropshadow = true;
+
+        const string zeroPageFntContent =
+            "info face=\"GumFontResolutionTest4665\" size=-14 bold=0 italic=0 charset=\"\" unicode=1 stretchH=100 smooth=1 aa=1 padding=0,0,0,0 spacing=1,1 outline=0\n" +
+            "common lineHeight=16 base=12 scaleW=1 scaleH=1 pages=0 packed=0 alphaChnl=0 redChnl=4 greenChnl=4 blueChnl=4\n" +
+            "chars count=0\n";
+
+        int shadowProbeCount = 0;
+        var previousHook = FileManager.CustomGetStreamFromFile;
+        try
+        {
+            FileManager.CustomGetStreamFromFile = path =>
+            {
+                // EndsWith (not Contains) - the absolute path is rooted under this test run's working
+                // directory, which can itself legitimately contain the substring "-shadow" (e.g. a
+                // worktree folder name), so only the actual "-shadow.fnt" suffix counts as a probe.
+                if (path.EndsWith("-shadow.fnt", StringComparison.OrdinalIgnoreCase))
+                {
+                    shadowProbeCount++;
+                    throw new System.IO.FileNotFoundException();
+                }
+                if (path.EndsWith(".fnt"))
+                {
+                    return new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(zeroPageFntContent));
+                }
+                throw new System.IO.FileNotFoundException();
+            };
+
+            // A single property change - unsuspended, each font-affecting property change triggers
+            // its own resolution (see the "Layout Suspension / Font Batching" region above), so
+            // setting only one keeps this test's probe count meaningful.
+            textRuntime.Font = "GumFontResolutionTest4665";
+
+            shadowProbeCount.ShouldBe(1, "HasDropshadow is true, so the shadow-sibling probe should fire once");
+        }
+        finally
+        {
+            FileManager.CustomGetStreamFromFile = previousHook;
+        }
+    }
+
+    #endregion
 }

--- a/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
+++ b/RenderingLibrary/Graphics/Fonts/BitmapFont.cs
@@ -153,7 +153,26 @@ public class BitmapFont : IDisposable
     /// Loads a bitmap font from a .fnt file on disk, loading the referenced texture pages.
     /// </summary>
     /// <param name="fontFile">Path to the .fnt file.</param>
-    public BitmapFont(string fontFile)
+    /// <inheritdoc cref="BitmapFont(string, bool)"/>
+    public BitmapFont(string fontFile) : this(fontFile, checkForShadowSibling: true)
+    {
+    }
+
+    /// <summary>
+    /// Loads a bitmap font from a .fnt file on disk, loading the referenced texture pages.
+    /// </summary>
+    /// <param name="fontFile">Path to the .fnt file.</param>
+    /// <param name="checkForShadowSibling">
+    /// Issue #4665: whether to probe for a "-shadow.fnt" sibling (see
+    /// <see cref="LoadShadowSiblingIfPresent"/>). The primary filename already bakes in whether a
+    /// dropshadow was requested (<c>BmfcSave.GetFontCacheFileNameFor</c> appends a "_ds{blur}"
+    /// suffix), so a dropshadow and non-dropshadow request for the same base font never share a
+    /// cache entry/instance - it's safe for a caller that knows the answer up front (e.g.
+    /// <c>CustomSetPropertyOnRenderable.GetOrCreateBakedFont</c>, from <c>TextRuntime.HasDropshadow</c>)
+    /// to skip this probe entirely rather than pay it for every font nobody ever configured with a
+    /// dropshadow. Defaults to <see langword="true"/> for callers (the tool, tests) with no such signal.
+    /// </param>
+    public BitmapFont(string fontFile, bool checkForShadowSibling)
     {
         Encoding encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
         string fontContents = ContainsAscii(fontFile) ? FileManager.FromFileText(fontFile, encoding) : FileManager.FromFileText(fontFile);
@@ -165,7 +184,10 @@ public class BitmapFont : IDisposable
 
         SetFontPattern();
 
-        LoadShadowSiblingIfPresent(fontFile);
+        if (checkForShadowSibling)
+        {
+            LoadShadowSiblingIfPresent(fontFile);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- `BitmapFont`'s constructor probed for a `-shadow.fnt` sibling on every font load, unconditionally - a guaranteed-miss `FileManager.FileExists` check for any font never configured with a dropshadow, expensive on platforms where a file check is a network round trip (KNI + Blazor WASM - the cause of #4665's reported 404 spam).
- Adds an optional `checkForShadowSibling` parameter to `BitmapFont`'s file-path constructor (defaults `true`, so every other caller - the tool, tests - is unaffected).
- `CustomSetPropertyOnRenderable.GetOrCreateBakedFont` now passes `TextRuntime.HasDropshadow` through (`false` under `#if FRB`, which doesn't compile `TextRuntime`).
- Safe without any lazy/memoization scheme: `GetFontCacheFileName` already bakes `HasDropshadow` into the resolved filename (a `_ds{blur}` suffix - see `BmfcSave.cs:731-737`), so a dropshadow and non-dropshadow request for the same base font never share a cache entry/`BitmapFont` instance to begin with.
- Scoped to the BitmapFont/XNALIKE (MonoGame/KNI/FNA) path; Raylib's separate shadow mechanism (`RaylibFontShadowRegistry`) is untouched.

## Test plan
- [x] New tests: `BitmapFontTests.Constructor_ShouldNotProbeForShadowSibling_WhenCheckForShadowSiblingIsFalse` / `..._WhenCheckForShadowSiblingIsTrue`, `FontServiceTests.FontResolution_ShouldNotProbeForShadow_WhenHasDropshadowIsFalse` / `..._ShouldProbeForShadow_WhenHasDropshadowIsTrue` - red before the fix (compile error), green after
- [x] `MonoGameGum.Tests`: 2286/2286 passed
- [x] `RaylibGum.Tests`: 640/640 passed
- [x] FRB canary (`GumCore.DesktopGlNet6.csproj`): 0 errors, matches baseline
- Manual test: not needed - behavior-preserving for every existing caller (default `true`); the new opt-out path is exercised directly by the unit tests above via `FileManager.CustomGetStreamFromFile`.

Closes #4668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lsp7Jez83izryY7Q7vzaM1
