### PR TITLE
Target net10.0 across the tool graph (Avalonia migration prerequisite)

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Codegen Drift Check
         run: |
           dotnet build "Tools/Gum.Cli/Gum.Cli.csproj" --configuration Release --verbosity quiet -p:WarningLevel=0
-          $cli = "Tools/Gum.Cli/bin/Release/net8.0/GumCli.exe"
+          $cli = "Tools/Gum.Cli/bin/Release/net10.0/GumCli.exe"
           $gumxProjects = @(
             "Tests/CodeGen_Maui_FullCodegen/Content/GumProject/CodeGenTestProject.gumx",
             "Tests/CodeGen_MonoGame_ByReference/Content/GumProject/CodeGenTestProject.gumx",
@@ -616,11 +616,11 @@ jobs:
           if (-not $opengl) { Write-Error "x64 opengl32.dll not found in Mesa archive"; exit 1 }
           $dests = @(
             "Tests/RaylibGum.Tests/bin/Release/net8.0",
-            "Tests/Gum.ProjectServices.Raylib.Tests/bin/Release/net8.0",
-            "Tests/Gum.Cli.Tests/bin/Release/net8.0",
+            "Tests/Gum.ProjectServices.Raylib.Tests/bin/Release/net10.0",
+            "Tests/Gum.Cli.Tests/bin/Release/net10.0",
             "Tests/MonoGameGum.IntegrationTests/bin/Release/net8.0",
             "Tests/MonoGameGum.Shapes.Tests/bin/Release/net8.0",
-            "Tests/Gum.ProjectServices.MonoGame.Tests/bin/Release/net8.0"
+            "Tests/Gum.ProjectServices.MonoGame.Tests/bin/Release/net10.0"
           )
           foreach ($dest in $dests) {
             Copy-Item (Join-Path $opengl.Directory.FullName "*.dll") -Destination $dest -Force

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- Lets net8.0-windows tool/plugin projects compile on non-Windows OSes (NETSDK1100) by
+  <!-- Lets net10.0-windows tool/plugin projects compile on non-Windows OSes (NETSDK1100) by
        pulling Windows Desktop reference assemblies instead of failing outright. Compile-only:
        running the WPF tool still requires Windows or Wine (see setup_gum_linux.sh). No-op on
        Windows itself, since NETSDK1100 never fires there. -->

--- a/FlatRedBall.SpecializedXnaControls/FlatRedBall.SpecializedXnaControls.csproj
+++ b/FlatRedBall.SpecializedXnaControls/FlatRedBall.SpecializedXnaControls.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
 
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -39,7 +39,5 @@
     <ProjectReference Include="..\XnaAndWinforms\XnaAndWinforms.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Gum/CodeOutputPlugin/CodeOutputPlugin.csproj
+++ b/Gum/CodeOutputPlugin/CodeOutputPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<LangVersion>12.0</LangVersion>
 		<Nullable>enable</Nullable>
@@ -26,9 +26,7 @@
 		<ProjectReference Include="..\..\XnaAndWinforms\XnaAndWinforms.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Gum/CommonFormsAndControls/CommonFormsAndControls.csproj
+++ b/Gum/CommonFormsAndControls/CommonFormsAndControls.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<OutputType>Library</OutputType>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<!-- Fixes github actions https://github.com/vchelaru/Gum/actions/runs/16967916954/job/48096714923?pr=1273: -->
@@ -19,7 +19,5 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 </Project>

--- a/Gum/Controls/ThemedScrollbar.cs
+++ b/Gum/Controls/ThemedScrollbar.cs
@@ -1,3 +1,4 @@
+#pragma warning disable WFO1000 // WinForms designer-serialization analyzer; this control is never designer-hosted and goes away with the WPF head.
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;

--- a/Gum/ConvertToJsonPlugin/ConvertToJsonPlugin.csproj
+++ b/Gum/ConvertToJsonPlugin/ConvertToJsonPlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<OutputType>Library</OutputType>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>

--- a/Gum/CsvLibrary/CsvLibrary.csproj
+++ b/Gum/CsvLibrary/CsvLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
 
 	  <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -19,8 +19,6 @@
 		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Class1.cs" />

--- a/Gum/EventOutputPlugin/EventOutputPlugin.csproj
+++ b/Gum/EventOutputPlugin/EventOutputPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<OutputType>Library</OutputType>
 		<LangVersion>12.0</LangVersion>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -18,9 +18,7 @@
 		<ProjectReference Include="..\Gum.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<OutputType>WinExe</OutputType>
 		<LangVersion>12.0</LangVersion>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -393,7 +393,6 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
 			<Version>4.12.0</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting">
 			<Version>9.0.0</Version>
 		</PackageReference>
@@ -417,15 +416,12 @@
 			<Version>0.5.18</Version>
 		</PackageReference>
 		<PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-		<PackageReference Include="System.Drawing.Common" Version="10.0.0" />
 		<PackageReference Include="System.Management" Version="9.0.3" />
 
 		<PackageReference Include="nkast.Xna.Framework" Version="4.2.9001" />
 		<PackageReference Include="nkast.Xna.Framework.Graphics" Version="4.2.9001" />
 		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
 		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
-		<PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
 		<PackageReference Include="MaterialDesignThemes" Version="5.1.0" />
 	</ItemGroup>
 	<ItemGroup>
@@ -522,9 +518,9 @@
 	     This target does NOT build Gum.Cli itself — the solution handles that. When building from
 	     Gum.sln (which does not include Gum.Cli), the condition is false and this is skipped. -->
 	<Target Name="CopyGumCli" AfterTargets="Build"
-			Condition="Exists('..\Tools\Gum.Cli\bin\$(Configuration)\net8.0\gumcli.exe') OR Exists('..\Tools\Gum.Cli\bin\$(Configuration)\net8.0\gumcli.dll')">
+			Condition="Exists('..\Tools\Gum.Cli\bin\$(Configuration)\net10.0\gumcli.exe') OR Exists('..\Tools\Gum.Cli\bin\$(Configuration)\net10.0\gumcli.dll')">
 		<ItemGroup>
-			<GumCliFiles Include="..\Tools\Gum.Cli\bin\$(Configuration)\net8.0\**\*.*" />
+			<GumCliFiles Include="..\Tools\Gum.Cli\bin\$(Configuration)\net10.0\**\*.*" />
 		</ItemGroup>
 		<Copy SourceFiles="@(GumCliFiles)"
 			  DestinationFiles="@(GumCliFiles->'$(OutDir)GumCli\%(RecursiveDir)%(Filename)%(Extension)')"

--- a/Gum/GumFormsPlugin/GumFormsPlugin.csproj
+++ b/Gum/GumFormsPlugin/GumFormsPlugin.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<LangVersion>12.0</LangVersion>

--- a/Gum/ImportFromGumxPlugin/ImportFromGumxPlugin.csproj
+++ b/Gum/ImportFromGumxPlugin/ImportFromGumxPlugin.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
@@ -56,7 +56,7 @@
 		     StandardDiffDetailsViewModel / IGumxSourceService / IGumxDependencyResolver /
 		     IGumxImportService / the import enums / GumxImportService / GumxDependencyResolver
 		     (both concrete classes - their whole dependency closures were already headless) live
-		     in the headless net8.0 Gum.Presentation assembly (no WPF, ADR-0005) so their logic is
+		     in the headless net10.0 Gum.Presentation assembly (no WPF, ADR-0005) so their logic is
 		     unit-testable without standing up WPF. Gum.Presentation itself references
 		     Gum.ProjectServices (kept here too since other plugin code uses it directly). -->
 		<ProjectReference Include="..\..\Tools\Gum.ProjectServices\Gum.ProjectServices.csproj" />

--- a/Gum/PerformanceMeasurementPlugin/PerformanceMeasurementPlugin.csproj
+++ b/Gum/PerformanceMeasurementPlugin/PerformanceMeasurementPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -28,9 +28,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<ItemGroup>

--- a/Gum/StateAnimationPlugin/StateAnimationPlugin.csproj
+++ b/Gum/StateAnimationPlugin/StateAnimationPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <!-- Target a specific Windows version so that SkiaSharp.Views.WPF doesn't fall back to old .NET Framework 4.X -->
-	  <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+	  <TargetFramework>net10.0-windows10.0.19041</TargetFramework>
     <OutputType>Library</OutputType>
     <LangVersion>12.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FlatRedBall.InterpolationCore" Version="2025.4.22.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
@@ -50,7 +49,6 @@
       <Version>3.119.1</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>  
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <ItemGroup>

--- a/Gum/SvgPlugin/SkiaPlugin.csproj
+++ b/Gum/SvgPlugin/SkiaPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
@@ -40,7 +40,6 @@
          Gum.csproj (see Gum/Embedded/SkiaShapes/ and Gum/Logic/SkiaShapeStandardsLogic.cs)
          so the project-authoring half is no longer Skia-plugin-specific. SkiaPlugin
          keeps the rendering half. -->
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SkiaSharp.Extended">
       <Version>1.60.0</Version>
     </PackageReference>
@@ -54,7 +53,6 @@
       <Version>0.5.18</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <ItemGroup>

--- a/Gum/TextureCoordinateSelectionPlugin/TextureCoordinateSelectionPlugin.csproj
+++ b/Gum/TextureCoordinateSelectionPlugin/TextureCoordinateSelectionPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <LangVersion>12.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -32,9 +32,7 @@
     <ProjectReference Include="..\..\XnaAndWinforms\XnaAndWinforms.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="9.0.3" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <ItemGroup>

--- a/GumProjectFontGenerator/GumProjectFontGenerator.csproj
+++ b/GumProjectFontGenerator/GumProjectFontGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/InputLibrary/InputLibrary.csproj
+++ b/InputLibrary/InputLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<!-- This is always complaining even if we put a min version of 7.0, so let's suppress it:-->
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
 		<OutputType>Library</OutputType>
@@ -20,15 +20,13 @@
 		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<!--
 			Cursor implements IGumCursorState so the headless wireframe-editing family (Gum.Presentation,
 			part of #3846) can poll live cursor state without referencing this project directly — a
-			net8.0 project can't reference this net8.0-windows7.0 one (NU1201), but the reverse (this
-			net8.0-windows7.0 project referencing a plain net8.0 one) is the normal, allowed direction.
+			net10.0 project can't reference this net10.0-windows one (NU1201), but the reverse (this
+			net10.0-windows project referencing a plain net10.0 one) is the normal, allowed direction.
 		-->
 		<ProjectReference Include="..\Tools\Gum.Presentation\Gum.Presentation.csproj" />
 	</ItemGroup>

--- a/MonoGameGum.Tests/MonoGameGum.Tests.csproj
+++ b/MonoGameGum.Tests/MonoGameGum.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>

--- a/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
+++ b/Samples/WpfRenderSurfaceHostHarness/WpfRenderSurfaceHostHarness.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<IsPackable>false</IsPackable>

--- a/Tests/CrossAssemblyAttributeFixture/CrossAssemblyAttributeFixture.csproj
+++ b/Tests/CrossAssemblyAttributeFixture/CrossAssemblyAttributeFixture.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/GenerateAllCodeGenProjects.bat
+++ b/Tests/GenerateAllCodeGenProjects.bat
@@ -5,7 +5,7 @@ rem regeneration and CI verification can never diverge. Commit the resulting
 rem diff; CI fails if checked-in generated code is stale.
 
 dotnet build "%~dp0..\Tools\Gum.Cli\Gum.Cli.csproj" --configuration Release || exit /b 1
-set CLI=%~dp0..\Tools\Gum.Cli\bin\Release\net8.0\GumCli.exe
+set CLI=%~dp0..\Tools\Gum.Cli\bin\Release\net10.0\GumCli.exe
 
 echo 0/100 Starting to generate...
 "%CLI%" codegen %~dp0CodeGen_Maui_FullCodegen/Content/GumProject/CodeGenTestProject.gumx

--- a/Tests/Gum.Analyzers.Tests/Gum.Analyzers.Tests.csproj
+++ b/Tests/Gum.Analyzers.Tests/Gum.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>12.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/Tests/Gum.AssemblyNameGuard.Tests/Gum.AssemblyNameGuard.Tests.csproj
+++ b/Tests/Gum.AssemblyNameGuard.Tests/Gum.AssemblyNameGuard.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
+++ b/Tests/Gum.Bundle.Tests/Gum.Bundle.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
+++ b/Tests/Gum.Cli.Tests/Gum.Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.ImageDiff.Tests/Gum.ImageDiff.Tests.csproj
+++ b/Tests/Gum.ImageDiff.Tests/Gum.ImageDiff.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj
+++ b/Tests/Gum.Presentation.Tests/Gum.Presentation.Tests.csproj
@@ -6,7 +6,7 @@
     ViewModels are unit-testable without standing up the UI (ADR-0003).
   -->
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.ProjectServices.MonoGame.Tests/Gum.ProjectServices.MonoGame.Tests.csproj
+++ b/Tests/Gum.ProjectServices.MonoGame.Tests/Gum.ProjectServices.MonoGame.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.ProjectServices.Raylib.Tests/Gum.ProjectServices.Raylib.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Raylib.Tests/Gum.ProjectServices.Raylib.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
+++ b/Tests/Gum.ProjectServices.SkiaGum.Tests/Gum.ProjectServices.SkiaGum.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
+++ b/Tests/Gum.ProjectServices.Tests/Gum.ProjectServices.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>

--- a/Tool/EditorTabPlugin_XNA/EditorTabPlugin_XNA.csproj
+++ b/Tool/EditorTabPlugin_XNA/EditorTabPlugin_XNA.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 
 
 		<OutputType>Library</OutputType>
@@ -41,7 +41,6 @@
 		</Compile>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<!--
 			ShadowDusk compiles a render-target Container's SourceShaderFile (.fx) into an Effect at
 			runtime (no content pipeline) for the WYSIWYG preview; see RenderTargetShaderResolver.
@@ -51,7 +50,6 @@
 		<PackageReference Include="ShadowDusk.Compiler" Version="0.17.0" />
 		<PackageReference Include="nkast.Kni.Platform.WinForms.DX11" Version="4.2.9001" />
 		<PackageReference Include="nkast.Xna.Framework.Input" Version="4.2.9001" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 		<ProjectReference Include="..\..\FlatRedBall.SpecializedXnaControls\FlatRedBall.SpecializedXnaControls.csproj" />
 		<ProjectReference Include="..\..\Gum\Gum.csproj" />
 		<ProjectReference Include="..\..\MonoGameGum\KniGum\KniGum.csproj" />

--- a/Tool/HtmlToGum/HtmlToGumPlugin.csproj
+++ b/Tool/HtmlToGum/HtmlToGumPlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Tool/Tests/AutomatedTests/AutomatedTests.csproj
+++ b/Tool/Tests/AutomatedTests/AutomatedTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
+++ b/Tool/Tests/GumToolUnitTests/GumToolUnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Matches StateAnimationPlugin's TFM so it can be referenced (it pins 10.0.19041 for SkiaSharp.Views.WPF). -->
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Tools/Gum.Cli/Gum.Cli.csproj
+++ b/Tools/Gum.Cli/Gum.Cli.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
 		<AssemblyName>gumcli</AssemblyName>

--- a/Tools/Gum.FormsStaging/Gum.FormsStaging.csproj
+++ b/Tools/Gum.FormsStaging/Gum.FormsStaging.csproj
@@ -10,7 +10,7 @@
 			mobile workloads just to build the WPF tool. See #4236.
 		-->
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>

--- a/Tools/Gum.ImageDiff/Gum.ImageDiff.csproj
+++ b/Tools/Gum.ImageDiff/Gum.ImageDiff.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
   </PropertyGroup>

--- a/Tools/Gum.Presentation/Gum.Presentation.csproj
+++ b/Tools/Gum.Presentation/Gum.Presentation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<!--
-		Gum.Presentation — headless (net8.0) home for tool ViewModels and the
+		Gum.Presentation — headless (net10.0) home for tool ViewModels and the
 		framework-neutral presentation logic they depend on. See ADR-0005.
 
 		This assembly must NEVER reference WPF or WinForms. The project-reference
@@ -11,7 +11,7 @@
 		(which transitively pulls in GumCommon) plus the .NET BCL.
 	-->
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
 		<NoWarn>1591</NoWarn>

--- a/Tools/Gum.ProjectServices.MonoGame/Gum.ProjectServices.MonoGame.csproj
+++ b/Tools/Gum.ProjectServices.MonoGame/Gum.ProjectServices.MonoGame.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>

--- a/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
+++ b/Tools/Gum.ProjectServices.Raylib/Gum.ProjectServices.Raylib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
     <!-- RaylibScreenshotService flattens Image.Data's alpha channel in place when a screenshot

--- a/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
+++ b/Tools/Gum.ProjectServices.SkiaGum/Gum.ProjectServices.SkiaGum.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>

--- a/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
+++ b/Tools/Gum.ProjectServices/Gum.ProjectServices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
 		<NoWarn>1591</NoWarn>

--- a/WpfDataUi/WpfDataUi.csproj
+++ b/WpfDataUi/WpfDataUi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<OutputType>Library</OutputType>
 		<LangVersion>12.0</LangVersion>
 		<!-- This is always complaining even if we put a min version of 7.0, so let's suppress it:-->
@@ -36,8 +36,6 @@
 		<AppDesigner Include="Properties\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<Resource Include="Content\Icons\OpenFolder.png" />

--- a/XnaAndWinforms/XnaAndWinforms.csproj
+++ b/XnaAndWinforms/XnaAndWinforms.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<!-- This is always complaining even if we put a min version of 7.0, so let's suppress it:-->
 		<NoWarn>$(NoWarn);CA1416</NoWarn>
 		<OutputType>Library</OutputType>
@@ -30,7 +30,5 @@
 		<EmbeddedResource Include="Content\Font18Arial_0.png" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Stacked on #4671 (the plan); retarget to `main` once that merges.

## What

The prerequisite step in `Direction/avalonia-migration/README.md`: every project in the `gum.exe` graph, the `Gum.ProjectServices` family, `Gum.Cli`, and their tests move from `net8.0` / `net8.0-windows` to `net10.0` / `net10.0-windows`. Runtime NuGet libraries that games consume (`GumCommon`, `MonoGameGum`, `KniGum`, `SkiaGum`, `RaylibGum`, `GumShapes`, `GumExpressions`) stay on `net8.0`.

## Why

.NET 8 leaves LTS support in November 2026, inside the migration window, and the repo SDK pin, CI, and about 70 projects were already on .NET 10. The Avalonia head will be `net10.0`, and it cannot reference a `net8.0`-only `Gum.Presentation` cleanly.

## Fallout handled

- WinForms analyzer WFO1000 becomes an error under net10 for `ThemedScrollbar`'s properties; suppressed in that one legacy file, which is deleted at cutover.
- NuGet NU1510: `Microsoft.CSharp`, `System.Data.DataSetExtensions`, `System.Drawing.Common`, `System.Resources.Extensions` are in-box; their package references are removed where flagged.
- Hardcoded `net8.0` output paths updated: `Gum.csproj` CLI bundling, `Tests/GenerateAllCodeGenProjects.bat`, CI test paths for the three bumped test projects. Runtime test paths and the AOT harness stay `net8.0` on purpose.
- Two consumers outside the tool graph that reference bumped projects (`MonoGameGum.Tests` via `Gum.Cli`, `Samples/WpfRenderSurfaceHostHarness` via `XnaAndWinforms`) are bumped too.

## Verified

`dotnet build GumFull.sln`: succeeded, no new warnings. Tests, all green: Gum.Presentation.Tests 989, GumToolUnitTests 1350, Gum.ProjectServices.Tests 569, Gum.Cli.Tests 81, Gum.Bundle.Tests 75, Gum.Analyzers.Tests 24, Gum.ProjectServices.SkiaGum.Tests 12, Gum.ImageDiff.Tests 9, Gum.AssemblyNameGuard.Tests 7, Gum.ProjectServices.MonoGame.Tests 3, MonoGameGum.Tests 2281.

## User-facing consequence

The Windows release and the `GumCli` global tool will require the .NET 10 runtime from the next release. Docs only name a .NET version in the Wine and macOS-under-Wine sections, which are being retired by the migration, so no doc change here.