### PR TITLE
Add Blur and Sepia example shaders

### DIFF
--- a/Gum/Content/Shaders/Blur.slang
+++ b/Gum/Content/Shaders/Blur.slang
@@ -1,0 +1,37 @@
+// Example fixed-radius 9x9 box blur, authored in Slang. Gum's render-target-effect blit sets no
+// shader parameters and runs a single pass, so the sample spacing below is a compile-time
+// constant, not a host-adjustable radius -- an adjustable blur would need parameter-setting plus
+// multi-pass support Gum doesn't have yet. The "texel" constant assumes a 128-pixel-square render
+// target; if your own container is a different size, change 128.0 to match its Width/Height so
+// the blur samples land one (or two) real pixels apart instead of drifting off scale.
+Texture2D SpriteTexture;
+SamplerState SpriteTextureSampler;
+
+struct VertexShaderOutput
+{
+    float4 Position : SV_POSITION;
+    float4 Color : COLOR0;
+    float2 TextureCoordinates : TEXCOORD0;
+};
+
+[shader("fragment")]
+float4 MainPS(VertexShaderOutput input) : COLOR0
+{
+    // Two texels between taps (not one) so the 9x9 grid covers a visibly larger area instead of
+    // just adding softer sampling density over the same small radius.
+    float2 texel = float2(2.0 / 128.0, 2.0 / 128.0);
+    float4 total = float4(0, 0, 0, 0);
+
+    [unroll]
+    for (int y = -4; y <= 4; y++)
+    {
+        [unroll]
+        for (int x = -4; x <= 4; x++)
+        {
+            float2 uv = input.TextureCoordinates + float2(x, y) * texel;
+            total += SpriteTexture.Sample(SpriteTextureSampler, uv);
+        }
+    }
+
+    return (total / 81.0) * input.Color;
+}

--- a/Gum/Content/Shaders/Grayscale.slang
+++ b/Gum/Content/Shaders/Grayscale.slang
@@ -1,0 +1,23 @@
+// Example grayscale post-process shader, authored in Slang instead of raw HLSL: a shader-stage
+// attribute marks the entry point below, and there's no technique/pass block to write since
+// ShadowDusk synthesizes one (issue #4677). Point a render-target Container's SourceShaderFile at
+// a copy of this file to use it -- see the "Render Target Shaders" docs page for the full setup
+// (IsRenderTarget + SourceShaderFile). Single-pass, no host-set parameters: the render-target
+// blit sets no shader parameters, so effects like this must be self-contained.
+Texture2D SpriteTexture;
+SamplerState SpriteTextureSampler;
+
+struct VertexShaderOutput
+{
+    float4 Position : SV_POSITION;
+    float4 Color : COLOR0;
+    float2 TextureCoordinates : TEXCOORD0;
+};
+
+[shader("fragment")]
+float4 MainPS(VertexShaderOutput input) : COLOR0
+{
+    float4 color = SpriteTexture.Sample(SpriteTextureSampler, input.TextureCoordinates) * input.Color;
+    float gray = dot(color.rgb, float3(0.299, 0.587, 0.114));
+    return float4(gray, gray, gray, color.a);
+}

--- a/Gum/Content/Shaders/Sepia.slang
+++ b/Gum/Content/Shaders/Sepia.slang
@@ -1,0 +1,23 @@
+// Example classic sepia-tone post-process shader, authored in Slang. Single-pass, no host-set
+// parameters -- see Grayscale.slang for the simplest possible example of that shape; this one
+// just replaces the grayscale weights with the standard three-channel sepia matrix.
+Texture2D SpriteTexture;
+SamplerState SpriteTextureSampler;
+
+struct VertexShaderOutput
+{
+    float4 Position : SV_POSITION;
+    float4 Color : COLOR0;
+    float2 TextureCoordinates : TEXCOORD0;
+};
+
+[shader("fragment")]
+float4 MainPS(VertexShaderOutput input) : COLOR0
+{
+    float4 color = SpriteTexture.Sample(SpriteTextureSampler, input.TextureCoordinates) * input.Color;
+    float3 sepia;
+    sepia.r = dot(color.rgb, float3(0.393, 0.769, 0.189));
+    sepia.g = dot(color.rgb, float3(0.349, 0.686, 0.168));
+    sepia.b = dot(color.rgb, float3(0.272, 0.534, 0.131));
+    return float4(saturate(sepia), color.a);
+}

--- a/Gum/Gum.csproj
+++ b/Gum/Gum.csproj
@@ -103,6 +103,18 @@
 		<None Update="Content\TestFont.fnt">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<!-- Example post-process shaders (issue #4679) staged alongside the tool so a user pointing
+		     SourceShaderFile's file-picker somewhere for the first time lands on working starting
+		     points, not an empty folder. -->
+		<None Update="Content\Shaders\Grayscale.slang">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Content\Shaders\Blur.slang">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="Content\Shaders\Sepia.slang">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="CommonFormsAndControls\CommonFormsAndControls.csproj" />

--- a/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
+++ b/Gum/Plugins/InternalPlugins/VariableGrid/PropertyGridManager.cs
@@ -1125,17 +1125,27 @@ public partial class PropertyGridManager : IBehaviorVariablePropertyGridSink
             foreach (var member in category.Members)
             {
                 var rootVariableName = (member as StateReferencingInstanceMember)?.RootVariableName;
-                if(rootVariableName == "CustomFontFile")
+                var filter = GetFileFilterForRootVariableName(rootVariableName);
+                if (filter != null)
                 {
-                    member.PropertiesToSetOnDisplayer["Filter"] = "Bitmap Font Generator Font|*.fnt";
-                }
-                else if(rootVariableName == "SourceShaderFile")
-                {
-                    member.PropertiesToSetOnDisplayer["Filter"] = "Effect File (*.fx)|*.fx";
+                    member.PropertiesToSetOnDisplayer["Filter"] = filter;
                 }
             }
         }
     }
+
+    /// <summary>
+    /// The file-picker <c>Filter</c> string for a variable's root name, or null if that variable
+    /// has no file-browser filter to apply. <c>SourceShaderFile</c> accepts both ShadowDusk input
+    /// formats (issues #4677/#4679): raw HLSL <c>.fx</c> and the lower-boilerplate <c>.slang</c>.
+    /// </summary>
+    internal static string? GetFileFilterForRootVariableName(string? rootVariableName) =>
+        rootVariableName switch
+        {
+            "CustomFontFile" => "Bitmap Font Generator Font|*.fnt",
+            "SourceShaderFile" => "Effect File (*.fx;*.slang)|*.fx;*.slang",
+            _ => null
+        };
 
     private void AdjustFontSourceToggle(List<MemberCategory> categories, StateSave stateSave, InstanceSave? instance)
     {

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Blur.slang
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Blur.slang
@@ -1,5 +1,5 @@
-// Fixed-radius 3x3 box blur, authored in Slang (issue #4679). Gum's render-target-effect blit
-// sets no shader parameters and runs a single pass, so this bakes its sample offset in as a
+// Fixed-radius 9x9 box blur, authored in Slang (issue #4679). Gum's render-target-effect blit
+// sets no shader parameters and runs a single pass, so this bakes its sample spacing in as a
 // constant sized for this demo's 128x128 render target (one texel is 1/128) instead of exposing a
 // host-settable radius -- an adjustable blur would need parameter-setting plus multi-pass support
 // Gum doesn't have yet (tracked separately in issue #4679's discussion).
@@ -16,19 +16,21 @@ struct VertexShaderOutput
 [shader("fragment")]
 float4 MainPS(VertexShaderOutput input) : COLOR0
 {
-    float2 texel = float2(1.0 / 128.0, 1.0 / 128.0);
+    // Two texels between taps (not one) so the 9x9 grid covers a visibly larger area instead of
+    // just adding softer sampling density over the same small radius.
+    float2 texel = float2(2.0 / 128.0, 2.0 / 128.0);
     float4 total = float4(0, 0, 0, 0);
 
     [unroll]
-    for (int y = -1; y <= 1; y++)
+    for (int y = -4; y <= 4; y++)
     {
         [unroll]
-        for (int x = -1; x <= 1; x++)
+        for (int x = -4; x <= 4; x++)
         {
             float2 uv = input.TextureCoordinates + float2(x, y) * texel;
             total += SpriteTexture.Sample(SpriteTextureSampler, uv);
         }
     }
 
-    return (total / 9.0) * input.Color;
+    return (total / 81.0) * input.Color;
 }

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Blur.slang
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Blur.slang
@@ -1,0 +1,34 @@
+// Fixed-radius 3x3 box blur, authored in Slang (issue #4679). Gum's render-target-effect blit
+// sets no shader parameters and runs a single pass, so this bakes its sample offset in as a
+// constant sized for this demo's 128x128 render target (one texel is 1/128) instead of exposing a
+// host-settable radius -- an adjustable blur would need parameter-setting plus multi-pass support
+// Gum doesn't have yet (tracked separately in issue #4679's discussion).
+Texture2D SpriteTexture;
+SamplerState SpriteTextureSampler;
+
+struct VertexShaderOutput
+{
+    float4 Position : SV_POSITION;
+    float4 Color : COLOR0;
+    float2 TextureCoordinates : TEXCOORD0;
+};
+
+[shader("fragment")]
+float4 MainPS(VertexShaderOutput input) : COLOR0
+{
+    float2 texel = float2(1.0 / 128.0, 1.0 / 128.0);
+    float4 total = float4(0, 0, 0, 0);
+
+    [unroll]
+    for (int y = -1; y <= 1; y++)
+    {
+        [unroll]
+        for (int x = -1; x <= 1; x++)
+        {
+            float2 uv = input.TextureCoordinates + float2(x, y) * texel;
+            total += SpriteTexture.Sample(SpriteTextureSampler, uv);
+        }
+    }
+
+    return (total / 9.0) * input.Color;
+}

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Sepia.slang
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Content/Sepia.slang
@@ -1,0 +1,24 @@
+// Classic sepia-tone post-process, authored in Slang (issue #4679). Single-pass, no host-set
+// parameters, matching Gum's render-target-effect contract -- see Grayscale.slang for the
+// simplest possible example of that shape; this one just replaces the grayscale weights with the
+// standard three-channel sepia matrix.
+Texture2D SpriteTexture;
+SamplerState SpriteTextureSampler;
+
+struct VertexShaderOutput
+{
+    float4 Position : SV_POSITION;
+    float4 Color : COLOR0;
+    float2 TextureCoordinates : TEXCOORD0;
+};
+
+[shader("fragment")]
+float4 MainPS(VertexShaderOutput input) : COLOR0
+{
+    float4 color = SpriteTexture.Sample(SpriteTextureSampler, input.TextureCoordinates) * input.Color;
+    float3 sepia;
+    sepia.r = dot(color.rgb, float3(0.393, 0.769, 0.189));
+    sepia.g = dot(color.rgb, float3(0.349, 0.686, 0.168));
+    sepia.b = dot(color.rgb, float3(0.272, 0.534, 0.131));
+    return float4(saturate(sepia), color.a);
+}

--- a/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetShaderScreen.cs
+++ b/Samples/MonoGameGumInCode/MonoGameGumInCode/Screens/RenderTargetShaderScreen.cs
@@ -52,7 +52,10 @@ namespace MonoGameGumInCode.Screens;
 /// <c>SKRuntimeEffect.CreateShader</c> (<c>resources/Grayscale.sksl</c>). Left is the unmodified
 /// bear for comparison. A fourth, MonoGame-only cell (<c>Content/Grayscale.slang</c>) repeats the
 /// SourceShaderFile wiring style for Slang input instead of raw HLSL (issue #4677) — ShadowDusk's
-/// Slang frontend converts it to <c>.fx</c> text before compiling.
+/// Slang frontend converts it to <c>.fx</c> text before compiling. A second, MonoGame-only row
+/// (issue #4679) adds two more single-pass Slang examples the same way: <c>Content/Blur.slang</c>
+/// (fixed radius — Gum's render-target-effect blit sets no shader parameters, so the blur amount
+/// is a compile-time constant, not host-adjustable) and <c>Content/Sepia.slang</c>.
 /// </summary>
 internal class RenderTargetShaderScreen : FrameworkElement
 {
@@ -70,6 +73,12 @@ internal class RenderTargetShaderScreen : FrameworkElement
     // boilerplate, no technique/pass block. ShadowDusk's Slang frontend converts it to .fx text
     // before compiling; see RenderTargetShaderResolver.ResolveFxSource for the tool-side twin.
     private const string SlangShaderFileName = "Grayscale.slang";
+    // Two more single-pass, parameterless Slang examples (issue #4679). Blur's radius is a
+    // constant baked into the shader itself, sized for this demo's 128x128 cells — Gum's
+    // render-target-effect blit sets no shader parameters and runs a single pass, so an
+    // adjustable blur isn't possible without new engine work.
+    private const string BlurSlangShaderFileName = "Blur.slang";
+    private const string SepiaSlangShaderFileName = "Sepia.slang";
 #endif
 
     public RenderTargetShaderScreen() : base(new ContainerRuntime())
@@ -131,13 +140,33 @@ internal class RenderTargetShaderScreen : FrameworkElement
         // Fourth cell, XNA-like only: the same effect authored in Slang (Content/Grayscale.slang)
         // instead of raw HLSL, referenced the same way via SourceShaderFile — proves the Slang
         // frontend wiring (issue #4677) end to end, not just that .fx still works.
-        string slangEffectPath = ToolsUtilities.FileManager.RelativeDirectory + SlangShaderFileName;
-        EffectType? slangEffect = CompileEffectFromFile(slangEffectPath, out _);
-        row.AddChild(BuildCell("SourceShaderFile (.slang)",
-            effect: null,
-            sourceShaderFile: slangEffect != null ? SlangShaderFileName : null));
+        row.AddChild(BuildSlangSourceShaderFileCell("SourceShaderFile (.slang)", SlangShaderFileName));
+
+        // Second row, XNA-like only: two more example shaders (issue #4679), same wiring style.
+        var effectsRow = new ContainerRuntime();
+        effectsRow.ChildrenLayout = ChildrenLayout.LeftToRightStack;
+        effectsRow.StackSpacing = 48;
+        effectsRow.WidthUnits = DimensionUnitType.RelativeToChildren;
+        effectsRow.HeightUnits = DimensionUnitType.RelativeToChildren;
+        effectsRow.Width = 0;
+        effectsRow.Height = 0;
+        root.AddChild(effectsRow);
+
+        effectsRow.AddChild(BuildSlangSourceShaderFileCell("Blur (.slang, fixed radius)", BlurSlangShaderFileName));
+        effectsRow.AddChild(BuildSlangSourceShaderFileCell("Sepia (.slang)", SepiaSlangShaderFileName));
 #endif
     }
+
+#if !RAYLIB && !SKIA
+    // Compiles a .slang shader (relative to FileManager.RelativeDirectory) and wires it up via
+    // SourceShaderFile, gating on a known-good compile the same way the .fx cell above does.
+    private static ContainerRuntime BuildSlangSourceShaderFileCell(string caption, string slangFileName)
+    {
+        string effectPath = ToolsUtilities.FileManager.RelativeDirectory + slangFileName;
+        EffectType? effect = CompileEffectFromFile(effectPath, out _);
+        return BuildCell(caption, effect: null, sourceShaderFile: effect != null ? slangFileName : null);
+    }
+#endif
 
     // Portable color construction across the three backends' Color aliases (XNA / Raylib_cs /
     // SKColor all expose a (byte,byte,byte,byte) form), matching RenderTargetScreen's Rgba helper.

--- a/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerFileFilterTests.cs
+++ b/Tool/Tests/GumToolUnitTests/PropertyGridHelpers/PropertyGridManagerFileFilterTests.cs
@@ -1,0 +1,33 @@
+using Gum.Managers;
+using Shouldly;
+
+namespace GumToolUnitTests.PropertyGridHelpers;
+
+public class PropertyGridManagerFileFilterTests : BaseTestClass
+{
+    [Fact]
+    public void GetFileFilterForRootVariableName_SourceShaderFile_IncludesFxAndSlang()
+    {
+        string? filter = PropertyGridManager.GetFileFilterForRootVariableName("SourceShaderFile");
+
+        filter.ShouldNotBeNull();
+        filter.ShouldContain("*.fx");
+        filter.ShouldContain("*.slang");
+    }
+
+    [Fact]
+    public void GetFileFilterForRootVariableName_CustomFontFile_ReturnsFntFilter()
+    {
+        string? filter = PropertyGridManager.GetFileFilterForRootVariableName("CustomFontFile");
+
+        filter.ShouldBe("Bitmap Font Generator Font|*.fnt");
+    }
+
+    [Fact]
+    public void GetFileFilterForRootVariableName_UnrelatedVariable_ReturnsNull()
+    {
+        string? filter = PropertyGridManager.GetFileFilterForRootVariableName("Text");
+
+        filter.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Adds two more example post-process shaders alongside the existing Grayscale demo (issue #4679):

- `Content/Blur.slang` -- fixed-radius box blur (9x9 kernel, 2-texel spacing, strengthened after review). Gum's render-target-effect blit sets no shader parameters and runs a single pass, so the radius is baked in as a constant rather than exposed as a host-adjustable value.
- `Content/Sepia.slang` -- standard three-channel sepia matrix.

Both wired into the `MonoGameGumInCode` sample's `RenderTargetShaderScreen` as a second row of `SourceShaderFile` cells (MonoGame-only), same wiring style as the existing Grayscale cells. Extracted `BuildSlangSourceShaderFileCell` to share the compile-gate-then-wire pattern across all three instead of copy-pasting a third time.

**Also ships all three with the Gum tool itself** (the "how do these ship" question the issue deliberately left open, resolved to the lightweight option): `Gum/Content/Shaders/{Grayscale,Blur,Sepia}.slang`, staged into the built tool's output (`Gum/bin/<Config>/Content/Shaders/`) the same way `Gum.csproj` already ships its Fonts/Icons content. No new dialog/UI -- a user browsing for a shader via the property grid's file-picker now lands somewhere with three working examples instead of an empty folder.

**Fixes a real bug found along the way:** `PropertyGridManager`'s `SourceShaderFile` file-picker filter was hardcoded to `*.fx` only, so a `.slang` file was invisible in the browse dialog even after #4677/#4678 added `.slang` support. Extracted the filter-selection logic into `GetFileFilterForRootVariableName` (internal static, no instance state) so it's unit-testable without the heavy `StateReferencingInstanceMember` constructor.

## Test plan

- `dotnet build GumFull.sln` -- clean, no new warnings.
- `dotnet build Samples/MonoGameGumInCode/MonoGameGumInCode/MonoGameGumInCode.csproj` -- clean, no new warnings.
- Full `GumToolUnitTests` suite: 1353 passing, 2 pre-existing skips, including the new `PropertyGridManagerFileFilterTests` (confirmed red against the old `*.fx`-only filter before restoring the fix).
- Verified all three shaders convert (`SlangFrontend.ConvertToFx`) and compile (`EffectCompiler.Compile`) for both OpenGL and DirectX targets via a throwaway debug test (removed before commit).
- Confirmed all three `.slang` files copy to both the sample's `Content/` output and the tool's `Content/Shaders/` output.

Manual test: needed.
1. **Sample:** run `Samples/MonoGameGumInCode` (F5), navigate to the "Render Target Shader" screen. First row unchanged (all grayscale). New second row: "Blur (.slang, fixed radius)" should look visibly softened; "Sepia (.slang)" should look warm brown/sepia-toned.
2. **Tool:** in the Gum tool, select a Container, set `IsRenderTarget = true`, click the `SourceShaderFile` browse button. The file dialog should now show both `.fx` and `.slang` files. Browsing to the built tool's own `Content/Shaders/` folder (next to `Gum.exe`) should show all three example shaders.

FRB canary: not needed -- every changed file is Gum tool-only (`Gum/Plugins/InternalPlugins/VariableGrid/`, `Gum/Content/`) or sample/test content, none of it FRB1-shared source.

Closes #4679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VPJS3fB3nQYobMFYdvLRT
